### PR TITLE
Typo in traverse_errors/2 example

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2079,7 +2079,7 @@ defmodule Ecto.Changeset do
 
       iex> traverse_errors(changeset, fn {msg, opts} ->
       ...>   Enum.reduce(opts, msg, fn {key, value}, acc ->
-      ...>     String.replace(msg, "%{#{key}}", to_string(value))
+      ...>     String.replace(acc, "%{#{key}}", to_string(value))
       ...>   end)
       ...> end)
       %{title: ["should be at least 3 characters"]}


### PR DESCRIPTION
I think this is a long typo. Example should use accumulator to replace one all entries of options, and not only on the last one. And `acc` should throw warning that is not used in old example.