### PR TITLE
Adds support for commenting on PostgreSQL

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -604,7 +604,8 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     def execute_ddl({:create, %Constraint{}=constraint}) do
-      "ALTER TABLE #{quote_table(constraint.prefix, constraint.table)} ADD #{new_constraint_expr(constraint)}"
+      "ALTER TABLE #{quote_table(constraint.prefix, constraint.table)} ADD #{new_constraint_expr(constraint)}" <>
+      comment_on(:constraint, constraint.name, constraint.comment)
     end
 
     def execute_ddl({:drop, %Constraint{}=constraint}) do
@@ -636,6 +637,10 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp comment_on(:table, name, comment) do
       "; COMMENT ON TABLE #{quote_name(name)} IS #{single_quote(comment)}"
+    end
+
+    defp comment_on(:constraint, name, comment) do
+      "; COMMENT ON CONSTRAINT #{quote_name(name)} IS #{single_quote(comment)}"
     end
 
     defp comments_for_columns(table, columns) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -828,7 +828,7 @@ if Code.ensure_loaded?(Postgrex) do
       <<?", name::binary, ?">>
     end
 
-    defp single_quote(value), do: "'#{value}'"
+    defp single_quote(value), do: "\'#{value}\'"
 
     defp assemble(list) do
       list

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -833,7 +833,7 @@ if Code.ensure_loaded?(Postgrex) do
       <<?", name::binary, ?">>
     end
 
-    defp single_quote(value), do: "\'#{value}\'"
+    defp single_quote(value), do: "\'#{escape_string(value)}\'"
 
     defp assemble(list) do
       list

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -542,9 +542,9 @@ if Code.ensure_loaded?(Postgrex) do
     @drops [:drop, :drop_if_exists]
 
     def execute_ddl({command, %Table{}=table, columns}) when command in [:create, :create_if_not_exists] do
-      options            = options_expr(table.options)
-      if_not_exists      = if command == :create_if_not_exists, do: " IF NOT EXISTS", else: ""
-      pk_definition      = pk_definition(columns)
+      options       = options_expr(table.options)
+      if_not_exists = if command == :create_if_not_exists, do: " IF NOT EXISTS", else: ""
+      pk_definition = pk_definition(columns)
 
       "CREATE TABLE" <> if_not_exists <>
         " #{quote_table(table.prefix, table.name)}" <>

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -545,13 +545,11 @@ if Code.ensure_loaded?(Postgrex) do
       options            = options_expr(table.options)
       if_not_exists      = if command == :create_if_not_exists, do: " IF NOT EXISTS", else: ""
       pk_definition      = pk_definition(columns)
-      comment_on_table   = comment_on(:table, table.name, table.comment)
-      comment_on_columns = comments_for_columns(table, columns)
 
       "CREATE TABLE" <> if_not_exists <>
         " #{quote_table(table.prefix, table.name)}" <>
         " (#{column_definitions(table, columns)}#{pk_definition})" <> options <>
-        comment_on_table <> comment_on_columns
+        comment_on(:table, table.name, table.comment) <> comments_for_columns(table, columns)
     end
 
     def execute_ddl({command, %Table{}=table}) when command in @drops do
@@ -561,11 +559,8 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     def execute_ddl({:alter, %Table{}=table, changes}) do
-      comment_on_table   = comment_on(:table, table.name, table.comment)
-      comment_on_columns = comments_for_columns(table, changes)
-
       "ALTER TABLE #{quote_table(table.prefix, table.name)} #{column_changes(table, changes)}" <>
-      comment_on_table <> comment_on_columns
+      comment_on(:table, table.name, table.comment) <> comments_for_columns(table, changes)
     end
 
     def execute_ddl({:create, %Index{}=index}) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -639,9 +639,8 @@ if Code.ensure_loaded?(Postgrex) do
       "; COMMENT ON COLUMN #{column_name} IS #{single_quote(comment)}"
     end
 
-    defp comment_on(database_object, name, comment) do
-      formatted_db_object = database_object |> Atom.to_string |> String.upcase
-      "; COMMENT ON #{formatted_db_object} #{quote_name(name)} IS #{single_quote(comment)}"
+    defp comment_on(:table, name, comment) do
+      "; COMMENT ON TABLE #{quote_name(name)} IS #{single_quote(comment)}"
     end
 
     defp comments_for_columns(table, columns) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -575,7 +575,8 @@ if Code.ensure_loaded?(Postgrex) do
                 quote_table(index.prefix, index.table),
                 if_do(index.using, "USING #{index.using}"),
                 "(#{fields})",
-                if_do(index.where, "WHERE #{index.where}")])
+                if_do(index.where, "WHERE #{index.where}"),
+                if_do(index.comment, comment_on(:index, index.name, index.comment))])
     end
 
     def execute_ddl({:create_if_not_exists, %Index{}=index}) do
@@ -641,6 +642,10 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp comment_on(:constraint, name, comment) do
       "; COMMENT ON CONSTRAINT #{quote_name(name)} IS #{single_quote(comment)}"
+    end
+
+    defp comment_on(:index, name, comment) do
+      "; COMMENT ON INDEX #{quote_name(name)} IS #{single_quote(comment)}"
     end
 
     defp comments_for_columns(table, columns) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -130,6 +130,18 @@ defmodule Ecto.Migration do
   See the `index/3` function for more information on creating/dropping indexes
   concurrently.
 
+  ## Comments
+
+  Migrations where you create or alter a table support specifying table and column comments if using Postgres,
+  for now there is no support for adding comments on MySQL.
+
+      def up do
+        create table(:weather, prefix: :north_america, comment: "Table Comment") do
+          add :city, :string, size: 40, comment: "Column Comment"
+          timestamps
+        end
+      end
+
   ## Schema Migrations table
 
   Version numbers of migrations will be saved in `schema_migrations` table.
@@ -168,7 +180,7 @@ defmodule Ecto.Migration do
     @moduledoc """
     Defines a table struct used in migrations.
     """
-    defstruct name: nil, prefix: nil, primary_key: true, engine: nil, options: nil
+    defstruct name: nil, prefix: nil, comment: nil, primary_key: true, engine: nil, options: nil
     @type t :: %__MODULE__{name: atom, prefix: atom | nil, primary_key: boolean,
                            engine: atom, options: String.t}
   end

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -197,9 +197,9 @@ defmodule Ecto.Migration do
     @moduledoc """
     Defines a Constraint struct used in migrations.
     """
-    defstruct name: nil, table: nil, check: nil, exclude: nil, prefix: nil
+    defstruct name: nil, table: nil, check: nil, exclude: nil, prefix: nil, comment: nil
     @type t :: %__MODULE__{name: atom, table: atom, prefix: atom | nil,
-                           check: String.t | nil, exclude: String.t | nil}
+                           check: String.t | nil, exclude: String.t | nil, comment: String.t | nil}
   end
 
   alias Ecto.Migration.Runner

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -162,7 +162,8 @@ defmodule Ecto.Migration do
               unique: false,
               concurrently: false,
               using: nil,
-              where: nil
+              where: nil,
+              comment: nil
 
     @type t :: %__MODULE__{
       table: atom,
@@ -172,7 +173,8 @@ defmodule Ecto.Migration do
       unique: boolean,
       concurrently: boolean,
       using: atom | String.t,
-      where: atom | String.t
+      where: atom | String.t,
+      comment: String.t | nil
     }
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -181,7 +181,7 @@ defmodule Ecto.Migration do
     Defines a table struct used in migrations.
     """
     defstruct name: nil, prefix: nil, comment: nil, primary_key: true, engine: nil, options: nil
-    @type t :: %__MODULE__{name: atom, prefix: atom | nil, primary_key: boolean,
+    @type t :: %__MODULE__{name: atom, prefix: atom | nil, comment: String.t | nil, primary_key: boolean,
                            engine: atom, options: String.t}
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -132,10 +132,13 @@ defmodule Ecto.Migration do
 
   ## Comments
 
-  Migrations where you create or alter a table support specifying table and column comments if using Postgres,
-  for now there is no support for adding comments on MySQL.
+  Migrations where you create or alter a table support specifying table
+  and column comments, the same can be done when creating constraints
+  and indexes. At the moment there is support only for Postgres.
 
       def up do
+        create index(:posts, [:name], comment: "Index Comment")
+        create constraint(:products, "price_must_be_positive", check: "price > 0", comment: "Index Comment")
         create table(:weather, prefix: :north_america, comment: "Table Comment") do
           add :city, :string, size: 40, comment: "Column Comment"
           timestamps

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -844,6 +844,14 @@ defmodule Ecto.Adapters.PostgresTest do
            ~s|ALTER TABLE "products" ADD CONSTRAINT "price_must_be_positive" EXCLUDE USING gist (int4range("from", "to", '[]') WITH &&)|
   end
 
+  test "create constraint with comment" do
+    create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0", prefix: "foo", comment: "comment")}
+    assert SQL.execute_ddl(create) == """
+    ALTER TABLE "foo"."products" ADD CONSTRAINT "price_must_be_positive" CHECK (price > 0);
+    COMMENT ON CONSTRAINT "price_must_be_positive" IS 'comment'
+    """ |> remove_newlines
+  end
+
   test "drop constraint" do
     drop = {:drop, constraint(:products, "price_must_be_positive")}
     assert SQL.execute_ddl(drop) ==

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -779,6 +779,14 @@ defmodule Ecto.Adapters.PostgresTest do
            ~s|CREATE INDEX "posts$main" ON "foo"."posts" (lower(permalink))|
   end
 
+  test "create index with comment" do
+    create = {:create, index(:posts, [:category_id, :permalink], prefix: :foo, comment: "comment")}
+    assert SQL.execute_ddl(create) == """
+    CREATE INDEX "posts_category_id_permalink_index" ON "foo"."posts" ("category_id", "permalink")
+    ; COMMENT ON INDEX "posts_category_id_permalink_index" IS 'comment'
+    """ |> remove_newlines
+  end
+
   test "create unique index" do
     create = {:create, index(:posts, [:permalink], unique: true)}
     assert SQL.execute_ddl(create) ==


### PR DESCRIPTION
TODO:

- [x] Support comments when doing changes to tables and columns (ALTER TABLE)
- [x] Support comments on constraints and anything else supported by us on [this list](https://www.postgresql.org/docs/9.5/static/sql-comment.html)