### PR TITLE
Add type alter query cache tests

### DIFF
--- a/integration_test/mysql/all_test.exs
+++ b/integration_test/mysql/all_test.exs
@@ -1,3 +1,4 @@
+Code.require_file "../sql/alter.exs", __DIR__
 Code.require_file "../sql/lock.exs", __DIR__
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/sandbox.exs", __DIR__

--- a/integration_test/pg/all_test.exs
+++ b/integration_test/pg/all_test.exs
@@ -1,3 +1,4 @@
+Code.require_file "../sql/alter.exs", __DIR__
 Code.require_file "../sql/lock.exs", __DIR__
 Code.require_file "../sql/migration.exs", __DIR__
 Code.require_file "../sql/sandbox.exs", __DIR__

--- a/integration_test/sql/alter.exs
+++ b/integration_test/sql/alter.exs
@@ -1,0 +1,84 @@
+defmodule Ecto.Integration.AlterTest do
+  use Ecto.Integration.Case, async: false
+
+  alias Ecto.Integration.PoolRepo
+
+  defmodule AlterMigrationOne do
+    use Ecto.Migration
+
+    def up do
+      create table(:alter_col_type) do
+        add :value, :integer
+      end
+
+      execute "INSERT INTO alter_col_type (value) VALUES (1)"
+    end
+
+    def down do
+      drop table(:alter_col_type)
+    end
+  end
+
+  defmodule AlterMigrationTwo do
+    use Ecto.Migration
+
+    def up do
+      alter table(:alter_col_type) do
+        modify :value, :numeric
+      end
+    end
+
+    def down do
+      alter table(:alter_col_type) do
+        modify :value, :integer
+      end
+    end
+  end
+
+  import Ecto.Query, only: [from: 1, from: 2]
+  import Ecto.Migrator, only: [up: 4, down: 4]
+
+  test "reset cache on returning query after alter column type" do
+    values = from v in "alter_col_type", select: v.value
+
+    assert :ok == up(PoolRepo, 20161112120000, AlterMigrationOne, log: false)
+    assert PoolRepo.all(values) == [1]
+
+    assert :ok == up(PoolRepo, 20161112130000, AlterMigrationTwo, log: false)
+    assert_raise ArgumentError, ~r"stale type",
+      fn() -> PoolRepo.all(values) end
+
+    PoolRepo.transaction(fn() ->
+      assert [%Decimal{}] = PoolRepo.all(values)
+
+      assert :ok == down(PoolRepo, 20161112130000, AlterMigrationTwo, log: false)
+      catch_error PoolRepo.all(values, [mode: :savepoint])
+      assert PoolRepo.all(values) == [1]
+    end)
+
+  after
+    assert :ok == down(PoolRepo, 20161112120000, AlterMigrationOne, log: false)
+  end
+
+  test "reset cache on paramterised query after alter column type" do
+    values = from v in "alter_col_type"
+
+    assert :ok == up(PoolRepo, 20161112120000, AlterMigrationOne, log: false)
+    assert PoolRepo.update_all(values, [set: [value: 2]]) == {1, nil}
+
+    assert :ok == up(PoolRepo, 20161112130000, AlterMigrationTwo, log: false)
+    assert_raise ArgumentError, ~r"stale type information",
+      fn() -> PoolRepo.update_all(values, [set: [value: 3]]) end
+
+    PoolRepo.transaction(fn() ->
+      assert PoolRepo.update_all(values, [set: [value: Decimal.new(3)]]) == {1, nil}
+
+      assert :ok == down(PoolRepo, 20161112130000, AlterMigrationTwo, log: false)
+      
+      assert PoolRepo.update_all(values, [set: [value: 4]]) == {1, nil}
+    end)
+
+  after
+    assert :ok == down(PoolRepo, 20161112120000, AlterMigrationOne, log: false)
+  end
+end


### PR DESCRIPTION
This is work in progress to ensure our query cache recovers if a migration is done live. The tests are designed around how postgresql behaves but mysql may not have matching behaviour. However we need to investigate when or if the tests fail for mysql. Given that mariaex ignores all type information saved in the query struct it might be that migrations do not break the query cache and that it should fine to no longer store this information.