### PR TITLE
WIP: Validate log levels at compile time

### DIFF
--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -51,7 +51,7 @@ defmodule Ecto.LogEntry do
   The logger call won't be removed at compile time as
   custom level is given.
   """
-  def log(entry, level) do
+  def log(entry, level) when level in ~w(error info warn debug)a do
     Logger.log(level, fn ->
       {_entry, iodata} = Ecto.LogEntry.to_iodata(entry)
       iodata


### PR DESCRIPTION
I'm trying this (inspired on @mtwilliams' suggestion), but with no success. Can anyone point me in the right direction here? Should I use [Typespecs](http://elixir-lang.org/docs/stable/elixir/typespecs)?

The output I'm getting is like the following:

```
$ iex -S mix
Erlang/OTP 19 [erts-8.1] [source] [async-threads:10] [hipe] [kernel-poll:false]

Compiling 3 files (.ex)
Generated friends app
Interactive Elixir (1.3.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Friends.Person |> Friends.Repo.get(1)
** (FunctionClauseError) no function clause matching in Ecto.LogEntry.log/2
             (ecto) lib/ecto/log_entry.ex:54: Ecto.LogEntry.log(%Ecto.LogEntry{ansi_color: nil, connection_pid: nil, decode_time: 17805, params: [1], query: "SELECT p0.\"id\", p0.\"first_name\", p0.\"last_name\", p0.\"age\" FROM \"people\" AS p0 WHERE (p0.\"id\" = $1)", query_time: 2630768, queue_time: 96162, result: {:ok, %Postgrex.Result{columns: ["id", "first_name", "last_name", "age"], command: :select, connection_id: 1171, num_rows: 1, rows: [[%Friends.Person{__meta__: #Ecto.Schema.Metadata<:loaded, "people">, age: nil, first_name: nil, id: 1, last_name: nil}]]}}, source: "people"}, :notice)
    (db_connection) lib/db_connection.ex:966: DBConnection.log/6
             (ecto) lib/ecto/adapters/postgres/connection.ex:74: Ecto.Adapters.Postgres.Connection.prepare_execute/5
             (ecto) lib/ecto/adapters/sql.ex:244: Ecto.Adapters.SQL.sql_call/6
             (ecto) lib/ecto/adapters/sql.ex:410: Ecto.Adapters.SQL.execute_and_cache/7
             (ecto) lib/ecto/repo/queryable.ex:121: Ecto.Repo.Queryable.execute/5
             (ecto) lib/ecto/repo/queryable.ex:35: Ecto.Repo.Queryable.all/4
             (ecto) lib/ecto/repo/queryable.ex:59: Ecto.Repo.Queryable.one/4
iex(1)>
```

I guess we're looking for some kind of error _before_ being able to run the query.

Related to #1744 
