### PR TITLE
Allow inserting association without primary keys

### DIFF
--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -333,6 +333,18 @@ defmodule Ecto.Changeset.BelongsToTest do
       Relation.change(assoc, [name: "michal"], profile)
     assert changeset.action == :update
     assert changeset.changes == %{name: "michal"}
+
+    profile = %Profile{name: "other"}
+
+    assert {:ok, changeset, true, false} =
+      Relation.change(assoc, %{name: "michal"}, profile)
+    assert changeset.action == :insert
+    assert changeset.changes == %{name: "michal"}
+
+    assert {:ok, changeset, true, false} =
+      Relation.change(assoc, [name: "michal"], profile)
+    assert changeset.action == :insert
+    assert changeset.changes == %{name: "michal"}
   end
 
   test "change belongs_to with struct" do
@@ -354,7 +366,7 @@ defmodule Ecto.Changeset.BelongsToTest do
 
   test "change belongs_to keeps appropriate action from changeset" do
     assoc = Author.__schema__(:association, :profile)
-    assoc_schema = %Profile{}
+    assoc_schema = %Profile{id: 1}
 
     # Adding
     changeset = %{Changeset.change(assoc_schema, name: "michal") | action: :insert}

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -446,6 +446,18 @@ defmodule Ecto.Changeset.EmbeddedTest do
       Relation.change(assoc, %{name: "michal"}, nil)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
+
+    profile = %Profile{name: "other"}
+
+    assert {:ok, changeset, true, false} =
+      Relation.change(assoc, %{name: "michal"}, profile)
+    assert changeset.action == :insert
+    assert changeset.changes == %{name: "michal"}
+
+    assert {:ok, changeset, true, false} =
+      Relation.change(assoc, [name: "michal"], profile)
+    assert changeset.action == :insert
+    assert changeset.changes == %{name: "michal"}
   end
 
   test "change embeds_one with structs" do
@@ -459,7 +471,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
   test "change embeds_one keeps appropriate action from changeset" do
     embed = Author.__schema__(:embed, :profile)
-    embed_schema = %Profile{}
+    embed_schema = %Profile{id: 1}
 
     # Adding
     changeset = %{Changeset.change(embed_schema, name: "michal") | action: :insert}
@@ -565,6 +577,18 @@ defmodule Ecto.Changeset.EmbeddedTest do
     assert {:ok, [changeset], true, false} =
       Relation.change(assoc, [[title: "hello"]], [post])
     assert changeset.action == :update
+    assert changeset.changes == %{title: "hello"}
+
+    post = %Post{title: "other"}
+
+    assert {:ok, [changeset], true, false} =
+      Relation.change(assoc, [%{title: "hello"}], [post])
+    assert changeset.action == :insert
+    assert changeset.changes == %{title: "hello"}
+
+    assert {:ok, [changeset], true, false} =
+      Relation.change(assoc, [[title: "hello"]], [post])
+    assert changeset.action == :insert
     assert changeset.changes == %{title: "hello"}
   end
 

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -557,6 +557,18 @@ defmodule Ecto.Changeset.HasAssocTest do
       Relation.change(assoc, [name: "michal"], profile)
     assert changeset.action == :update
     assert changeset.changes == %{name: "michal"}
+
+    profile = %Profile{name: "other"}
+
+    assert {:ok, changeset, true, false} =
+      Relation.change(assoc, %{name: "michal"}, profile)
+    assert changeset.action == :insert
+    assert changeset.changes == %{name: "michal"}
+
+    assert {:ok, changeset, true, false} =
+      Relation.change(assoc, [name: "michal"], profile)
+    assert changeset.action == :insert
+    assert changeset.changes == %{name: "michal"}
   end
 
   test "change has_one with structs" do
@@ -585,7 +597,7 @@ defmodule Ecto.Changeset.HasAssocTest do
 
   test "change has_one keeps appropriate action from changeset" do
     assoc = Author.__schema__(:association, :profile)
-    assoc_schema = %Profile{}
+    assoc_schema = %Profile{id: 1}
 
     # Adding
     changeset = %{Changeset.change(assoc_schema, name: "michal") | action: :insert}
@@ -692,6 +704,18 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert {:ok, [changeset], true, false} =
       Relation.change(assoc, [[title: "hello"]], [post])
     assert changeset.action == :update
+    assert changeset.changes == %{title: "hello"}
+
+    post = %Post{title: "other"}
+
+    assert {:ok, [changeset], true, false} =
+      Relation.change(assoc, [%{title: "hello"}], [post])
+    assert changeset.action == :insert
+    assert changeset.changes == %{title: "hello"}
+
+    assert {:ok, [changeset], true, false} =
+      Relation.change(assoc, [[title: "hello"]], [post])
+    assert changeset.action == :insert
     assert changeset.changes == %{title: "hello"}
   end
 


### PR DESCRIPTION
When there's already a value for an association, but the primary keys
are empty, treat it as a new value and allow a changeset with insert

Closes #1621

---

I'm opening this as a PR, since I'm not 100% sure of this changes and I would love a review.