### PR TITLE
Add docs badge to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_script:
   - mix deps.get
 script:
   - MIX_ENV=all mix test
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ecto
 
 [![Build Status](https://travis-ci.org/elixir-lang/ecto.png?branch=master)](https://travis-ci.org/elixir-lang/ecto)
+[![Inline docs](http://inch-ci.org/github/elixir-lang/ecto.svg?branch=master&style=flat)](http://inch-ci.org/github/elixir-lang/ecto)
 
 Ecto is a domain specific language for writing queries and interacting with databases in Elixir. Here is an example:
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule Ecto.Mixfile do
      {:decimal, "~> 0.2.3"},
      {:postgrex, "~> 0.6.0", optional: true},
      {:ex_doc, "~> 0.6", only: :docs},
-     {:earmark, "~> 0.1", only: :docs}]
+     {:earmark, "~> 0.1", only: :docs},
+     {:inch_ex, only: :docs}]
   end
 
   defp test_paths(:pg),  do: ["integration_test/pg"]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{"decimal": {:hex, :decimal, "0.2.5"},
   "earmark": {:hex, :earmark, "0.1.12"},
   "ex_doc": {:hex, :ex_doc, "0.6.2"},
+  "inch_ex": {:hex, :inch_ex, "0.2.3"},
+  "poison": {:hex, :poison, "1.3.0"},
   "poolboy": {:hex, :poolboy, "1.4.2"},
   "postgrex": {:hex, :postgrex, "0.6.0"}}


### PR DESCRIPTION
Hi José,

this patch is a rebased version of this one: https://github.com/elixir-lang/ecto/pull/302

It adds a docs badge to the README: [![Inline docs](http://inch-ci.org/github/elixir-lang/ecto.svg?branch=master&style=flat)](http://inch-ci.org/github/elixir-lang/ecto)

Thanks for considering!
