### PR TITLE
Handle not loaded associations in get/fetch_field

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -681,7 +681,7 @@ defmodule Ecto.Changeset do
         {:changes, change_as_field(types, key, value)}
       :error ->
         case Map.fetch(data, key) do
-          {:ok, value} -> {:data, value}
+          {:ok, value} -> {:data, data_as_field(data, types, key, value)}
           :error       -> :error
         end
     end
@@ -713,7 +713,7 @@ defmodule Ecto.Changeset do
         change_as_field(types, key, value)
       :error ->
         case Map.fetch(data, key) do
-          {:ok, value} -> value
+          {:ok, value} -> data_as_field(data, types, key, value)
           :error       -> default
         end
     end
@@ -723,6 +723,15 @@ defmodule Ecto.Changeset do
     case Map.get(types, key) do
       {tag, relation} when tag in @relations ->
          Relation.apply_changes(relation, value)
+      _other ->
+        value
+    end
+  end
+
+  defp data_as_field(data, types, key, value) do
+    case Map.get(types, key) do
+      {tag, _relation} when tag in @relations ->
+        Relation.load!(data, value)
       _other ->
         value
     end

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -64,7 +64,7 @@ defmodule Ecto.Changeset.Relation do
   def load!(struct, %NotLoaded{__field__: field}) do
     raise "attempting to cast or change association `#{field}` " <>
           "from `#{inspect struct.__struct__}` that was not loaded. Please preload your " <>
-          "associations before casting or changing the struct"
+          "associations before manipulating them through changesets"
   end
 
   def load!(_struct, loaded), do: loaded

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -754,6 +754,19 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = Changeset.change(%Author{profile: profile})
     assert Changeset.get_field(changeset, :profile) == profile
     assert Changeset.fetch_field(changeset, :profile) == {:data, profile}
+
+    changeset = Changeset.change(%Author{})
+    assert Changeset.get_field(changeset, :profile) == nil
+    assert Changeset.fetch_field(changeset, :profile) == {:data, nil}
+
+    schema = put_in(%Author{}.__meta__.state, :loaded)
+    changeset = Changeset.change(schema)
+    assert_raise RuntimeError, ~r"Please preload", fn ->
+      Changeset.get_field(changeset, :profile)
+    end
+    assert_raise RuntimeError, ~r"Please preload", fn ->
+      Changeset.fetch_field(changeset, :profile)
+    end
   end
 
   test "get_field/3, fetch_field/2 with has many" do
@@ -780,6 +793,19 @@ defmodule Ecto.Changeset.HasAssocTest do
       |> Changeset.put_assoc(:posts, [post_changeset])
     assert Changeset.get_field(changeset, :posts) == []
     assert Changeset.fetch_field(changeset, :posts) == {:changes, []}
+
+    changeset = Changeset.change(%Author{})
+    assert Changeset.get_field(changeset, :posts) == []
+    assert Changeset.fetch_field(changeset, :posts) == {:data, []}
+
+    schema = put_in(%Author{}.__meta__.state, :loaded)
+    changeset = Changeset.change(schema)
+    assert_raise RuntimeError, ~r"Please preload", fn ->
+      Changeset.get_field(changeset, :posts)
+    end
+    assert_raise RuntimeError, ~r"Please preload", fn ->
+      Changeset.fetch_field(changeset, :posts)
+    end
   end
 
   test "apply_changes" do


### PR DESCRIPTION
We should do exactly the same thing that we do when we try to
cast/change the associations when you try to access them and they are
not loaded