### PR TITLE
add complex subtypes support

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -801,6 +801,14 @@ defmodule Ecto.Migration do
     validate_type!(subtype)
   end
 
+  defp validate_type!({type, subtype}) when is_atom(type) and is_list(subtype) do
+    for t <- subtype, do: validate_type!(t)
+  end
+
+  defp validate_type!({type, subtype}) when is_atom(type) and is_tuple(subtype) do
+    validate_type!({type, Tuple.to_list(subtype)})
+  end
+
   defp validate_type!(%Reference{} = reference) do
     reference
   end


### PR DESCRIPTION
Just sequel of [1782](https://github.com/elixir-ecto/ecto/pull/1782)
[Cassandra DB](http://cassandra.apache.org/) supports different complex types such as [tuples](http://docs.datastax.com/en/cql/3.1/cql/cql_reference/tupleType.html), tuple of tuples, [maps of
maps](http://docs.datastax.com/en/cql/3.1/cql/cql_reference/tupleType.html), etc… And it is really important to modify a little bit type
validation. So migrations could look like:
```elixir
create table(@table, primary_key: false) do
  add :id, :uuid, primary_key: true
  add :value1, {:tuple, [:integer, :string, :float]}
  add :value2, {:tuple, [:integer, :string, {:tuple, [:integer, :integer]}]}
  add :value3, {:map, {:integer, :integer}}
end
```
For types with defined number of subtypes we use tuples (example `{:map, {:integer, :integer}}`)
For types with undefined number of subtypes we use lists (example `{:tuple, [:integer, :string, :float]}`)
If we want to make tuple with only one element we use just single atom (example `{:tuple, :integer}`