### PR TITLE
Avoid relative names in type checking messages

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -66,7 +66,7 @@ end
 defmodule Ecto.Query.TypeCheckError do
   import Inspect.Ecto.Query, only: [pp_from_query: 2]
 
-  defexception [:expr, :types, :allowed, :type, :query, :file, :line]
+  defexception [:expr, :types, :allowed, :query, :file, :line]
 
   @moduledoc """
   Exception raised when a query does not type check.

--- a/lib/ecto/query/validator.ex
+++ b/lib/ecto/query/validator.ex
@@ -566,9 +566,13 @@ defmodule Ecto.Query.Validator do
   defp rescue_metadata(query, type, %QueryExpr{expr: expr, file: file, line: line}, fun) do
     try do
       fun.()
-    rescue e in [Ecto.QueryError, Ecto.Query.TypeCheckError] ->
-      stacktrace = System.stacktrace
-      reraise %{e | type: type, query: query, expr: expr, file: file, line: line}, stacktrace
+    rescue
+      e in [Ecto.QueryError] ->
+        stacktrace = System.stacktrace
+        reraise %{e | type: type, query: query, expr: expr, file: file, line: line}, stacktrace
+      e in [Ecto.Query.TypeCheckError] ->
+        stacktrace = System.stacktrace
+        reraise %{e | query: query, expr: expr, file: file, line: line}, stacktrace
     end
   end
 


### PR DESCRIPTION
This also simplifies the error message by not showing the full query. Only the offending expression is shown.

Tests are passing, but I'm not sure if the removal of the query makes the message less usable/specific in some edge cases.
