### PR TITLE
Update docs: Ecto.Pools.Poolboy is now DBConnection.Poolboy

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -18,7 +18,7 @@ defmodule Ecto.Adapters.MySQL do
   recompilation in order to make an effect.
 
     * `:adapter` - The adapter name, in this case, `Ecto.Adapters.MySQL`
-    * `:pool` - The connection pool module, defaults to `Ecto.Pools.Poolboy`
+    * `:pool` - The connection pool module, defaults to `DBConnection.Poolboy`
     * `:pool_timeout` - The default timeout to use on pool calls, defaults to `5000`
     * `:timeout` - The default timeout to use on queries, defaults to `15000`
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -26,7 +26,7 @@ defmodule Ecto.Adapters.Postgres do
 
     * `:adapter` - The adapter name, in this case, `Ecto.Adapters.Postgres`
     * `:name`- The name of the Repo supervisor process
-    * `:pool` - The connection pool module, defaults to `Ecto.Pools.Poolboy`
+    * `:pool` - The connection pool module, defaults to `DBConnection.Poolboy`
     * `:pool_timeout` - The default timeout to use on pool calls, defaults to `5000`
     * `:timeout` - The default timeout to use on queries, defaults to `15000`
 


### PR DESCRIPTION
It looks like `Ecto.Pools.Poolboy` no longer exists.