### PR TITLE
Update README and Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Create an entity:
 defmodule Post do
   use Ecto.Entity
 
-  dataset :posts do
+  dataset "posts" do
     field :title, :string
     field :content, :string
   end
@@ -65,7 +65,7 @@ query = from p in Post,
      select: p.title
 
 # Run the query against the database to actually fetch the data
-titles = MyRepo.fetch(query)
+titles = MyRepo.all(query)
 ```
 
 ### Examples

--- a/examples/simple/lib/simple.ex
+++ b/examples/simple/lib/simple.ex
@@ -23,7 +23,7 @@ end
 defmodule Simple.Weather do
   use Ecto.Entity
 
-  dataset :weather, nil do
+  dataset "weather", nil do
     field :city, :string
     field :temp_lo, :integer
     field :temp_hi, :integer
@@ -46,6 +46,6 @@ defmodule Simple do
     query = from w in Simple.Weather,
           where: w.prcp > 0 or w.prcp == nil,
          select: w
-    Simple.MyRepo.fetch(query)
+    Simple.MyRepo.all(query)
   end
 end


### PR DESCRIPTION
It seems to me that the README and the Example app aren't up to date with the latest API. Firstly this pull changes the dataset definition from an atom to a string otherwise Elixir fails to compile and throws the following error:

```
** (FunctionClauseError) no function clause matching in String.Unicode.next_grapheme/1
    /private/tmp/elixir-4KO4/lib/elixir/priv/unicode.ex:171: String.Unicode.next_grapheme(:weather)
    /private/tmp/elixir-4KO4/lib/elixir/lib/string.ex:669: String.first/1
    /Users/Tristan/Desktop/ecto/lib/ecto/adapters/postgres/sql.ex:317: Ecto.Adapters.Postgres.SQL."-create_names/1-fun-0-"/2
    /private/tmp/elixir-4KO4/lib/elixir/lib/enum.ex:1522: Enumerable.List.reduce/3
    /Users/Tristan/Desktop/ecto/lib/ecto/adapters/postgres/sql.ex:316: Ecto.Adapters.Postgres.SQL.create_names/1
    /Users/Tristan/Desktop/ecto/lib/ecto/adapters/postgres/sql.ex:27: Ecto.Adapters.Postgres.SQL.select/1
    /Users/Tristan/Desktop/ecto/lib/ecto/adapters/postgres.ex:39: Ecto.Adapters.Postgres.all/2
    /Users/Tristan/Desktop/ecto/lib/ecto/repo.ex:231: Ecto.Repo.all/3
```

Also `fetch` no longer exists and the equivalent appears to be `all` now.
