### PR TITLE
Correct configuration typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ config :my_app, Sample.Repo,
   database: "ecto_simple",
   username: "postgres",
   password: "postgres",
-  host: "localhost",
+  hostname: "localhost",
   port: "5432"
 
 # In your application code


### PR DESCRIPTION
So this doesn't seem to be a issue when running on local, as Ecto will fallback to localhost, if hostname is nil. But hopefully, now there won't be connection confusing, when using Ecto in docker or production, for people who copy pasted the configuration from the readme, as i did 😄 .