### PR TITLE
Allow date_add & datetime_add to work with ecto types

### DIFF
--- a/integration_test/cases/interval.exs
+++ b/integration_test/cases/interval.exs
@@ -67,6 +67,15 @@ defmodule Ecto.Integration.IntervalTest do
     assert [{2014, 1, 3}]  = TestRepo.all(from p in Post, select: date_add(^posted, ^48, ^"hour"))
   end
 
+  test "date_add with Ecto.Date" do
+    posted = @posted |> Date.to_erl |> Ecto.Date.from_erl
+    assert [{2015, 1, 1}]  = TestRepo.all(from p in Post, select: date_add(^posted, ^1, ^"year"))
+    assert [{2014, 4, 1}]  = TestRepo.all(from p in Post, select: date_add(^posted, ^3, ^"month"))
+    assert [{2014, 1, 22}] = TestRepo.all(from p in Post, select: date_add(^posted, ^3, ^"week"))
+    assert [{2014, 1, 6}]  = TestRepo.all(from p in Post, select: date_add(^posted, ^5, ^"day"))
+    assert [{2014, 1, 3}]  = TestRepo.all(from p in Post, select: date_add(^posted, ^48, ^"hour"))
+  end
+
   test "date_add with negative interval" do
     dec = Decimal.new(-1)
     assert [{2013, 1, 1}] = TestRepo.all(from p in Post, select: date_add(p.posted, -1, "year"))
@@ -233,6 +242,19 @@ defmodule Ecto.Integration.IntervalTest do
            TestRepo.all(from p in Post, where: field(p, ^field) > datetime_add(^inserted_at, ^-3, ^"week"))
     assert [_]  =
            TestRepo.all(from p in Post, where: field(p, ^field) > datetime_add(^inserted_at, -5, ^"day"))
+  end
+
+  test "datetime_add with Ecto.DateTime" do
+    inserted_at = @inserted_at |> NaiveDateTime.to_erl |> Ecto.DateTime.from_erl
+    field = :inserted_at
+    assert [_]  =
+      TestRepo.all(from p in Post, where: p.inserted_at > datetime_add(^inserted_at, ^-1, "year"))
+    assert [_]  =
+      TestRepo.all(from p in Post, where: p.inserted_at > datetime_add(^inserted_at, -3, "month"))
+    assert [_]  =
+      TestRepo.all(from p in Post, where: field(p, ^field) > datetime_add(^inserted_at, ^-3, ^"week"))
+    assert [_]  =
+      TestRepo.all(from p in Post, where: field(p, ^field) > datetime_add(^inserted_at, -5, ^"day"))
   end
 
   test "datetime_add with negative interval" do


### PR DESCRIPTION
This is done to keep backwards compatibility until we remove ecto
calendar types completely.

Closes #1466