### PR TITLE
Pass validators data to traverse_errors/3 in Ecto.Changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2076,6 +2076,7 @@ defmodule Ecto.Changeset do
       {"should be at least %{count} characters", [count: 3, validation: :min_length]}
 
   ## Examples
+
       iex> traverse_errors(changeset, fn {msg, opts} ->
       ...>   Enum.reduce(opts, msg, fn {key, value}, acc ->
       ...>     String.replace(msg, "%{#{key}}", to_string(value))

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -249,7 +249,6 @@ defmodule Ecto.Changeset do
 
   @relations [:embed, :assoc]
   @match_types [:exact, :suffix]
-  @validation_opts [:validation, :format, :data]
 
   @doc """
   Wraps the given data in a changeset or adds changes to a changeset.

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -487,7 +487,7 @@ defmodule Ecto.Changeset do
          {errors, valid?} = error_on_nil(kind, key, Map.get(changes, key, current), errors, valid?)
          {changes, errors, valid?}
        :invalid ->
-         {changes, [{key, {"is invalid", [type: type, validation: :type]}} | errors], false}
+         {changes, [{key, {"is invalid", [type: type, validation: :cast]}} | errors], false}
      end}
   end
 
@@ -1465,21 +1465,21 @@ defmodule Ecto.Changeset do
 
   defp wrong_length(_type, value, value, _opts), do: nil
   defp wrong_length(:string, _length, value, opts), do:
-    {message(opts, "should be %{count} character(s)"), count: value, validation: :length}
+    {message(opts, "should be %{count} character(s)"), count: value, validation: :length, is: value}
   defp wrong_length(:list, _length, value, opts), do:
-    {message(opts, "should have %{count} item(s)"), count: value, validation: :length}
+    {message(opts, "should have %{count} item(s)"), count: value, validation: :length, is: value}
 
   defp too_short(_type, length, value, _opts) when length >= value, do: nil
   defp too_short(:string, _length, value, opts), do:
-    {message(opts, "should be at least %{count} character(s)"), count: value, validation: :min_length}
+    {message(opts, "should be at least %{count} character(s)"), count: value, validation: :length, min: value}
   defp too_short(:list, _length, value, opts), do:
-    {message(opts, "should have at least %{count} item(s)"), count: value, validation: :min_length}
+    {message(opts, "should have at least %{count} item(s)"), count: value, validation: :length, min: value}
 
   defp too_long(_type, length, value, _opts) when length <= value, do: nil
   defp too_long(:string, _length, value, opts), do:
-    {message(opts, "should be at most %{count} character(s)"), count: value, validation: :max_length}
+    {message(opts, "should be at most %{count} character(s)"), count: value, validation: :length, max: value}
   defp too_long(:list, _length, value, opts), do:
-    {message(opts, "should have at most %{count} item(s)"), count: value, validation: :max_length}
+    {message(opts, "should have at most %{count} item(s)"), count: value, validation: :length, max: value}
 
   @doc """
   Validates the properties of a number.

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2073,7 +2073,7 @@ defmodule Ecto.Changeset do
   error message as the changeset is traversed. The error message
   function receives an error tuple `{msg, opts}`, for example:
 
-      {"should be at least %{count} characters", [count: 3, validation: :min_length]}
+      {"should be at least %{count} characters", [count: 3, validation: :length, min: 3]}
 
   ## Examples
 
@@ -2084,7 +2084,7 @@ defmodule Ecto.Changeset do
       ...> end)
       %{title: ["should be at least 3 characters"]}
 
-  Optionally function can accept three arguments: `changeset`, `field` and `{msg, opts}`.
+  Optionally function can accept three arguments: `changeset`, `field` and error tuple `{msg, opts}`.
   It is useful whenever you want to extract validations rules from `changeset.validations`
   to build detailed error description.
   """

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2064,13 +2064,17 @@ defmodule Ecto.Changeset do
 
   @doc ~S"""
   Traverses changeset errors and applies the given function to error messages.
+
   This function is particularly useful when associations and embeds
   are cast in the changeset as it will traverse all associations and
   embeds and place all errors in a series of nested maps.
+
   A changeset is supplied along with a function to apply to each
   error message as the changeset is traversed. The error message
   function receives an error tuple `{msg, opts}`, for example:
+
       {"should be at least %{count} characters", [count: 3, validation: :min_length]}
+
   ## Examples
       iex> traverse_errors(changeset, fn {msg, opts} ->
       ...>   Enum.reduce(opts, msg, fn {key, value}, acc ->
@@ -2083,7 +2087,7 @@ defmodule Ecto.Changeset do
   validation rules applied to it.
   """
   @spec traverse_errors(t, (error -> String.t) | (error, Keyword.t -> String.t)) :: %{atom => [String.t]}
- def traverse_errors(%Changeset{errors: errors, changes: changes, types: types, validations: validations}, msg_func)
+  def traverse_errors(%Changeset{errors: errors, changes: changes, types: types, validations: validations}, msg_func)
       when is_function(msg_func, 1) or is_function(msg_func, 2) do
     errors
     |> Enum.reverse()

--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -65,7 +65,7 @@ defmodule Ecto.Changeset.BelongsToTest do
   test "cast belongs_to with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile)
     assert changeset.changes.profile.changes == %{name: nil}
-    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", [validation: :required]}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
@@ -146,17 +146,17 @@ defmodule Ecto.Changeset.BelongsToTest do
     changeset = cast(%Author{}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{}, %{}, :profile, required: true, required_message: "a custom message")
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"a custom message", []}]
+    assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
 
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -166,12 +166,12 @@ defmodule Ecto.Changeset.BelongsToTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
   end
 
   test "cast belongs_to with optional" do

--- a/test/ecto/changeset/embedded_no_pk_test.exs
+++ b/test/ecto/changeset/embedded_no_pk_test.exs
@@ -95,7 +95,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   test "cast embeds_one with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", [validation: :required]}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
@@ -135,12 +135,12 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true, required_message: "a custom message")
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"a custom message", []}]
+    assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -150,12 +150,12 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
   end
 
   test "cast embeds_one with optional" do
@@ -311,7 +311,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.changes == %{}

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -797,11 +797,11 @@ defmodule Ecto.Changeset.EmbeddedTest do
   test "traverses changeset errors with embeds_many when required" do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", [validation: :required]}]}
 
     changeset = cast(%Author{}, %{"posts" => []}, :posts, required: true)
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", [validation: :required]}]}
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.errors == [posts: {"is invalid", [type: {:array, :map}]}]
@@ -809,6 +809,6 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
     changeset = cast(%Author{posts: []}, %{"posts" => [%{title: nil}]}, :posts, required: true)
     assert changeset.errors == []
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", []}]}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", [validation: :required]}]}]}
   end
 end

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -100,7 +100,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
   test "cast embeds_one with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", [validation: :required]}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
@@ -174,12 +174,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true, required_message: "a custom message")
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"a custom message", []}]
+    assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -189,12 +189,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
   end
 
   test "cast embeds_one with optional" do
@@ -365,7 +365,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
     assert new.valid?
 
     assert second.data.id == 2
-    assert second.errors == [title: {"can't be blank", []}]
+    assert second.errors == [title: {"can't be blank", [validation: :required]}]
     assert second.action == :update
     refute second.valid?
 
@@ -411,7 +411,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.changes == %{}
@@ -796,11 +796,11 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
   test "traverses changeset errors with embeds_many when required" do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
 
     changeset = cast(%Author{}, %{"posts" => []}, :posts, required: true)
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -90,7 +90,7 @@ defmodule Ecto.Changeset.HasAssocTest do
   test "cast has_one with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile)
     assert changeset.changes.profile.changes == %{name: nil}
-    assert changeset.changes.profile.errors  == [name: {"can't be blank", []}]
+    assert changeset.changes.profile.errors  == [name: {"can't be blank", [validation: :required]}]
     assert changeset.changes.profile.action  == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
@@ -185,17 +185,17 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{}, %{}, :profile, required: true, required_message: "a custom message")
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"a custom message", []}]
+    assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
 
     changeset = cast(%Author{profile: nil}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{}, :profile, required: true)
     assert changeset.required == [:profile]
@@ -205,12 +205,12 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{profile: nil}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{profile: %Profile{}}, %{"profile" => nil}, :profile, required: true)
     assert changeset.required == [:profile]
     assert changeset.changes == %{profile: nil}
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
   end
 
   test "cast has_one with optional" do
@@ -388,7 +388,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert new.valid?
 
     assert second.data.id == 2
-    assert second.errors == [title: {"can't be blank", []}]
+    assert second.errors == [title: {"can't be blank", [validation: :required]}]
     assert second.action == :update
     refute second.valid?
 
@@ -440,12 +440,12 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{posts: []}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{posts: []}
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.required == [:posts]
@@ -919,15 +919,15 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert Changeset.traverse_errors(changeset, &(&1)) == %{}
 
     changeset = cast(%Author{}, %{}, :profile, required: true)
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"can't be blank", []}]}
 
     changeset = cast(%Author{}, %{"profile" => nil}, :profile, required: true)
-    assert changeset.errors == [profile: {"can't be blank", []}]
+    assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"can't be blank", []}]}
 
     changeset = cast(%Author{}, %{}, :profile, required: true, required_message: "a custom message")
-    assert changeset.errors == [profile: {"a custom message", []}]
+    assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"a custom message", []}]}
 
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile, required: true)
@@ -945,7 +945,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", []}]}]}
 
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
@@ -953,7 +953,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"is invalid", [type: {:array, :map}]}]}
 
     changeset = cast(%Author{}, %{posts: []}, :posts, required: true)
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
   end
 end

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -920,19 +920,19 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = cast(%Author{}, %{}, :profile, required: true)
     assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"can't be blank", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"can't be blank", [validation: :required]}]}
 
     changeset = cast(%Author{}, %{"profile" => nil}, :profile, required: true)
     assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"can't be blank", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"can't be blank", [validation: :required]}]}
 
     changeset = cast(%Author{}, %{}, :profile, required: true, required_message: "a custom message")
     assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"a custom message", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: [{"a custom message", [validation: :required]}]}
 
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile, required: true)
     assert changeset.errors == []
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: %{name: [{"can't be blank", []}]}}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{profile: %{name: [{"can't be blank", [validation: :required]}]}}
   end
 
   test "traverses changeset errors with has_many when required" do
@@ -942,11 +942,11 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = cast(%Author{}, %{posts: [%{title: nil}]}, :posts, required: true)
     assert changeset.errors == []
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", []}]}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", [validation: :required]}]}]}
 
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", [validation: :required]}]}
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.errors == [posts: {"is invalid", [type: {:array, :map}]}]
@@ -954,6 +954,6 @@ defmodule Ecto.Changeset.HasAssocTest do
 
     changeset = cast(%Author{}, %{posts: []}, :posts, required: true)
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
-    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", []}]}
+    assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", [validation: :required]}]}
   end
 end

--- a/test/ecto/changeset/many_to_many_test.exs
+++ b/test/ecto/changeset/many_to_many_test.exs
@@ -94,7 +94,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assert new.valid?
 
     assert second.data.id == 2
-    assert second.errors == [title: {"can't be blank", []}]
+    assert second.errors == [title: {"can't be blank", [validation: :required]}]
     assert second.action == :update
     refute second.valid?
 
@@ -146,12 +146,12 @@ defmodule Ecto.Changeset.ManyToManyTest do
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: {"can't be blank", []}]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true, required_message: "a custom message")
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
-    assert changeset.errors == [posts: {"a custom message", []}]
+    assert changeset.errors == [posts: {"a custom message", [validation: :required]}]
 
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.required == [:posts]

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -148,7 +148,7 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(body))
     assert changeset.changes == %{}
-    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :type]}]
+    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :cast]}]
     refute changeset.valid?
   end
 
@@ -190,7 +190,7 @@ defmodule Ecto.ChangesetTest do
                 |> validate_required([:body])
 
     assert changeset.changes == %{}
-    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :type]}]
+    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :cast]}]
     refute changeset.valid?
   end
 
@@ -701,18 +701,18 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, min: 6)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :min_length}]
+    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :length, min: 6}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, max: 4)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :max_length}]
+    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :length, max: 4}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be %{count} character(s)", count: 10, validation: :length}]
+    assert changeset.errors == [title: {"should be %{count} character(s)", count: 10, validation: :length, is: 10}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
-    assert changeset.errors == [title: {"yada", count: 10, validation: :length}]
+    assert changeset.errors == [title: {"yada", count: 10, validation: :length, is: 10}]
   end
 
   test "validate_length/3 with list" do
@@ -729,18 +729,18 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 6, foo: true)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :min_length}]
+    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :length, min: 6}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, max: 2)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :max_length}]
+    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :length, max: 2}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have %{count} item(s)", count: 10, validation: :length}]
+    assert changeset.errors == [topics: {"should have %{count} item(s)", count: 10, validation: :length, is: 10}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10, message: "yada")
-    assert changeset.errors == [topics: {"yada", count: 10, validation: :length}]
+    assert changeset.errors == [topics: {"yada", count: 10, validation: :length, is: 10}]
   end
 
   test "validate_number/3" do
@@ -1061,7 +1061,7 @@ defmodule Ecto.ChangesetTest do
       |> add_error(:title, "is taken", name: "your title")
 
     errors = traverse_errors(changeset, fn
-      {"is invalid", [type: type, validation: :type]} ->
+      {"is invalid", [type: type, validation: :cast]} ->
         "expected to be #{inspect(type)}"
       {"is taken", keys} ->
         String.upcase("#{keys[:name]} is taken")
@@ -1087,11 +1087,11 @@ defmodule Ecto.ChangesetTest do
       |> add_error(:title, "is taken", name: "your title")
 
     errors = traverse_errors(changeset, fn
-      {_, [type: type, validation: :type]}, _field ->
+      {_, [type: type, validation: :cast]}, _field ->
         "expected to be #{inspect(type)}"
       {_, [name: "your title"] = keys}, _field ->
         String.upcase("#{keys[:name]} is taken")
-      {_, [count: 3, validation: :min_length] = keys}, _field ->
+      {_, [count: 3, validation: :length, min: 3] = keys}, _field ->
         "should be at least #{keys[:count]} character(s)"
         |> String.upcase()
       {_, [validation: :format]}, field ->

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -148,7 +148,7 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(body))
     assert changeset.changes == %{}
-    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :cast]}]
+    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :type]}]
     refute changeset.valid?
   end
 
@@ -190,7 +190,7 @@ defmodule Ecto.ChangesetTest do
                 |> validate_required([:body])
 
     assert changeset.changes == %{}
-    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :cast]}]
+    assert changeset.errors == [body: {"is invalid", [type: :string, validation: :type]}]
     refute changeset.valid?
   end
 
@@ -615,13 +615,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "foobar"})
       |> validate_format(:title, ~r/@/)
     refute changeset.valid?
-    assert changeset.errors == [title: {"has invalid format", [validation: :format, format: ~r/@/]}]
+    assert changeset.errors == [title: {"has invalid format", [validation: :format]}]
     assert changeset.validations == [title: {:format, ~r/@/}]
 
     changeset =
       changeset(%{"title" => "foobar"})
       |> validate_format(:title, ~r/@/, message: "yada")
-    assert changeset.errors == [title: {"yada", [validation: :format, format: ~r/@/]}]
+    assert changeset.errors == [title: {"yada", [validation: :format]}]
   end
 
   test "validate_inclusion/3" do
@@ -636,13 +636,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world))
     refute changeset.valid?
-    assert changeset.errors == [title: {"is invalid", [validation: :inclusion, data: ~w(world)]}]
+    assert changeset.errors == [title: {"is invalid", [validation: :inclusion]}]
     assert changeset.validations == [title: {:inclusion, ~w(world)}]
 
     changeset =
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
-    assert changeset.errors == [title: {"yada", [validation: :inclusion, data: ~w(world)]}]
+    assert changeset.errors == [title: {"yada", [validation: :inclusion]}]
   end
 
   test "validate_subset/3" do
@@ -657,13 +657,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"topics" => ["cat", "laptop"]})
       |> validate_subset(:topics, ~w(cat dog))
     refute changeset.valid?
-    assert changeset.errors == [topics: {"has an invalid entry", [validation: :subset, data: ~w(cat dog)]}]
+    assert changeset.errors == [topics: {"has an invalid entry", [validation: :subset]}]
     assert changeset.validations == [topics: {:subset, ~w(cat dog)}]
 
     changeset =
       changeset(%{"topics" => ["laptop"]})
       |> validate_subset(:topics, ~w(cat dog), message: "yada")
-    assert changeset.errors == [topics: {"yada", [validation: :subset, data: ~w(cat dog)]}]
+    assert changeset.errors == [topics: {"yada", [validation: :subset]}]
   end
 
   test "validate_exclusion/3" do
@@ -678,13 +678,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world))
     refute changeset.valid?
-    assert changeset.errors == [title: {"is reserved", [validation: :exclusion, data: ~w(world)]}]
+    assert changeset.errors == [title: {"is reserved", [validation: :exclusion]}]
     assert changeset.validations == [title: {:exclusion, ~w(world)}]
 
     changeset =
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world), message: "yada")
-    assert changeset.errors == [title: {"yada", [validation: :exclusion, data: ~w(world)]}]
+    assert changeset.errors == [title: {"yada", [validation: :exclusion]}]
   end
 
   test "validate_length/3 with string" do
@@ -701,11 +701,11 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, min: 6)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :length_min}]
+    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :min_length}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, max: 4)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :length_max}]
+    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :max_length}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10)
     refute changeset.valid?
@@ -729,11 +729,11 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 6, foo: true)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :length_min}]
+    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :min_length}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, max: 2)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :length_max}]
+    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :max_length}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10)
     refute changeset.valid?
@@ -836,22 +836,22 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"title" => "title"})
                 |> validate_confirmation(:title, required: true)
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"can't be blank", [validation: :confirmation_missing]}]
+    assert changeset.errors == [title_confirmation: {"can't be blank", [validation: :required]}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => nil})
                 |> validate_confirmation(:title)
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation_doesnt_match]}]
+    assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation]}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title)
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation_doesnt_match]}]
+    assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation]}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title, message: "doesn't match field below")
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"doesn't match field below", [validation: :confirmation_doesnt_match]}]
+    assert changeset.errors == [title_confirmation: {"doesn't match field below", [validation: :confirmation]}]
 
     # Skip when no parameter
     changeset = changeset(%{"title" => "title"})
@@ -869,13 +869,13 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"password" => "", "password_confirmation" => "password"})
                 |> validate_confirmation(:password)
     refute changeset.valid?
-    assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation_doesnt_match]}]
+    assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation]}]
 
     # With missing change
     changeset = changeset(%{"password_confirmation" => "password"})
                 |> validate_confirmation(:password)
     refute changeset.valid?
-    assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation_doesnt_match]}]
+    assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation]}]
   end
 
   test "validate_acceptance/3" do
@@ -1061,7 +1061,7 @@ defmodule Ecto.ChangesetTest do
       |> add_error(:title, "is taken", name: "your title")
 
     errors = traverse_errors(changeset, fn
-      {"is invalid", [type: type]} ->
+      {"is invalid", [type: type, validation: :type]} ->
         "expected to be #{inspect(type)}"
       {"is taken", keys} ->
         String.upcase("#{keys[:name]} is taken")
@@ -1073,31 +1073,6 @@ defmodule Ecto.ChangesetTest do
 
     assert errors == %{
       body: ["HAS INVALID FORMAT", "SHOULD BE AT LEAST 3 CHARACTER(S)"],
-      title: ["YOUR TITLE IS TAKEN"],
-      upvotes: ["expected to be :integer"],
-    }
-  end
-
-  test "traverses changeset errors includes validations" do
-    changeset =
-      changeset(%{"title" => "title", "body" => "hi", "upvotes" => :bad})
-      |> validate_length(:body, min: 3)
-      |> validate_format(:body, ~r/888/)
-      |> add_error(:title, "is taken", name: "your title")
-
-    errors = traverse_errors(changeset, fn
-      {_, [type: type, validation: :cast]} ->
-        "expected to be #{inspect(type)}"
-      {"is taken", keys} ->
-        String.upcase("#{keys[:name]} is taken")
-      {_, [validation: :format, format: format]} ->
-        "expected format #{inspect format}"
-      {_, [count: count, validation: :length_min]} ->
-        "expected minimum #{inspect count} characters"
-    end, true)
-
-    assert errors == %{
-      body: ["expected format ~r/888/", "expected minimum 3 characters"],
       title: ["YOUR TITLE IS TAKEN"],
       upvotes: ["expected to be :integer"],
     }


### PR DESCRIPTION
Fixes #1751.

Open questions:
1. Should we add `include_validations?` option to `traverse_errors/3`? It can be better for backwards compatibility, but boolean flags is ugly. Also I can make another method for this purpose, but then lets figure out a name for it.
2. Any suggestions to validators naming or it's metadata?
3. Is it ok to add `data` and `format` to message options?
4. My PR doesn't look elegant, maybe there is a better way to do this?