### PR TITLE
Allow single column indexes to not use a list

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -498,19 +498,23 @@ defmodule Ecto.Migration do
       create index(:products, [:user_id], where: "price = 0", name: :free_products_index)
 
   """
-  def index(table, columns, opts \\ []) when is_atom(table) and is_list(columns) do
+  def index(table, columns, opts \\ [])
+  def index(table, columns, opts) when is_atom(table) and is_list(columns) do
     index = struct(%Index{table: table, columns: columns}, opts)
     %{index | name: index.name || default_index_name(index)}
   end
+  def index(table, column, opts) when is_atom(table) and is_atom(column), do: index(table, [column], opts)
 
   @doc """
   Shortcut for creating a unique index.
 
   See `index/3` for more information.
   """
-  def unique_index(table, columns, opts \\ []) when is_atom(table) and is_list(columns) do
+  def unique_index(table, columns, opts \\ [])
+  def unique_index(table, columns, opts) when is_atom(table) and is_list(columns) do
     index(table, columns, [unique: true] ++ opts)
   end
+  def unique_index(table, column, opts) when is_atom(table) and is_atom(column), do: unique_index(table, [column], opts)
 
   defp default_index_name(index) do
     [index.table, index.columns, "index"]

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -39,11 +39,15 @@ defmodule Ecto.MigrationTest do
   test "creates an index" do
     assert index(:posts, [:title]) ==
            %Index{table: :posts, unique: false, name: :posts_title_index, columns: [:title]}
+    assert index(:posts, :title) ==
+           %Index{table: :posts, unique: false, name: :posts_title_index, columns: [:title]}
     assert index(:posts, ["lower(title)"]) ==
            %Index{table: :posts, unique: false, name: :posts_lower_title_index, columns: ["lower(title)"]}
     assert index(:posts, [:title], name: :foo, unique: true) ==
            %Index{table: :posts, unique: true, name: :foo, columns: [:title]}
     assert unique_index(:posts, [:title], name: :foo) ==
+           %Index{table: :posts, unique: true, name: :foo, columns: [:title]}
+    assert unique_index(:posts, :title, name: :foo) ==
            %Index{table: :posts, unique: true, name: :foo, columns: [:title]}
   end
 


### PR DESCRIPTION
The following code crashes when running a migration:

```elixir
create unique_index(:users, :email)
```

When Ecto is expecting instead

```elixir
create unique_index(:users, [:email])
```

Since the error message is a no such function error, it's a bit confusing what the user has done wrong.

Instead, this PR just wraps it in a list so everyone is happy.