### PR TITLE
Ecto.LogEntry: fix module documentation

### DIFF
--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -1,5 +1,5 @@
 defmodule Ecto.LogEntry do
-  @doc """
+  @moduledoc """
   Struct used for logging entries.
 
   It is composed of the following fields:


### PR DESCRIPTION
Thought this might be a `@moduledoc`, too.