### PR TITLE
Squashing credo consistency issue about spaces around operators

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -769,7 +769,7 @@ if Code.ensure_loaded?(Mariaex) do
     defp assemble(list, joiner) do
       list
       |> List.flatten
-      |> Enum.reject(fn(v)-> v == "" end)
+      |> Enum.reject(fn(v) -> v == "" end)
       |> Enum.join(joiner)
     end
 


### PR DESCRIPTION
There was a space missing before the `->`