### PR TITLE
Fix typo in ecto.rollback docs

### DIFF
--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
 
     * `-r`, `--repo` - the repo to rollback
     * `--all` - revert all applied migrations
-    * `--step` / `-n` - rever n number of applied migrations
+    * `--step` / `-n` - revert n number of applied migrations
     * `--to` / `-v` - revert all migrations down to and including version
     * `--quiet` - do not log migration commands
     * `--prefix` - the prefix to run migrations on


### PR DESCRIPTION
This PR fixes a typo in the ecto.rollback documentation.