### PR TITLE
Fixed dep warnings for List.concat

### DIFF
--- a/lib/ecto/query/validator.ex
+++ b/lib/ecto/query/validator.ex
@@ -329,7 +329,7 @@ defmodule Ecto.Query.Validator do
       Enum.map(expr.expr, fn({ var, field }) ->
         { Util.find_entity(entities, var), field }
       end)
-    end) |> List.concat |> Enum.uniq
+    end) |> Enum.concat |> Enum.uniq
   end
 
   defp check_grouped(entity_field, state) do


### PR DESCRIPTION
Was getting dep warning:

```
List.concat/1 is deprecated, please use Enum.concat/1 instead
    /Users/ortuna/Desktop/code/opensource/elixir/lib/elixir/lib/list.ex:17: List.concat/1
    lib/ecto/query/validator.ex:332: Ecto.Query.Validator.group_by_entities/2
    lib/ecto/query/validator.ex:34: Ecto.Query.Validator.validate/3
    /Users/ortuna/Desktop/code/opensource/elixir/lib/ex_unit/lib/ex_unit/assertions.ex:342: ExUnit.Assertions.assert_raise/2
    /Users/ortuna/Desktop/code/opensource/elixir/lib/ex_unit/lib/ex_unit/assertions.ex:316: ExUnit.Assertions.assert_raise/3
    test/ecto/query/validator_test.exs:47: Ecto.Query.ValidatorTest."test where expression must be boolean"/1
    /Users/ortuna/Desktop/code/opensource/elixir/lib/ex_unit/lib/ex_unit/runner.ex:138: ExUnit.Runner."-run_test/3-fun-0-"/3
```
