### PR TITLE
Add Ecto.Multi.empty?/1

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -353,6 +353,15 @@ defmodule Ecto.Multi do
   defp format_operation(other),
     do: other
 
+  @doc """
+  Determines if the `Ecto.Multi` is empty.
+
+  Returns `true` if `multi` is empty, otherwise `false`.
+  """
+  @spec empty?(t) :: true | false
+  def empty?(%Multi{operations: []}), do: true
+  def empty?(_multi), do: false
+
   @doc false
   def __apply__(%Multi{} = multi, repo, wrap, return) do
     multi.operations

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -360,4 +360,14 @@ defmodule Ecto.MultiTest do
       TestRepo.transaction(multi)
     end
   end
+
+  test "empty?/1" do
+    assert Multi.empty?(Multi.new)
+
+    changeset = Changeset.change(%Comment{})
+    multi     =
+      Multi.new
+      |> Multi.insert(:comment, changeset)
+    refute Multi.empty?(multi)
+  end
 end


### PR DESCRIPTION
This adds a simple check for a `Multi` with no operations.