### PR TITLE
Implements ON DELETE RESTRICT for PostgreSQL

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -768,6 +768,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
+    defp reference_on_delete(:restrict), do: " ON DELETE RESTRICT"
     defp reference_on_delete(_), do: ""
 
     defp reference_on_update(:nilify_all), do: " ON UPDATE SET NULL"

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -688,7 +688,8 @@ defmodule Ecto.Migration do
     * `:column` - The foreign key column, default is `:id`
     * `:type`   - The foreign key type, default is `:serial`
     * `:on_delete` - What to perform if the entry is deleted.
-         May be `:nothing`, `:delete_all` or `:nilify_all`.
+         May be `:nothing`, `:delete_all`, `:nilify_all` or
+         `restrict`.
          Defaults to `:nothing`.
     * `:on_update` - What to perform if the entry is updated.
          May be `:nothing`, `:update_all` or `:nilify_all`.
@@ -698,7 +699,7 @@ defmodule Ecto.Migration do
   def references(table, opts \\ []) when is_atom(table) do
     reference = struct(%Reference{table: table}, opts)
 
-    unless reference.on_delete in [:nothing, :delete_all, :nilify_all] do
+    unless reference.on_delete in [:nothing, :delete_all, :nilify_all, :restrict] do
       raise ArgumentError, "unknown :on_delete value: #{inspect reference.on_delete}"
     end
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -485,10 +485,11 @@ defmodule Ecto.Schema do
       associations. Read below for more information
 
     * `:on_delete` - The action taken on associations when parent record
-      is deleted. May be `:nothing` (default), `:nilify_all` and `:delete_all`.
+      is deleted. May be `:nothing` (default), `:nilify_all`, `:delete_all`
+      or `restrict`.
       Notice `:on_delete` may also be set in migrations when creating a
       reference. If supported, relying on the database via migrations
-      is preferred
+      is preferred.
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be
@@ -619,10 +620,11 @@ defmodule Ecto.Schema do
       associations. Read the section in `has_many/3` for more information
 
     * `:on_delete` - The action taken on associations when parent record
-      is deleted. May be `:nothing` (default), `:nilify_all` and `:delete_all`.
+      is deleted. May be `:nothing` (default), `:nilify_all`, `:delete_all`
+      or `restrict`.
       Notice `:on_delete` may also be set in migrations when creating a
       reference. If supported, relying on the database via migrations
-      is preferred
+      is preferred.
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be


### PR DESCRIPTION
**Changes**
1. Changes `Reference` to support `ON DELETE RESTRICT`.
2. Amends documentation.

**Verification**
It works for my app.

**Questions**
1. Shall we also patch this for other databases?
2. Do we need additional test cases written?

Thank you!