### PR TITLE
Add new changeset action :ignore

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -70,6 +70,25 @@ defmodule Ecto.Integration.RepoTest do
     assert post.inserted_at
   end
 
+  test "insert, update and delete with action :ignore" do
+    changeset = %{Post.changeset(%Post{}, %{title: "hello"}) | action: :ignore}
+    TestRepo.insert! changeset
+    assert [] == TestRepo.all(Post)
+
+    changeset = %{Post.changeset(%Post{}, %{title: "hello"}) | action: :ignore, valid?: false}
+    {:error, ^changeset} = TestRepo.insert changeset
+
+    post = TestRepo.insert!(%Post{title: "hello"})
+
+    changeset = %{Post.changeset(post, %{title: "title1"}) | action: :ignore}
+    TestRepo.update! changeset
+    assert [] == TestRepo.all from p in Post, where: p.title == "title1"
+
+    changeset = %{Post.changeset(post, %{title: "title1"}) | action: :ignore}
+    TestRepo.delete! changeset
+    assert TestRepo.get_by(Post, title: "hello")
+  end
+
   @tag :composite_pk
   test "insert, update and delete with composite pk" do
     c1 = TestRepo.insert!(%CompositePk{a: 1, b: 2, name: "first"})

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -235,7 +235,7 @@ defmodule Ecto.Changeset do
                         types: nil | %{atom => Ecto.Type.t}}
 
   @type error :: {String.t, Keyword.t}
-  @type action :: nil | :insert | :update | :delete | :replace
+  @type action :: nil | :insert | :update | :delete | :replace | :ignore
   @type constraint :: %{type: :unique, constraint: String.t, match: :exact | :suffix,
                         field: atom, message: error}
   @type data :: map()

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -187,6 +187,14 @@ defmodule Ecto.RepoTest do
     assert {:error, ^delete} = TestRepo.delete(invalid)
   end
 
+  test "insert, update, insert_or_update and delete with changeset action :ignore" do
+    ignored = %Ecto.Changeset{valid?: true, data: %MySchema{id: 123}, action: :ignore}
+    assert {:ok, %MySchema{}} = TestRepo.insert(ignored)
+    assert {:ok, %MySchema{}} = TestRepo.update(ignored)
+    assert {:ok, %MySchema{}} = TestRepo.insert_or_update(ignored)
+    assert {:ok, %MySchema{}} = TestRepo.delete(ignored)
+  end
+
   test "insert!, update! and delete! accepts changesets" do
     valid = Ecto.Changeset.cast(%MySchema{id: 1}, %{}, [])
     assert %MySchema{} = TestRepo.insert!(valid)


### PR DESCRIPTION
Ecto mailing list discussion - https://groups.google.com/forum/#!topic/elixir-ecto/ScPo16tfllc

Workaround with `cast_assoc/3` to ignore association with empty parameters:

```elixir
defmodule Post do
  use Ecto.Schema
  import Ecto.Changeset

  schema "posts" do
    field :title, :string
    field :body, :string
    has_many :comments, Comment
  end

  def changeset(post, params) do
    cast(post, params, [:title, :body])
    |> cast_assoc(:comments, with: &Comment.changeset_ignored_without_required_fields/2)
  end
end

defmodule Comment do
  use Ecto.Schema
  import Ecto.Changeset

  schema "comments" do
    field :body, :string
    belongs_to :post, Post
  end

  def changeset_ignored_without_required_fields(comment, params) do
    cast(comment, params, [:body])
    |> maybe_ignore
  end

  defp maybe_ignore(%{changes: %{body: body}} = changeset) when is_nil(body) or body == "" do
    %{changeset | action: :ignored}
  end
  defp maybe_ignore(changeset) do
    changeset
  end
end
```
