### PR TITLE
Fix typo in comments regarding foreign key type.

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -684,7 +684,7 @@ defmodule Ecto.Schema do
       field, implying the user is defining the field manually elsewhere
 
     * `:type` - Sets the type of automatically defined `:foreign_key`.
-      Defaults to: `:id` and can be set per schema via `@foreign_key_type`
+      Defaults to: `:integer` and can be set per schema via `@foreign_key_type`
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be


### PR DESCRIPTION
- Comment erroneously suggested that the type of the foreign key in a
`belongs_to` association defaults to `:id`, when it in fact defaults to
`:integer`.