### PR TITLE
Fixes SQL syntax on alter with primary key

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -287,6 +287,19 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule AlterPrimaryKeyMigration do
+    use Ecto.Migration
+
+    def change do
+      create table(:no_pk, primary_key: false) do
+        add :dummy, :string
+      end
+      alter table(:no_pk) do
+        add :id, :serial, primary_key: true
+      end
+    end
+  end
+
   import Ecto.Query, only: [from: 2]
   import Ecto.Migrator, only: [up: 4, down: 4]
 
@@ -405,5 +418,11 @@ defmodule Ecto.Integration.MigrationTest do
   test "prefix" do
     assert :ok == up(PoolRepo, 20151012120000, PrefixMigration, log: false)
     assert :ok == down(PoolRepo, 20151012120000, PrefixMigration, log: false)
+  end
+
+  @tag :alter_primary_key
+  test "alter primary key" do
+    assert :ok == up(PoolRepo, 20151012120000, AlterPrimaryKeyMigration, log: false)
+    assert :ok == down(PoolRepo, 20151012120000, AlterPrimaryKeyMigration, log: false)
   end
 end

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -510,7 +510,7 @@ if Code.ensure_loaded?(Mariaex) do
     def execute_ddl({:alter, %Table{}=table, changes}) do
       pk_definition = case pk_definition(changes) do
         nil -> ""
-        pk -> " ADD #{pk}"
+        pk -> ", ADD #{pk}"
       end
       "ALTER TABLE #{quote_table(table.prefix, table.name)} #{column_changes(table, changes)}" <>
       "#{pk_definition}"

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -564,7 +564,7 @@ if Code.ensure_loaded?(Postgrex) do
     def execute_ddl({:alter, %Table{}=table, changes}) do
       pk_definition = case pk_definition(changes) do
         nil -> ""
-        pk -> " ADD #{pk}"
+        pk -> ", ADD #{pk}"
       end
       "ALTER TABLE #{quote_table(table.prefix, table.name)} #{column_changes(table, changes)}" <>
       "#{pk_definition}" <> comment_on(:table, table.name, table.comment) <>

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -622,7 +622,7 @@ defmodule Ecto.Adapters.MySQLTest do
 
     assert SQL.execute_ddl(alter) == """
     ALTER TABLE `posts`
-    ADD `my_pk` serial
+    ADD `my_pk` serial,
     ADD PRIMARY KEY (`my_pk`)
     """ |> remove_newlines
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -765,7 +765,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
     assert SQL.execute_ddl(alter) == """
     ALTER TABLE "posts"
-    ADD COLUMN "my_pk" serial
+    ADD COLUMN "my_pk" serial,
     ADD PRIMARY KEY ("my_pk")
     """ |> remove_newlines
   end


### PR DESCRIPTION
Follow up on #1593, the SQL syntax generated by the PR is invalid (missing comma).
This could not be caught by the test suite, because the expected value was incorrect as well...

This has been tested on a real-world project, but you're more than encouraged to test further.

Should an integration test be added to avoid future regressions?

Sorry for the inconvenience...