### PR TITLE
Fix from builder optimisation when building queries

### DIFF
--- a/lib/ecto/model/schema.ex
+++ b/lib/ecto/model/schema.ex
@@ -180,7 +180,6 @@ defmodule Ecto.Model.Schema do
 
       Module.eval_quoted __MODULE__, [
         Ecto.Model.Schema.ecto_struct(@struct_fields),
-        Ecto.Model.Schema.ecto_queryable(@ecto_source, __MODULE__),
         Ecto.Model.Schema.ecto_fields(fields),
         Ecto.Model.Schema.ecto_assocs(assocs, @ecto_primary_key, fields),
         Ecto.Model.Schema.ecto_primary_key(@ecto_primary_key),
@@ -410,15 +409,6 @@ defmodule Ecto.Model.Schema do
   def ecto_struct(struct_fields) do
     quote do
       defstruct unquote(Macro.escape(struct_fields))
-    end
-  end
-
-  @doc false
-  def ecto_queryable(source, module) do
-    quote do
-      def __queryable__ do
-        %Ecto.Query{from: {unquote(source), unquote(module)}}
-      end
     end
   end
 

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -20,7 +20,7 @@ end
 defimpl Ecto.Queryable, for: Atom do
   def to_query(module) do
     try do
-      module.__queryable__
+      %Ecto.Query{from: {module.__schema__(:source), module}}
     rescue
       UndefinedFunctionError ->
         raise Protocol.UndefinedError,

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -113,7 +113,7 @@ defmodule Ecto.QueryTest do
       from(p in 123, []) |> select([p], p.title)
     end
 
-    assert_raise Protocol.UndefinedError, fn ->
+    assert_raise UndefinedFunctionError, fn ->
       from(p in NotAModel, []) |> select([p], p.title)
     end
   end


### PR DESCRIPTION
Construct the query at compile time but move the only dynamic part of query (the model’s source) to runtime. This removes unnecessary compile time dependencies between modules but still keeps the optimisation.
