### PR TITLE
Force to use TCP socket when hostname is localhost

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -301,7 +301,7 @@ defmodule Ecto.Adapters.MySQL do
 
     host = opts[:hostname] || System.get_env("MYSQL_HOST") || "localhost"
     port = opts[:port] || System.get_env("MYSQL_TCP_PORT") || "3306"
-    args = ["--user", opts[:username], "--host", host, "--port", to_string(port)] ++ opt_args
+    args = ["--user", opts[:username], "--host", host, "--port", to_string(port), "--protocol=tcp"] ++ opt_args
     System.cmd(cmd, args, env: env, stderr_to_stdout: true)
   end
 end


### PR DESCRIPTION
It is PR to force to use only TCP socket in Ecto.Adapters.MySQL when hostname is localhost.
https://github.com/elixir-ecto/ecto/issues/1694