### PR TITLE
Extract setting transaction isolation level logic to named function

### DIFF
--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -473,18 +473,22 @@ defmodule Ecto.Adapters.SQL.Sandbox do
     case DBConnection.Ownership.ownership_checkout(name, pool_opts) do
       :ok ->
         if isolation = opts[:isolation] do
-          query = "SET TRANSACTION ISOLATION LEVEL #{isolation}"
-          case Ecto.Adapters.SQL.query(repo, query, [], sandbox_subtransaction: false) do
-            {:ok, _} ->
-              :ok
-            {:error, error} ->
-              checkin(repo, opts)
-              raise error
-          end
+          set_transaction_isolation_level(repo, isolation)
         end
         :ok
       other ->
         other
+    end
+  end
+
+  defp set_transaction_isolation_level(repo, isolation) do
+    query = "SET TRANSACTION ISOLATION LEVEL #{isolation}"
+    case Ecto.Adapters.SQL.query(repo, query, [], sandbox_subtransaction: false) do
+      {:ok, _} ->
+        :ok
+      {:error, error} ->
+        checkin(repo, [])
+        raise error
     end
   end
 


### PR DESCRIPTION
This change will squash a credo warning around nesting.

I chose not to bring in all of `opts` in the function as it is only being pased to `checkin/2` which ignores it anyway.

No tests covering this logic, but I am confident the change is safe.