### PR TITLE
Rename option :primary_key to :references for associations

### DIFF
--- a/lib/ecto/associations/belongs_to.ex
+++ b/lib/ecto/associations/belongs_to.ex
@@ -65,12 +65,12 @@ defimpl Inspect, for: Ecto.Associations.BelongsTo do
     refl        = target.__entity__(:association, name)
     associated  = refl.associated
     foreign_key = refl.key
-    primary_key = refl.assoc_key
+    references  = refl.assoc_key
     kw = [
       name: name,
       target: target,
       associated: associated,
-      primary_key: primary_key,
+      references: references,
       foreign_key: foreign_key
     ]
     concat ["#Ecto.Associations.BelongsTo<", Kernel.inspect(kw, opts), ">"]

--- a/lib/ecto/associations/has_many.ex
+++ b/lib/ecto/associations/has_many.ex
@@ -88,13 +88,13 @@ defimpl Inspect, for: Ecto.Associations.HasMany do
     target      = assoc.__assoc__(:target)
     refl        = target.__entity__(:association, name)
     associated  = refl.associated
-    primary_key = refl.key
+    references  = refl.key
     foreign_key = refl.assoc_key
     kw = [
       name: name,
       target: target,
       associated: associated,
-      primary_key: primary_key,
+      references: references,
       foreign_key: foreign_key
     ]
     concat ["#Ecto.Associations.HasMany<", Kernel.inspect(kw, opts), ">"]

--- a/lib/ecto/associations/has_one.ex
+++ b/lib/ecto/associations/has_one.ex
@@ -68,13 +68,13 @@ defimpl Inspect, for: Ecto.Associations.HasOne do
     target      = assoc.__assoc__(:target)
     refl        = target.__entity__(:association, name)
     associated  = refl.associated
-    primary_key = refl.key
+    references  = refl.key
     foreign_key = refl.assoc_key
     kw = [
       name: name,
       target: target,
       associated: associated,
-      primary_key: primary_key,
+      references: references,
       foreign_key: foreign_key
     ]
     concat ["#Ecto.Associations.HasOne<", Kernel.inspect(kw, opts), ">"]

--- a/lib/ecto/entity.ex
+++ b/lib/ecto/entity.ex
@@ -87,7 +87,7 @@ defmodule Ecto.Entity do
 
     * `:foreign_key` - Sets the foreign key, this should map to a field on the
                        other entity, defaults to: `:"#{model}_id"`;
-    * `:primary_key` - Sets the key on the current entity to be used for the
+    * `:references`  - Sets the key on the current entity to be used for the
                        association, defaults to the primary key on the entity;
 
   ## Examples
@@ -138,7 +138,7 @@ defmodule Ecto.Entity do
 
     * `:foreign_key` - Sets the foreign key, this should map to a field on the
                        other entity, defaults to: `:"#{model}_id"`;
-    * `:primary_key` - Sets the key on the current entity to be used for the
+    * `:references`  - Sets the key on the current entity to be used for the
                        association, defaults to the primary key on the entity;
 
   ## Examples
@@ -187,7 +187,7 @@ defmodule Ecto.Entity do
 
     * `:foreign_key` - Sets the foreign key field name, defaults to:
                        `:"#{other_entity}_id"`;
-    * `:primary_key` - Sets the key on the other entity to be used for the
+    * `:references`  - Sets the key on the other entity to be used for the
                        association, defaults to: `:id`;
 
   ## Examples
@@ -317,7 +317,7 @@ defmodule Ecto.Entity do
   @doc false
   def __belongs_to__(mod, name, queryable, opts) do
     opts = opts
-           |> Keyword.put_new(:primary_key, :id)
+           |> Keyword.put_new(:references, :id)
            |> Keyword.put_new(:foreign_key, :"#{name}_id")
 
     __field__(mod, opts[:foreign_key], :integer, [])
@@ -346,7 +346,7 @@ defmodule Ecto.Entity do
     model = Module.get_attribute(mod, :ecto_model)
     if nil?(model) and nil?(foreign_key) do
       raise ArgumentError, message: "need to set `foreign_key` option for " <>
-        "assocation when model name can't be infered"
+        "association when model name can't be infered"
     end
   end
 
@@ -369,17 +369,17 @@ defmodule Ecto.Entity do
   defp ecto_assocs(assocs, primary_key, fields) do
     quoted = Enum.map(assocs, fn({ name, opts, }) ->
       quote bind_quoted: [name: name, opts: opts, primary_key: primary_key, fields: fields] do
-        pk = opts[:primary_key] || primary_key
+        pk = opts[:references] || primary_key
         virtual_name = :"__#{name}__"
 
         if nil?(pk) do
-          raise ArgumentError, message: "need to set `primary_key` option for " <>
+          raise ArgumentError, message: "need to set `references` option for " <>
             "association when entity has no primary key"
         end
 
         if opts[:type] in [:has_many, :has_one] do
           unless Enum.any?(fields, fn { name, _ } -> pk == name end) do
-            raise ArgumentError, message: "`primary_key` option on association " <>
+            raise ArgumentError, message: "`references` option on association " <>
               "doesn't match any field on the entity"
           end
         end

--- a/test/ecto/adapters/postgres/sql_test.exs
+++ b/test/ecto/adapters/postgres/sql_test.exs
@@ -328,7 +328,7 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
     use Ecto.Model
     queryable "comments" do
       belongs_to :post, Ecto.Adapters.Postgres.SQLTest.Post,
-        primary_key: :a,
+        references: :a,
         foreign_key: :b
     end
   end
@@ -337,10 +337,10 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
     use Ecto.Model
     queryable "posts" do
       has_many :comments, Ecto.Adapters.Postgres.SQLTest.Comment,
-        primary_key: :c,
+        references: :c,
         foreign_key: :d
       has_one :permalink, Ecto.Adapters.Postgres.SQLTest.Permalink,
-        primary_key: :e,
+        references: :e,
         foreign_key: :f
       field :c, :integer
       field :e, :integer

--- a/test/ecto/entity_test.exs
+++ b/test/ecto/entity_test.exs
@@ -229,10 +229,10 @@ defmodule Ecto.EntityTest do
   defmodule EntityAssocOpts do
     use Ecto.Entity, model: AssocOpts, primary_key: { :pk, :integer, [] }
 
-    has_many :posts, Post, primary_key: :pk, foreign_key: :fk
-    has_one :author, User, primary_key: :pk, foreign_key: :fk
-    belongs_to :permalink, Permalink, primary_key: :pk, foreign_key: :fk
-    belongs_to :permalink2, Permalink, primary_key: :pk
+    has_many :posts, Post, references: :pk, foreign_key: :fk
+    has_one :author, User, references: :pk, foreign_key: :fk
+    belongs_to :permalink, Permalink, references: :pk, foreign_key: :fk
+    belongs_to :permalink2, Permalink, references: :pk
   end
 
   test "has_many options" do
@@ -257,14 +257,14 @@ defmodule Ecto.EntityTest do
     assert :permalink2_id == refl.key
   end
 
-  test "primary_key option has to match a field on entity" do
-    message = "`primary_key` option on association doesn't match any field on the entity"
+  test "references option has to match a field on entity" do
+    message = "`references` option on association doesn't match any field on the entity"
     assert_raise ArgumentError, message, fn ->
       defmodule EntityPkAssocMisMatch do
         use Ecto.Entity, model: PkAssocMisMatch
 
-        has_many :posts, Post, primary_key: :pk
-        has_one :author, User, primary_key: :pk
+        has_many :posts, Post, references: :pk
+        has_one :author, User, references: :pk
       end
     end
   end


### PR DESCRIPTION
Hmm... I think I got it all!

Hopefully the current coverage was enough because I haven't added any new tests -- I figured this wasn't supposed to add any new feature, just make things easier to maintain moving forward.

It sure was confusing to have :primary_key sometimes referencing the model's primary_key and sometimes referencing the primary_key option... which I am sure is the reason for issue #122 in the first place!
