### PR TITLE
Add Join Schema example to many_to_many docs

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -934,6 +934,7 @@ defmodule Ecto.Schema do
         schema "user_organisation" do
           belongs_to :user, User
           belongs_to :organization, Organization
+          timestamps # Added bonus, a join schema will also allow you to set timestamps
         end
 
         def changeset(struct, params \\ %{}) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -919,6 +919,55 @@ defmodule Ecto.Schema do
       [post] = Repo.all(from(p in Post, where: p.id == 42, preload: :tags))
       post.tags #=> [%Tag{...}, ...]
 
+  ## Join Schema Example
+
+  You may prefer to use a join schema to handle many_to_many associations. The
+  decoupled nature of Ecto allows us to create a "join" struct which 
+  `belongs_to` both sides of the many to many association.
+
+  In our example, a User has and belongs to many Organizations
+
+      defmodule UserOrganization do
+        use Ecto.Schema
+
+        @primary_key false
+        schema "user_organisation" do
+          belongs_to :user, User
+          belongs_to :organization, Organization
+        end
+
+        def changeset(struct, params \\ %{}) do
+          struct
+          |> cast(params, [:user_id, :organization_id])
+          |> validate_required([:user_id, :organization_id])
+          # Maybe do some counter caching here!
+        end
+      end
+
+      defmodule User do
+        use Ecto.Schema
+
+        schema "users" do
+          many_to_many :organizations, join_through: UserOrganization
+        end
+      end
+
+      defmodule Organization do
+        use Ecto.Schema
+
+        schema "organizations" do
+          many_to_many :users, join_through: UserOrganization
+        end
+      end
+
+      # Then to create the association, pass in the ID's of an existing
+      # User and Organization to UserOrganization.changeset
+      changeset = UserOrganization.changeset(%UserOrganization{}, %{user_id: id, organization_id: id})
+
+      case Repo.insert(changeset) do
+        {:ok, assoc} -> # Assoc was created!
+        {:error, changeset} -> # Handle the error
+      end
   """
   defmacro many_to_many(name, queryable, opts \\ []) do
     quote do


### PR DESCRIPTION
What it says on the tin!

I noticed that a "join" schema example was not present in the docs for `many_to_many` associations. A common question amongst newcomers to Ecto is how to manage them. I personally believe this method is the easiest and most efficient

1. Supports timestamps.
2. Distinct changeset function allows easy counter caching, for starters.
3. In the case of a web app, this allows for logical extraction of assoc creation (in this case) to a controller named `UserOrganizationController`, for example, which keeps the app restful and reasonable.