### PR TITLE
Ignore Scheme in database URI

### DIFF
--- a/lib/ecto/repo/backend.ex
+++ b/lib/ecto/repo/backend.ex
@@ -103,9 +103,8 @@ defmodule Ecto.Repo.Backend do
 
   defp parse_url(url) do
   
-    # Ensure url starts with <scheme>:// (URI.parse doesn't enforce this)
     unless url =~ %r/^[^:\/?#\s]+:\/\// do
-      raise Ecto.InvalidURL, url: url, reason: "url has to start with a scheme before some credentials/domain"
+      raise Ecto.InvalidURL, url: url, reason: "url should start with a scheme, host should start with //"
     end
 
     info = URI.parse(url)

--- a/test/ecto/adapter_test.exs
+++ b/test/ecto/adapter_test.exs
@@ -32,7 +32,7 @@ defmodule Ecto.AdapterTest do
   end
 
   test "does not receive invalid urls" do
-    assert_raise Ecto.InvalidURL, %r"url has to start with a scheme", fn ->
+    assert_raise Ecto.InvalidURL, %r"url should start with a scheme", fn ->
       parse_url("eric:hunter2@host:123/mydb")
     end
 


### PR DESCRIPTION
As per the discussion in the mailing list and the issue #130 , the ecto:// scheme in the database URL makes it a bit tricky for people using Heroku (for instance), where their configuration only provides them with a URL starting with mysql:// or postgre://. However, as ecto doesn't do anything with the scheme actually, there is no impact in ignoring the scheme altogether.

The PR here ensures a scheme is present (using roughly the same regex as per the URI RFC document) but the parsing doesn't fail anymore if the URL doesn't start with ecto://.

I left a TODO for someday, do something with the scheme (such as ensuring it's part of a list schemes ecto can actually understand), but I assume this isn't really the priority.
