### PR TITLE
update :delete_all and :nilify_all docs to clarify lack of cascading

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -487,7 +487,8 @@ defmodule Ecto.Schema do
       is deleted. May be `:nothing` (default), `:nilify_all` and `:delete_all`.
       Notice `:on_delete` may also be set in migrations when creating a
       reference. If supported, relying on the database via migrations
-      is preferred
+      is preferred. `:nilify_all` and `:delete_all` will not cascade to child
+      records unless set via database migrations.
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be
@@ -621,7 +622,8 @@ defmodule Ecto.Schema do
       is deleted. May be `:nothing` (default), `:nilify_all` and `:delete_all`.
       Notice `:on_delete` may also be set in migrations when creating a
       reference. If supported, relying on the database via migrations
-      is preferred
+      is preferred. `:nilify_all` and `:delete_all` will not cascade to child
+      records unless set via database migrations.
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be
@@ -841,7 +843,8 @@ defmodule Ecto.Schema do
       `:delete_all` will only remove data from the join source, never the
       associated records. Notice `:on_delete` may also be set in migrations
       when creating a reference. If supported, relying on the database via
-      migrations is preferred
+      migrations is preferred. `:nilify_all` and `:delete_all` will not cascade to child
+      records unless set via database migrations.
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be


### PR DESCRIPTION
support unless set in the database via migrations.

I chatted with @ericmj briefly in the ecto slack channel and he explained that `on_delete: :delete_all` and `on_delete: :nilify_all` will not cascade to child records unless set via database migrations. I had expected it to cascade regardless, so this PR is to add a note to the docs to clarify.