### PR TITLE
Handle `:invalid` params in validate_acceptance

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1629,7 +1629,8 @@ defmodule Ecto.Changeset do
 
   """
   @spec validate_acceptance(t, atom, Keyword.t) :: t
-  def validate_acceptance(%{params: params} = changeset, field, opts \\ []) do
+  def validate_acceptance(changeset, field, opts \\ [])
+  def validate_acceptance(%{params: params} = changeset, field, opts) when is_map(params) do
     param = Atom.to_string(field)
     value = Map.get(params, param)
 
@@ -1637,6 +1638,9 @@ defmodule Ecto.Changeset do
       {:ok, true} -> changeset
       _ -> add_error(changeset, field, message(opts, "must be accepted"), [validation: :acceptance])
     end
+  end
+  def validate_acceptance(%{params: nil} = changeset, _, _) do
+    changeset
   end
 
   ## Optimistic lock

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -879,6 +879,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "validate_acceptance/3" do
+    # accepted
     changeset = changeset(%{"terms_of_service" => "true"})
                 |> validate_acceptance(:terms_of_service)
     assert changeset.valid?
@@ -889,13 +890,32 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
     assert changeset.errors == []
 
+    # not accepted
     changeset = changeset(%{"terms_of_service" => "false"})
                 |> validate_acceptance(:terms_of_service)
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be accepted", [validation: :acceptance]}]
 
+    changeset = changeset(%{"terms_of_service" => "other"})
+                |> validate_acceptance(:terms_of_service)
+    refute changeset.valid?
+    assert changeset.errors == [terms_of_service: {"must be accepted", [validation: :acceptance]}]
+
+    # empty params
     changeset = changeset(%{})
-                  |> validate_acceptance(:terms_of_service, message: "must be abided")
+                |> validate_acceptance(:terms_of_service)
+    refute changeset.valid?
+    assert changeset.errors == [terms_of_service: {"must be accepted", [validation: :acceptance]}]
+
+    # invalid params
+    changeset = changeset(:invalid)
+                |> validate_acceptance(:terms_of_service)
+    refute changeset.valid?
+    assert changeset.errors == []
+
+    # custom message
+    changeset = changeset(%{})
+                |> validate_acceptance(:terms_of_service, message: "must be abided")
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be abided", [validation: :acceptance]}]
   end


### PR DESCRIPTION
Previously, an error was raised:

     ** (BadMapError) expected a map, got: nil
     stacktrace:
       (stdlib) :maps.find("terms_of_service", nil)
       (elixir) lib/map.ex:145: Map.get/3
       (ecto) lib/ecto/changeset.ex:1467: Ecto.Changeset.validate_acceptance/3
       test/ecto/changeset_test.exs:897: (test)