### PR TITLE
Allow {"prefix", "source"} in from

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -265,6 +265,11 @@ defmodule Ecto.Query do
   prefix, so operations like update and delete will be applied to the
   proper prefix. In case you want to manually set the prefix for new data,
   specially on insert, use `Ecto.put_meta/2`.
+
+  Schemaless queries can use `{"prefix", "source"}` as the query source
+  to directly create a query with the required prefix. This is especially
+  useful when working with `Ecto.Repo.update_all/3` and mirrors the source
+  specification of `Ecto.Repo.insert_all/3`
   """
 
   defstruct [prefix: nil, sources: nil, from: nil, joins: [], wheres: [], select: nil,

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -66,7 +66,10 @@ defmodule Ecto.Query.Builder.From do
           # When a binary is used, there is no schema
           {1, query(nil, source, nil)}
 
-        {source, schema} when is_binary(source) ->
+        {prefix, source} when is_binary(prefix) and is_binary(source) ->
+          {1, query(prefix, source, nil)}
+
+        {source, schema} when is_binary(source) and is_atom(schema) ->
           prefix = quote do: unquote(schema).__schema__(:prefix)
           {1, query(prefix, source, schema)}
 

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -43,4 +43,6 @@ end
 defimpl Ecto.Queryable, for: Tuple do
   def to_query(from = {source, schema}) when is_binary(source) and is_atom(schema),
     do: %Ecto.Query{from: from, prefix: schema.__schema__(:prefix)}
+  def to_query({prefix, source}) when is_binary(prefix) and is_binary(source),
+    do: %Ecto.Query{from: {source, nil}, prefix: prefix}
 end

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -327,6 +327,10 @@ defmodule Ecto.Adapters.MySQLTest do
     query = from(m in Schema, update: [set: [x: 0]]) |> normalize(:update_all)
     assert SQL.update_all(%{query | prefix: "prefix"}) ==
            ~s{UPDATE `prefix`.`schema` AS s0 SET `x` = 0}
+
+    query = from(m in {"prefix", "schema"}, update: [set: [x: 0]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE `prefix`.`schema` AS s0 SET `x` = 0}
   end
 
   test "delete all" do
@@ -350,6 +354,9 @@ defmodule Ecto.Adapters.MySQLTest do
   test "delete all with prefix" do
     query = Schema |> Queryable.to_query |> normalize
     assert SQL.delete_all(%{query | prefix: "prefix"}) == ~s{DELETE s0.* FROM `prefix`.`schema` AS s0}
+
+    query = {"prefix", "schema"} |> Queryable.to_query |> normalize
+    assert SQL.delete_all(query) == ~s{DELETE s0.* FROM `prefix`.`schema` AS s0}
   end
 
   ## Joins

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -410,6 +410,10 @@ defmodule Ecto.Adapters.PostgresTest do
     query = from(m in Schema, update: [set: [x: 0]]) |> normalize(:update_all)
     assert SQL.update_all(%{query | prefix: "prefix"}) ==
            ~s{UPDATE "prefix"."schema" AS s0 SET "x" = 0}
+
+    query = from(m in {"prefix", "schema"}, update: [set: [x: 0]]) |> normalize(:update_all)
+    assert SQL.update_all(query) ==
+           ~s{UPDATE "prefix"."schema" AS s0 SET "x" = 0}
   end
 
   test "delete all" do
@@ -441,6 +445,9 @@ defmodule Ecto.Adapters.PostgresTest do
   test "delete all with prefix" do
     query = Schema |> Queryable.to_query |> normalize
     assert SQL.delete_all(%{query | prefix: "prefix"}) == ~s{DELETE FROM "prefix"."schema" AS s0}
+
+    query = {"prefix", "schema"} |> Queryable.to_query |> normalize
+    assert SQL.delete_all(query) == ~s{DELETE FROM "prefix"."schema" AS s0}
   end
 
   ## Joins


### PR DESCRIPTION
This mirrors what we have in insert_all - it was surprising that you
could do:

    insert_all({"prefix", "source"}, [%{x: 1])

But using the same in update_all or delete_all would fail:

    update_all({"prefix", "source"}, set: [x: 0])

\cc @josevalim I'm opening this as a PR, as I'm not 100% convinced about this feature.