### PR TITLE
fix typo

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -283,7 +283,7 @@ defmodule Ecto.Changeset do
       iex> changeset = cast(post, %{title: "Hello"}, [:title])
       iex> new_changeset = cast(changeset, %{title: "Foo", body: "Bar"}, [:body])
       iex> new_changeset.params
-      %{title: "Foo", body: "Bar"}
+      %{"title" => "Foo", "body" => "Bar"}
 
   Or creating a changeset from a simple map with types:
 


### PR DESCRIPTION
Params can only have keys of `String.t` type, if I read [this](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/changeset.ex#L148) correctly.