### PR TITLE
[WIP] Add lateral join for Postgres adapter.

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -231,14 +231,14 @@ if Code.ensure_loaded?(Mariaex) do
         %JoinExpr{on: %QueryExpr{expr: expr}, qual: qual, ix: ix, source: source} ->
           {join, name} = get_source(query, sources, ix, source)
           qual = join_qual(qual)
-          "#{qual} JOIN " <> join <> " AS #{name} ON " <> expr(expr, sources, query)
+          "#{qual} " <> join <> " AS #{name} ON " <> expr(expr, sources, query)
       end)
     end
 
-    defp join_qual(:inner), do: "INNER"
-    defp join_qual(:left),  do: "LEFT OUTER"
-    defp join_qual(:right), do: "RIGHT OUTER"
-    defp join_qual(:full),  do: "FULL OUTER"
+    defp join_qual(:inner), do: "INNER JOIN"
+    defp join_qual(:left),  do: "LEFT OUTER JOIN"
+    defp join_qual(:right), do: "RIGHT OUTER JOIN"
+    defp join_qual(:full),  do: "FULL OUTER JOIN"
 
     defp where(%Query{wheres: wheres} = query, sources) do
       boolean("WHERE", wheres, sources, query)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -291,14 +291,16 @@ if Code.ensure_loaded?(Postgrex) do
         %JoinExpr{on: %QueryExpr{expr: expr}, qual: qual, ix: ix, source: source} ->
           {join, name} = get_source(query, sources, ix, source)
           qual = join_qual(qual)
-          "#{qual} JOIN " <> join <> " AS " <> name <> " ON " <> expr(expr, sources, query)
+          "#{qual} " <> join <> " AS " <> name <> " ON " <> expr(expr, sources, query)
       end)
     end
 
-    defp join_qual(:inner), do: "INNER"
-    defp join_qual(:left),  do: "LEFT OUTER"
-    defp join_qual(:right), do: "RIGHT OUTER"
-    defp join_qual(:full),  do: "FULL OUTER"
+    defp join_qual(:inner), do: "INNER JOIN"
+    defp join_qual(:inner_lateral), do: "INNER JOIN LATERAL"
+    defp join_qual(:left),  do: "LEFT OUTER JOIN"
+    defp join_qual(:left_lateral),  do: "LEFT OUTER JOIN LATERAL"
+    defp join_qual(:right), do: "RIGHT OUTER JOIN"
+    defp join_qual(:full),  do: "FULL OUTER JOIN"
 
     defp delete_all_where([], query, sources), do: where(query, sources)
     defp delete_all_where(_joins, %Query{wheres: wheres} = query, sources) do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -497,9 +497,14 @@ defmodule Ecto.Query do
   `:full`. For a keyword query the `:join` keyword can be changed to:
   `:inner_join`, `:left_join`, `:right_join` or `:full_join`.
 
+  It is also possible to use the atoms `:inner_lateral` and `:left_lateral`
+  using the Postgres adapter.
+
   Currently it is possible to join on an Ecto.Schema (a module), an
   existing source (a binary representing a table), an association or a
-  fragment. See the examples below.
+  fragment. For a lateral join it is only possible to join on a fragment
+  since the join query must be able to access columns from the left side
+  of the join. See the examples below:
 
   ## Keywords examples
 
@@ -520,7 +525,7 @@ defmodule Ecto.Query do
       Post
         |> join(:left, [p], c in assoc(p, :comments))
         |> select([p, c], {p, c})
-        
+
       Post
         |> join(:left, [p], c in Comment, c.post_id == p.id and c.is_visible == true)
         |> select([p, c], {p, c})

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -180,7 +180,7 @@ defmodule Ecto.Query.Builder.Join do
     end
   end
 
-  @qualifiers [:inner, :left, :right, :full]
+  @qualifiers [:inner, :inner_lateral, :left, :left_lateral, :right, :full]
 
   @doc """
   Called at runtime to check dynamic qualifier.

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -185,10 +185,12 @@ defimpl Inspect, for: Ecto.Query do
     Enum.join [inspect(frag <> s)|Enum.reverse(args)], ", "
   end
 
-  defp join_qual(:inner), do: :join
-  defp join_qual(:left),  do: :left_join
-  defp join_qual(:right), do: :right_join
-  defp join_qual(:full),  do: :full_join
+  defp join_qual(:inner),         do: :join
+  defp join_qual(:inner_lateral), do: :join_lateral
+  defp join_qual(:left),          do: :left_join
+  defp join_qual(:left_lateral),  do: :left_join_lateral
+  defp join_qual(:right),         do: :right_join
+  defp join_qual(:full),          do: :full_join
 
   defp collect_sources(query) do
     [from_sources(query.from) | join_sources(query.joins)]


### PR DESCRIPTION
The current code supports lateral joins like:

```
query =
  Game 
  |> join(:inner_lateral, [g], gs in fragment("SELECT * FROM games_sold AS gs WHERE gs.game_id = ? ORDER BY gs.sold_ON LIMIT 2", g.id))
  |> select([g, gs], {g.name, gs.sold_on})

[debug] QUERY OK db=61.6ms
SELECT g0."name", f1."sold_on"
FROM "games" AS g0
INNER JOIN LATERAL (SELECT * FROM games_sold AS gs WHERE gs.game_id = g0."id" ORDER BY gs.sold_ON LIMIT 2) AS f1 ON TRUE []
```

I created a [small app](https://github.com/bernardoamc/lateral_join) with the instructions required to test these changes locally.