### PR TITLE
Allow poison 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Ecto.Mixfile do
 
      # Optional
      {:sbroker, "~> 1.0-beta", optional: true},
-     {:poison, "~> 2.2", optional: true},
+     {:poison, "~> 2.2 or ~> 3.0", optional: true},
 
      # Docs
      {:ex_doc, "~> 0.12", only: :docs},


### PR DESCRIPTION
Unfortunately right now `inch_ex` depends on 2.x. I opened a PR [there](https://github.com/rrrene/inch_ex/pull/34) as well.