### PR TITLE
Add tags for join and composite_pk

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -70,6 +70,7 @@ defmodule Ecto.Integration.RepoTest do
     assert post.inserted_at
   end
 
+  @tag :composite_pk
   test "insert, update and delete with composite pk" do
     c1 = TestRepo.insert!(%CompositePk{a: 1, b: 2, name: "first"})
     c2 = TestRepo.insert!(%CompositePk{a: 1, b: 3, name: "second"})
@@ -93,6 +94,7 @@ defmodule Ecto.Integration.RepoTest do
     end
   end
 
+  @tag :composite_pk
   test "insert, update and delete with associated composite pk" do
     user = TestRepo.insert!(%User{})
     post = TestRepo.insert!(%Post{title: "post title", text: "post text"})
@@ -317,6 +319,7 @@ defmodule Ecto.Integration.RepoTest do
     refute changeset.valid?
   end
 
+  @tag :join
   @tag :unique_constraint
   test "unique constraint violation error message with join table in single changeset" do
     post =
@@ -342,6 +345,7 @@ defmodule Ecto.Integration.RepoTest do
     refute changeset.valid?
   end
 
+  @tag :join
   @tag :unique_constraint
   test "unique constraint violation error message with join table and separate changesets" do
     post =


### PR DESCRIPTION
I am attempting to fix the mongodb_ecto adapter. In doing so, I needed to add a couple tags to some of the integration test cases.

* Mongo has no internal concept of a join.
* Mongo only somewhat supports composite keys. So for now, that is out of the scope of the adapter.

michalmuskala/mongodb_ecto#91