### PR TITLE
Keep lists of integers as lists when inspecting queries

### DIFF
--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -150,12 +150,10 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp expr_to_string({:^, _, [ix]}, _, _, %{params: params}) do
-    escaped =
-      case Enum.at(params || [], ix) do
-        {value, _type} -> Macro.escape(value)
-        _              -> {:..., [], nil}
-      end
-    Macro.to_string {:^, [], [escaped]}
+    case Enum.at(params || [], ix) do
+      {value, _type} -> "^" <> Kernel.inspect(value, char_lists: :as_lists)
+      _              -> "^..."
+    end
   end
 
   # Strip trailing ()

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -201,6 +201,9 @@ defmodule Ecto.Query.InspectTest do
   test "params" do
     assert i(from(x in Post, where: ^123 > ^(1 * 3))) ==
            ~s{from p in Inspect.Post, where: ^123 > ^3}
+
+    assert i(from(x in Post, where: x.id in ^[97])) ==
+           ~s{from p in Inspect.Post, where: p.id in ^[97]}
   end
 
   test "params after planner" do


### PR DESCRIPTION
@josevalim I'm opening this as a PR as I'm not sure about this change.

Is there a better way than to pattern match on the result of `Macro.to_string/2`?