### PR TITLE
Update repo.ex

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -730,7 +730,7 @@ defmodule Ecto.Repo do
 
       # With Ecto.Multi
       Ecto.Multi.new
-      |> Ecto.Multi.insert(%Post{})
+      |> Ecto.Multi.insert(:post, %Post{})
       |> MyRepo.transaction
 
   """


### PR DESCRIPTION
There is no `Ecto.Multi.insert/2`, name is required.
`** (UndefinedFunctionError) function Ecto.Multi.insert/2 is undefined or private.`