### PR TITLE
Fix cast_relation loaded struct when no association changes

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -684,11 +684,11 @@ defmodule Ecto.Changeset do
 
     on_cast  = Keyword.get_lazy(opts, :with, fn -> on_cast_default(type, related) end)
     original = Map.get(data, key)
-    current  = Relation.load!(data, original)
 
     changeset =
       case Map.fetch(params, param_key) do
         {:ok, value} ->
+          current  = Relation.load!(data, original)
           case Relation.cast(relation, value, current, on_cast) do
             {:ok, change, relation_valid?, false} when change != original ->
               missing_relation(%{changeset | changes: Map.put(changes, key, change),
@@ -699,7 +699,7 @@ defmodule Ecto.Changeset do
               %{changeset | errors: [{key, {message(opts, :invalid_message, "is invalid"), [type: expected_relation_type(relation)]}} | changeset.errors], valid?: false}
           end
         :error ->
-          missing_relation(changeset, key, current, required?, relation, opts)
+          missing_relation(changeset, key, original, required?, relation, opts)
       end
 
     update_in changeset.types[key], fn {type, relation} ->

--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -101,6 +101,7 @@ defmodule Ecto.Changeset.BelongsToTest do
     assert_raise RuntimeError, ~r"attempting to cast or change association `profile` .* that was not loaded", fn ->
       cast(loaded, %{"profile" => ""}, :profile)
     end
+    assert cast(loaded, %{}, :profile).changes == %{}
   end
 
   test "cast belongs_to with existing struct replacing" do

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -126,6 +126,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert_raise RuntimeError, ~r"attempting to cast or change association `profile` .* that was not loaded", fn ->
       cast(loaded, %{"profile" => ""}, :profile)
     end
+    assert cast(loaded, %{}, :profile).changes == %{}
   end
 
   test "cast has_one with existing struct replacing" do
@@ -364,6 +365,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert_raise RuntimeError, ~r"attempting to cast or change association `posts` .* that was not loaded", fn ->
       cast(loaded, %{"posts" => []}, :posts)
     end
+    assert cast(loaded, %{}, :posts).changes == %{}
   end
 
   # Please note the order is important in this test.

--- a/test/ecto/changeset/many_to_many_test.exs
+++ b/test/ecto/changeset/many_to_many_test.exs
@@ -70,6 +70,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assert_raise RuntimeError, ~r"attempting to cast or change association `posts` .* that was not loaded", fn ->
       cast(loaded, %{"posts" => []}, :posts)
     end
+    assert cast(loaded, %{}, :posts).changes == %{}
   end
 
   # Please note the order is important in this test.


### PR DESCRIPTION
Fix #1761