### PR TITLE
Correctly list the available options for creating constraints

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -771,8 +771,8 @@ defmodule Ecto.Migration do
 
   ## Options
 
-    * `:check` - The expression to evaluate on a row. Required when creating.
-    * `:name` - The name of the constraint - required.
+    * `:check` - A check constraint expresion. Required when creating a check constraint.
+    * `:exclude` - An exclusion constraint expression. Required when creating an exclusion constraint.
 
   """
   def constraint(table, name, opts \\ []) do


### PR DESCRIPTION
`:name` isn't really an option, and `:exclude` is, as shown in the examples. This was my mistake.