### PR TITLE
Do not run transaction for an empty Multi

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -375,6 +375,7 @@ defmodule Ecto.Multi do
   defp invalid_operation(_operation),
     do: nil
 
+  defp apply_operations({:ok, []}, _names, _repo, _wrap, _return), do: {:ok, %{}}
   defp apply_operations({:ok, operations}, names, repo, wrap, return) do
     wrap.(fn ->
       operations

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -14,6 +14,8 @@ defmodule Ecto.Repo.Queryable do
     adapter.transaction(repo, opts, fun)
   end
 
+  def transaction(_adapter, _repo, %Ecto.Multi{operations:  []}, _opts),
+    do: {:ok, %{}}
   def transaction(adapter, repo, %Ecto.Multi{} = multi, opts) do
     wrap   = &adapter.transaction(repo, opts, &1)
     return = &adapter.rollback(repo, &1)

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -14,8 +14,6 @@ defmodule Ecto.Repo.Queryable do
     adapter.transaction(repo, opts, fun)
   end
 
-  def transaction(_adapter, _repo, %Ecto.Multi{operations:  []}, _opts),
-    do: {:ok, %{}}
   def transaction(adapter, repo, %Ecto.Multi{} = multi, opts) do
     wrap   = &adapter.transaction(repo, opts, &1)
     return = &adapter.rollback(repo, &1)

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -222,6 +222,12 @@ defmodule Ecto.MultiTest do
     refute Map.has_key?(changes.run, :update)
   end
 
+  test "Repo.transaction with empty Multi" do
+    assert {:ok, changes} = TestRepo.transaction(Multi.new)
+    refute_received {:transaction, _}
+    assert changes == %{}
+  end
+
   test "Repo.transaction rolling back from run" do
     changeset = Changeset.change(%Comment{id: 1}, x: 1)
     multi =


### PR DESCRIPTION
This change bypasses the transaction for a `Multi` that has no operations.