### PR TITLE
Add clause of replace all to on_conflict

### DIFF
--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -4,7 +4,7 @@ Logger.configure(level: :info)
 # on MySQL 5.6 but that is not yet supported in travis.
 ExUnit.start exclude: [:array_type, :read_after_writes, :uses_usec, :uses_msec, :returning,
                        :strict_savepoint, :create_index_if_not_exists, :modify_column,
-                       :transaction_isolation, :rename_column, :upsert_all, :with_conflict_target]
+                       :transaction_isolation, :rename_column, :upsert_all, :with_conflict_target, :replace_all_with_conflict_target]
 
 # Configure Ecto for support and tests
 Application.put_env(:ecto, :lock_for_update, "FOR UPDATE")

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -77,10 +77,10 @@ _   = Ecto.Adapters.Postgres.storage_down(TestRepo.config)
 %{rows: [[version]]} = TestRepo.query!("SHOW server_version", [])
 
 if Version.match?(version, "~> 9.5") do
-  ExUnit.configure(exclude: [:without_conflict_target])
+  ExUnit.configure(exclude: [:without_conflict_target, :replace_all_without_conflict_target])
 else
   Application.put_env(:ecto, :postgres_map_type, "json")
-  ExUnit.configure(exclude: [:upsert, :upsert_all, :array_type])
+  ExUnit.configure(exclude: [:upsert, :upsert_all, :array_type, :upsert_all_only_replace_all])
 end
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -146,6 +146,16 @@ if Code.ensure_loaded?(Mariaex) do
       quoted = quote_name(field)
       " ON DUPLICATE KEY UPDATE " <> quoted <> " = " <> quoted
     end
+    defp on_conflict({:replace_all, _, []}, header) do
+      updates = Enum.map(header, fn field ->
+        quoted = quote_name(field)
+
+        quoted <> " = VALUES(" <> quoted <> ")"
+      end)
+      |> Enum.join(",")
+
+      " ON DUPLICATE KEY UPDATE " <> updates
+    end
     defp on_conflict({query, _, []}, _header) do
       " ON DUPLICATE KEY " <> update_all(query, "UPDATE")
     end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -183,6 +183,9 @@ if Code.ensure_loaded?(Postgrex) do
     defp on_conflict({:nothing, _, targets}) do
       "ON CONFLICT " <> conflict_target(targets) <> "DO NOTHING"
     end
+    defp on_conflict({:replace_all, _, targets}) do
+      error!(nil, "The :replace_all option is not supported by PostgreSQL")
+    end
     defp on_conflict({query, _, targets}) do
       "ON CONFLICT " <> conflict_target(targets) <> "DO " <> update_all(query, "UPDATE SET")
     end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -416,6 +416,8 @@ defmodule Ecto.Repo.Schema do
         raise ArgumentError, ":conflict_target option is forbidden when :on_conflict is :raise"
       :nothing ->
         {:nothing, [], conflict_target}
+      :replace_all ->
+        {:replace_all, [], conflict_target}
       [_ | _] = on_conflict ->
         from = if schema, do: {source, schema}, else: source
         query = Ecto.Query.from from, update: ^on_conflict

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -497,6 +497,9 @@ defmodule Ecto.Adapters.MySQLTest do
     update = from("schema", update: [set: [z: ^"foo"]]) |> normalize(:update_all, 2)
     query = SQL.insert(nil, "schema", [:x, :y], [[:x, :y]], {update, [], []}, [])
     assert query == ~s{INSERT INTO `schema` (`x`,`y`) VALUES (?,?) ON DUPLICATE KEY UPDATE `z` = ?}
+
+    query = SQL.insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], []}, [])
+    assert query == ~s{INSERT INTO `schema` (`x`,`y`) VALUES (?,?) ON DUPLICATE KEY UPDATE `x` = VALUES(`x`),`y` = VALUES(`y`)}
   end
 
   test "update" do
@@ -514,6 +517,7 @@ defmodule Ecto.Adapters.MySQLTest do
     query = SQL.delete("prefix", "schema", [:x, :y], [])
     assert query == ~s{DELETE FROM `prefix`.`schema` WHERE `x` = ? AND `y` = ?}
   end
+
 
   # DDL
 

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -518,7 +518,6 @@ defmodule Ecto.Adapters.MySQLTest do
     assert query == ~s{DELETE FROM `prefix`.`schema` WHERE `x` = ? AND `y` = ?}
   end
 
-
   # DDL
 
   import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3,

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -611,6 +611,13 @@ defmodule Ecto.Adapters.PostgresTest do
     update = from("schema", update: [set: [z: ^"foo"]], where: [w: true]) |> normalize(:update_all, 2)
     query = SQL.insert(nil, "schema", [:x, :y], [[:x, :y]], {update, [], [:x, :y]}, [:z])
     assert query == ~s{INSERT INTO "schema" AS s0 ("x","y") VALUES ($1,$2) ON CONFLICT ("x","y") DO UPDATE SET "z" = $3 WHERE (s0."w" = TRUE) RETURNING "z"}
+
+    # For :replace_all
+    query = SQL.insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], [:id]}, [])
+    assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT ("id") DO UPDATE SET "x" = EXCLUDED.x,"y" = EXCLUDED.y}
+
+    query = SQL.insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], []}, [])
+    assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT DO UPDATE SET "x" = EXCLUDED.x,"y" = EXCLUDED.y}
   end
 
   test "update" do


### PR DESCRIPTION
HI, Thanks for great Library.
I wanted to be able to set conditions for all columns when specifying the on_conflict clause in insert / insert_all. for example, it was necessary when doing large batch processing with RDB.
therefore, I added a little fix to the library. I would be happy if you could review.

Thanks.
