### PR TITLE
Mention `keys` at `Ecto.Changeset.add_error` docs

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1015,6 +1015,10 @@ defmodule Ecto.Changeset do
   @doc """
   Adds an error to the changeset.
 
+  An additional keyword list `keys` can be passed to provide additional
+  contextual information for the error. This is useful when using
+  `traverse_errors`
+
   ## Examples
 
       iex> changeset = change(%Post{}, %{title: ""})
@@ -1024,6 +1028,12 @@ defmodule Ecto.Changeset do
       iex> changeset.valid?
       false
 
+      iex> changeset = change(%Post{}, %{title: ""})
+      iex> changeset = add_error(changeset, :title, "empty", additional: "info")
+      iex> changeset.errors
+      [title: {"empty", [additional: "info"]}]
+      iex> changeset.valid?
+      false
   """
   @spec add_error(t, atom, String.t, Keyword.t) :: t
   def add_error(%{errors: errors} = changeset, key, message, keys \\ []) when is_binary(message) do


### PR DESCRIPTION
I ended up doing a lot of complicated logic to deal with errors in my app. In
the end, I was able to remove all the complication using the `keys` parameter of
`Ecto.Changeset.add_error` in combination with `Ecto.Changeset.traverse_errors`.

In my opinion, the docs of `add_error` where a bit lacking. I had to read the
source code & browse the issue tracker to understand what actually was happening
(#1341 in special)

I'm adding a mention to the `keys` parameter and `traverse_errors` in the hopes
that people won't follow the same path as I did :)

Also, since there were no tests using the `keys` parameter, I'm modifying existing ones
for `add_error` and `traverse_errors` to use it. Is that ok?

The doctests for `Ecto.Changeset` are not being included.

Is that intended? I tried to activate it with little success, so I'd guess its intentional.

Never used doctests before =x
