### PR TITLE
add String.Chars implementation for Ecto.DateTime

### DIFF
--- a/lib/ecto/types.ex
+++ b/lib/ecto/types.ex
@@ -9,6 +9,12 @@ defrecord Ecto.DateTime, [:year, :month, :day, :hour, :min, :sec] do
   end
 end
 
+defimpl String.Chars, for: Ecto.DateTime do
+  def to_string(Ecto.DateTime[year: year, month: month, day: day, hour: hour, min: min, sec: sec]) do
+    "#{year}-#{month}-#{day} #{hour}:#{min}:#{sec}"
+  end
+end
+
 defrecord Ecto.Interval, [:year, :month, :day, :hour, :min, :sec]
 
 defrecord Ecto.Binary, [:value] do


### PR DESCRIPTION
This will allow Ecto.DateTime to be passed to `to_string` to output datetime fields in a simple string format matching that of how it appears within postgres
