### PR TITLE
Fix unique constraint errors for many_to_many inserts (#1527)

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -295,12 +295,8 @@ defmodule Ecto.Integration.RepoTest do
         message: "has already been assigned")
       |> TestRepo.update
 
-    # The errors are nested insided changeset[:workers][%WorkersTasks<>].errors
-    # change = Enum.at(changeset.changes[:tasks], 1)
-    # assert change.errors == [task: {"has already been assigned", []}]
-
     errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
-    assert errors == %{tasks: [%{}, %{task: ["has already been assigned"]}]}
+    assert errors == %{tasks: [%{task: ["has already been assigned"]}]}
 
     refute changeset.valid?
   end

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -278,13 +278,13 @@ defmodule Ecto.Integration.RepoTest do
   end
   
   @tag :unique_constraint
-  test "unique constraint error message with join table" do
+  test "unique constraint violation error message with join table" do
     post = TestRepo.insert!(%Post{title: "some post"})
       |> TestRepo.preload(:unique_users)
 
     user = TestRepo.insert!(%User{name: "some user"})
 
-    # Violate the unique composite private key
+    # Violate the unique composite index
     {:error, changeset} = post
       |> Ecto.Changeset.change
       |> Ecto.Changeset.put_assoc(:unique_users, [user, user])
@@ -292,6 +292,33 @@ defmodule Ecto.Integration.RepoTest do
         name: :posts_users_composite_pk_post_id_user_id_index,
         message: "has already been assigned")
       |> TestRepo.update
+
+    errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
+    assert errors == %{unique_users: [%{user: ["has already been assigned"]}]}
+
+    refute changeset.valid?
+  end
+
+  @tag :unique_constraint
+  test "unique constraint violation error message with join table and separate changesets" do
+    post = TestRepo.insert!(%Post{title: "some post"})
+      |> TestRepo.preload(:unique_users)
+
+    user = TestRepo.insert!(%User{name: "some user"})
+
+    post
+    |> Ecto.Changeset.change
+    |> Ecto.Changeset.put_assoc(:unique_users, [user])
+    |> TestRepo.update
+
+    # Violate the unique composite index
+    {:error, changeset} = post
+    |> Ecto.Changeset.change
+    |> Ecto.Changeset.put_assoc(:unique_users, [user])
+    |> Ecto.Changeset.unique_constraint(:user,
+        name: :posts_users_composite_pk_post_id_user_id_index,
+        message: "has already been assigned")
+    |> TestRepo.update
 
     errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
     assert errors == %{unique_users: [%{user: ["has already been assigned"]}]}

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -101,19 +101,7 @@ defmodule Ecto.Integration.Migration do
       add :user_id, references(:users), primary_key: true
       timestamps()
     end
-
-    create table(:workers) do
-      add :name, :string
-    end
-
-    create table(:tasks) do
-      add :name, :string
-    end
     
-    create table(:workers_tasks) do
-      add :worker_id, references(:workers)
-      add :task_id, references(:tasks)
-    end
-    create unique_index(:workers_tasks, [:worker_id, :task_id])
+    create unique_index(:posts_users_composite_pk, [:post_id, :user_id])
   end
 end

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -101,5 +101,19 @@ defmodule Ecto.Integration.Migration do
       add :user_id, references(:users), primary_key: true
       timestamps()
     end
+
+    create table(:workers) do
+      add :name, :string
+    end
+
+    create table(:tasks) do
+      add :name, :string
+    end
+    
+    create table(:workers_tasks) do
+      add :worker_id, references(:workers)
+      add :task_id, references(:tasks)
+    end
+    create unique_index(:workers_tasks, [:worker_id, :task_id])
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -49,6 +49,8 @@ defmodule Ecto.Integration.Post do
     many_to_many :customs, Ecto.Integration.Custom,
       join_through: "posts_customs", join_keys: [post_id: :uuid, custom_id: :bid],
       on_delete: :delete_all, on_replace: :delete
+    many_to_many :unique_users, Ecto.Integration.User,
+      join_through: Ecto.Integration.PostUserCompositePk
     has_many :users_comments, through: [:users, :comments]
     has_many :comments_authors_permalinks, through: [:comments_authors, :permalink]
     timestamps()
@@ -147,6 +149,7 @@ defmodule Ecto.Integration.User do
     has_many :posts, Ecto.Integration.Post, foreign_key: :author_id, on_delete: :nothing, on_replace: :delete
     belongs_to :custom, Ecto.Integration.Custom, references: :bid, type: :binary_id
     many_to_many :schema_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUser
+    many_to_many :unique_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUserCompositePk
     timestamps()
   end
 end
@@ -260,52 +263,5 @@ defmodule Ecto.Integration.PostUserCompositePk do
     belongs_to :user, Ecto.Integration.User, primary_key: true
     belongs_to :post, Ecto.Integration.Post, primary_key: true
     timestamps()
-  end
-end
-
-
-defmodule Ecto.Integration.Worker do
-  @moduledoc """
-  This module is used to test:
-
-    * Many-to-many relationships are respecting unique constraint messages
-
-  """
-  use Ecto.Integration.Schema
-
-  schema "workers" do
-    field :name, :string
-    many_to_many :tasks, Ecto.Integration.Task, join_through: Ecto.Integration.WorkersTasks    
-  end
-end
-
-defmodule Ecto.Integration.Task do
-  @moduledoc """
-  This module is used to test:
-
-    * Many-to-many relationships are respecting unique constraint messages
-
-  """
-  use Ecto.Integration.Schema
-
-  schema "tasks" do
-    field :name, :string
-    many_to_many :workers, Ecto.Integration.Worker, join_through: Ecto.Integration.WorkersTasks    
-  end
-end
-
-defmodule Ecto.Integration.WorkersTasks do
-  @moduledoc """
-  This module is used to test:
-
-    * Unique constraints for has many relationships
-
-  """
-  use Ecto.Integration.Schema
-
-  @primary_key false
-  schema "workers_tasks" do
-    belongs_to :worker, Ecto.Integration.Worker
-    belongs_to :task, Ecto.Integration.Task
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -262,3 +262,50 @@ defmodule Ecto.Integration.PostUserCompositePk do
     timestamps()
   end
 end
+
+
+defmodule Ecto.Integration.Worker do
+  @moduledoc """
+  This module is used to test:
+
+    * Many-to-many relationships are respecting unique constraint messages
+
+  """
+  use Ecto.Integration.Schema
+
+  schema "workers" do
+    field :name, :string
+    many_to_many :tasks, Ecto.Integration.Task, join_through: Ecto.Integration.WorkersTasks    
+  end
+end
+
+defmodule Ecto.Integration.Task do
+  @moduledoc """
+  This module is used to test:
+
+    * Many-to-many relationships are respecting unique constraint messages
+
+  """
+  use Ecto.Integration.Schema
+
+  schema "tasks" do
+    field :name, :string
+    many_to_many :workers, Ecto.Integration.Worker, join_through: Ecto.Integration.WorkersTasks    
+  end
+end
+
+defmodule Ecto.Integration.WorkersTasks do
+  @moduledoc """
+  This module is used to test:
+
+    * Unique constraints for has many relationships
+
+  """
+  use Ecto.Integration.Schema
+
+  @primary_key false
+  schema "workers_tasks" do
+    belongs_to :worker, Ecto.Integration.Worker
+    belongs_to :task, Ecto.Integration.Task
+  end
+end

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -235,11 +235,16 @@ defmodule Ecto.Association do
               {[changeset|changesets], [struct | structs], halt, valid?}
             {:error, {error_changeset, :insert_join}} ->
               # Roll the errors originating from a join into the parent_changeset
-              [last_changeset | changesets] = changesets
-              errors = last_changeset.errors ++ error_changeset.errors
-              merged_changeset = %{last_changeset | errors: errors, valid?: error_changeset.valid?}
+              case changesets do
+                [last_changeset | changesets] ->
+                  errors = last_changeset.errors ++ error_changeset.errors
+                  merged_changeset = %{last_changeset | errors: errors, valid?: error_changeset.valid?}
 
-              {[merged_changeset|changesets], structs, halted?(halt, changeset, error_changeset), false}
+                  {[merged_changeset|changesets], structs, halted?(halt, changeset, error_changeset), false}
+                [] ->
+                  {[error_changeset|changesets], structs, halted?(halt, changeset, error_changeset), false}
+              end
+              
             {:error, error_changeset} ->
               {[error_changeset|changesets], structs, halted?(halt, changeset, error_changeset), false}
           end


### PR DESCRIPTION
Under certain conditions. unique key violations do not report the error messages that were defined through the `Ecto.Changeset.unique_constraint/3` function. This only happens when a changeset is applied to the database that inserts duplicate rows into a join table (e.g. because of a many-to-many relationship).