### PR TITLE
Improve doc of example of Ecto.Schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -18,9 +18,10 @@ defmodule Ecto.Schema do
         end
       end
 
-  By default, a schema will generate a primary key, named `id` and
-  of type `:integer`, and `belongs_to` associations in the schema will generate
-  foreign keys of type `:integer`. These settings can be seen below.
+  By default, a schema will automatically generate a primary key which is named
+  `id` and of type `:integer`. The `field` macro defines a field in the schema
+  with given name and type.  `has_many` associates many posts with the user
+  schema.
 
   ## Schema attributes
 


### PR DESCRIPTION
The example did not really correspond with the explanation.
There was no `belongs_to` in the example. The wording was off a bit.
It was not clear which settings were referenced.

This PR should fix the issues.