### PR TITLE
Cast :date, :time, and :datetime empty strings to {:ok, nil}

### DIFF
--- a/lib/ecto/date_time.ex
+++ b/lib/ecto/date_time.ex
@@ -144,6 +144,8 @@ defmodule Ecto.Date do
     do: from_parts(to_i(year), to_i(month), to_i(day))
   defp do_cast(%Ecto.Date{} = d),
     do: {:ok, d}
+  defp do_cast(empty) when empty in ["", nil],
+    do: {:ok, nil}
   defp do_cast(%{"year" => empty, "month" => empty, "day" => empty}) when empty in ["", nil],
     do: {:ok, nil}
   defp do_cast(%{year: empty, month: empty, day: empty}) when empty in ["", nil],
@@ -278,6 +280,9 @@ defmodule Ecto.Time do
   def cast(%{hour: hour, min: min} = map),
     do: from_parts(to_i(hour), to_i(min), to_i(Map.get(map, :sec, 0)), to_i(Map.get(map, :usec, 0)))
 
+
+  def cast(empty) when empty in ["", nil],
+    do: {:ok, nil}
   def cast(%{"hour" => empty, "minute" => empty}) when empty in ["", nil],
     do: {:ok, nil}
   def cast(%{hour: empty, minute: empty}) when empty in ["", nil],
@@ -463,6 +468,9 @@ defmodule Ecto.DateTime do
                to_i(hour), to_i(min), to_i(Map.get(map, :sec, 0)),
                to_i(Map.get(map, :usec, 0)))
   end
+
+  defp do_cast(empty) when empty in ["", nil],
+    do: {:ok, nil}
 
   defp do_cast(%{"year" => empty, "month" => empty, "day" => empty,
                  "hour" => empty, "minute" => empty}) when empty in ["", nil] do

--- a/test/ecto/date_time_test.exs
+++ b/test/ecto/date_time_test.exs
@@ -9,6 +9,7 @@ defmodule Ecto.DateTest do
   end
 
   test "cast strings" do
+    assert Ecto.Date.cast("") == {:ok, nil}
     assert Ecto.Date.cast("2015-12-31") == {:ok, @date}
     assert Ecto.Date.cast("2000-02-29") == {:ok, @leap_date}
     assert Ecto.Date.cast("2015-00-23") == :error
@@ -103,6 +104,7 @@ defmodule Ecto.TimeTest do
   end
 
   test "cast strings" do
+    assert Ecto.Time.cast("") == {:ok, nil}
     assert Ecto.Time.cast("23:50:07") == {:ok, @time}
     assert Ecto.Time.cast("23:50:07Z") == {:ok, @time}
 
@@ -221,6 +223,7 @@ defmodule Ecto.DateTimeTest do
   end
 
   test "cast strings" do
+    assert Ecto.DateTime.cast("") == {:ok, nil}
     assert Ecto.DateTime.cast("2015-01-23 23:50:07") == {:ok, @datetime}
     assert Ecto.DateTime.cast("2015-01-23T23:50:07") == {:ok, @datetime}
     assert Ecto.DateTime.cast("2015-01-23T23:50:07Z") == {:ok, @datetime}


### PR DESCRIPTION
1. Added cast/do_cast functions to `:date`, `:time`, and `:datetime` Ecto types to support casting of empty strings `""` to `{:ok, nil}`
2. Added assertions to each of the "cast strings" tests for each of types mentioned in 1. to ensure `cast("") == {:ok, nil}`

Fixes invalid problem related to #1600 