### PR TITLE
replace downcase(?) with lower(?) in the Fragments example

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -355,11 +355,11 @@ defmodule Ecto.Query.API do
   though, in particular when using fragments with `fragment/1`,
   you may want to tell Ecto you are expecting a particular type:
 
-      fragment("downcase(?)", p.title) == type(^title, :string)
+      fragment("lower(?)", p.title) == type(^title, :string)
 
   It is also possible to say the type must match the same of a column:
 
-      fragment("downcase(?)", p.title) == type(^title, p.title)
+      fragment("lower(?)", p.title) == type(^title, p.title)
   """
   def type(interpolated_value, type), do: doc! [interpolated_value, type]
 


### PR DESCRIPTION
Same reasoning as in [#1563](https://github.com/elixir-ecto/ecto/pull/1563).

> I understand that the use of `downcase(?)` was just for the sake of example, but wouldn't it be better to use the real function instead (both for postgres and mysql)?

Sorry for submitting that again. Should have changed it all in one PR.