### PR TITLE
Fix assoc schema_prefix on through-associations

### DIFF
--- a/integration_test/cases/assoc.exs
+++ b/integration_test/cases/assoc.exs
@@ -140,6 +140,25 @@ defmodule Ecto.Integration.AssocTest do
     assert u2.id == uid2
   end
 
+  test "assoc has_many with schema_prefix" do
+    u = TestRepo.insert!(%User{})
+    q = Ecto.assoc(u, :posts_with_prefix)
+    {sql, _} = Ecto.Adapters.SQL.to_sql(:all, TestRepo, q)
+
+    assert sql =~ ~r/ FROM ["`]my_prefix["`]\.["`]posts_with_prefix["`] /
+    assert [] == TestRepo.all(q)
+  end
+
+  test "assoc has_many with schema_prefix through schema with same schema_prefix" do
+    u = TestRepo.insert!(%User{})
+    q = Ecto.assoc(u, :comments_with_prefix)
+    {sql, _} = Ecto.Adapters.SQL.to_sql(:all, TestRepo, q)
+
+    assert sql =~ ~r/ FROM ["`]my_prefix["`]\.["`]comments_with_prefix["`] /
+    assert sql =~ ~r/ JOIN ["`]my_prefix["`]\.["`]posts_with_prefix["`] /
+    assert [] == TestRepo.all(q)
+  end
+
   ## Changesets
 
   test "has_one changeset assoc (on_replace: :delete)" do

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -57,7 +57,7 @@ defmodule Ecto.Integration.PoolRepo do
   end
 
   def drop_prefix(prefix) do
-    "drop database #{prefix}"
+    "drop database if exists #{prefix}"
   end
 end
 

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -53,7 +53,7 @@ defmodule Ecto.Integration.PoolRepo do
   end
 
   def drop_prefix(prefix) do
-    "drop schema #{prefix}"
+    "drop schema if exists #{prefix}"
   end
 end
 

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -104,5 +104,16 @@ defmodule Ecto.Integration.Migration do
     end
 
     create unique_index(:posts_users_composite_pk, [:post_id, :user_id])
+
+    execute Ecto.Integration.PoolRepo.drop_prefix(:my_prefix)
+    execute Ecto.Integration.PoolRepo.create_prefix(:my_prefix)
+
+    create table(:posts_with_prefix, prefix: :my_prefix) do
+      add :user_id, :integer
+    end
+
+    create table(:comments_with_prefix, prefix: :my_prefix) do
+      add :post_with_prefix_id, references(:posts_with_prefix)
+    end
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -153,6 +153,8 @@ defmodule Ecto.Integration.User do
     belongs_to :custom, Ecto.Integration.Custom, references: :bid, type: :binary_id
     many_to_many :schema_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUser
     many_to_many :unique_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUserCompositePk
+    has_many :posts_with_prefix, Ecto.Integration.PostWithPrefix
+    has_many :comments_with_prefix, through: [:posts_with_prefix, :comments_with_prefix]
     timestamps(type: :utc_datetime)
   end
 end
@@ -269,5 +271,36 @@ defmodule Ecto.Integration.PostUserCompositePk do
     belongs_to :user, Ecto.Integration.User, primary_key: true
     belongs_to :post, Ecto.Integration.Post, primary_key: true
     timestamps()
+  end
+end
+
+defmodule Ecto.Integration.PostWithPrefix do
+  @moduledoc """
+  This module is used to test:
+
+    * Ecto.assoc schema_prefix on through-associations
+
+  """
+  use Ecto.Schema
+  @schema_prefix "my_prefix"
+
+  schema "posts_with_prefix" do
+    belongs_to :user, Ecto.Integration.User
+    has_many :comments_with_prefix, Ecto.Integration.CommentWithPrefix
+  end
+end
+
+defmodule Ecto.Integration.CommentWithPrefix do
+  @moduledoc """
+  This module is used to test:
+
+    * Ecto.assoc schema_prefix on through-associations
+
+  """
+  use Ecto.Schema
+  @schema_prefix "my_prefix"
+
+  schema "comments_with_prefix" do
+    belongs_to :posts_with_prefix, Ecto.Integration.Post, foreign_key: :post_with_prefix_id
   end
 end

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -160,7 +160,7 @@ defmodule Ecto.Association do
   end
 
   def assoc_query(refl, t, query, values) do
-    query = query || %Ecto.Query{from: {"join expression", nil}}
+    query = query || %Ecto.Query{from: {"join expression", nil}, prefix: refl.queryable.__schema__(:prefix)}
 
     # Find the position for upcoming joins
     position = length(query.joins) + 1


### PR DESCRIPTION
Fix #1746
Added two schemes in integration tests: `PostWithPrefix`, `CommentWithPrefix` to test through association.
Tests contain generated SQL expectations for clarity.