### PR TITLE
Removing nil keys and values from insert cluases

### DIFF
--- a/integration_test/pg/sql_escape_test.exs
+++ b/integration_test/pg/sql_escape_test.exs
@@ -2,7 +2,7 @@ defmodule Ecto.Integration.SQLEscapeTest do
   use Ecto.Integration.Postgres.Case
 
   test "Repo.all escape" do
-    TestRepo.create(Post.new())
+    TestRepo.create(Post.new(text: "hello"))
 
     query = from(p in Post, select: "'\\")
     assert ["'\\"] == TestRepo.all(query)
@@ -16,7 +16,7 @@ defmodule Ecto.Integration.SQLEscapeTest do
   end
 
   test "Repo.update escape" do
-    p = TestRepo.create(Post.new())
+    p = TestRepo.create(Post.new(text: "hello"))
     TestRepo.update(p.text("'"))
 
     query = from(p in Post, select: p.text)
@@ -24,7 +24,7 @@ defmodule Ecto.Integration.SQLEscapeTest do
   end
 
   test "Repo.update_all escape" do
-    TestRepo.create(Post.new())
+    TestRepo.create(Post.new(text: "hello"))
     TestRepo.update_all(Post, text: "'")
 
     query = from(p in Post, select: p.text)
@@ -35,7 +35,7 @@ defmodule Ecto.Integration.SQLEscapeTest do
   end
 
   test "Repo.delete_all escape" do
-    TestRepo.create(Post.new())
+    TestRepo.create(Post.new(text: "hello"))
     assert [_] = TestRepo.all(Post)
 
     TestRepo.delete_all(from(Post, where: "'" == "'"))

--- a/lib/ecto/repo/backend.ex
+++ b/lib/ecto/repo/backend.ex
@@ -52,13 +52,7 @@ defmodule Ecto.Repo.Backend do
 
   def create(repo, adapter, entity) do
     validate_entity(entity)
-    primary_key = adapter.create(repo, entity)
-
-    if primary_key do
-      entity.primary_key(primary_key)
-    else
-      entity
-    end
+    adapter.create(repo, entity)
   end
 
   def update(repo, adapter, entity) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-[ "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "a5ff9956feeea113509125e5b29623c1fa7e3be4", []},
-  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "91b68de43d49bcccf2631016febda70b20d7aa75", []},
-  "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "3424ee5334af9f52cde3a2f90a452e73fd20be0f", []} ]
+[ "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "2e0716ac0450a029dce2a30c871b50d98baf4aee", []},
+  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "c2c939b51aba06790ca51fa78b14c254a6ea977d", []},
+  "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "73778e19ce08877f4fe713329a3dbc99ca5e2056", []} ]

--- a/test/ecto/adapters/postgres/sql_test.exs
+++ b/test/ecto/adapters/postgres/sql_test.exs
@@ -193,8 +193,13 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
   end
 
   test "insert" do
-    query = SQL.insert(Model.Entity[x: 123, y: "456"])
+    query = SQL.insert(Model.Entity[x: 123, y: "456"], [:id])
     assert query == "INSERT INTO model (x, y)\nVALUES (123, '456'::text)\nRETURNING id"
+  end
+
+  test "insert with several missing values" do
+    query = SQL.insert(Model.Entity[x: 123], [:id, :y])
+    assert query == "INSERT INTO model (x)\nVALUES (123)\nRETURNING id, y"
   end
 
   test "update" do
@@ -375,14 +380,14 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
 
   test "primary key any location" do
     model = PKModel.Entity[x: 10, y: 30]
-    assert SQL.insert(model) == "INSERT INTO model (x, y)\nVALUES (10, 30)\nRETURNING pk"
+    assert SQL.insert(model, [:pk]) == "INSERT INTO model (x, y)\nVALUES (10, 30)\nRETURNING pk"
 
     model = PKModel.Entity[x: 10, pk: 20, y: 30]
     assert SQL.insert(model) == "INSERT INTO model (x, pk, y)\nVALUES (10, 20, 30)"
   end
 
   test "send explicit set primary key" do
-    model = Model.Entity[id: 123, x: 0, y: 1]
-    assert SQL.insert(model) == "INSERT INTO model (id, x, y)\nVALUES (123, 0, 1)"
+    model = Model.Entity[id: 123, x: 0, y: 2]
+    assert SQL.insert(model) == "INSERT INTO model (id, x, y)\nVALUES (123, 0, 2)"
   end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -5,7 +5,9 @@ defmodule Ecto.RepoTest.MockAdapter do
   def start_link(_repo, _opts), do: :ok
   def stop(_repo), do: :ok
   def all(_repo, _query), do: []
-  def create(_repo, _record), do: 42
+  def create(_repo, record) do
+    record.id(45)
+  end
   def update(_repo, _record), do: 1
   def update_all(_repo, _query, _values), do: 1
   def delete(_repo, _record), do: 1


### PR DESCRIPTION
So I ran into this issue, say we have a table:

``` sql
CREATE TABLE items( id integer serial, data text, created timestamp default CURRENT_TIMESTAMP)
```

And I have a model

``` elixir
 defmodule Item do
    use Ecto.Model
    queryable "items" do
      field :data, :string
      field :created, :datetime
    end
  end
```

I and I try to create a new item like so:

``` elixir
item = Item.new(data: "hello world!")
Repo.create(item)
```

I expect to get back an item like the following (excuse me if I messed up EctoDate its from memory)

``` elixir
[id: 1, data: "Hello World", created: EctoDate[date[year: 2013, month: 12, day: 9], time[hour: 8, min: 25, sec 20]]]
```

Instead I get

``` elixir
[id 1, data: "Hello World", created null]
```

Because the ecto postgres adapter here https://github.com/elixir-lang/ecto/blob/master/lib/ecto/adapters/postgres/sql.ex#L75 joins on all of the fields.

My proposed solution is to ignore fields set to NIL on insert and let the database handle that case. 

I ran all tests following the contribution guidelines before pushing. 

```
[10:32:28] <ericmj>  peregrine81: you probably want to change the adapter to return the full entity instead
[10:33:21] <ericmj>  you can use __entity__(:allocate, ...) to create an entity from a keyword list, there should be examples in the postgrex.ex file
[10:33:52] <ericmj>  peregrine81: right now adapter.create just returns the primary key and repo.create puts the key on the entity
[10:34:31] <ericmj>  so you want change Postgres.create and Backend.create
```
#### TODO:
- [x] Update Postgres.create to return entity with the rows instead of key on entity
- [x] Update Backend.create to return entity with the rows instead of key on entity
- [x] Fix 38 failing integration tests
