### PR TITLE
Use single atom for simple types

### DIFF
--- a/lib/ecto/entity.ex
+++ b/lib/ecto/entity.ex
@@ -133,7 +133,8 @@ defmodule Ecto.Entity.Dataset do
 
     quote do
       name = unquote(name)
-      type = unquote(format_type(type))
+      type = unquote(type)
+      Ecto.Entity.Dataset.check_type(type)
 
       clash = Enum.any?(@ecto_fields, fn({ prev_name, _ }) -> name == prev_name end)
       if clash do
@@ -146,18 +147,13 @@ defmodule Ecto.Entity.Dataset do
     end
   end
 
-  defp format_type(type) when is_atom(type), do: { type, nil }
-
-  defp format_type({ outer, inner }) when is_atom(outer) do
+  @doc false
+  def check_type({ outer, inner }) when is_atom(outer) do
     check_type(outer)
-    { outer, format_type(inner) }
+    check_type(inner)
   end
 
-  defp format_type(other) do
-    raise ArgumentError, message: "`#{Macro.to_string(other)}` is not a valid field type"
-  end
-
-  defp check_type(type) do
+  def check_type(type) do
     unless type in @types do
       raise ArgumentError, message: "`#{Macro.to_string(type)}` is not a valid field type"
     end

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -54,8 +54,6 @@ defexception Ecto.TypeCheckError, [:expr, :types, :allowed] do
     types  = Enum.map(e.types, &QueryUtil.type_to_ast/1)
     actual = Macro.to_string({ name, [], types })
 
-    IO.inspect e.types
-
     """
     the following expression does not type check:
 

--- a/lib/ecto/query/validator.ex
+++ b/lib/ecto/query/validator.ex
@@ -112,7 +112,7 @@ defmodule Ecto.Query.Validator do
         state = state.vars(vars)
         expr_type = type_check(expr.expr, state)
 
-        unless expr_type == { :boolean, nil } do
+        unless expr_type == :boolean do
           format_expr_type = QueryUtil.type_to_ast(expr_type) |> Macro.to_string
           raise Ecto.InvalidQuery, reason: "#{type} expression `#{Macro.to_string(expr.expr)}` " <>
             "is of type `#{format_expr_type}`, has to be of boolean type"
@@ -175,7 +175,7 @@ defmodule Ecto.Query.Validator do
 
     case types do
       [] ->
-        { :list, { :any, nil } }
+        { :list, :any }
       [type|rest] ->
         unless Enum.all?(rest, &QueryUtil.type_eq?(type, &1)) do
           raise Ecto.InvalidQuery, reason: "all elements in list has to be of same type"

--- a/test/ecto/entity_test.exs
+++ b/test/ecto/entity_test.exs
@@ -27,10 +27,10 @@ defmodule Ecto.EntityTest do
 
   test "metadata" do
     fields = [
-      { :id, [type: { :integer, nil }, primary_key: true] },
-      { :name, [type: { :string, nil }, default: "eric"] },
-      { :email, [type: { :string, nil }, uniq: true] },
-      { :array, [type: { :list, { :string, nil } }] }
+      { :id, [type: :integer, primary_key: true] },
+      { :name, [type: :string, default: "eric"] },
+      { :email, [type: :string, uniq: true] },
+      { :array, [type: { :list, :string }] }
     ]
 
     assert MyEntity.__ecto__(:dataset) == "my_entity"


### PR DESCRIPTION
Examples:
{ :integer, nil } => :integer
{ :list, { :string, nil } } => { :list, :string }
