### PR TITLE
Replace grammatically incorrect "associated to" with "associated with"

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -452,7 +452,7 @@ defmodule Ecto.Integration.RepoTest do
       |> Ecto.Changeset.change
       |> Ecto.Changeset.no_assoc_constraint(:permalink)
       |> TestRepo.delete()
-    assert changeset.errors == [permalink: {"is still associated to this entry", []}]
+    assert changeset.errors == [permalink: {"is still associated with this entry", []}]
   end
 
   test "insert and update with failing child foreign key" do

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -471,7 +471,7 @@ defmodule Ecto do
 
   ## Examples
 
-  In the example below, we get all comments associated to the given
+  In the example below, we get all comments associated with the given
   post:
 
       post = Repo.get Post, 1

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -580,7 +580,7 @@ defmodule Ecto.Changeset do
       |> Ecto.Changeset.cast_assoc(:addresses)
 
   Once `cast_assoc/3` is called, Ecto will compare those parameters
-  with the addresses already associated to the user and act as follows:
+  with the addresses already associated with the user and act as follows:
 
     * If the parameter does not contain an ID, the parameter data
       will be passed to `changeset/2` with a new struct and become
@@ -1981,8 +1981,8 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:message` - the message in case the constraint check fails,
-      defaults to "is still associated to this entry" (for has_one)
-      and "are still associated to this entry" (for has_many)
+      defaults to "is still associated with this entry" (for has_one)
+      and "are still associated with this entry" (for has_many)
     * `:name` - the constraint name. By default, the constraint
       name is inferred from the association table + association
       field. May be required explicitly for complex cases
@@ -2030,8 +2030,8 @@ defmodule Ecto.Changeset do
     add_constraint(changeset, :exclude, to_string(constraint), match_type, field, {message, []})
   end
 
-  defp no_assoc_message(:one), do: "is still associated to this entry"
-  defp no_assoc_message(:many), do: "are still associated to this entry"
+  defp no_assoc_message(:one), do: "is still associated with this entry"
+  defp no_assoc_message(:many), do: "are still associated with this entry"
 
 
   defp add_constraint(changeset, type, constraint, match, field, error)

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -297,10 +297,10 @@ defmodule Ecto.Changeset.Relation do
         changeset
       action == :insert ->
         raise "cannot #{action} related #{inspect changeset.data} " <>
-              "because it is already associated to the given struct"
+              "because it is already associated with the given struct"
       true ->
         raise "cannot #{action} related #{inspect changeset.data} because " <>
-              "it already exists and it is not currently associated to the " <>
+              "it already exists and it is not currently associated with the " <>
               "given struct. Ecto forbids casting existing records through " <>
               "the association field for security reasons. Instead, set " <>
               "the foreign key value accordingly"

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -976,7 +976,7 @@ defmodule Ecto.Query do
       Repo.all from p in Post, preload: [:comments]
 
   The example above will fetch all posts from the database and then do
-  a separate query returning all comments associated to the given posts.
+  a separate query returning all comments associated with the given posts.
 
   However, often times, you want posts and comments to be selected and
   filtered in the same query. For such cases, you can explicitly tell

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -805,7 +805,7 @@ defmodule Ecto.Schema do
   to easily retrieve associated comments to a given post or
   task:
 
-      # Fetch all comments associated to the given task
+      # Fetch all comments associated with the given task
       Repo.all(assoc(task, :comments))
 
   Or all comments in a given table:

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -990,7 +990,7 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> no_assoc_constraint(:comments)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey", match: :exact,
-              error: {"are still associated to this entry", []}}]
+              error: {"are still associated with this entry", []}}]
 
     changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: :whatever, message: "exists")
     assert changeset.constraints ==
@@ -1002,7 +1002,7 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> no_assoc_constraint(:comment)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :comment, constraint: "comments_post_id_fkey", match: :exact,
-              error: {"is still associated to this entry", []}}]
+              error: {"is still associated with this entry", []}}]
 
     changeset = change(%Post{}) |> no_assoc_constraint(:comment, name: :whatever, message: "exists")
     assert changeset.constraints ==


### PR DESCRIPTION
Both default validation error messages and source code comments are affected by this change.