### PR TITLE
[wip] Fix #1610 -- Add option to scope schema relations

### DIFF
--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -26,7 +26,7 @@ defmodule Ecto.Integration.Post do
   use Ecto.Integration.Schema
   import Ecto.Changeset
 
-  schema "posts" do
+  schema Ecto.Integration, "posts" do
     field :counter, :id # Same as integer
     field :title, :string
     field :text, :binary
@@ -40,21 +40,21 @@ defmodule Ecto.Integration.Post do
     field :meta, :map
     field :links, {:map, :string}
     field :posted, Ecto.Date
-    has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
-    has_one :permalink, Ecto.Integration.Permalink, on_delete: :delete_all, on_replace: :delete
+    has_many :comments, Comment, on_delete: :delete_all, on_replace: :delete
+    has_one :permalink, Permalink, on_delete: :delete_all, on_replace: :delete
     has_many :comments_authors, through: [:comments, :author]
-    belongs_to :author, Ecto.Integration.User
-    many_to_many :users, Ecto.Integration.User,
+    belongs_to :author, User
+    many_to_many :users, User,
       join_through: "posts_users", on_delete: :delete_all, on_replace: :delete
-    many_to_many :customs, Ecto.Integration.Custom,
+    many_to_many :customs, Custom,
       join_through: "posts_customs", join_keys: [post_id: :uuid, custom_id: :bid],
       on_delete: :delete_all, on_replace: :delete
-    many_to_many :unique_users, Ecto.Integration.User,
-      join_through: Ecto.Integration.PostUserCompositePk
+    many_to_many :unique_users, User,
+      join_through: PostUserCompositePk
     has_many :users_comments, through: [:users, :comments]
     has_many :comments_authors_permalinks, through: [:comments_authors, :permalink]
     timestamps()
-    has_one :post_user_composite_pk, Ecto.Integration.PostUserCompositePk
+    has_one :post_user_composite_pk, PostUserCompositePk
   end
 
   def changeset(schema, params) do
@@ -89,11 +89,11 @@ defmodule Ecto.Integration.Comment do
   """
   use Ecto.Integration.Schema
 
-  schema "comments" do
+  schema Ecto.Integration, "comments" do
     field :text, :string
     field :lock_version, :integer, default: 1
-    belongs_to :post, Ecto.Integration.Post
-    belongs_to :author, Ecto.Integration.User
+    belongs_to :post, Post
+    belongs_to :author, User
     has_one :post_permalink, through: [:post, :permalink]
   end
 end
@@ -108,10 +108,10 @@ defmodule Ecto.Integration.Permalink do
   """
   use Ecto.Integration.Schema
 
-  schema "permalinks" do
+  schema Ecto.Integration, "permalinks" do
     field :url, :string
-    belongs_to :post, Ecto.Integration.Post, on_replace: :nilify
-    belongs_to :user, Ecto.Integration.User
+    belongs_to :post, Post, on_replace: :nilify
+    belongs_to :user, User
     has_many :post_comments_authors, through: [:post, :comments_authors]
   end
 end
@@ -125,9 +125,9 @@ defmodule Ecto.Integration.PostUser do
   """
   use Ecto.Integration.Schema
 
-  schema "posts_users_pk" do
-    belongs_to :user, Ecto.Integration.User
-    belongs_to :post, Ecto.Integration.Post
+  schema Ecto.Integration, "posts_users_pk" do
+    belongs_to :user, User
+    belongs_to :post, Post
     timestamps()
   end
 end
@@ -143,14 +143,14 @@ defmodule Ecto.Integration.User do
   """
   use Ecto.Integration.Schema
 
-  schema "users" do
+  schema Ecto.Integration, "users" do
     field :name, :string
-    has_many :comments, Ecto.Integration.Comment, foreign_key: :author_id, on_delete: :nilify_all, on_replace: :nilify
-    has_one :permalink, Ecto.Integration.Permalink, on_replace: :nilify
-    has_many :posts, Ecto.Integration.Post, foreign_key: :author_id, on_delete: :nothing, on_replace: :delete
-    belongs_to :custom, Ecto.Integration.Custom, references: :bid, type: :binary_id
-    many_to_many :schema_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUser
-    many_to_many :unique_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUserCompositePk
+    has_many :comments, Comment, foreign_key: :author_id, on_delete: :nilify_all, on_replace: :nilify
+    has_one :permalink, Permalink, on_replace: :nilify
+    has_many :posts, Post, foreign_key: :author_id, on_delete: :nothing, on_replace: :delete
+    belongs_to :custom, Custom, references: :bid, type: :binary_id
+    many_to_many :schema_posts, Post, join_through: PostUser
+    many_to_many :unique_posts, Post, join_through: PostUserCompositePk
     timestamps()
   end
 end
@@ -197,10 +197,10 @@ defmodule Ecto.Integration.Tag do
   """
   use Ecto.Integration.Schema
 
-  schema "tags" do
+  schema Ecto.Integration, "tags" do
     field :ints, {:array, :integer}
     field :uuids, {:array, Ecto.UUID}
-    embeds_many :items, Ecto.Integration.Item
+    embeds_many :items, Item
   end
 end
 
@@ -228,8 +228,8 @@ defmodule Ecto.Integration.Order do
   """
   use Ecto.Integration.Schema
 
-  schema "orders" do
-    embeds_one :item, Ecto.Integration.Item
+  schema Ecto.Integration, "orders" do
+    embeds_one :item, Item
   end
 end
 
@@ -260,9 +260,9 @@ defmodule Ecto.Integration.PostUserCompositePk do
   use Ecto.Integration.Schema
 
   @primary_key false
-  schema "posts_users_composite_pk" do
-    belongs_to :user, Ecto.Integration.User, primary_key: true
-    belongs_to :post, Ecto.Integration.Post, primary_key: true
+  schema Ecto.Integration, "posts_users_composite_pk" do
+    belongs_to :user, User, primary_key: true
+    belongs_to :post, Post, primary_key: true
     timestamps()
   end
 end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -286,12 +286,13 @@ defmodule Ecto.Schema do
   @doc false
   defmacro __using__(_) do
     quote do
-      import Ecto.Schema, only: [schema: 2, embedded_schema: 1]
+      import Ecto.Schema, only: [schema: 2, schema: 3, embedded_schema: 1]
 
       @primary_key nil
       @timestamps_opts []
       @foreign_key_type :id
       @schema_prefix nil
+      @association_scope nil
 
       Module.register_attribute(__MODULE__, :ecto_primary_keys, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_fields, accumulate: true)
@@ -316,6 +317,16 @@ defmodule Ecto.Schema do
   """
   defmacro embedded_schema([do: block]) do
     schema(nil, false, :binary_id, block)
+  end
+
+  @doc """
+  TODO
+  """
+  defmacro schema(scope, source, [do: block]) do
+    quote do
+      Module.put_attribute(__MODULE__, :association_scope, unquote(scope))
+      schema(unquote(source), [do: unquote(block)])
+    end
   end
 
   @doc """
@@ -1147,11 +1158,14 @@ defmodule Ecto.Schema do
   def __has_many__(mod, name, queryable, opts) do
     check_options!(opts, @valid_has_options, "has_many/3")
 
-    if is_list(queryable) and Keyword.has_key?(queryable, :through) do
-      association(mod, :many, name, Ecto.Association.HasThrough, queryable)
+    scoped_queryable = Ecto.Schema.__build_assoc_module__(mod, queryable)
+
+    if is_list(scoped_queryable) and Keyword.has_key?(scoped_queryable, :through) do
+      association(mod, :many, name, Ecto.Association.HasThrough, scoped_queryable)
     else
       struct =
-        association(mod, :many, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
+        association(mod, :many, name, Ecto.Association.Has, [queryable: scoped_queryable] ++ opts)
+
       Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
     end
   end
@@ -1160,11 +1174,13 @@ defmodule Ecto.Schema do
   def __has_one__(mod, name, queryable, opts) do
     check_options!(opts, @valid_has_options, "has_one/3")
 
-    if is_list(queryable) and Keyword.has_key?(queryable, :through) do
-      association(mod, :one, name, Ecto.Association.HasThrough, queryable)
+    scoped_queryable = Ecto.Schema.__build_assoc_module__(mod, queryable)
+
+    if is_list(scoped_queryable) and Keyword.has_key?(scoped_queryable, :through) do
+      association(mod, :one, name, Ecto.Association.HasThrough, scoped_queryable)
     else
       struct =
-        association(mod, :one, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
+        association(mod, :one, name, Ecto.Association.Has, [queryable: scoped_queryable] ++ opts)
       Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
     end
   end
@@ -1175,6 +1191,8 @@ defmodule Ecto.Schema do
   @doc false
   def __belongs_to__(mod, name, queryable, opts) do
     check_options!(opts, @valid_belongs_to_options, "belongs_to/3")
+
+    scoped_queryable = Ecto.Schema.__build_assoc_module__(mod, queryable)
 
     opts = Keyword.put_new(opts, :foreign_key, :"#{name}_id")
     foreign_key_type = opts[:type] || Module.get_attribute(mod, :foreign_key_type)
@@ -1188,7 +1206,7 @@ defmodule Ecto.Schema do
     end
 
     struct =
-      association(mod, :one, name, Ecto.Association.BelongsTo, [queryable: queryable] ++ opts)
+      association(mod, :one, name, Ecto.Association.BelongsTo, [queryable: scoped_queryable] ++ opts)
     Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
   end
 
@@ -1198,22 +1216,41 @@ defmodule Ecto.Schema do
   def __many_to_many__(mod, name, queryable, opts) do
     check_options!(opts, @valid_many_to_many_options, "many_to_many/3")
 
+    join_through = Keyword.get(opts, :join_through, nil)
+
+    scoped_opts = if join_through && is_atom(join_through) do
+      scoped_join_through =
+        Ecto.Schema.__build_assoc_module__(mod, join_through)
+
+      Keyword.put(opts, :join_through, scoped_join_through)
+    else
+      opts
+    end
+
+    scoped_queryable = Ecto.Schema.__build_assoc_module__(mod, queryable)
+
     struct =
-      association(mod, :many, name, Ecto.Association.ManyToMany, [queryable: queryable] ++ opts)
+      association(mod, :many, name, Ecto.Association.ManyToMany, [queryable: scoped_queryable] ++ scoped_opts)
     Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
   end
 
   @doc false
   def __embeds_one__(mod, name, schema, opts) do
     check_options!(opts, [:strategy, :on_replace], "embeds_one/3")
-    embed(mod, :one, name, schema, opts)
+
+    scoped_schema = Ecto.Schema.__build_assoc_module__(mod, schema)
+
+    embed(mod, :one, name, scoped_schema, opts)
   end
 
   @doc false
   def __embeds_many__(mod, name, schema, opts) do
     check_options!(opts, [:strategy, :on_replace], "embeds_many/3")
+
+    scoped_schema = Ecto.Schema.__build_assoc_module__(mod, schema)
+
     opts = Keyword.put(opts, :default, [])
-    embed(mod, :many, name, schema, opts)
+    embed(mod, :many, name, scoped_schema, opts)
   end
 
   ## Quoted callbacks
@@ -1327,6 +1364,26 @@ defmodule Ecto.Schema do
       def __schema__(:autogenerate), do: unquote(Macro.escape(insert))
       def __schema__(:autoupdate), do: unquote(Macro.escape(update))
     end
+  end
+
+  @doc false
+  def __build_assoc_module__(mod, {table, queryable}) do
+    {table, __build_assoc_module__(mod, queryable)}
+  end
+  def __build_assoc_module__(mod, queryable) when is_list(queryable) do
+    if Keyword.has_key?(queryable, :through) do
+      through_queryable = Keyword.get(queryable, :through)
+      scoped_queryable = __build_assoc_module__(mod, through_queryable)
+
+      Keyword.put(queryable, :through, scoped_queryable)
+    else
+      queryable
+    end
+  end
+  def __build_assoc_module__(mod, queryable) do
+    if (scope = Module.get_attribute(mod, :association_scope)),
+      do: Module.concat([scope, queryable]),
+      else: queryable
   end
 
   ## Private

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -25,4 +25,27 @@ defmodule Ecto.EmbeddedTest do
     assert Author.__schema__(:embed, :posts) ==
       %Embedded{field: :posts, cardinality: :many, owner: Author, on_replace: :delete, related: Post}
   end
+
+  defmodule ScopedAuthor do
+    use Ecto.Schema
+
+    schema Scoped, "authors" do
+      field :name, :string
+
+      embeds_one :profile, Profile, on_replace: :delete
+      embeds_one :post, Post
+      embeds_many :posts, Post, on_replace: :delete
+    end
+  end
+
+  test "__schema__, scoped" do
+    assert ScopedAuthor.__schema__(:embeds) ==
+      [:profile, :post, :posts]
+
+    assert ScopedAuthor.__schema__(:embed, :profile) ==
+      %Embedded{field: :profile, cardinality: :one, owner: ScopedAuthor, on_replace: :delete, related: Scoped.Profile}
+
+    assert ScopedAuthor.__schema__(:embed, :posts) ==
+      %Embedded{field: :posts, cardinality: :many, owner: ScopedAuthor, on_replace: :delete, related: Scoped.Post}
+  end
 end


### PR DESCRIPTION
As discussed in #1610, this PR adds the option to scope Ecto relations so that no compile-time dependencies are created. 

I still have some doubts about the implementation/tests, so I wanted to make sure I'm on the right track before heading out to write the docs. I have added inline comments to the points I have doubts.

I couldn't find a good way to decide whether or not to scope custom types -- like Ecto.Date. I struggled for some time with this and wasn't able to get to a solution that looked good.

Fixes #1610 

