### PR TITLE
run the compile task before migration

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -15,6 +15,8 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
   """
   def run(args) do
+    Mix.Task.run "compile"
+
     case parse_repo(args) do
       { repo, [name] } ->
         ensure_repo(repo)

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -27,6 +27,8 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
   """
   def run(args, migrator // &Ecto.Migrator.run/4) do
+    Mix.Task.run "compile"
+
     { opts, args, _ } = OptionParser.parse args,
       switches: [all: :boolean, step: :integer, version: :integer],
       aliases: [n: :step, v: :to]

--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -28,6 +28,8 @@ defmodule Mix.Tasks.Ecto.Rollback do
 
   """
   def run(args, migrator // &Ecto.Migrator.run/4) do
+    Mix.Task.run "compile"
+
     { opts, args, _ } = OptionParser.parse args,
       switches: [all: :boolean, step: :integer, version: :integer],
       aliases: [n: :step, v: :to]


### PR DESCRIPTION
Run the compile task before a migration is generated. This ensures that a newly added Repo will be found by the migration task.
