### PR TITLE
Don't automatically reconnect postgrex connection

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -18,6 +18,7 @@ if Code.ensure_loaded?(Postgrex) do
         opts
         |> Keyword.update(:extensions, extensions, &(&1 ++ extensions))
         |> Keyword.update(:port, @default_port, &normalize_port/1)
+        |> Keyword.put(:backoff_type, :stop)
 
       Postgrex.start_link(opts)
     end


### PR DESCRIPTION
* Transaction queries may continue on new connection outside a transaction
* after_connect will not be run

I am unsure how to test this.