### PR TITLE
Fix `put_assoc` with schema_prefix

### DIFF
--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -210,8 +210,8 @@ defmodule Ecto.MultiTest do
     assert {:ok, changes} = TestRepo.transaction(multi)
     assert_received {:transaction, _}
     assert {:messages, actions} = Process.info(self(), :messages)
-    assert actions == [:insert, :update, :delete, {:insert_all, "comments", [[x: 1]]},
-                       {:update_all, "comments"}, {:delete_all, "comments"}]
+    assert actions == [{:insert, {nil, "comments"}}, {:update, {nil, "comments"}}, {:delete, {nil, "comments"}}, {:insert_all, {nil, "comments"}, [[x: 1]]},
+                       {:update_all, {nil, "comments"}}, {:delete_all, {nil, "comments"}}]
     assert %Comment{} = changes.insert
     assert %Comment{} = changes.update
     assert %Comment{} = changes.delete
@@ -234,7 +234,7 @@ defmodule Ecto.MultiTest do
     assert {:error, :run, "error from run", changes} = TestRepo.transaction(multi)
     assert_received {:transaction, _}
     assert_received {:rollback, _}
-    assert {:messages, [:insert]} == Process.info(self(), :messages)
+    assert {:messages, [{:insert, {nil, "comments"}}]} == Process.info(self(), :messages)
     assert %Comment{} = changes.insert
     refute Map.has_key?(changes, :run)
     refute Map.has_key?(changes, :update)
@@ -255,7 +255,7 @@ defmodule Ecto.MultiTest do
     assert {:error, :update, error, changes} = TestRepo.transaction(multi)
     assert_received {:transaction, _}
     assert_received {:rollback, _}
-    assert {:messages, [:insert]} == Process.info(self(), :messages)
+    assert {:messages, [{:insert, {nil, "comments"}}]} == Process.info(self(), :messages)
     assert %Comment{} = changes.insert
     assert "ok" == changes.run
     assert error.errors == [x: {"has already been taken", []}]

--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -53,29 +53,29 @@ defmodule Ecto.Repo.AutogenerateTest do
     default = TestRepo.insert!(%Company{})
     assert %NaiveDateTime{} = default.inserted_at
     assert %NaiveDateTime{} = default.updated_at
-    assert_received :insert
+    assert_received {:insert, _}
 
     # No change
     changeset = Ecto.Changeset.change(%Company{id: 1})
     default = TestRepo.update!(changeset)
     refute default.inserted_at
     refute default.updated_at
-    refute_received :update
+    refute_received {:update, _}
 
     # Change in children
     changeset = Ecto.Changeset.change(%Company{id: 1})
     default = TestRepo.update!(Ecto.Changeset.put_assoc(changeset, :manager, %Manager{}))
     refute default.inserted_at
     refute default.updated_at
-    assert_received :insert
-    refute_received :update
+    assert_received {:insert, _}
+    refute_received {:update, _}
 
     # Force change
     changeset = Ecto.Changeset.change(%Company{id: 1})
     default = TestRepo.update!(changeset, force: true)
     refute default.inserted_at
     assert %NaiveDateTime{} = default.updated_at
-    assert_received :update
+    assert_received {:update, _}
   end
 
   test "does not set inserted_at and updated_at values if they were previously set" do

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -50,6 +50,21 @@ defmodule Ecto.Repo.BelongsToTest do
     assert assoc.inserted_at
   end
 
+  test "handles assocs on insert preserving parent schema_prefix" do
+    sample = %MyAssoc{x: "xyz"}
+
+    changeset =
+      %MySchema{}
+      |> Ecto.put_meta(prefix: "prefix")
+      |> Ecto.Changeset.change
+      |> Ecto.Changeset.put_assoc(:assoc, sample)
+    schema = TestRepo.insert!(changeset)
+    assoc = schema.assoc
+
+    {schema_prefix, _} = assoc.__meta__.source
+    assert schema_prefix == "prefix"
+  end
+
   test "handles assocs from struct on insert" do
     schema = TestRepo.insert!(%MySchema{assoc: %MyAssoc{x: "xyz"}})
     assoc = schema.assoc
@@ -165,6 +180,22 @@ defmodule Ecto.Repo.BelongsToTest do
     refute_received {:rollback, _}
   end
 
+  test "handles valid nested assocs on insert preserving parent schema_prefix" do
+    assoc =
+      %MyAssoc{x: "xyz"}
+      |> Ecto.Changeset.change
+      |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+    changeset =
+      %MySchema{}
+      |> Ecto.put_meta(prefix: "prefix")
+      |> Ecto.Changeset.change
+      |> Ecto.Changeset.put_assoc(:assoc, assoc)
+    schema = TestRepo.insert!(changeset)
+
+    {schema_prefix, _} = schema.assoc.sub_assoc.__meta__.source
+    assert schema_prefix == "prefix"
+  end
+
   test "handles invalid nested assocs on insert" do
     sub_assoc_change = %{Ecto.Changeset.change(%SubAssoc{y: "xyz"}) | valid?: false}
     assoc =
@@ -214,6 +245,21 @@ defmodule Ecto.Repo.BelongsToTest do
     assert assoc.updated_at
   end
 
+    test "inserting assocs on update preserving parent schema_prefix" do
+    sample = %MyAssoc{x: "xyz"}
+
+    changeset =
+      %MySchema{id: 1}
+      |> Ecto.put_meta(prefix: "prefix")
+      |> Ecto.Changeset.change
+      |> Ecto.Changeset.put_assoc(:assoc, sample)
+    schema = TestRepo.update!(changeset)
+    assoc = schema.assoc
+
+    {schema_prefix, _} = assoc.__meta__.source
+    assert schema_prefix == "prefix"
+  end
+
   test "replacing assocs on update (on_replace: :delete)" do
     sample = %MyAssoc{id: 10, x: "xyz"} |> Ecto.put_meta(state: :loaded)
 
@@ -228,9 +274,9 @@ defmodule Ecto.Repo.BelongsToTest do
     assert assoc.x == "abc"
     assert assoc.id == schema.assoc_id
     assert assoc.updated_at
-    assert_received :update # Parent
-    assert_received :insert # New assoc
-    assert_received :delete # Old assoc
+    assert_received {:update, _} # Parent
+    assert_received {:insert, _} # New assoc
+    assert_received {:delete, _} # Old assoc
 
     # Replacing assoc with nil
     changeset =
@@ -240,9 +286,9 @@ defmodule Ecto.Repo.BelongsToTest do
     schema = TestRepo.update!(changeset)
     refute schema.assoc
     refute schema.assoc_id
-    assert_received :update # Parent
-    refute_received :insert # New assoc
-    assert_received :delete # Old assoc
+    assert_received {:update, _} # Parent
+    refute_received {:insert, _} # New assoc
+    assert_received {:delete, _} # Old assoc
   end
 
   test "replacing assocs on update (on_replace: :nilify)" do
@@ -259,9 +305,9 @@ defmodule Ecto.Repo.BelongsToTest do
     assert assoc.x == "abc"
     assert assoc.id == schema.nilify_assoc_id
     assert assoc.updated_at
-    assert_received :update # Parent
-    assert_received :insert # New assoc
-    refute_received :delete # Old assoc
+    assert_received {:update, _} # Parent
+    assert_received {:insert, _} # New assoc
+    refute_received {:delete, _} # Old assoc
 
     # Replacing assoc with nil
     changeset =
@@ -271,9 +317,9 @@ defmodule Ecto.Repo.BelongsToTest do
     schema = TestRepo.update!(changeset)
     refute schema.nilify_assoc
     refute schema.nilify_assoc_id
-    assert_received :update # Parent
-    refute_received :insert # New assoc
-    refute_received :delete # Old assoc
+    assert_received {:update, _} # Parent
+    refute_received {:insert, _} # New assoc
+    refute_received {:delete, _} # Old assoc
   end
 
   test "changing assocs on update raises if there is no id" do
@@ -305,7 +351,7 @@ defmodule Ecto.Repo.BelongsToTest do
     assert assoc.x == "abc"
     refute assoc.inserted_at
     assert assoc.updated_at
-    refute_received :delete # Same assoc should not emit delete
+    refute_received {:delete, _} # Same assoc should not emit delete
   end
 
   test "removing assocs on update raises if there is no id" do
@@ -348,6 +394,18 @@ defmodule Ecto.Repo.BelongsToTest do
       |> Ecto.Changeset.put_assoc(:assoc, nil)
     schema = TestRepo.update!(changeset)
     assert schema.assoc == nil
+  end
+
+  test "removing assocs on update preserving parent schema_prefix" do
+    assoc = %MyAssoc{x: "xyz", id: 1} |> Ecto.put_meta(state: :loaded)
+
+    changeset =
+      %MySchema{id: 1, assoc: assoc}
+      |> Ecto.put_meta(prefix: "prefix")
+      |> Ecto.Changeset.change
+      |> Ecto.Changeset.put_assoc(:assoc, nil)
+    TestRepo.update!(changeset)
+    assert_received {:delete, {"prefix", "my_assoc"}}
   end
 
   test "returns untouched changeset on invalid children on update" do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -243,13 +243,13 @@ defmodule Ecto.RepoTest do
       %MySchema{y: "loaded"}
       |> TestRepo.insert!
       |> Ecto.Changeset.cast(%{y: "updated"}, [:y])
-    assert_received :insert
+    assert_received {:insert, _}
 
     TestRepo.insert_or_update built
-    assert_received :insert
+    assert_received {:insert, _}
 
     TestRepo.insert_or_update loaded
-    assert_received :update
+    assert_received {:update, _}
   end
 
   test "insert_or_update fails on invalid states" do

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -49,14 +49,14 @@ defmodule Ecto.TestAdapter do
     {1, nil}
   end
 
-  def execute(_repo, _meta, {:nocache, {op, %{from: {source, _}}}}, _params, _preprocess, _opts) do
-    send self(), {op, source}
+  def execute(_repo, meta, {:nocache, {op, %{from: {source, _}}}}, _params, _preprocess, _opts) do
+    send self(), {op, {meta.prefix,source}}
     {1, nil}
   end
 
   ## Schema
 
-  def insert_all(_repo, %{source: {_, source}}, _header, rows, _returning, _opts) do
+  def insert_all(_repo, %{source: source}, _header, rows, _returning, _opts) do
     send self(), {:insert_all, source, rows}
     {1, nil}
   end
@@ -67,19 +67,19 @@ defmodule Ecto.TestAdapter do
     {:ok, [version: 1]}
   end
 
-  def insert(_repo, %{context: nil}, _fields, return, _opts),
-    do: send(self(), :insert) && {:ok, Enum.zip(return, 1..length(return))}
+  def insert(_repo, %{context: nil, source: source}, _fields, return, _opts),
+    do: send(self(), {:insert, source}) && {:ok, Enum.zip(return, 1..length(return))}
   def insert(_repo, %{context: {:invalid, _}=res}, _fields, _return, _opts),
     do: res
 
   # Notice the list of changes is never empty.
-  def update(_repo, %{context: nil}, [_|_], _filters, return, _opts),
-    do: send(self(), :update) && {:ok, Enum.zip(return, 1..length(return))}
+  def update(_repo, %{context: nil, source: source}, [_|_], _filters, return, _opts),
+    do: send(self(), {:update, source}) && {:ok, Enum.zip(return, 1..length(return))}
   def update(_repo, %{context: {:invalid, _}=res}, [_|_], _filters, _return, _opts),
     do: res
 
-  def delete(_repo, _schema_meta, _filter, _opts),
-    do: send(self(), :delete) && {:ok, []}
+  def delete(_repo, meta, _filter, _opts),
+    do: send(self(), {:delete, meta.source}) && {:ok, []}
 
   ## Transactions
 


### PR DESCRIPTION
# Inserting/Updating/Deleting associations through a changeset does not respect `schema_prefix`

```elixir
defmodule MyApp.Person do
  schema "people" do
    has_many :cats, MyApp.Cat
  end

  def changeset(model, params \\ %{}) do
    model
    |> cast(params, [:name], [])
    |> cast_assoc(:cats) # Is this needed? What does it even do?
  end
end

model = %MyApp.Person{}
|> Ecto.put_meta(prefix: "my_tenant_database")

MyApp.Person.changeset(model, %{name: "José"})
|> put_assoc(:cats, [%{name: "Fluffy"}])
|> MyApp.Repo.insert!
# => ERROR: Unknown table `cats`
```

# Expected result

Both a new Person and Cat get inserted into `my_tenant_database`.

# Actual result

An error message that the cats table does not exist on the global database.

# Solution

Copy the prefix from the parent changeset when it is set.

# Question

- I would love to add a test for this but I might need some pointers on where to start.
- I don't know the use of the `cast_assoc` inside the changeset, it seems to work without it, but the docs are quite vague as to what it is used for...