### PR TITLE
Add support for query cache resetting

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -136,7 +136,7 @@ defmodule Ecto.Adapter do
   @callback execute(repo, query_meta, query, params :: list(), process | nil, options) :: result when
               result: {integer, [[term]] | nil} | no_return,
               query: {:nocache, prepared} |
-                     {:cached, cached} |
+                     {:cached, (prepared -> :ok), cached} |
                      {:cache, (cached -> :ok), prepared}
 
   @doc """

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -24,8 +24,10 @@ defmodule Ecto.Adapters.SQL.Connection do
   @doc """
   Executes the given prepared query with `DBConnection`.
   """
-  @callback execute(connection :: DBConnection.t, prepared_query :: prepared | cached, params :: [term], options :: Keyword.t) ::
+  @callback execute(connection :: DBConnection.t, prepared_query :: prepared, params :: [term], options :: Keyword.t) ::
             {:ok, term} | {:error, Exception.t}
+  @callback execute(connection :: DBConnection.t, prepared_query :: cached, params :: [term], options :: Keyword.t) ::
+            {:ok, term} | {:error | :reset, Exception.t}
 
   @doc """
   Receives the exception returned by `query/4`.

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -49,7 +49,8 @@ defmodule Ecto.Query.Planner do
       {:nocache, select, prepared} ->
         {build_meta(query, select), {:nocache, prepared}, params}
       {_, :cached, select, cached} ->
-        {build_meta(query, select), {:cached, cached}, params}
+        reset = &cache_reset(repo, key, &1)
+        {build_meta(query, select), {:cached, reset, cached}, params}
       {_, :cache, select, prepared} ->
         update = &cache_update(repo, key, &1)
         {build_meta(query, select), {:cache, update, prepared}, params}
@@ -91,6 +92,11 @@ defmodule Ecto.Query.Planner do
 
   defp cache_update(repo, key, cached) do
     _ = :ets.update_element(repo, key, [{2, :cached}, {4, cached}])
+    :ok
+  end
+
+  defp cache_reset(repo, key, prepared) do
+    _ = :ets.update_element(repo, key, [{2, :cache}, {4, prepared}])
     :ok
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -43,8 +43,9 @@ defmodule Ecto.Mixfile do
      {:decimal, "~> 1.0"},
 
      # Drivers
-     {:db_connection, "~> 1.0-rc.2", optional: true},
-     {:postgrex, "~> 0.11.2", optional: true},
+     {:db_connection, "~> 1.0-rc.4", optional: true},
+     {:postgrex, "~> 0.11.2",
+       optional: true, github: "elixir-ecto/postgrex", ref: "f305dfe"},
      {:mariaex, "~> 0.7.7", optional: true},
 
      # Optional

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
-  "connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},
-  "db_connection": {:hex, :db_connection, "1.0.0-rc.2", "c5b2329651ef046d85e47ec2c947cb0e3d10a69eb49fdb71e365e72d6758e4c5", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.2", [hex: :sbroker, optional: true]}]},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "db_connection": {:hex, :db_connection, "1.0.0-rc.5", "1d9ab6e01387bdf2de7a16c56866971f7c2f75aea7c69cae2a0346e4b537ae0d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
@@ -8,5 +8,5 @@
   "mariaex": {:hex, :mariaex, "0.7.7", "620a636ec2276c3fa031ac528039fc9d2bf7992e050e37a56b3c796511e94d6d", [:mix], [{:db_connection, "~> 1.0.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
-  "sbroker": {:hex, :sbroker, "1.0.0-beta.2", "4682fdeb0b3d2c4e7eef8f220472ba7edbae667f019f7588624e38efaba2be4b", [:rebar3], []}}
+  "postgrex": {:git, "https://github.com/elixir-ecto/postgrex.git", "f305dfe3293bba73328fa05bd7d2c88f3985f65f", [ref: "f305dfe"]},
+  "sbroker": {:hex, :sbroker, "1.0.0-beta.3", "7fd35f29ff9db15887106c6a25afc87d95799a9690c10bd42349cfb670fe9c26", [:rebar3], []}}


### PR DESCRIPTION
** Don't merge: pointing at git ref **

@janjiss please can you try this branch as a fix for https://github.com/elixir-ecto/postgrex/issues/212

This branch adds support for changing the column types on the fly and resetting the query cache. Will reset the cache one query at a time. It is possible we update/reset queries many times, possibly in quick succession but that is okay because we always keep the same name.

Note that this change breaks backwards compatibility on the query planner for anyone caching queries. I think this is just the SQL adapter.