### PR TITLE
fix #1545 typo

### DIFF
--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
 
       migrated =
         try do
-          migrator.(repo, migrations_path(repo), :up, opts)
+          migrator.(repo, migrations_path(repo), :down, opts)
         after
           sandbox? && Ecto.Adapters.SQL.Sandbox.checkin(repo)
         end


### PR DESCRIPTION
I should have waited for the tests to pass; then I'd have caught that I didn't change `:up` to `:down`.