### PR TITLE
Rename example migration module

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -8,7 +8,7 @@ defmodule Ecto.Migration do
 
   Here is an example:
 
-      defmodule MyRepo.Migrations.CreatePosts do
+      defmodule MyRepo.Migrations.AddWeatherTable do
         use Ecto.Migration
 
         def up do
@@ -46,7 +46,7 @@ defmodule Ecto.Migration do
   `change/0` instead of `up/0` and `down/0`. For example, the
   migration above can be written as:
 
-      defmodule MyRepo.Migrations.CreatePosts do
+      defmodule MyRepo.Migrations.AddWeatherTable do
         use Ecto.Migration
 
         def change do


### PR DESCRIPTION
The example is about a Weather table and a few lines further down the
docs is a sample `mix ecto.gen.migration` that uses `add_weather_table`,
so it makes sense to change `CreatePosts` to `AddWeatherTable`.