### PR TITLE
Update docs: Adapter options are passed to pool

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -10,7 +10,9 @@ defmodule Ecto.Adapters.MySQL do
 
   MySQL options split in different categories described
   below. All options should be given via the repository
-  configuration.
+  configuration. These options are also passed to the module
+  specified in the `:pool` option, so check that module's
+  documentation for more options.
 
   ### Compile time options
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -17,7 +17,9 @@ defmodule Ecto.Adapters.Postgres do
 
   Postgres options split in different categories described
   below. All options should be given via the repository
-  configuration.
+  configuration. These options are also passed to the module
+  specified in the `:pool` option, so check that module's
+  documentation for more options.
 
   ### Compile time options
 


### PR DESCRIPTION
This is related to #1671.

I'm new to Ecto (and Elixir) and I was having trouble figuring out how to configure the pool size. [This documentation in `Ecto.Repo`](https://github.com/elixir-ecto/ecto/blob/b8658b04b21969a01e351a5839658dd59da8f8ce/lib/ecto/repo.ex#L26-L28) pointed me to the documentation for `Ecto.Adapters.Postgres`, which was great. But I had to dig through the code to realize that these options were also passed to the pool module and that I could find additional options in the docs for [`DBConnection.Poolboy`](https://hexdocs.pm/db_connection/DBConnection.Poolboy.html).

Hopefully, this documentation update will make this more clear to other developers who are new to Ecto.

Thanks!
