### PR TITLE
Allow to alter primary keys on tables

### DIFF
--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -616,6 +616,17 @@ defmodule Ecto.Adapters.MySQLTest do
     """ |> remove_newlines
   end
 
+  test "alter table with primary key" do
+    alter = {:alter, table(:posts),
+               [{:add, :my_pk, :serial, [primary_key: true]}]}
+
+    assert SQL.execute_ddl(alter) == """
+    ALTER TABLE `posts`
+    ADD `my_pk` serial
+    ADD PRIMARY KEY (`my_pk`)
+    """ |> remove_newlines
+  end
+
   test "create index" do
     create = {:create, index(:posts, [:category_id, :permalink])}
     assert SQL.execute_ddl(create) ==

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -759,6 +759,17 @@ defmodule Ecto.Adapters.PostgresTest do
     """ |> remove_newlines
   end
 
+  test "alter table with primary key" do
+    alter = {:alter, table(:posts),
+               [{:add, :my_pk, :serial, [primary_key: true]}]}
+
+    assert SQL.execute_ddl(alter) == """
+    ALTER TABLE "posts"
+    ADD COLUMN "my_pk" serial
+    ADD PRIMARY KEY ("my_pk")
+    """ |> remove_newlines
+  end
+
   test "create index" do
     create = {:create, index(:posts, [:category_id, :permalink])}
     assert SQL.execute_ddl(create) ==


### PR DESCRIPTION
According to the documentation, `add/3` (https://hexdocs.pm/ecto/Ecto.Migration.html#add/3) works for both `CREATE` and`ALTER`.

This PR brings the code that was missing for `ALTER`.