### PR TITLE
Fix for ecto.migrate task

### DIFF
--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
     {repo, _} = parse_repo(args)
     ensure_repo(repo)
-    if opts[:no_start], do: ensure_started(repo)
+    unless opts[:no_start], do: ensure_started(repo)
 
     unless opts[:to] || opts[:step] || opts[:all] do
       opts = Keyword.put(opts, :all, true)


### PR DESCRIPTION
Was throwing an error when executed. Talking to @josevalim on the google group and it turned out the fix is simply changing the "if" at line 45 to an "unless". Changing it resolved the error.
