### PR TITLE
Removing ::text casting with strings.

### DIFF
--- a/lib/ecto/adapters/postgres/sql.ex
+++ b/lib/ecto/adapters/postgres/sql.ex
@@ -329,7 +329,7 @@ defmodule Ecto.Adapters.Postgres.SQL do
   end
 
   defp literal(literal) when is_binary(literal) do
-    "'#{escape_string(literal)}'::text"
+    "'#{escape_string(literal)}'"
   end
 
   defp literal(literal) when is_number(literal) do

--- a/test/ecto/adapters/postgres/sql_test.exs
+++ b/test/ecto/adapters/postgres/sql_test.exs
@@ -89,10 +89,10 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
   test "string escape" do
     x = "'\\ \n"
     query = from(Model) |> select([], ^x) |> normalize
-    assert SQL.select(query) == "SELECT '''\\ \n'::text\nFROM model AS m0"
+    assert SQL.select(query) == "SELECT '''\\ \n'\nFROM model AS m0"
 
     query = from(Model) |> select([], "'") |> normalize
-    assert SQL.select(query) == "SELECT ''''::text\nFROM model AS m0"
+    assert SQL.select(query) == "SELECT ''''\nFROM model AS m0"
   end
 
   test "unary ops" do
@@ -166,10 +166,10 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
     assert SQL.select(query) == "SELECT FALSE\nFROM model AS m0"
 
     query = from(Model) |> select([], "abc") |> normalize
-    assert SQL.select(query) == "SELECT 'abc'::text\nFROM model AS m0"
+    assert SQL.select(query) == "SELECT 'abc'\nFROM model AS m0"
 
     query = from(Model) |> select([], <<?a,?b,?c>>) |> normalize
-    assert SQL.select(query) == "SELECT 'abc'::text\nFROM model AS m0"
+    assert SQL.select(query) == "SELECT 'abc'\nFROM model AS m0"
 
     query = from(Model) |> select([], binary(<<0,1,2>>)) |> normalize
     assert SQL.select(query) == "SELECT '\\x000102'::bytea\nFROM model AS m0"
@@ -194,7 +194,7 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
 
   test "insert" do
     query = SQL.insert(Model.Entity[x: 123, y: "456"], [:id])
-    assert query == "INSERT INTO model (x, y)\nVALUES (123, '456'::text)\nRETURNING id"
+    assert query == "INSERT INTO model (x, y)\nVALUES (123, '456')\nRETURNING id"
   end
 
   test "insert with several missing values" do
@@ -204,7 +204,7 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
 
   test "update" do
     query = SQL.update(Model.Entity[id: 42, x: 123, y: "456"])
-    assert query == "UPDATE model SET x = 123, y = '456'::text\nWHERE id = 42"
+    assert query == "UPDATE model SET x = 123, y = '456'\nWHERE id = 42"
   end
 
   test "delete" do
@@ -231,7 +231,7 @@ defmodule Ecto.Adapters.Postgres.SQLTest do
 
     query = Model |> Queryable.to_query |> normalize
     assert SQL.update_all(query, x: 0, y: "123") ==
-           "UPDATE model AS m0\nSET x = 0, y = '123'::text"
+           "UPDATE model AS m0\nSET x = 0, y = '123'"
   end
 
   test "delete all" do


### PR DESCRIPTION
Postgres does not require this cast to happen and in most cases can figure it out on its own without the hint. Other ORMs like Sequel do not do this cast so I feel fine removing it. 

This breaks in cases of non-text fields that 'act' like strings. Example: uuid

``` elixir
Repo.get(MyUUIDModel, uuid_key)
(Postgrex.Error) ERROR (42883): operator does not exist: uuid = text
```

Making this change allows it to work.
