### PR TITLE
Remove broken example from Ecto.Query.select docs

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -683,7 +683,7 @@ defmodule Ecto.Query do
       from(c in City, select: c) # returns the schema as a struct
       from(c in City, select: {c.name, c.population})
       from(c in City, select: [c.name, c.county])
-      from(c in City, select: {c.name, ^to_string(40 + 2), 43})
+      from(c in City, select: {c.name, type(^to_string(40 + 2), :string), 43})
       from(c in City, select: %{n: c.name, answer: 42})
 
   It is also possible to select a struct and limit the returned

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -683,7 +683,6 @@ defmodule Ecto.Query do
       from(c in City, select: c) # returns the schema as a struct
       from(c in City, select: {c.name, c.population})
       from(c in City, select: [c.name, c.county])
-      from(c in City, select: {c.name, type(^to_string(40 + 2), :string), 43})
       from(c in City, select: %{n: c.name, answer: 42})
 
   It is also possible to select a struct and limit the returned


### PR DESCRIPTION
Previously, an error was raised:

    ** (Postgrex.Error) ERROR 42P18 (indeterminate_datatype): could not
    determine data type of parameter $1