### PR TITLE
Ecto.Migration.timestamps/1 amendments

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -626,25 +626,28 @@ defmodule Ecto.Migration do
   @doc """
   Adds `:inserted_at` and `:updated_at` timestamps columns.
 
-  Those columns are of `:datetime` type and by default cannot
-  be null. `opts` can be given to customize the generated
-  fields.
+  Those columns are of `:datetime` or `:date` type
+  and by default cannot be null.
+  `opts` can be given to customize the generated fields.
 
   ## Options
 
-    * `:inserted_at` -  the name of the column for insertion times
-    * `:updated_at` - the name of the column for update times
+    * `:inserted_at` -  the name of the column for insertion times, providing `false` disables column
+    * `:updated_at` - the name of the column for update times, providing `false` disables column
+    * `:type` - column type, one of `:datetime` (default) or `:date`
   """
   def timestamps(opts \\ []) do
     opts = Keyword.put_new(opts, :null, false)
 
-    inserted_at = opts[:inserted_at] || :inserted_at
-    updated_at = opts[:updated_at] || :updated_at
+    inserted_at = opts[:inserted_at]
+    updated_at = opts[:updated_at]
+    type = opts[:type] || :datetime
+    unless type in [:datetime, :date], do: raise ArgumentError, "unknown :type value: #{inspect type}"
 
-    opts = Keyword.drop opts, [:inserted_at, :updated_at]
+    opts = Keyword.drop opts, [:inserted_at, :updated_at, :type]
 
-    add(inserted_at, :datetime, opts)
-    add(updated_at, :datetime, opts)
+    unless inserted_at == false, do: add(inserted_at || :inserted_at, type, opts)
+    unless updated_at == false, do: add(updated_at || :updated_at, type, opts)
   end
 
   @doc """

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -126,6 +126,38 @@ defmodule Ecto.MigrationTest do
               [{:add, :title, :string, []}]}
   end
 
+  test "forward: creates a table without updated_at timestamp" do
+    create table = table(:posts, primary_key: false) do
+      timestamps(inserted_at: :created_at, updated_at: false)
+    end
+    flush()
+
+    assert last_command() ==
+           {:create, table,
+              [{:add, :created_at, :datetime, [null: false]}]}
+  end
+
+  test "forward: creates a table with timestamps of type date" do
+    create table = table(:posts, primary_key: false) do
+      timestamps(inserted_at: :inserted_on, updated_at: :updated_on, type: :date)
+    end
+    flush()
+
+    assert last_command() ==
+           {:create, table,
+              [{:add, :inserted_on, :date, [null: false]},
+               {:add, :updated_on, :date, [null: false]}]}
+  end
+
+  test "forward: raises on invalid timestamps type" do
+    assert_raise ArgumentError, "unknown :type value: :time", fn ->
+      create table(:posts, primary_key: false) do
+        timestamps(type: :time)
+      end
+      flush()
+    end
+  end
+
   test "forward: creates an empty table" do
     create table = table(:posts)
     flush()


### PR DESCRIPTION
#1646 
Allow passing false to disable a timestamp field:

```elixir
create table(:posts) do
  timestamps(inserted_at: :created_at, updated_at: false)
end
```

Add option type for passing the field type:

```elixir
create table(:posts) do
  timestamps(inserted_at: :inserted_on, updated_at: :updated_on, type: :date)
end
```