### PR TITLE
Ecto is not able to handle malformed UUID.

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -519,6 +519,25 @@ defmodule Ecto.Integration.RepoTest do
     assert_raise Ecto.NoResultsError, fn ->
       TestRepo.get!(Post, post1.id)
     end
+
+    assert_raise Ecto.NoResultsError, fn ->
+      TestRepo.get!(Post, "01") # With malformed
+    end
+  end
+
+  test "get(!) with UUID" do
+    post = TestRepo.insert!(%Post{uuid: nil})
+    malformed_uuid = "6fa459ea-ee8a-3ca4-894e-db77e160355"
+
+    assert TestRepo.get(Post, post.uuid) == post
+
+    assert_raise Ecto.NoResultsError, fn ->
+      TestRepo.get(Post, nil) # With empty
+    end
+
+    assert_raise Ecto.NoResultsError, fn ->
+      TestRepo.get(Post, malformed_uuid) # With malformed
+    end
   end
 
   test "get(!) with custom source" do


### PR DESCRIPTION
ordinary ID - can.

I think simple `Ecto.UUID.cast` should happen on input param to return an `:error` other then raising `cannot be cast to type`

Idea is to utilise existing `preprocess` in `lib/ecto/repo/queryable.ex` to perform validation/casting w/o raising error hence returning it to user. This will follow general logic of Ecto - return errors to use them in cond, case, and conditions.