### PR TITLE
Poison Encoder for Decimal should return a JSON Number, not String

### DIFF
--- a/lib/ecto/poison.ex
+++ b/lib/ecto/poison.ex
@@ -1,6 +1,6 @@
 if Code.ensure_loaded?(Poison) do
   defimpl Poison.Encoder, for: Decimal do
-    def encode(decimal, _opts), do: <<?", Decimal.to_string(decimal)::binary, ?">>
+    def encode(decimal, _opts), do: Decimal.to_string(decimal)
   end
 
   defimpl Poison.Encoder, for: [Ecto.Date, Ecto.Time, Ecto.DateTime] do

--- a/test/ecto/poison_test.exs
+++ b/test/ecto/poison_test.exs
@@ -22,7 +22,7 @@ defmodule Ecto.PoisonTest do
 
   test "encodes decimal" do
     decimal = Decimal.new("1.0")
-    assert Poison.encode!(decimal) == ~s("1.0")
+    assert Poison.encode!(decimal) == ~s(1.0)
   end
 
   test "fails on association not loaded" do


### PR DESCRIPTION
Poison `Encoder` protocol implementation currently encodes Decimal to double-quoted JSON `String`.
That causes unexpected behavior in object-mapping on clients due to the confused JSON numeric type.
This PR changes the `Encoder` implementation to encode Decimal to JSON `Number` type.

**Before:**
```
iex(5)> Poison.encode!(%{"number": Decimal.new("2.5")})  
"{\"number\":\"2.5\"}"
```
**After this change:**
```
iex(5)> Poison.encode!(%{"number": Decimal.new("2.5")})  
"{\"number\":2.5}"
```