### PR TITLE
More flexible repo constraint violation matching

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1852,7 +1852,7 @@ defmodule Ecto.Changeset do
     constraint = opts[:name] || "#{get_source(changeset)}_#{field}_exclusion"
     message    = message(opts, "violates an exclusion constraint")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :exclude, to_string(constraint), :exact, field, {message, []})
+    add_constraint(changeset, :exclude, to_string(constraint), match_type, field, {message, []})
   end
 
   defp no_assoc_message(:one), do: "is still associated to this entry"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -158,7 +158,7 @@ defmodule Ecto.Changeset do
 
   @type error :: {String.t, Keyword.t}
   @type action :: nil | :insert | :update | :delete | :replace
-  @type constraint :: %{type: :unique, constraint: String.t, match: atom,
+  @type constraint :: %{type: :unique, constraint: String.t, match: :exact | :suffix,
                         field: atom, message: error}
   @type data :: map()
   @type types :: Keyword.t | map()

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1861,7 +1861,7 @@ defmodule Ecto.Changeset do
 
   defp add_constraint(changeset, type, constraint, match, field, error)
        when is_binary(constraint) and is_atom(field) and is_tuple(error) and is_atom(match)  do
-    unless match in @match_types, do: raise(ArgumentError, "Invalid match type: #{inspect match}. Allowed match types: #{inspect @match_types}")
+    unless match in @match_types, do: raise(ArgumentError, "invalid match type: #{inspect match}. Allowed match types: #{inspect @match_types}")
     update_in changeset.constraints, &[%{type: type, constraint: constraint, match: match,
                                          field: field, error: error}|&1]
   end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -393,7 +393,11 @@ defmodule Ecto.Repo.Schema do
       Enum.map constraints, fn {type, constraint} ->
         user_constraint =
           Enum.find(user_constraints, fn c ->
-            c.type == type and c.constraint == constraint
+            case {c.type, c.constraint,  c.match} do
+              {^type, ^constraint, :exact} -> true
+              {^type, cc, :suffix} -> String.ends_with?(constraint, cc)
+              _ -> false
+            end
           end)
 
         case user_constraint do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -961,7 +961,7 @@ defmodule Ecto.ChangesetTest do
            [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
               error: {"cannot be more than 15 characters", []}}]
 
-    assert_raise ArgumentError, ~r/Invalid match type: :invalid/, fn ->
+    assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> check_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
     end
 
@@ -984,7 +984,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.constraints ==
            [%{type: :unique, field: :title, constraint: "whatever", match: :suffix, error: {"is taken", []}}]
 
-    assert_raise ArgumentError, ~r/Invalid match type: :invalid/, fn ->
+    assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
     end
   end
@@ -1070,7 +1070,7 @@ defmodule Ecto.ChangesetTest do
            [%{type: :exclude, field: :title, constraint: "whatever", match: :exact,
               error: {"is invalid", []}}]
 
-    assert_raise ArgumentError, ~r/Invalid match type: :invalid/, fn ->
+    assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
     end
   end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -961,6 +961,10 @@ defmodule Ecto.ChangesetTest do
            [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
               error: {"cannot be more than 15 characters", []}}]
 
+    assert_raise ArgumentError, ~r/Invalid match type: :invalid/, fn ->
+      change(%Post{}) |> check_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
+    end
+
     assert_raise ArgumentError, ~r/supply the name/, fn ->
       check_constraint(:title, message: "cannot be more than 15 characters")
     end
@@ -980,10 +984,9 @@ defmodule Ecto.ChangesetTest do
     assert changeset.constraints ==
            [%{type: :unique, field: :title, constraint: "whatever", match: :suffix, error: {"is taken", []}}]
 
-    # Assert invalid match type falls back to default bahavior
-    changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
-    assert changeset.constraints ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :exact, error: {"is taken", []}}]
+    assert_raise ArgumentError, ~r/Invalid match type: :invalid/, fn ->
+      change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
+    end
   end
 
   test "foreign_key_constraint/3" do
@@ -1066,6 +1069,10 @@ defmodule Ecto.ChangesetTest do
     assert changeset.constraints ==
            [%{type: :exclude, field: :title, constraint: "whatever", match: :exact,
               error: {"is invalid", []}}]
+
+    assert_raise ArgumentError, ~r/Invalid match type: :invalid/, fn ->
+      change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
+    end
   end
 
   ## traverse_errors

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -953,12 +953,12 @@ defmodule Ecto.ChangesetTest do
   test "check_constraint/3" do
     changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short)
     assert changeset.constraints ==
-           [%{type: :check, field: :title, constraint: "title_must_be_short",
+           [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
               error: {"is invalid", []}}]
 
     changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short, message: "cannot be more than 15 characters")
     assert changeset.constraints ==
-           [%{type: :check, field: :title, constraint: "title_must_be_short",
+           [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
               error: {"cannot be more than 15 characters", []}}]
 
     assert_raise ArgumentError, ~r/supply the name/, fn ->
@@ -969,34 +969,43 @@ defmodule Ecto.ChangesetTest do
   test "unique_constraint/3" do
     changeset = change(%Post{}) |> unique_constraint(:title)
     assert changeset.constraints ==
-           [%{type: :unique, field: :title, constraint: "posts_title_index",
+           [%{type: :unique, field: :title, constraint: "posts_title_index", match: :exact,
               error: {"has already been taken", []}}]
 
     changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, message: "is taken")
     assert changeset.constraints ==
-           [%{type: :unique, field: :title, constraint: "whatever", error: {"is taken", []}}]
+           [%{type: :unique, field: :title, constraint: "whatever", match: :exact, error: {"is taken", []}}]
+
+    changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :suffix, message: "is taken")
+    assert changeset.constraints ==
+           [%{type: :unique, field: :title, constraint: "whatever", match: :suffix, error: {"is taken", []}}]
+
+    # Assert invalid match type falls back to default bahavior
+    changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
+    assert changeset.constraints ==
+           [%{type: :unique, field: :title, constraint: "whatever", match: :exact, error: {"is taken", []}}]
   end
 
   test "foreign_key_constraint/3" do
     changeset = change(%Comment{}) |> foreign_key_constraint(:post_id)
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :post_id, constraint: "comments_post_id_fkey",
+           [%{type: :foreign_key, field: :post_id, constraint: "comments_post_id_fkey", match: :exact,
               error: {"does not exist", []}}]
 
     changeset = change(%Comment{}) |> foreign_key_constraint(:post_id, name: :whatever, message: "is not available")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :post_id, constraint: "whatever", error: {"is not available", []}}]
+           [%{type: :foreign_key, field: :post_id, constraint: "whatever", match: :exact, error: {"is not available", []}}]
   end
 
   test "assoc_constraint/3" do
     changeset = change(%Comment{}) |> assoc_constraint(:post)
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :post, constraint: "comments_post_id_fkey",
+           [%{type: :foreign_key, field: :post, constraint: "comments_post_id_fkey", match: :exact,
               error: {"does not exist", []}}]
 
     changeset = change(%Comment{}) |> assoc_constraint(:post, name: :whatever, message: "is not available")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :post, constraint: "whatever", error: {"is not available", []}}]
+           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :exact, error: {"is not available", []}}]
   end
 
   test "assoc_constraint/3 with errors" do
@@ -1014,24 +1023,24 @@ defmodule Ecto.ChangesetTest do
   test "no_assoc_constraint/3 with has_many" do
     changeset = change(%Post{}) |> no_assoc_constraint(:comments)
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey",
+           [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey", match: :exact,
               error: {"are still associated to this entry", []}}]
 
     changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: :whatever, message: "exists")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :comments, constraint: "whatever",
+           [%{type: :foreign_key, field: :comments, constraint: "whatever", match: :exact,
               error: {"exists", []}}]
   end
 
   test "no_assoc_constraint/3 with has_one" do
     changeset = change(%Post{}) |> no_assoc_constraint(:comment)
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :comment, constraint: "comments_post_id_fkey",
+           [%{type: :foreign_key, field: :comment, constraint: "comments_post_id_fkey", match: :exact,
               error: {"is still associated to this entry", []}}]
 
     changeset = change(%Post{}) |> no_assoc_constraint(:comment, name: :whatever, message: "exists")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :comment, constraint: "whatever",
+           [%{type: :foreign_key, field: :comment, constraint: "whatever", match: :exact,
               error: {"exists", []}}]
   end
 
@@ -1050,12 +1059,12 @@ defmodule Ecto.ChangesetTest do
   test "exclusion_constraint/3" do
     changeset = change(%Post{}) |> exclusion_constraint(:title)
     assert changeset.constraints ==
-           [%{type: :exclude, field: :title, constraint: "posts_title_exclusion",
+           [%{type: :exclude, field: :title, constraint: "posts_title_exclusion", match: :exact,
               error: {"violates an exclusion constraint", []}}]
 
     changeset = change(%Post{}) |> exclusion_constraint(:title, name: :whatever, message: "is invalid")
     assert changeset.constraints ==
-           [%{type: :exclude, field: :title, constraint: "whatever",
+           [%{type: :exclude, field: :title, constraint: "whatever", match: :exact,
               error: {"is invalid", []}}]
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -335,7 +335,7 @@ defmodule Ecto.RepoTest do
       |> Ecto.Changeset.change(x: "foo")
       |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index")
     assert_raise Ecto.ConstraintError, fn ->
-     TestRepo.update(changeset)
+      TestRepo.update(changeset)
     end
   end
 
@@ -346,7 +346,7 @@ defmodule Ecto.RepoTest do
       |> Ecto.Changeset.change(x: "foo")
       |> Ecto.Changeset.unique_constraint(:foo)
     assert_raise Ecto.ConstraintError, fn ->
-     TestRepo.update(changeset)
+      TestRepo.update(changeset)
     end
   end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -307,4 +307,46 @@ defmodule Ecto.RepoTest do
     assert Process.get(:ecto_repo) == TestRepo
     assert Process.get(:ecto_counter) == 2
   end
+
+  test "insert maps repo constraint violation to changeset constraint" do
+    my_schema = %MySchema{id: 1}
+    changeset =
+      put_in(my_schema.__meta__.context, {:invalid, [unique: "custom_foo_index"]})
+      |> Ecto.Changeset.change(x: "foo")
+      |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index")
+    assert {:error, changeset} = TestRepo.update(changeset)
+    refute changeset.valid?
+  end
+
+  test "insert maps repo constraint violation to changeset constraint using suffix match" do
+    my_schema = %MySchema{id: 1}
+    changeset =
+      put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
+      |> Ecto.Changeset.change(x: "foo")
+      |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index", match: :suffix)
+    assert {:error, changeset} = TestRepo.update(changeset)
+    refute changeset.valid?
+  end
+
+  test "insert fails to maps repo constraint violation to changeset constraint with non-matching name" do
+    my_schema = %MySchema{id: 1}
+    changeset =
+      put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
+      |> Ecto.Changeset.change(x: "foo")
+      |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index")
+    assert_raise Ecto.ConstraintError, fn ->
+     TestRepo.update(changeset)
+    end
+  end
+
+  test "that an unknown constraint violation falls through and raises an exception" do
+    my_schema = %MySchema{id: 1}
+    changeset =
+      put_in(my_schema.__meta__.context, {:invalid, [invalid_constraint_type: "my_schema_foo_index"]})
+      |> Ecto.Changeset.change(x: "foo")
+      |> Ecto.Changeset.unique_constraint(:foo)
+    assert_raise Ecto.ConstraintError, fn ->
+     TestRepo.update(changeset)
+    end
+  end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -339,7 +339,7 @@ defmodule Ecto.RepoTest do
     end
   end
 
-  test "that an unknown constraint violation falls through and raises an exception" do
+  test "unknown constraint violation falls through and raises an exception" do
     my_schema = %MySchema{id: 1}
     changeset =
       put_in(my_schema.__meta__.context, {:invalid, [invalid_constraint_type: "my_schema_foo_index"]})


### PR DESCRIPTION
Allows changeset constraints to map to repo constraints as a suffix, as an alternative to the default behavior of exact matching. 

This allows users more flexibility in mapping low-level backend errors to higher-level errors, and is a key piece of functionality for high-scale applications which utilize advanced Repo management techniques which are incompatible with the current constraint mapping. 

Because constraints and accesses are implicitly scoped to a table access, there should be no confusion as a result of similar constraint match clauses for different tables. Additionally one could, if desired, use this to write a wildcard style matching or other flexible aggregation for constraints in normal single-table cases.

Motivating Use Case
====

I'm using Ecto to manage a very large dataset which takes advantage of Postgres partitioning to operate efficiently. A result of this is that what appears as one Repo is actually in the backend many individual tables, transparently routed to within postgres and completely compatible with Ecto, except when constraint violations are raised. 

The key trouble is that index names must be unique, and so they are prefixed by the table names. When you insert to the root table, and PG performs the actual insert to the appropriate partition, constraint violations result in a different name than expected

A constraint defined as:

`|> unique_constraint(:column_a, name: :table_column_a_idx)`

May result in: 
```
     ** (Ecto.ConstraintError) constraint error when attempting to insert struct:
     
         * unique: table_partition0_column_a_idx
     
     If you would like to convert this constraint into an error, please
     call unique_constraint/3 in your changeset and define the proper
     constraint name. The changeset defined the following constraints:
     
         * unique: table_column_a_idx
```

Adding a `match:` option to the changeset `unique_constraint` with supported values of `:exact` and `:suffix` allow us to write a constraint which look like:

`|> unique_constraint(:column_a, name: :column_a_idx, match: :suffix)`

And for any access of `table` that causes a constraint violation will return:

`errors: [column_a: {"has already been taken", []}]`

Even when the the underlying repo returns an error matching: 
```
column_a_idx
table_partition0_column_a_idx
table_partition1_column_a_idx
...
```

Not Implemented
=====
1. `match:` option for changeset constraints other than `unique_constraint`. 
2. Match types other than `:exact` and `:suffix`

