### PR TITLE
Update `Multi.run/3` spec and docs

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -188,7 +188,7 @@ defmodule Ecto.Multi do
 
   Duplicated operations are not allowed.
   """
-  @spec merge(t, merge) :: t
+  @spec merge(t, (t -> {:ok | :error, any})) :: t
   def merge(%Multi{} = multi, merge) when is_function(merge, 1) do
     Map.update!(multi, :operations, &[{:merge, {:merge, merge}} | &1])
   end
@@ -274,7 +274,7 @@ defmodule Ecto.Multi do
   The function should return either `{:ok, value}` or `{:error, value}`, and
   receives changes so far as an argument.
   """
-  @spec run(t, name, run) :: t
+  @spec run(t, name, (t -> {:ok | :error, any})) :: t
   def run(multi, name, run) when is_function(run, 1) do
     add_operation(multi, name, {:run, run})
   end

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -274,9 +274,9 @@ defmodule Ecto.Multi do
   The function should return either `{:ok, value}` or `{:error, value}`, and
   receives changes so far as an argument.
   """
-  @spec run(t, name, fun) :: t
-  def run(multi, name, fun) when is_function(fun, 1) do
-    add_operation(multi, name, {:run, fun})
+  @spec run(t, name, run) :: t
+  def run(multi, name, run) when is_function(run, 1) do
+    add_operation(multi, name, {:run, run})
   end
 
   @doc """

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -274,9 +274,9 @@ defmodule Ecto.Multi do
   The function should return either `{:ok, value}` or `{:error, value}`, and
   receives changes so far as an argument.
   """
-  @spec run(t, name, run) :: t
-  def run(multi, name, run) when is_function(run, 1) do
-    add_operation(multi, name, {:run, run})
+  @spec run(t, name, fun) :: t
+  def run(multi, name, fun) when is_function(fun, 1) do
+    add_operation(multi, name, {:run, fun})
   end
 
   @doc """

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -284,7 +284,7 @@ defmodule Ecto.Multi do
 
   Similar to `run/3`, but allows to pass module name, function and arguments.
   The function should return either `{:ok, value}` or `{:error, value}`, and
-  will receive changes so far as the first argument (prepened to those passed in
+  will receive changes so far as the first argument (prepended to those passed in
   the call to the function).
   """
   @spec run(t, name, module, function, args) :: t


### PR DESCRIPTION
I noticed that the function argument to `Ecto.Multi.run` is named `run` itself. This goes against convention of naming function arguments `fun` and was probably just a typo! 😅 

A simple PR which updates the `run` function argument to `fun`, and also fixes an unrelated, small typo that I noticed