### PR TITLE
Add documentation and tests to use custom data type options in Ecto.Migration

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -75,6 +75,11 @@ defmodule Ecto.Migration do
   `:varchar` or `:char` in your migrations as `add :field_name, :text`.
   In your Ecto schema, they will all map to the same `:string` type.
 
+  Remember, atoms can containing arbitrary characters by enclosing in
+  double quotes the characters following the colon. So, if you want to use
+  field type with your database specific options, you can pass atoms containing
+  these options like `:"int unsigned"`, `:"time without time zone"`.
+
   ## Prefixes
 
   Migrations support specifying a table prefix or index prefix which will target either a schema

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -520,12 +520,16 @@ defmodule Ecto.Adapters.MySQLTest do
                [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
                 {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
                 {:add, :on_hand, :integer, [default: 0, null: true]},
+                {:add, :likes, :"smallint unsigned", [default: 0, null: false]},
+                {:add, :published_at, :"datetime(6)", [null: true]},
                 {:add, :is_active, :boolean, [default: true]}]}
 
     assert SQL.execute_ddl(create) == """
     CREATE TABLE `posts` (`name` varchar(20) DEFAULT 'Untitled' NOT NULL,
     `price` numeric(8,2) DEFAULT expr,
     `on_hand` integer DEFAULT 0 NULL,
+    `likes` smallint unsigned DEFAULT 0 NOT NULL,
+    `published_at` datetime(6) NULL,
     `is_active` boolean DEFAULT true) ENGINE = INNODB
     """ |> remove_newlines
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -640,6 +640,7 @@ defmodule Ecto.Adapters.PostgresTest do
                [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
                 {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
                 {:add, :on_hand, :integer, [default: 0, null: true]},
+                {:add, :published_at, :"time without time zone", [null: true]},
                 {:add, :is_active, :boolean, [default: true]},
                 {:add, :tags, {:array, :string}, [default: []]}]}
 
@@ -647,6 +648,7 @@ defmodule Ecto.Adapters.PostgresTest do
     CREATE TABLE "posts" ("name" varchar(20) DEFAULT 'Untitled' NOT NULL,
     "price" numeric(8,2) DEFAULT expr,
     "on_hand" integer DEFAULT 0 NULL,
+    "published_at" time without time zone NULL,
     "is_active" boolean DEFAULT true,
     "tags" varchar(255)[] DEFAULT ARRAY[]::varchar[])
     """ |> remove_newlines

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -100,6 +100,7 @@ defmodule Ecto.MigrationTest do
     result = create(table = table(:posts)) do
       add :title, :string
       add :cost, :decimal, precision: 3
+      add :likes, :"int UNSIGNED", default: 0
       add :author_id, references(:authors)
       timestamps()
     end
@@ -110,6 +111,7 @@ defmodule Ecto.MigrationTest do
               [{:add, :id, :serial, [primary_key: true]},
                {:add, :title, :string, []},
                {:add, :cost, :decimal, [precision: 3]},
+               {:add, :likes, :"int UNSIGNED", [default: 0]},
                {:add, :author_id, %Reference{table: :authors}, []},
                {:add, :inserted_at, :naive_datetime, [null: false]},
                {:add, :updated_at, :naive_datetime, [null: false]}]}
@@ -147,6 +149,18 @@ defmodule Ecto.MigrationTest do
            {:create, table,
               [{:add, :inserted_on, :date, [null: false]},
                {:add, :updated_on, :date, [null: false]}]}
+  end
+
+  test "forward: creates a table with timestamps of database specific type" do
+    create table = table(:posts, primary_key: false) do
+      timestamps(type: :"datetime(6)")
+    end
+    flush()
+
+    assert last_command() ==
+           {:create, table,
+              [{:add, :inserted_at, :"datetime(6)", [null: false]},
+               {:add, :updated_at, :"datetime(6)", [null: false]}]}
   end
 
   test "forward: creates an empty table" do


### PR DESCRIPTION
In [this topic](https://groups.google.com/forum/#!topic/elixir-ecto/uv73OIukcok), I found that we can use database specific options of field types in Ecto.Migration.

```elixir
create table(:posts) do
  add :title, :"VARCHAR(255) CHARACTER SET utf8mb4", null: false
  add :pub_time, :"timestamp WITH TIME ZONE"
end
```

If this behavior is not a kind of bug, I think it is helpful to add documentation and tests.