### PR TITLE
Worker monitor caller to kill connection if caller dies

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -255,6 +255,7 @@ defmodule Ecto.Adapters.Postgres do
         worker
       nil ->
         worker = :poolboy.checkout(pool)
+        Worker.monitor_me(worker)
         Process.put(key, { worker, 1 })
         worker
     end
@@ -266,6 +267,7 @@ defmodule Ecto.Adapters.Postgres do
 
     case Process.get(key) do
       { worker, 1 } ->
+        Worker.demonitor_me(worker)
         :poolboy.checkin(pool, worker)
         Process.delete(key)
       { worker, counter } ->

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-[ "decimal": {:git, "git://github.com/ericmj/decimal.git", "ca3ca3de2425b1ee19d175eca92d80dcfe02fdb1", []},
-  "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "dc0397d15686315dad653ed13c4836e4c6ef54e3", []},
-  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "d47df5df57b22eb183b0c48c8dcc5f9827fad71b", []},
-  "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "c6fbb72d6f0678efd02e58b38cf2308397f0566a", []} ]
+[ "decimal": {:git, "git://github.com/ericmj/decimal.git", "ab1b6637aac1eabce5dc5a57290b5366878c2e84", []},
+  "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "1419e7adc1c289cd75587d9f435c412c70c297d9", []},
+  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "64e1eaef0b1e88849c7e7ba9ff75f8cd4dba2a3b", []},
+  "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "4333cc5d6f99e4ebbe1d1bf569574d1f5fd3bd4a", []} ]


### PR DESCRIPTION
This is to ensure that caller doesn’t leave the connection in a bad
state and it is put back into the pool. For example connections with
open transactions should not be put back into the pool.

/cc @josevalim @devinus
