### PR TITLE
Add `Repo.log/2`

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -121,11 +121,15 @@ defmodule Ecto.Repo do
         true
       end
 
+      def log(arg, fun) do
+        fun.()
+      end
+
       def query_apis do
         [Ecto.Query.API]
       end
 
-      defoverridable [query_apis: 0]
+      defoverridable [log: 2, query_apis: 0]
     end
   end
 
@@ -311,7 +315,24 @@ defmodule Ecto.Repo do
   defcallback adapter() :: Ecto.Adapter.t
 
   @doc """
-  Returns the supported query APIs.
+  Enables logging and debugging of adapter actions such as sending queries to
+  the database. Should be overridden to customize behaviour.
+
+  ## Examples
+
+      def log({ :query, sql }, fun) do
+        { time, result } = :timer.tc(fun)
+        Logger.log({ sql, time })
+        result
+      end
+
+      def log(_arg, fun), do: fun.()
+
   """
-  defcallback query_apis :: [module]
+  defcallback log(any, (() -> any)) :: any
+
+  @doc """
+  Returns the supported query APIs. Should be overridden to customize.
+  """
+  defcallback query_apis() :: [module]
 end


### PR DESCRIPTION
Enables hooking of adapter functions for logging and debugging.

Questions:
- Is `adapter_hook` the best name?
- Should you be able to pass the arguments to the anonymous function in `adapter_hook`? This would enable you to, for example, change the SQL code of a query before it's sent to the DB.

/cc @devinus @josevalim
