### PR TITLE
Allow using params when directly calling Ecto.Adapters.Postgres.query

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -94,10 +94,10 @@ defmodule Ecto.Adapters.Postgres do
     nrows
   end
 
-  def query(repo, sql) do
+  def query(repo, sql, params \\ []) do
     repo.log({ :query, sql }, fn ->
       use_worker(repo, fn worker ->
-        Worker.query!(worker, sql)
+        Worker.query!(worker, sql, params)
       end)
     end)
   end

--- a/lib/ecto/adapters/postgres/worker.ex
+++ b/lib/ecto/adapters/postgres/worker.ex
@@ -9,8 +9,8 @@ defmodule Ecto.Adapters.Postgres.Worker do
     :gen_server.start_link __MODULE__, args, []
   end
 
-  def query!(worker, sql) do
-    case :gen_server.call(worker, { :query, sql }) do
+  def query!(worker, sql, params \\ []) do
+    case :gen_server.call(worker, { :query, sql, params }) do
       { :ok, res } -> res
       { :error, Postgrex.Error[] = err } -> raise err
     end
@@ -61,8 +61,8 @@ defmodule Ecto.Adapters.Postgres.Worker do
     end
   end
 
-  def handle_call({ :query, sql }, _from, state(conn: conn) = s) do
-    { :reply, Postgrex.Connection.query(conn, sql), s }
+  def handle_call({ :query, sql, params }, _from, state(conn: conn) = s) do
+    { :reply, Postgrex.Connection.query(conn, sql, params), s }
   end
 
   def handle_call(:begin, _from, state(conn: conn) = s) do


### PR DESCRIPTION
Here's attempt number 2 :)

It has a small improvement too, as the previous version still used the old default parameter syntax.
