### PR TITLE
Allow column specification for MySQL index

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -647,6 +647,8 @@ if Code.ensure_loaded?(Mariaex) do
     defp default_expr(:error),
       do: []
 
+    defp index_expr(literal) when is_binary(literal),
+      do: literal
     defp index_expr(literal), do: quote_name(literal)
 
     defp engine_expr(nil), do: engine_expr("INNODB")

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -640,9 +640,9 @@ defmodule Ecto.Adapters.MySQLTest do
     assert SQL.execute_ddl(create) ==
            ~s|CREATE INDEX `posts_category_id_permalink_index` ON `posts` (`category_id`, `permalink`)|
 
-    create = {:create, index(:posts, ["lower(permalink)"], name: "posts$main")}
+    create = {:create, index(:posts, ["permalink(8)"], name: "posts$main")}
     assert SQL.execute_ddl(create) ==
-           ~s|CREATE INDEX `posts$main` ON `posts` (`lower(permalink)`)|
+           ~s|CREATE INDEX `posts$main` ON `posts` (permalink(8))|
   end
 
   test "create index with prefix" do
@@ -652,9 +652,9 @@ defmodule Ecto.Adapters.MySQLTest do
   end
 
   test "create index asserting concurrency" do
-    create = {:create, index(:posts, ["lower(permalink)"], name: "posts$main", concurrently: true)}
+    create = {:create, index(:posts, ["permalink(8)"], name: "posts$main", concurrently: true)}
     assert SQL.execute_ddl(create) ==
-           ~s|CREATE INDEX `posts$main` ON `posts` (`lower(permalink)`) LOCK=NONE|
+           ~s|CREATE INDEX `posts$main` ON `posts` (permalink(8)) LOCK=NONE|
   end
 
   test "create unique index" do


### PR DESCRIPTION
Now it is allowed to `create index(:table, ["token(16)"])` like for
postgres adapter.

Additionally fixed two test cases where column specification should not be
quoted.
btw, MySQL does not have functional indexes