### PR TITLE
add Ecto.Changeset.validate_acceptance/2

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1400,6 +1400,30 @@ defmodule Ecto.Changeset do
     Keyword.get(opts, key, default)
   end
 
+  @doc """
+  Validates that a checkbox was checked.
+
+  ## Options
+
+    * `:message` - the message on failure, defaults to "must be accepted"
+
+  ## Examples
+
+      validate_acceptance(changeset, :terms_of_service)
+      validate_acceptance(changeset, :rules, message: "please accept rules")
+
+  """
+  @spec validate_acceptance(t, atom, Keyword.t) :: t
+  def validate_acceptance(%{params: params} = changeset, field, opts \\ []) do
+    param = Atom.to_string(field)
+    value = Map.get(params, param)
+
+    case Ecto.Type.cast(:boolean, value) do
+      {:ok, true} -> changeset
+      _ -> add_error(changeset, field, message(opts, "must be accepted"))
+    end
+  end
+
   ## Optimistic lock
 
   @doc ~S"""

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -903,6 +903,28 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == []
   end
 
+  test "validate_acceptance/3" do
+    changeset = changeset(%{"terms_of_service" => "true"})
+                |> validate_acceptance(:terms_of_service)
+    assert changeset.valid?
+    assert changeset.errors == []
+
+    changeset = changeset(%{"terms_of_service" => "1"})
+                |> validate_acceptance(:terms_of_service, message: "must be abided")
+    assert changeset.valid?
+    assert changeset.errors == []
+
+    changeset = changeset(%{"terms_of_service" => "false"})
+                |> validate_acceptance(:terms_of_service)
+    refute changeset.valid?
+    assert changeset.errors == [terms_of_service: {"must be accepted", []}]
+
+    changeset = changeset(%{})
+                  |> validate_acceptance(:terms_of_service, message: "must be abided")
+    refute changeset.valid?
+    assert changeset.errors == [terms_of_service: {"must be abided", []}]
+  end
+
   ## Locks
 
   test "optimistic_lock/3 with changeset" do


### PR DESCRIPTION
`validate_acceptance/2` encapsulates the pattern of wanting to validate the acceptance of a terms of service check box (or similar agreement). 

Example:
```elixir
# Model
defmodule Shop.Booking do
  use Shop.Web, :model

  schema "bookings" do
    field :email, :string
    field :terms, :boolean, virtual: true
  end

  def changeset(struct, params \\ %{}) do
    struct
    |> cast(params, [:email, :terms])
    |> validate_acceptance(:terms)
  end
end
```

```slim
/ Slim template
= form_for @changeset, fn f ->
  .form-group
    = label f, :email, class: "control-label"
    = text_input f, :email, class: "form-control"

  .checkbox
    label
      = checkbox f, :terms
      | Terms

```