### PR TITLE
Update repo callbacks

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -723,7 +723,7 @@ defmodule Ecto.Repo do
         {:error, changeset} -> # Something went wrong
       end
   """
-  @callback insert_or_update(changeset :: Ecto.Changeset.t, opts :: Keyword.t) ::
+  @callback insert_or_update(struct_or_changeset :: Ecto.Schema.t | Ecto.Changeset.t, opts :: Keyword.t) ::
             {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
 
   @doc """
@@ -772,7 +772,7 @@ defmodule Ecto.Repo do
   Same as `insert_or_update/2` but returns the struct or raises if the changeset
   is invalid.
   """
-  @callback insert_or_update!(changeset :: Ecto.Changeset.t, opts :: Keyword.t) ::
+  @callback insert_or_update!(struct_or_changeset :: Ecto.Schema.t | Ecto.Changeset.t, opts :: Keyword.t) ::
             Ecto.Schema.t | no_return
 
   @doc """


### PR DESCRIPTION
* Update the insert_or_update and insert_or_update! callbacks to allow
either a struct or changeset input

* This resolves the dialyzer error:

```
repo.ex:2: The inferred type for the 1st argument of insert_or_update/2
(#{'__struct__':='Elixir.Ecto.Changeset',
'data':=#{'__meta__':=#{'state':=_, _=>_}, _=>_}, 'valid?'=>boolean(),
_=>_}) is not a supertype of #{'__struct__':='Elixir.Ecto.Changeset',
'action':='delete' | 'insert' | 'nil' | 'replace' | 'update',
'changes':=#{atom()=>_}, 'constraints':=[#{'constraint':=binary(),
'field':=atom(), 'match':='exact' | 'suffix',
'message':={binary(),[{atom(),_}]}, 'type':='unique'}], 'data':='nil' |
#{'__struct__':=atom()}, 'empty_values':=_,
'errors':=[{atom(),{binary(),[{atom(),_}]}}], 'filters':=#{atom()=>_},
'params':='nil' | #{binary()=>_},
'prepare':=[fun((#{'__struct__':='Elixir.Ecto.Changeset',
'action':='delete' | 'insert' | 'nil' | 'replace' | 'update',
'changes':=map(), 'constraints':=[any()], _=>_}) ->
#{'__struct__':='Elixir.Ecto.Changeset', 'action':='delete' | 'insert'
| 'nil' | 'replace' | 'update', 'changes':=map(),
'constraints':=[any()], _=>_})], 'repo':=atom(), 'required':=[atom()],
'types':='nil' | #{atom()=>atom() | {'array',_} |
{'embed',#{'__struct__':='Elixir.Ecto.Embedded', 'cardinality':='many'
| 'one', 'field':=atom(), 'on_cast':='nil' | fun(),
'on_replace':='delete' | 'mark_as_invalid' | 'raise', 'owner':=atom(),
'related':=atom()}} | {'in',_} | {'map',_}}, 'valid?':=boolean(),
'validations':=[{atom(),_}]}, which is expected type for this argument
in the callback of the 'Elixir.Ecto.Repo' behaviour
```