### PR TITLE
Fix Changeset.types type

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -237,7 +237,7 @@ defmodule Ecto.Changeset do
   @type constraint :: %{type: :unique, constraint: String.t, match: :exact | :suffix,
                         field: atom, message: error}
   @type data :: map()
-  @type types :: Keyword.t | map()
+  @type types :: map()
 
   @number_validators %{
     less_than:                {&</2,  "must be less than %{number}"},


### PR DESCRIPTION
Looks like it never used Keyword.t. I verified in the commit that
introduced schemaless changesets (019e2bc)