### PR TITLE
Fix ecto.migrate task

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -71,14 +71,10 @@ defmodule Ecto.Migrator do
   defp ensure_no_duplication([]), do: :ok
 
   defp filter_migrated(migrations, repo) do
-    case repo.adapter.migrated_versions(repo) do
-      { :error, error } ->
-        raise Ecto.MigrationError, message: "could not migrate, got: #{inspect error}"
-      { :ok, versions } ->
-        Enum.filter(migrations, fn { version, _file } ->
-          not (version in versions)
-        end)
-    end
+    versions = repo.adapter.migrated_versions(repo)
+    Enum.filter(migrations, fn { version, _file } ->
+      not (version in versions)
+    end)
   end
 
   defp execute_migrations(migrations, repo) do
@@ -90,8 +86,6 @@ defmodule Ecto.Migrator do
 
       commands = List.wrap(mod.up)
       case repo.adapter.migrate_up(repo, version, commands) do
-        { :error, error } ->
-          raise Ecto.MigrationError, message: "could not migrate, got: #{inspect error}"
         :already_up ->
           version
         :ok ->

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -11,21 +11,13 @@ defmodule Ecto.MigratorTest do
     end
 
     def migrate_up(__MODULE__, id, ["up"]) do
-      case migrated_versions(__MODULE__) do
-        { :ok, versions } ->
-          if id in versions, do: :already_up, else: :ok
-        error ->
-          error
-      end
+      versions = migrated_versions(__MODULE__)
+      if id in versions, do: :already_up, else: :ok
     end
 
     def migrate_down(__MODULE__, id, ["down"]) do
-      case migrated_versions(__MODULE__) do
-        { :ok, versions } ->
-          if id in versions, do: :ok, else: :already_down
-        error ->
-          error
-      end
+      versions = migrated_versions(__MODULE__)
+      if id in versions, do: :ok, else: :already_down
     end
 
     def migrated_versions(__MODULE__) do
@@ -44,7 +36,7 @@ defmodule Ecto.MigratorTest do
   end
 
   setup do
-    Process.put(:migrated_versions, { :ok, [1, 2, 3] })
+    Process.put(:migrated_versions, [1, 2, 3])
     :ok
   end
 
@@ -76,15 +68,6 @@ defmodule Ecto.MigratorTest do
     in_tmp fn path ->
       create_migration "a_sample.exs"
       assert Ecto.Migrator.run_up(ProcessRepo, path) == []
-    end
-  end
-
-  test "fails if it cannot contact the database" do
-    in_tmp fn path ->
-      Process.put(:migrated_versions, { :error, :oops })
-      assert_raise Ecto.MigrationError, "could not migrate, got: :oops", fn ->
-        Ecto.Migrator.run_up(ProcessRepo, path)
-      end
     end
   end
 


### PR DESCRIPTION
This fixes the migrator mix task `mix ecto.migrate Repo`

migrated_versions/1 no longer returns a tuple pair `{:ok, _}` since changes in https://github.com/elixir-lang/ecto/commit/6c604801af06fb683bfc9c26be921172b3230e32 make adapter methods raise exceptions rather than returning tuple pairs `{:error, _reason}` and `{:ok, _result}`
