### PR TITLE
Partial denormalization: duplicate parent fields

### DIFF
--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -8,6 +8,11 @@ defmodule Ecto.Integration.Migration do
       timestamps()
     end
 
+    create table(:groups) do
+      add :name, :string
+      timestamps()
+    end
+
     create table(:posts) do
       add :title, :string, size: 100
       add :counter, :integer
@@ -22,6 +27,7 @@ defmodule Ecto.Integration.Migration do
       add :intensity, :float
       add :author_id, :integer
       add :posted, :date
+      add :group_id, references(:groups)
       timestamps null: true
     end
 
@@ -52,6 +58,7 @@ defmodule Ecto.Integration.Migration do
       add :lock_version, :integer, default: 1
       add :post_id, references(:posts)
       add :author_id, references(:users)
+      add :group_id, references(:groups)
     end
 
     create table(:customs, primary_key: false) do
@@ -102,7 +109,7 @@ defmodule Ecto.Integration.Migration do
       add :user_id, references(:users), primary_key: true
       timestamps()
     end
-    
+
     create unique_index(:posts_users_composite_pk, [:post_id, :user_id])
   end
 end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -387,7 +387,7 @@ defmodule Ecto.Repo.Schema do
   defp metadata(%{__struct__: schema, __meta__: %{context: context, source: {prefix, source}}}, opts) do
     %{autogenerate_id: schema.__schema__(:autogenerate_id),
       context: context,
-      schema: schema, 
+      schema: schema,
       source: {Keyword.get(opts, :prefix, prefix), source}}
   end
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -292,6 +292,7 @@ defmodule Ecto.Schema do
       @timestamps_opts []
       @foreign_key_type :id
       @schema_prefix nil
+      @duplicated_parent_fields nil
 
       Module.register_attribute(__MODULE__, :ecto_primary_keys, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_fields, accumulate: true)
@@ -357,6 +358,9 @@ defmodule Ecto.Schema do
           other ->
             raise ArgumentError, "@primary_key must be false or {name, type, opts}"
         end
+
+      if @duplicated_parent_fields && !is_list(@duplicated_parent_fields), do: raise ArgumentError, "@duplicated_parent_fields must be a list"
+      Module.put_attribute(__MODULE__, :struct_fields, {:__duplicated_parent_fields__, @duplicated_parent_fields})
 
       try do
         import Ecto.Schema


### PR DESCRIPTION
Hi, I understand that this PR seems odd and probably will not be merged.
But maybe this kind of feature is interesting or there is already ability to do this.

### The problem

**Store chosen foreign key(s) of a parent table for better queries performance.**

### Example

![normilized](https://cloud.githubusercontent.com/assets/1169424/18420816/44169bc0-7884-11e6-9692-7dd3c292af6d.png)


Model `Group` has many `posts` (model `Post`),
model `Post` has many `comments` (model `Comment`)

table `posts` stores foreign key `group_id`
table `comments` stores foreign key `post_id`

To check if user has access to the `Comment` I need to check `group_id` which is stored in `posts`.
So I need to do join table or an extra query on every read.

### Solution

![partiallly_denormilized](https://cloud.githubusercontent.com/assets/1169424/18420817/4d39ac56-7884-11e6-9afd-a271ecf8310c.png)


Add column `group_id` to table `comments` and copy value from model `Post`
on creating `Comment` and on updating `Post` group (for all post's comments).

It is easy to do this almost everywhere but not in `cast_assoc`.

Please see my changes and maybe you have some better suggestions.

Thanks

