### PR TITLE
Address deprecations of Kernel.<-/2 and Enum.first/1 in elixir v0.12.2

### DIFF
--- a/integration_test/pg/transaction_test.exs
+++ b/integration_test/pg/transaction_test.exs
@@ -131,14 +131,14 @@ defmodule Ecto.Integration.TransactionTest do
       TestRepo1.transaction(fn ->
         e = TestRepo1.create(Trans.Entity[text: "7"])
         assert [^e] = TestRepo1.all(Trans)
-        pid <- :in_transaction
+        send(pid, :in_transaction)
         receive do
           :commit -> :ok
         after
           5000 -> raise "timeout"
         end
       end)
-      pid <- :commited
+      send(pid, :commited)
     end
 
     receive do
@@ -148,7 +148,7 @@ defmodule Ecto.Integration.TransactionTest do
     end
     assert [] = TestRepo1.all(Trans)
 
-    new_pid <- :commit
+    send(new_pid, :commit)
     receive do
       :commited -> :ok
     after

--- a/integration_test/pg/worker_test.exs
+++ b/integration_test/pg/worker_test.exs
@@ -11,7 +11,7 @@ defmodule Ecto.Integration.WorkerTest do
   test "worker reconnects to database when connecton exits" do
     { :ok, worker } = Worker.start_link(worker_opts)
     { :links, links } = Process.info(worker, :links)
-    conn = Enum.first(Enum.reject(links, &(&1 == self)))
+    conn = List.first(Enum.reject(links, &(&1 == self)))
     Process.exit(conn, :normal)
     result = Worker.query!(worker, "SELECT TRUE")
     assert is_record(result, Postgrex.Result)

--- a/lib/ecto/adapters/postgres/sql.ex
+++ b/lib/ecto/adapters/postgres/sql.ex
@@ -295,7 +295,7 @@ defmodule Ecto.Adapters.Postgres.SQL do
   defp expr({ fun, _, args }, sources) when is_atom(fun) and is_list(args) do
     case translate_name(fun, length(args)) do
       { :unary_op, op } ->
-        arg = expr(Enum.first(args), sources)
+        arg = expr(List.first(args), sources)
         op <> arg
       { :binary_op, op } ->
         [left, right] = args

--- a/lib/ecto/associations.ex
+++ b/lib/ecto/associations.ex
@@ -35,7 +35,7 @@ defmodule Ecto.Associations do
   end
 
   def set_loaded(record, refl, loaded) do
-    if not is_record(refl, HasMany), do: loaded = Enum.first(loaded)
+    if not is_record(refl, HasMany), do: loaded = List.first(loaded)
     field = refl.field
     association = apply(record, field, [])
     association = association.__assoc__(:loaded, loaded)

--- a/lib/ecto/associations/preloader.ex
+++ b/lib/ecto/associations/preloader.ex
@@ -35,7 +35,7 @@ defmodule Ecto.Associations.Preloader do
   defp do_run([], _repo, _field), do: []
 
   defp do_run(records, repo, { field, sub_fields }) do
-    record = Enum.first(records)
+    record = List.first(records)
     module = elem(record, 0)
     refl = module.__entity__(:association, field)
     should_sort? = should_sort?(records, refl)
@@ -161,7 +161,7 @@ defmodule Ecto.Associations.Preloader do
 
   defp should_sort?(records, refl) do
     key = refl.key
-    first = Enum.first(records)
+    first = List.first(records)
 
     Enum.reduce(records, { first, false }, fn record, { last, sort? } ->
       if last && record && elem(record, 0) != elem(last, 0) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-[ "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "637b3f09030aeef24961290b0d33fd2d40bd3b0c", []},
-  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "c2c939b51aba06790ca51fa78b14c254a6ea977d", []},
-  "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "218db4af386045984c20eabe5771447abd5bd096", []} ]
+[ "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "aecbe8cf755fc81d76e2924d69a33642b7945af9", []},
+  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "d47df5df57b22eb183b0c48c8dcc5f9827fad71b", []},
+  "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "d5edcd2466ea9260c57f1cb1e67990731c3c9608", []} ]

--- a/test/ecto/query/normalizer_test.exs
+++ b/test/ecto/query/normalizer_test.exs
@@ -25,7 +25,7 @@ defmodule Ecto.Query.NormalizerTest do
     query = from(p in Post, group_by: [p, p.text]) |> normalize
     var = { :&, [], [0] }
     assert [{ var, :id }, { var, :title }, { var, :text }, { var, :text }] =
-           Enum.first(query.group_bys).expr
+           List.first(query.group_bys).expr
   end
 
   test "normalize assoc joins" do


### PR DESCRIPTION
On a related note, the [`Postgrex.Connection.send/2` function](https://github.com/ericmj/postgrex/blob/master/lib/postgrex/connection.ex#L739) now conflicts with elixir's `Kernel.send/2`, leading to a build failure if postgrex is used.

I had to do a quick and dirty hack to postgrex (changing send/2 to send_msg/2) to get Ecto to work, but I think I should leave it to @ericmj to institute the proper fix. This is also the reason for the Travis CI failure:

```
* Compiling postgrex
Compiled lib/postgrex/binary_utils.ex
Compiled lib/postgrex/records.ex
Compiled lib/postgrex/types.ex
Compiled lib/postgrex/protocol.ex
== Compilation error on file lib/postgrex/connection.ex ==
could not compile dependency postgrex, mix compile failed. You can recompile this dependency with `mix deps.compile postgrex` or update it with `mix deps.update postgrex`
** (CompileError) deps/postgrex/lib/postgrex/connection.ex:1: imported Kernel.send/2 conflicts with local function
    (elixir) src/elixir_locals.erl:149: :elixir_locals."-ensure_no_function_conflict/4-lc$^0/1-0-"/3
    (elixir) src/elixir_locals.erl:147: :elixir_locals.ensure_no_function_conflict/4
    (stdlib) erl_eval.erl:569: :erl_eval.do_apply/6
    (elixir) src/elixir.erl:140: :elixir.eval_forms/4
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/2
```
