### PR TITLE
Switch id fields to default to BIGINT

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -751,7 +751,8 @@ if Code.ensure_loaded?(Mariaex) do
     defp ecto_to_db(type, query \\ nil)
     defp ecto_to_db({:array, _}, query),
       do: error!(query, "Array type is not supported by MySQL")
-    defp ecto_to_db(:id, _query),             do: "integer"
+    defp ecto_to_db(:id, _query),             do: "bigint unsigned"
+    defp ecto_to_db(:serial, _query),         do: "bigint unsigned not null auto_increment"
     defp ecto_to_db(:binary_id, _query),      do: "binary(16)"
     defp ecto_to_db(:string, _query),         do: "varchar"
     defp ecto_to_db(:float, _query),          do: "double"

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -687,6 +687,7 @@ if Code.ensure_loaded?(Mariaex) do
       do: quote_name(name)
 
     defp reference_column_type(:serial, _opts), do: "BIGINT UNSIGNED"
+    defp reference_column_type(:bigserial, _opts), do: "BIGINT UNSIGNED"
     defp reference_column_type(type, opts), do: column_type(type, opts)
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
@@ -753,6 +754,7 @@ if Code.ensure_loaded?(Mariaex) do
       do: error!(query, "Array type is not supported by MySQL")
     defp ecto_to_db(:id, _query),             do: "bigint unsigned"
     defp ecto_to_db(:serial, _query),         do: "bigint unsigned not null auto_increment"
+    defp ecto_to_db(:bigserial, _query),      do: "bigint unsigned not null auto_increment"
     defp ecto_to_db(:binary_id, _query),      do: "binary(16)"
     defp ecto_to_db(:string, _query),         do: "varchar"
     defp ecto_to_db(:float, _query),          do: "double"

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -752,7 +752,7 @@ if Code.ensure_loaded?(Mariaex) do
     defp ecto_to_db(type, query \\ nil)
     defp ecto_to_db({:array, _}, query),
       do: error!(query, "Array type is not supported by MySQL")
-    defp ecto_to_db(:id, _query),             do: "bigint unsigned"
+    defp ecto_to_db(:id, _query),             do: "integer"
     defp ecto_to_db(:serial, _query),         do: "bigint unsigned not null auto_increment"
     defp ecto_to_db(:bigserial, _query),      do: "bigint unsigned not null auto_increment"
     defp ecto_to_db(:binary_id, _query),      do: "binary(16)"

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -845,6 +845,7 @@ if Code.ensure_loaded?(Postgrex) do
       do: quote_name(name)
 
     defp reference_column_type(:serial, _opts), do: "bigint"
+    defp reference_column_type(:bigserial, _opts), do: "bigint"
     defp reference_column_type(type, opts), do: column_type(type, opts)
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
@@ -915,8 +916,9 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp ecto_to_db({:array, t}),     do: [ecto_to_db(t), ?[, ?]]
-    defp ecto_to_db(:id),             do: "bigint"
-    defp ecto_to_db(:serial),         do: "bigserial"
+    defp ecto_to_db(:id),             do: "integer"
+    defp ecto_to_db(:serial),         do: "serial"
+    defp ecto_to_db(:bigserial),      do: "bigserial"
     defp ecto_to_db(:binary_id),      do: "uuid"
     defp ecto_to_db(:string),         do: "varchar"
     defp ecto_to_db(:binary),         do: "bytea"

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -844,7 +844,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp reference_name(%Reference{name: name}, _table, _column),
       do: quote_name(name)
 
-    defp reference_column_type(:serial, _opts), do: "bigint"
+    defp reference_column_type(:serial, _opts), do: "integer"
     defp reference_column_type(:bigserial, _opts), do: "bigint"
     defp reference_column_type(type, opts), do: column_type(type, opts)
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -838,13 +838,13 @@ if Code.ensure_loaded?(Postgrex) do
            ") REFERENCES ", quote_table(table.prefix, ref.table), ?(, quote_name(ref.column), ?),
            reference_on_delete(ref.on_delete), reference_on_update(ref.on_update)]
 
-    # A reference pointing to a serial column becomes integer in postgres
+    # A reference pointing to a serial column becomes bigint in postgres
     defp reference_name(%Reference{name: nil}, table, column),
       do: quote_name("#{table.name}_#{column}_fkey")
     defp reference_name(%Reference{name: name}, _table, _column),
       do: quote_name(name)
 
-    defp reference_column_type(:serial, _opts), do: "integer"
+    defp reference_column_type(:serial, _opts), do: "bigint"
     defp reference_column_type(type, opts), do: column_type(type, opts)
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
@@ -915,7 +915,8 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp ecto_to_db({:array, t}),     do: [ecto_to_db(t), ?[, ?]]
-    defp ecto_to_db(:id),             do: "integer"
+    defp ecto_to_db(:id),             do: "bigint"
+    defp ecto_to_db(:serial),         do: "bigserial"
     defp ecto_to_db(:binary_id),      do: "uuid"
     defp ecto_to_db(:string),         do: "varchar"
     defp ecto_to_db(:binary),         do: "bytea"

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -838,7 +838,6 @@ if Code.ensure_loaded?(Postgrex) do
            ") REFERENCES ", quote_table(table.prefix, ref.table), ?(, quote_name(ref.column), ?),
            reference_on_delete(ref.on_delete), reference_on_update(ref.on_update)]
 
-    # A reference pointing to a serial column becomes bigint in postgres
     defp reference_name(%Reference{name: nil}, table, column),
       do: quote_name("#{table.name}_#{column}_fkey")
     defp reference_name(%Reference{name: name}, _table, _column),

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -206,7 +206,7 @@ defmodule Ecto.Migration do
 
     To define a reference in a migration, see `Ecto.Migration.references/2`
     """
-    defstruct name: nil, table: nil, column: :id, type: :serial, on_delete: :nothing, on_update: :nothing
+    defstruct name: nil, table: nil, column: :id, type: :bigserial, on_delete: :nothing, on_update: :nothing
     @type t :: %__MODULE__{table: atom, column: atom, type: atom, on_delete: atom, on_update: atom}
   end
 
@@ -244,7 +244,7 @@ defmodule Ecto.Migration do
   Creates a table.
 
   By default, the table will also include a primary_key of name `:id`
-  and type `:serial`. Check `table/2` docs for more information.
+  and type `:bigserial`. Check `table/2` docs for more information.
 
   ## Examples
 
@@ -276,7 +276,7 @@ defmodule Ecto.Migration do
       Runner.start_command({unquote(command), Ecto.Migration.__prefix__(table)})
 
       if table.primary_key do
-        add(:id, :serial, primary_key: true)
+        add(:id, :bigserial, primary_key: true)
       end
 
       unquote(block)
@@ -359,7 +359,7 @@ defmodule Ecto.Migration do
   defp do_create(table, command) do
     columns =
       if table.primary_key do
-        [{:add, :id, :serial, primary_key: true}]
+        [{:add, :id, :bigserial, primary_key: true}]
       else
         []
       end
@@ -737,7 +737,7 @@ defmodule Ecto.Migration do
     * `:name` - The name of the underlying reference,
       defaults to "#{table}_#{column}_fkey"
     * `:column` - The foreign key column, default is `:id`
-    * `:type`   - The foreign key type, default is `:serial`
+    * `:type`   - The foreign key type, default is `:bigserial`
     * `:on_delete` - What to perform if the referenced entry
          is deleted. May be `:nothing`, `:delete_all` or
          `:nilify_all`. Defaults to `:nothing`.

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -568,7 +568,7 @@ defmodule Ecto.Adapters.MySQLTest do
     create = {:create, table(:posts, engine: :myisam),
                [{:add, :id, :serial, [primary_key: true]}]}
     assert execute_ddl(create) ==
-           [~s|CREATE TABLE `posts` (`id` serial, PRIMARY KEY (`id`)) ENGINE = MYISAM|]
+           [~s|CREATE TABLE `posts` (`id` bigint unsigned not null auto_increment, PRIMARY KEY (`id`)) ENGINE = MYISAM|]
   end
 
   test "create table with references" do
@@ -581,7 +581,7 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:add, :category_4, references(:categories, on_delete: :nilify_all), []}]}
 
     assert execute_ddl(create) == ["""
-    CREATE TABLE `posts` (`id` serial,
+    CREATE TABLE `posts` (`id` bigint unsigned not null auto_increment,
     `category_0` BIGINT UNSIGNED,
     CONSTRAINT `posts_category_0_fkey` FOREIGN KEY (`category_0`) REFERENCES `categories`(`id`),
     `category_1` BIGINT UNSIGNED,
@@ -601,7 +601,7 @@ defmodule Ecto.Adapters.MySQLTest do
                [{:add, :id, :serial, [primary_key: true]},
                 {:add, :created_at, :datetime, []}]}
     assert execute_ddl(create) ==
-           [~s|CREATE TABLE `posts` (`id` serial, `created_at` datetime, PRIMARY KEY (`id`)) ENGINE = INNODB WITH FOO=BAR|]
+           [~s|CREATE TABLE `posts` (`id` bigint unsigned not null auto_increment, `created_at` datetime, PRIMARY KEY (`id`)) ENGINE = INNODB WITH FOO=BAR|]
   end
 
   test "create table with both engine and options" do
@@ -609,7 +609,7 @@ defmodule Ecto.Adapters.MySQLTest do
                [{:add, :id, :serial, [primary_key: true]},
                 {:add, :created_at, :datetime, []}]}
     assert execute_ddl(create) ==
-           [~s|CREATE TABLE `posts` (`id` serial, `created_at` datetime, PRIMARY KEY (`id`)) ENGINE = MYISAM WITH FOO=BAR|]
+           [~s|CREATE TABLE `posts` (`id` bigint unsigned not null auto_increment, `created_at` datetime, PRIMARY KEY (`id`)) ENGINE = MYISAM WITH FOO=BAR|]
   end
 
   test "create table with composite key" do
@@ -672,7 +672,7 @@ defmodule Ecto.Adapters.MySQLTest do
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE `posts`
-    ADD `my_pk` serial,
+    ADD `my_pk` bigint unsigned not null auto_increment,
     ADD PRIMARY KEY (`my_pk`)
     """ |> remove_newlines]
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -247,10 +247,10 @@ defmodule Ecto.Adapters.PostgresTest do
     assert SQL.all(query) == ~s{SELECT $1::uuid FROM "schema" AS s0}
 
     query = Schema |> select([], type(^1, Custom.Permalink)) |> normalize
-    assert SQL.all(query) == ~s{SELECT $1::integer FROM "schema" AS s0}
+    assert SQL.all(query) == ~s{SELECT $1::bigint FROM "schema" AS s0}
 
     query = Schema |> select([], type(^[1,2,3], {:array, Custom.Permalink})) |> normalize
-    assert SQL.all(query) == ~s{SELECT $1::integer[] FROM "schema" AS s0}
+    assert SQL.all(query) == ~s{SELECT $1::bigint[] FROM "schema" AS s0}
   end
 
   test "nested expressions" do
@@ -676,7 +676,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
     assert execute_ddl(create) == ["""
     CREATE TABLE "foo"."posts"
-    ("category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "foo"."categories"("id"))
+    ("category_0" bigint CONSTRAINT "posts_category_0_fkey" REFERENCES "foo"."categories"("id"))
     """ |> remove_newlines]
   end
 
@@ -689,7 +689,7 @@ defmodule Ecto.Adapters.PostgresTest do
               ]}
     assert execute_ddl(create) == [remove_newlines("""
     CREATE TABLE "posts"
-    ("category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"), "created_at" timestamp, "updated_at" timestamp)
+    ("category_0" bigint CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"), "created_at" timestamp, "updated_at" timestamp)
     """),
     ~s|COMMENT ON TABLE "posts" IS 'comment'|,
     ~s|COMMENT ON COLUMN "posts"."category_0" IS 'column comment'|,
@@ -701,7 +701,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :category_0, references(:categories), []}]}
     assert execute_ddl(create) == [remove_newlines("""
     CREATE TABLE "posts"
-    ("category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"))
+    ("category_0" bigint CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"))
     """),
     ~s|COMMENT ON TABLE "posts" IS 'table comment'|]
   end
@@ -715,7 +715,7 @@ defmodule Ecto.Adapters.PostgresTest do
               ]}
     assert execute_ddl(create) == [remove_newlines("""
     CREATE TABLE "posts"
-    ("category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"), "created_at" timestamp, "updated_at" timestamp)
+    ("category_0" bigint CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"), "created_at" timestamp, "updated_at" timestamp)
     """),
     ~s|COMMENT ON COLUMN "posts"."category_0" IS 'column comment'|,
     ~s|COMMENT ON COLUMN "posts"."updated_at" IS 'column comment 2'|]
@@ -735,16 +735,16 @@ defmodule Ecto.Adapters.PostgresTest do
                {:add, :category_8, references(:categories, on_delete: :nilify_all, on_update: :update_all), [null: false]}]}
 
     assert execute_ddl(create) == ["""
-    CREATE TABLE "posts" ("id" serial,
-    "category_0" integer CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"),
-    "category_1" integer CONSTRAINT "foo_bar" REFERENCES "categories"("id"),
-    "category_2" integer CONSTRAINT "posts_category_2_fkey" REFERENCES "categories"("id"),
-    "category_3" integer NOT NULL CONSTRAINT "posts_category_3_fkey" REFERENCES "categories"("id") ON DELETE CASCADE,
-    "category_4" integer CONSTRAINT "posts_category_4_fkey" REFERENCES "categories"("id") ON DELETE SET NULL,
-    "category_5" integer CONSTRAINT "posts_category_5_fkey" REFERENCES "categories"("id"),
-    "category_6" integer NOT NULL CONSTRAINT "posts_category_6_fkey" REFERENCES "categories"("id") ON UPDATE CASCADE,
-    "category_7" integer CONSTRAINT "posts_category_7_fkey" REFERENCES "categories"("id") ON UPDATE SET NULL,
-    "category_8" integer NOT NULL CONSTRAINT "posts_category_8_fkey" REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CREATE TABLE "posts" ("id" bigserial,
+    "category_0" bigint CONSTRAINT "posts_category_0_fkey" REFERENCES "categories"("id"),
+    "category_1" bigint CONSTRAINT "foo_bar" REFERENCES "categories"("id"),
+    "category_2" bigint CONSTRAINT "posts_category_2_fkey" REFERENCES "categories"("id"),
+    "category_3" bigint NOT NULL CONSTRAINT "posts_category_3_fkey" REFERENCES "categories"("id") ON DELETE CASCADE,
+    "category_4" bigint CONSTRAINT "posts_category_4_fkey" REFERENCES "categories"("id") ON DELETE SET NULL,
+    "category_5" bigint CONSTRAINT "posts_category_5_fkey" REFERENCES "categories"("id"),
+    "category_6" bigint NOT NULL CONSTRAINT "posts_category_6_fkey" REFERENCES "categories"("id") ON UPDATE CASCADE,
+    "category_7" bigint CONSTRAINT "posts_category_7_fkey" REFERENCES "categories"("id") ON UPDATE SET NULL,
+    "category_8" bigint NOT NULL CONSTRAINT "posts_category_8_fkey" REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE,
     PRIMARY KEY ("id"))
     """ |> remove_newlines]
   end
@@ -754,7 +754,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :id, :serial, [primary_key: true]},
                {:add, :created_at, :naive_datetime, []}]}
     assert execute_ddl(create) ==
-      [~s|CREATE TABLE "posts" ("id" serial, "created_at" timestamp, PRIMARY KEY ("id")) WITH FOO=BAR|]
+      [~s|CREATE TABLE "posts" ("id" bigserial, "created_at" timestamp, PRIMARY KEY ("id")) WITH FOO=BAR|]
   end
 
   test "create table with composite key" do
@@ -790,13 +790,13 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(alter) == ["""
     ALTER TABLE "posts"
     ADD COLUMN "title" varchar(100) DEFAULT 'Untitled' NOT NULL,
-    ADD COLUMN "author_id" integer CONSTRAINT "posts_author_id_fkey" REFERENCES "author"("id"),
+    ADD COLUMN "author_id" bigint CONSTRAINT "posts_author_id_fkey" REFERENCES "author"("id"),
     ALTER COLUMN "price" TYPE numeric(8,2),
     ALTER COLUMN "price" DROP NOT NULL,
     ALTER COLUMN "cost" TYPE integer,
     ALTER COLUMN "cost" SET NOT NULL,
     ALTER COLUMN "cost" SET DEFAULT NULL,
-    ALTER COLUMN "permalink_id" TYPE integer,
+    ALTER COLUMN "permalink_id" TYPE bigint,
     ADD CONSTRAINT "posts_permalink_id_fkey" FOREIGN KEY ("permalink_id") REFERENCES "permalinks"("id"),
     ALTER COLUMN "permalink_id" SET NOT NULL,
     DROP COLUMN "summary"
@@ -815,7 +815,7 @@ defmodule Ecto.Adapters.PostgresTest do
     ADD COLUMN "title" varchar(100) DEFAULT 'Untitled' NOT NULL,
     ALTER COLUMN "price" TYPE numeric(8,2),
     ALTER COLUMN "price" DROP NOT NULL,
-    ALTER COLUMN "permalink_id" TYPE integer,
+    ALTER COLUMN "permalink_id" TYPE bigint,
     ADD CONSTRAINT "posts_permalink_id_fkey" FOREIGN KEY ("permalink_id") REFERENCES "permalinks"("id"),
     ALTER COLUMN "permalink_id" SET NOT NULL,
     DROP COLUMN "summary"
@@ -833,8 +833,8 @@ defmodule Ecto.Adapters.PostgresTest do
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE "foo"."posts"
-    ADD COLUMN "author_id" integer CONSTRAINT "posts_author_id_fkey" REFERENCES "foo"."author"("id"),
-    ALTER COLUMN \"permalink_id\" TYPE integer,
+    ADD COLUMN "author_id" bigint CONSTRAINT "posts_author_id_fkey" REFERENCES "foo"."author"("id"),
+    ALTER COLUMN \"permalink_id\" TYPE bigint,
     ADD CONSTRAINT "posts_permalink_id_fkey" FOREIGN KEY ("permalink_id") REFERENCES "foo"."permalinks"("id"),
     ALTER COLUMN "permalink_id" SET NOT NULL
     """ |> remove_newlines]
@@ -846,7 +846,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE "posts"
-    ADD COLUMN "my_pk" serial,
+    ADD COLUMN "my_pk" bigserial,
     ADD PRIMARY KEY ("my_pk")
     """ |> remove_newlines]
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -53,7 +53,7 @@ defmodule Ecto.MigrationTest do
 
   test "creates a reference" do
     assert references(:posts) ==
-           %Reference{table: :posts, column: :id, type: :serial}
+           %Reference{table: :posts, column: :id, type: :bigserial}
     assert references(:posts, type: :uuid, column: :other) ==
            %Reference{table: :posts, column: :other, type: :uuid}
   end
@@ -108,7 +108,7 @@ defmodule Ecto.MigrationTest do
 
     assert last_command() ==
            {:create, table,
-              [{:add, :id, :serial, [primary_key: true]},
+              [{:add, :id, :bigserial, [primary_key: true]},
                {:add, :title, :string, []},
                {:add, :cost, :decimal, [precision: 3]},
                {:add, :likes, :"int UNSIGNED", [default: 0]},
@@ -168,7 +168,7 @@ defmodule Ecto.MigrationTest do
     flush()
 
     assert last_command() ==
-           {:create, table, [{:add, :id, :serial, [primary_key: true]}]}
+           {:create, table, [{:add, :id, :bigserial, [primary_key: true]}]}
   end
 
   test "forward: alters a table" do


### PR DESCRIPTION
This is an initial cut at implementing BIGINT as the default for primary/foreign keys within Ecto for consideration (especially given this is my first proposed PR for this project).

There are some outstanding issues which I need to document as a second commit within this PR but I wasn't sure on the best place. They are:

### PostgreSQL
PostgreSQL will silently ignore differences between foreign key column types and keep functioning, until it doesn’t (This would be right around the id 2147483647 as best I can tell).

Options:

  1. Update the existing Types to be compatible with Ecto (recommended):
        1. Alter the type of the primary key in existing tables to be `bigserial`
        2. Alter the type of foreign key in existing tables to be `bigint`

  2. Alter the `type` option provided to the `references` function when creating any new foreign key  to be `:integer`

### MySQL
MySQL will not ignore differences between foreign_key column types and instead provides the following error:

ERROR 1005 (HY000): Can't create table `database`.`table_name` (errno: 150 "Foreign key constraint is incorrectly formed")

Options:

  1. Update the existing Types to be compatible with Ecto:
	 1. Alter the type of the primary key in existing tables to be `bigint unsigned not null auto_increment`
	 2. Alter the type of foreign key in existing tables to be `bigint unsigned`

  2. Alter the `type` option provided to the `references` function when creating any new foreign key to be `:integer`

