### PR TITLE
Fix creating table with just comment on columns

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -699,7 +699,6 @@ if Code.ensure_loaded?(Postgrex) do
     defp add_comment([query], ""), do: query
     defp add_comment(queries, comment), do: queries ++ [comment]
 
-
     defp comment_on(_database_object, _name, nil), do:  ""
     defp comment_on(:column, {table_name, column_name}, comment) do
       column_name = quote_table(table_name, column_name)
@@ -718,6 +717,8 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp add_comments_for_columns(queries, []), do: queries
+    defp add_comments_for_columns(query, comments) when is_binary(query),
+      do: add_comments_for_columns([query], comments)
     defp add_comments_for_columns(queries, comments), do: queries ++ comments
 
     defp comments_for_columns(table, columns) do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -681,6 +681,33 @@ defmodule Ecto.Adapters.PostgresTest do
     ]
   end
 
+  test "create table with comment on table" do
+    create = {:create, table(:posts, comment: "table comment"),
+               [{:add, :category_0, references(:categories), []}]}
+    assert SQL.execute_ddl(create) == [remove_newlines("""
+    CREATE TABLE "posts"
+    ("category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"))
+    """),
+    ~s|COMMENT ON TABLE "posts" IS 'table comment'|,
+    ]
+  end
+
+  test "create table with comment on columns" do
+    create = {:create, table(:posts),
+               [
+                 {:add, :category_0, references(:categories), [comment: "column comment"]},
+                 {:add, :created_at, :timestamp, []},
+                 {:add, :updated_at, :timestamp, [comment: "column comment 2"]}
+               ]}
+    assert SQL.execute_ddl(create) == [remove_newlines("""
+    CREATE TABLE "posts"
+    ("category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"), "created_at" timestamp, "updated_at" timestamp)
+    """),
+    ~s|COMMENT ON COLUMN "posts"."category_0" IS 'column comment'|,
+    ~s|COMMENT ON COLUMN "posts"."updated_at" IS 'column comment 2'|
+    ]
+  end
+
   test "create table with references" do
     create = {:create, table(:posts),
                [{:add, :id, :serial, [primary_key: true]},


### PR DESCRIPTION
Previously, exception was raised when putting comment just on columns without specifying table comment. Commenting just on table worked, but I added a test for that.

```
17:41:21.417 [info]  create table example
** (ArgumentError) argument error
    :erlang.++("CREATE TABLE \"example\" (\"id\" serial, \"foo\" decimal, PRIMARY KEY (\"id\"))", ["COMMENT ON COLUMN \"example\".\"foo\" IS 'bar'"])
    (ecto) lib/ecto/adapters/postgres/connection.ex:717: Ecto.Adapters.Postgres.Connection.add_comments_for_columns/2
    (ecto) lib/ecto/adapters/postgres.ex:71: Ecto.Adapters.Postgres.execute_ddl/3
    (ecto) lib/ecto/migration/runner.ex:98: anonymous fn/2 in Ecto.Migration.Runner.flush/0
    (elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/migration/runner.ex:96: Ecto.Migration.Runner.flush/0
    (stdlib) timer.erl:181: :timer.tc/2
    (ecto) lib/ecto/migration/runner.ex:27: Ecto.Migration.Runner.run/6
```