### PR TITLE
replace downcase(?) with lower(?) in the Fragments example

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -209,21 +209,21 @@ defmodule Ecto.Query.API do
       def unpublished_by_title(title) do
         from p in Post,
           where: is_nil(p.published_at) and
-                 fragment("downcase(?)", p.title) == ^title
+                 fragment("lower(?)", p.title) == ^title
       end
 
-  In the example above, we are using the downcase procedure in the
+  In the example above, we are using the lower procedure in the
   database to downcase the title column.
 
   It is very important to keep in mind that Ecto is unable to do any
   type casting described above when fragments are used. You can
   however use the `type/2` function to give Ecto some hints:
 
-      fragment("downcase(?)", p.title) == type(^title, :string)
+      fragment("lower(?)", p.title) == type(^title, :string)
 
   Or even say the right side is of the same type as `p.title`:
 
-      fragment("downcase(?)", p.title) == type(^title, p.title)
+      fragment("lower(?)", p.title) == type(^title, p.title)
 
   It is possible to make use of PostgreSQL's JSON/JSONB data type
   with fragments, as well:


### PR DESCRIPTION
Same reasoning as in [#1563](https://github.com/elixir-ecto/ecto/pull/1563).

> I understand that the use of `downcase(?)` was just for the sake of example, but wouldn't it be better to use the real function instead (both for postgres and mysql)?