### PR TITLE
Use normal, not scientific encoding for Decimals in Poison

### DIFF
--- a/lib/ecto/poison.ex
+++ b/lib/ecto/poison.ex
@@ -1,6 +1,6 @@
 if Code.ensure_loaded?(Poison) do
   defimpl Poison.Encoder, for: Decimal do
-    def encode(decimal, _opts), do: <<?", Decimal.to_string(decimal)::binary, ?">>
+    def encode(decimal, _opts), do: <<?", Decimal.to_string(decimal, :normal)::binary, ?">>
   end
 
   defimpl Poison.Encoder, for: Ecto.Association.NotLoaded do


### PR DESCRIPTION
This change shouldn't matter for database saving of JSONs (besides the fact that sometimes the `:normal` string representation might be a bit bigger in size than the `:scientific` one) but it makes difference when you want to use `Decimal` JSON encoding in different contextes.

For example, let's say we have a struct: `%{d: Decimal.new("-0.00000001")}`
Please tell me which JSON representation is better:

`{"d":"-1E-8"}`

or:

`{"d":"-0.00000001"}`

I opt for the second option therefore this PR. There is also an issue with those zeroes staying behind sometimes (for instance `Decimal.new("0.00000000")`) so maybe we should use some kind of cleanup before parsing? But that would obviously cost performance. What are your thoughts on this?