### PR TITLE
Test that values of numeric-comparison-predicates are numbers.

### DIFF
--- a/lib/ecto/validator/predicates.ex
+++ b/lib/ecto/validator/predicates.ex
@@ -174,7 +174,7 @@ defmodule Ecto.Validator.Predicates do
   """
   def greater_than(attr, value, check, opts \\ [])
   def greater_than(_attr, value, check, _opts) when
-        is_number(check) and (nil?(value) or value > check), do: []
+        is_number(check) and (nil?(value) or (is_number(value) and value > check)), do: []
   def greater_than(attr, _value, check, opts) when is_number(check), do:
         [{attr, opts[:message] || "must be greater than #{check}"}]
 
@@ -194,7 +194,7 @@ defmodule Ecto.Validator.Predicates do
   """
   def greater_than_or_equal_to(attr, value, check, opts \\ [])
   def greater_than_or_equal_to(_attr, value, check, _opts) when
-        is_number(check) and (nil?(value) or value >= check), do: []
+        is_number(check) and (nil?(value) or (is_number(value) and value >= check)), do: []
   def greater_than_or_equal_to(attr, _value, check, opts) when is_number(check), do:
         [{attr, opts[:message] || "must be greater than or equal to #{check}"}]
 
@@ -214,7 +214,7 @@ defmodule Ecto.Validator.Predicates do
   """
   def less_than(attr, value, check, opts \\ [])
   def less_than(_attr, value, check, _opts) when
-        is_number(check) and (nil?(value) or value < check), do: []
+        is_number(check) and (nil?(value) or (is_number(value) and value < check)), do: []
   def less_than(attr, _value, check, opts) when is_number(check), do:
         [{attr, opts[:message] || "must be less than #{check}"}]
 
@@ -234,7 +234,7 @@ defmodule Ecto.Validator.Predicates do
   """
   def less_than_or_equal_to(attr, value, check, opts \\ [])
   def less_than_or_equal_to(_attr, value, check, _opts) when
-        is_number(check) and (nil?(value) or value <= check), do: []
+        is_number(check) and (nil?(value) or (is_number(value) and value <= check)), do: []
   def less_than_or_equal_to(attr, _value, check, opts) when is_number(check), do:
         [{attr, opts[:message] || "must be less than or equal to #{check}"}]
 
@@ -254,7 +254,7 @@ defmodule Ecto.Validator.Predicates do
   """
   def between(attr, value, range, opts \\ [])
   def between(_attr, value, min..max, _opts) when
-    is_number(min) and is_number(max) and (nil?(value) or value in min..max), do: []
+    is_number(min) and is_number(max) and (nil?(value) or (is_number(value) and value in min..max)), do: []
   def between(attr, _value, min..max, opts) when is_number(min) and is_number(max), do:
     [{attr, opts[:message] || "must be between #{min} and #{max}"}]
 

--- a/test/ecto/validator/predicates_test.exs
+++ b/test/ecto/validator/predicates_test.exs
@@ -144,6 +144,10 @@ defmodule Ecto.Validator.PredicatesTest do
     assert greater_than(:age, 5, 10, message: "bad number") == [age: "bad number"]
   end
 
+  test "greater_than fails on non-numeric values" do
+    assert greater_than(:age, "12312", 5) == [age: "must be greater than 5"]
+  end
+
   ## Greater than or equal to
 
   test "greater_than_or_equal_to on invalid" do
@@ -164,6 +168,10 @@ defmodule Ecto.Validator.PredicatesTest do
 
   test "greater_than_or_equal_to with custom message" do
     assert greater_than_or_equal_to(:age, 5, 10, message: "bad number") == [age: "bad number"]
+  end
+
+  test "greater_than_or_equal_to fails on non-numeric values" do
+    assert greater_than_or_equal_to(:age, "12312", 5) == [age: "must be greater than or equal to 5"]
   end
 
   ## Less than
@@ -188,6 +196,11 @@ defmodule Ecto.Validator.PredicatesTest do
     assert less_than(:age, 10, 5, message: "bad number") == [age: "bad number"]
   end
 
+  # Beware, since numbers are the "smallest" term in Elixir this wouldn't fail even if the is_numeric guard isn't here.
+  test "less_than fails on non-numeric values" do
+    assert less_than(:age, "12312", 5) == [age: "must be less than 5"]
+  end
+
   ## Less than or equal to
 
   test "less_than_or_equal_to on invalid" do
@@ -210,6 +223,11 @@ defmodule Ecto.Validator.PredicatesTest do
     assert less_than_or_equal_to(:age, 10, 5, message: "bad number") == [age: "bad number"]
   end
 
+  # Beware, since numbers are the "smallest" term in Elixir this wouldn't fail even if the is_numeric guard isn't here.
+  test "less_than_or_equal_to fails on non-numeric values" do
+    assert less_than_or_equal_to(:age, "12312", 5) == [age: "must be less than or equal to 5"]
+  end
+
   ## Between
 
   test "between on invalid" do
@@ -228,6 +246,11 @@ defmodule Ecto.Validator.PredicatesTest do
 
   test "between with custom message" do
     assert between(:age, 24, 18..21, message: "bad number") == [age: "bad number"]
+  end
+
+  # Beware, since numbers are the "smallest" term in Elixir this wouldn't fail even if the is_numeric guard isn't here.
+  test "between fails on non-numeric values" do
+    assert between(:age, "12312", 18..21) == [age: "must be between 18 and 21"]
   end
 
   ## Not member of


### PR DESCRIPTION
Unfortunately since the Elixir term order makes numbers compare as less to any other term the tests for `less_than` and `less_than_or_equal_to` will never fail.

If you have any ideas how to properly test that please let me know
