### PR TITLE
add options field to Index struct

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -172,7 +172,8 @@ defmodule Ecto.Migration do
               concurrently: false,
               using: nil,
               where: nil,
-              comment: nil
+              comment: nil,
+              options: nil
 
     @type t :: %__MODULE__{
       table: atom,
@@ -183,7 +184,8 @@ defmodule Ecto.Migration do
       concurrently: boolean,
       using: atom | String.t,
       where: atom | String.t,
-      comment: String.t | nil
+      comment: String.t | nil,
+      options: String.t
     }
   end
 


### PR DESCRIPTION
I am currently developing adapter for [Cassandra DB](http://cassandra.apache.org/).
It may have numerous different options for index according to
its type. Here you can find an [example](https://docs.datastax.com/en/cql/3.3/cql/cql_using/useSASIIndex.html).
And I think it might be useful for other adapters. 
