### PR TITLE
Raise ArgumentError at compile time if unsupported log level is set for Ecto.LogEntry

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -94,6 +94,8 @@ defmodule Ecto.Repo do
         Enum.reduce(config[:loggers] || [Ecto.LogEntry], quote(do: entry), fn
           mod, acc when is_atom(mod) ->
             quote do: unquote(mod).log(unquote(acc))
+          {Ecto.LogEntry, :log, [level]}, _acc when not level in [:error, :info, :warn, :debug] ->
+            raise ArgumentError, "the log level #{inspect level} is not supported in Ecto.LogEntry"
           {mod, fun, args}, acc ->
             quote do: unquote(mod).unquote(fun)(unquote(acc), unquote_splicing(args))
         end)


### PR DESCRIPTION
Fixes #1744