### PR TITLE
Improve Ecto.InvalidChangesetError message for embeds

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -87,18 +87,28 @@ defmodule Ecto.InvalidChangesetError do
     """
     could not perform #{action} because changeset is invalid.
 
-    Changeset changes
+    Changes
 
-        #{inspect changes}
+    #{pretty changes}
 
-    Changeset params
+    Params
 
-        #{inspect changeset.params}
+    #{pretty changeset.params}
 
-    Changeset errors
+    Errors
 
-        #{inspect errors}
+    #{pretty errors}
+
+    Changeset
+
+    #{pretty changeset}
     """
+  end
+
+  defp pretty(term) do
+    inspect(term, pretty: true)
+    |> String.split("\n")
+    |> Enum.map_join("\n", &"    " <> &1)
   end
 
   defp extract_changes(%Ecto.Changeset{changes: changes}) do

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -120,7 +120,7 @@ defmodule Ecto.InvalidChangesetError do
     end)
   end
   defp extract_changes([%Ecto.Changeset{action: :delete} | tail]),
-    do: [extract_changes(tail)]
+    do: extract_changes(tail)
   defp extract_changes([%Ecto.Changeset{} = changeset | tail]),
     do: [extract_changes(changeset) | extract_changes(tail)]
   defp extract_changes(other),

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -113,9 +113,14 @@ defmodule Ecto.InvalidChangesetError do
 
   defp extract_changes(%Ecto.Changeset{changes: changes}) do
     Enum.reduce(changes, %{}, fn({key, value}, acc) ->
-      Map.put(acc, key, extract_changes(value))
+      case value do
+        %Ecto.Changeset{action: :delete} -> acc
+        _ -> Map.put(acc, key, extract_changes(value))
+      end
     end)
   end
+  defp extract_changes([%Ecto.Changeset{action: :delete} | tail]),
+    do: [extract_changes(tail)]
   defp extract_changes([%Ecto.Changeset{} = changeset | tail]),
     do: [extract_changes(changeset) | extract_changes(tail)]
   defp extract_changes(other),

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -87,7 +87,7 @@ defmodule Ecto.InvalidChangesetError do
     """
     could not perform #{action} because changeset is invalid.
 
-    Changes
+    Applied changes
 
     #{pretty changes}
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -196,7 +196,7 @@ defmodule Ecto.RepoTest do
   end
 
   test "insert!, update!, insert_or_update! and delete! fail on invalid changeset" do
-    invalid = %Ecto.Changeset{valid?: false, data: %MySchema{}}
+    invalid = %Ecto.Changeset{valid?: false, data: %MySchema{}, types: %{}}
 
     assert_raise Ecto.InvalidChangesetError,
                  ~r"could not perform insert because changeset is invalid", fn ->


### PR DESCRIPTION
Discussed on ML: https://groups.google.com/forum/#!topic/elixir-ecto/dB8Iu02YQO4

Before:

```
could not perform insert because changeset is invalid.

* Changeset changes

%{posts: [#Ecto.Changeset<action: :insert, changes: %{}, errors: [title: {"can't be blank", [validation: :required]}], data: #Ecto.ErrorTest.Post<>, valid?: false>, #Ecto.Changeset<action: :insert, changes: %{comments: [#Ecto.Changeset<action: :insert, changes: %{}, errors: [text: {"can't be blank", [validation: :required]}], data: #Ecto.ErrorTest.Comment<>, valid?: false>]}, errors: [title: {"can't be blank", [validation: :required]}], data: #Ecto.ErrorTest.Post<>, valid?: false>]}

* Changeset params

%{"name" => "", "posts" => [%{}, %{"comments" => [%{"text" => ""}], "title" => ""}]}

* Changeset errors

[name: {"can't be blank", [validation: :required]}]
```

After:

```
could not perform insert because changeset is invalid.

Changeset changes

    %{posts: [%{comments: [%{}]}]}

Changeset params

    %{"name" => "", "posts" => [%{"comments" => [%{"text" => ""}], "title" => ""}]}

Changeset errors

    %{name: [{"can't be blank", [validation: :required]}], posts: [%{title: [{"can't be blank", [validation: :required]}]}, %{comments: [%{text: [{"can't be blank", [validation: :required]}]}], title: [{"can't be blank", [validation: :required]}]}]}
```

(see an included temporary test that generates this message)

Note: I've initially used `traverse_error/2` to showcase deeply nested changesets. Problem with just using traverse_error that is we'd lose distinction between `changeset.errors` and `changeset.changes.foo.errors` which may or may not be a good thing. Alternatively, something close to what was originally proposed on ML could be used, e.g.: (not sure about the exact format)

```
Changeset errors

    [name: {"can't be blank", [validation: :required]}]
    posts:
      [title: {"can't be blank", [validation: :required]}] # changeset.changes.posts[0]

      [title: {"can't be blank", [validation: :required]}] # changeset.changes.posts[1]
      comments:
        [title: {"can't be blank", [validation: :required]}]
```