### PR TITLE
[WIP] Allow cast_assoc to work inside embeds

### DIFF
--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -62,10 +62,14 @@ defmodule Ecto.Changeset.Relation do
     cardinality_to_empty(cardinality)
   end
 
-  def load!(struct, %NotLoaded{__field__: field}) do
+  def load!(%{__meta__: _, __struct__: struct}, %NotLoaded{__field__: field}) do
     raise "attempting to cast or change association `#{field}` " <>
-          "from `#{inspect struct.__struct__}` that was not loaded. Please preload your " <>
+          "from `#{inspect struct}` that was not loaded. Please preload your " <>
           "associations before manipulating them through changesets"
+  end
+
+  def load!(_struct, %NotLoaded{__cardinality__: cardinality}) do
+    cardinality_to_empty(cardinality)
   end
 
   def load!(_struct, loaded), do: loaded


### PR DESCRIPTION
The issue is that embeds don't have the `__meta__` field, so we want to
raise only for regular schemas.
This, unfortunately, creates another problem. We don't know if the embed
was just created or loaded from database and needs preloading the
association data. This is very risky to use as it may cause data loss
if used improperly.

---

The use case for associations inside embeds is NoSQL databases, where this seems like a reasonable thing to do.

If we're going to merge this, we need more tests around this functionality.