### PR TITLE
Manual rollback with term

### DIFF
--- a/integration_test/pg/transaction_test.exs
+++ b/integration_test/pg/transaction_test.exs
@@ -124,6 +124,17 @@ defmodule Ecto.Integration.TransactionTest do
     assert [] = TestRepo2.all(Trans)
   end
 
+  test "manual rollback with term" do
+    x = TestRepo1.transaction(fn ->
+      e = TestRepo1.create(Trans.Entity[text: "6"])
+      assert [^e] = TestRepo1.all(Trans)
+      throw { :ecto_rollback, "ecto" }
+    end)
+
+    assert x == { :error, "ecto" }
+    assert [] = TestRepo2.all(Trans)
+  end
+
   test "transactions are not shared in repo" do
     pid = self
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -217,6 +217,9 @@ defmodule Ecto.Adapters.Postgres do
       :throw, :ecto_rollback ->
         Worker.rollback!(worker)
         :error
+      :throw, { :ecto_rollback, term } ->
+        Worker.rollback!(worker)
+        { :error, term }
       type, term ->
         Worker.rollback!(worker)
         :erlang.raise(type, term, System.stacktrace)

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -257,8 +257,9 @@ defmodule Ecto.Repo do
   Runs the given function inside a transaction. If an unhandled error occurs the
   transaction will be rolled back. If no error occurred the transaction will be
   commited when the function returns. A transaction can be explicitly rolled
-  back by throwing `:ecto_rollback`, this will leave immediately leave the given
-  function but the throw will not bubble up. Transactions can be nested.
+  back by throwing `:ecto_rollback` or `{ :ecto_rollback`, term }, this will
+  leave immediately leave the given function but the throw will not bubble up.
+  Transactions can be nested.
 
   ## Examples
 


### PR DESCRIPTION
``` elixir
MyRepo.transaction(fn ->
  throw { :ecto_rollback, "reason" }
end)
#=> { :error, "reason" }
```
