### PR TITLE
Promote Mnesia adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Database   | Ecto Adapter           | Dependency                   | Ecto 2.0 co
 :----------| :--------------------- | :----------------------------| :-------------------
 PostgreSQL | Ecto.Adapters.Postgres | [postgrex][postgrex]         | Yes
 MySQL      | Ecto.Adapters.MySQL    | [mariaex][mariaex]           | Yes
-Mnesia     | Ecto.Adapters.Mnesia   | [ecto_mnesia][ecto_mnesia]   | Yes
+Mnesia     | EctoMnesia.Adapter     | [ecto_mnesia][ecto_mnesia]   | Yes
 MSSQL      | Tds.Ecto               | [tds_ecto][tds_ecto]         | No
 SQLite3    | Sqlite.Ecto            | [sqlite_ecto][sqlite_ecto]   | No
 MongoDB    | Mongo.Ecto             | [mongodb_ecto][mongodb_ecto] | No

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Database   | Ecto Adapter           | Dependency                   | Ecto 2.0 co
 :----------| :--------------------- | :----------------------------| :-------------------
 PostgreSQL | Ecto.Adapters.Postgres | [postgrex][postgrex]         | Yes
 MySQL      | Ecto.Adapters.MySQL    | [mariaex][mariaex]           | Yes
+Mnesia     | Ecto.Adapters.Mnesia   | [ecto_mnesia][ecto_mnesia]   | Yes
 MSSQL      | Tds.Ecto               | [tds_ecto][tds_ecto]         | No
 SQLite3    | Sqlite.Ecto            | [sqlite_ecto][sqlite_ecto]   | No
 MongoDB    | Mongo.Ecto             | [mongodb_ecto][mongodb_ecto] | No
@@ -78,6 +79,7 @@ MongoDB    | Mongo.Ecto             | [mongodb_ecto][mongodb_ecto] | No
 [tds_ecto]: https://github.com/livehelpnow/tds_ecto
 [sqlite_ecto]: https://github.com/jazzyb/sqlite_ecto
 [mongodb_ecto]: https://github.com/michalmuskala/mongodb_ecto
+[ecto_mnesia]: https://github.com/Nebo15/ecto_mnesia
 
 For example, if you want to use PostgreSQL, add to your `mix.exs` file:
 


### PR DESCRIPTION
Hello,

I've spent some time to create [Ecto 2.0 compatible adapter for Mnesia Erlang term database](https://github.com/Nebo15/ecto_mnesia). Right now it can be used as drop-in replacement with few drawbacks:
- Joins and some other SQL-stuff is not supported. It can be emulated, but emulating them may look like a shot in the foot.
- SQL sandbox is not supported (because there are no connection pool that is needed to work with it).
- No type casting (and probably we don't need it at all).
- Other small stuff listed in readme.md.

Code may be dirty, any help, suggestions or pedantic code review is greatly appreciated 💯 👍 .

PR can be merged whenever community decides that adapter is ready to be promoted.