### PR TITLE
Mix tasks now use port if specified in ecto URL

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -469,6 +469,10 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         command = ~s(PGUSER=#{username} ) <> command
       end
 
+      if port = database[:port] do
+        command = ~s(PGPORT=#{port} ) <> command
+      end
+
       command =
         command <>
         ~s(psql --quiet ) <>


### PR DESCRIPTION
Mix tasks used to not care about the port number specified in ecto URL.

Resolves https://github.com/elixir-lang/ecto/issues/311
