### PR TITLE
Use postgres database when running psql commands for ecto.create and ecto.drop.

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -418,6 +418,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
       command =
         command <>
         ~s(psql --quiet ) <>
+        ~s(template1 ) <>
         ~s(--host #{database[:hostname]} ) <>
         ~s(-c "#{sql_command};" )
 


### PR DESCRIPTION
Rather than relying on the default database, I think we should specify the `postgres` database for the `ecto.create` and `ecto.drop` mix tasks. This is similar to the strategy used by rails[1].

Perhaps this is something that could be configurable in the future?

I didn't see an obvious way to test this change, but I did test it locally by specifying this repo as a local dependency and using the create/drop tasks. If some automated testing should be added around this, I'd be happy to poke around more and find an appropriate place for it.

[1] - https://github.com/rails/rails/blob/master/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb#L75-L80
