### PR TITLE
Add to_ansidata/1 to Ecto.LogEntry

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -506,7 +506,8 @@ defmodule Ecto.Adapters.SQL do
       pool_time: queue_time, result: result, query: query} = entry
     repo.__log__(%Ecto.LogEntry{query_time: query_time, decode_time: decode_time,
                                 queue_time: queue_time, result: log_result(result),
-                                params: params, query: String.Chars.to_string(query)})
+                                params: params, query: String.Chars.to_string(query),
+                                ansi_color: sql_color(query)})
   end
 
   defp log_result({:ok, _query, res}), do: {:ok, res}
@@ -529,4 +530,14 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp key(pool), do: {__MODULE__, pool}
+
+  defp sql_color("SELECT" <> _), do: :cyan
+  defp sql_color("ROLLBACK" <> _), do: :red
+  defp sql_color("LOCK" <> _), do: :white
+  defp sql_color("INSERT" <> _), do: :green
+  defp sql_color("UPDATE" <> _), do: :yellow
+  defp sql_color("DELETE" <> _), do: :red
+  defp sql_color("begin" <> _), do: :magenta
+  defp sql_color("commit" <> _), do: :magenta
+  defp sql_color(_), do: :blue
 end

--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -11,6 +11,7 @@ defmodule Ecto.LogEntry do
     * decode_time - the time spent decoding the result in native units (it may be nil);
     * queue_time - the time spent to check the connection out in native units (it may be nil);
     * connection_pid - the connection process that executed the query;
+    * ansi_color - the color that chould be used when logging the entry.
 
   Notice all times are stored in native unit. You must convert them to
   the proper unit by using `System.convert_time_unit/3` before logging.
@@ -23,7 +24,7 @@ defmodule Ecto.LogEntry do
                        queue_time: integer | nil, connection_pid: pid | nil,
                        result: {:ok, term} | {:error, Exception.t}}
   defstruct query: nil, params: [], query_time: nil, decode_time: nil,
-            queue_time: nil, result: nil, connection_pid: nil
+            queue_time: nil, result: nil, connection_pid: nil, ansi_color: nil
 
   require Logger
 


### PR DESCRIPTION
Like discussed in the mailing list, this PR adds a color code based on the SQL statement type.
It is heavily inspired by the Rails 5.0 feature 😉 

The function `to_ansidata/1` is not yet used by the logger because we will need to find a way to use it from a config or even better to use it by default and fallback to `to_iodata/1` from a config.

Here is a screenshot of the output in action in one of my app:

![image](https://cloud.githubusercontent.com/assets/464900/16675266/85424a3e-448d-11e6-8e93-c7fdc9ec492c.png)

🌈 