### PR TITLE
Support passing `:ownership_timeout` when checking out a connection.

### DIFF
--- a/integration_test/sql/sandbox.exs
+++ b/integration_test/sql/sandbox.exs
@@ -127,4 +127,18 @@ defmodule Ecto.Integration.SandboxTest do
 
     assert_receive :success
   end
+
+  test "allows an ownership timeout to be passed for an individual `checkout` call" do
+    log = capture_log fn ->
+      :ok = Sandbox.checkout(TestRepo, ownership_timeout: 20)
+
+      Process.sleep(1000)
+
+      assert_raise DBConnection.OwnershipError, fn ->
+        TestRepo.all(Post)
+      end
+    end
+
+    assert log =~ ~r/timed out.*20ms/
+  end
 end


### PR DESCRIPTION
Fixes elixir-ecto/db_connection#62.

I wasn't sure how to test this so I'm hoping one of the Ecto maintainers can suggest a good way to do that.

Also, I wasn't sure if there were any other options that we should let be overriden by the `checkout` call.  For now it's just `:ownership_timeout` but the list can easily be expanded.

/cc @fishcakez 