### PR TITLE
Ecto.Subquery: fix module documentation

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1,5 +1,5 @@
 defmodule Ecto.SubQuery do
-  @doc """
+  @moduledoc """
   Stores subquery information.
   """
   defstruct [:query, :params, :types, :fields, :sources, :select, :cache, :take]


### PR DESCRIPTION
Thought this might be a `@moduledoc`.