### PR TITLE
Add docs badge to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_script:
   - mix deps.get
 script:
   - MIX_ENV=all mix test
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ecto
 
 [![Build Status](https://travis-ci.org/elixir-lang/ecto.png?branch=master)](https://travis-ci.org/elixir-lang/ecto)
+[![Inline docs](http://inch-ci.org/github/elixir-lang/ecto.svg?branch=master)](http://inch-ci.org/github/elixir-lang/ecto)
 
 Ecto is a domain specific language for writing queries and interacting with databases in Elixir. Here is an example:
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule Ecto.Mixfile do
      {:decimal, "~> 0.2.3"},
      {:postgrex, "~> 0.6.0", optional: true},
      {:ex_doc, "~> 0.6", only: :dev},
-     {:earmark, "~> 0.1", only: :dev}]
+     {:earmark, "~> 0.1", only: :dev},
+     {:inch_ex, only: :docs}]
   end
 
   defp test_paths(:pg),  do: ["integration_test/pg"]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{"decimal": {:package, "0.2.5"},
   "earmark": {:package, "0.1.10"},
   "ex_doc": {:package, "0.6.0"},
+  "inch_ex": {:package, "0.2.1"},
+  "json": {:package, "0.3.2"},
   "poolboy": {:package, "1.3.0"},
   "postgrex": {:package, "0.6.0"}}


### PR DESCRIPTION
Hi guys,

this patch would add a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/elixir-lang/ecto.svg?branch=master)](http://inch-ci.org/github/elixir-lang/ecto)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Elixir programmers to document their public modules/functions and treat documentation as a first class citizen.

The Elixir support is still new, but [I already convinced Chris and José](https://github.com/phoenixframework/phoenix/pull/404) to give it a try and include it in the Phoenix Framework's README and we are having an active discussion about what can be changed to make this a useful tool for the Elixir community.

What do you think?
