### PR TITLE
Enum.count on has_many associations shouldn't break

### DIFF
--- a/integration_test/pg/repo_test.exs
+++ b/integration_test/pg/repo_test.exs
@@ -412,6 +412,15 @@ defmodule Ecto.Integration.RepoTest do
     [{ ^p1, ^post }, { ^p2, ^post }] = TestRepo.all(query)
   end
 
+  test "has_many implements Enum.count protocol correctly" do
+    post = TestRepo.create(Post.Entity[title: "1"])
+    TestRepo.create(Comment.Entity[text: "1", post_id: post.id])
+
+    post1 = TestRepo.all(from p in Post, preload: [:comments]) |> hd
+
+    assert Enum.count(post1.comments) == 1
+  end
+
   test "has_many queryable" do
     p1 = TestRepo.create(Post.Entity[title: "1"])
     p2 = TestRepo.create(Post.Entity[title: "1"])

--- a/lib/ecto/associations/has_many.ex
+++ b/lib/ecto/associations/has_many.ex
@@ -105,7 +105,7 @@ defimpl Ecto.Queryable, for: Ecto.Associations.HasMany do
 end
 
 defimpl Enumerable, for: Ecto.Associations.HasMany do
-  def count(assoc), do: length(assoc.to_list)
+  def count(assoc), do: { :ok, length(assoc.to_list) }
   def member?(assoc, value), do: value in assoc.to_list
   def reduce(assoc, acc, fun), do: Enumerable.List.reduce(assoc.to_list, acc, fun)
 end


### PR DESCRIPTION
Hey, while upgrading a pet project of mine to the latest elixir/dynamo/ecto bits I stumbled over a regression in our app. 

Apparently the Enumerable protocol has changed for the count function. It is now required to return a tuple {:ok, value} instead of value alone. 

I added also a test for this regression.

Cheerio
Björn
