### PR TITLE
Don't require adapters to be supervisioned

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -90,10 +90,14 @@ defmodule Ecto.Repo.Supervisor do
   ## Callbacks
 
   def init({repo, _otp_app, adapter, opts}) do
-    children = [adapter.child_spec(repo, opts)]
-    if Keyword.get(opts, :query_cache_owner, true) do
-      :ets.new(repo, [:set, :public, :named_table, read_concurrency: true])
+    case adapter.child_spec(repo, opts) do
+      nil ->
+        :ok
+      child_spec ->
+        if Keyword.get(opts, :query_cache_owner, true) do
+          :ets.new(repo, [:set, :public, :named_table, read_concurrency: true])
+        end
+        supervise([child_spec], strategy: :one_for_one)
     end
-    supervise(children, strategy: :one_for_one)
   end
 end

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -90,13 +90,14 @@ defmodule Ecto.Repo.Supervisor do
   ## Callbacks
 
   def init({repo, _otp_app, adapter, opts}) do
+    if Keyword.get(opts, :query_cache_owner, true) do
+      :ets.new(repo, [:set, :public, :named_table, read_concurrency: true])
+    end
+
     case adapter.child_spec(repo, opts) do
       nil ->
         :ok
       child_spec ->
-        if Keyword.get(opts, :query_cache_owner, true) do
-          :ets.new(repo, [:set, :public, :named_table, read_concurrency: true])
-        end
         supervise([child_spec], strategy: :one_for_one)
     end
   end


### PR DESCRIPTION
Ecto is expecting that all of it's adapters should be added to it's supervision tree, but there are DB back-ends that don't need this (for example, Mnesia, that is another OTP app and supervisioned by application supervisor).

Without this fix adapter needs to fake PID:
```
  def start_link(_conn_mod, _opts \\ []) do
    Task.start(fn -> :ok end)
  end
```

I may be wrong, so please tell how to avoid this issue :).