### PR TITLE
fix assoc example in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Ecto also supports joins with associations:
 query = from p in Post,
       where: p.id == 42,
   left_join: c in p.comments,
-     select: assoc(p, c)
+     select: assoc(p, comments: c)
 
 [post] = Repo.all(query)
 


### PR DESCRIPTION
assoc() needs keywords as a 2nd argument, thus the example in the Readme wasn't working.
Please note that documentation in the Ecto.Query module is in turn OK on this.
