### PR TITLE
typo?

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -52,7 +52,7 @@ defmodule Ecto.Repo do
   above could be rewritten to:
 
       config :my_app, Repo,
-        url: "ecto://postgres:postgres@localhost/ecto_simple"
+        url: "postgres://postgres:postgres@localhost/ecto_simple"
 
   The schema can be of any value. The path represents the database name
   while options are simply merged in.


### PR DESCRIPTION
I am not sure if that's actually a typo, but should not the URL be the same as in [`Ecto` docs](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto.ex#L48)?