### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ def update(id, params) do
   weather = Repo.get(Weather, id).update(params)
 
   case Weather.validate(weather) do
-    []     -> json weather: Repo.create(weather)
+    []     -> json weather: Repo.update(weather)
     errors -> json errors: errors
   end
 end


### PR DESCRIPTION
This example in the documentation is creating a new record
rather than updating one. This was confusing to me since I was writing
a similar function using Dynamo and getting duplicate key errors since
the entities "id" attribute was being passed into `create`
