### PR TITLE
Allow migrations to log raw SQL if required

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -16,7 +16,7 @@ defmodule Ecto.Migration.Runner do
   def run(repo, module, direction, operation, migrator_direction, opts) do
     level = Keyword.get(opts, :log, :info)
     sql = Keyword.get(opts, :log_sql, false)
-    log = [level: level, sql: sql]
+    log = %{level: level, sql: sql}
     args  = [self(), repo, direction, migrator_direction, log]
 
     {:ok, runner} = Supervisor.start_child(Ecto.Migration.Supervisor, args)
@@ -214,7 +214,7 @@ defmodule Ecto.Migration.Runner do
     end)
   end
 
-  defp log_and_execute_ddl(repo, [level: level, sql: sql], command) do
+  defp log_and_execute_ddl(repo, %{level: level, sql: sql}, command) do
     log(level, command(command))
     repo.__adapter__.execute_ddl(repo, command, [timeout: :infinity, log: sql])
   end

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -94,7 +94,7 @@ defmodule Ecto.Migration.Runner do
     commands  = if direction == :backward, do: commands, else: Enum.reverse(commands)
 
     for command <- commands do
-      {repo, direction, log} = runner_config
+      {repo, direction, log} = runner_config()
       execute_in_direction(repo, direction, log, command)
     end
   end

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -64,12 +64,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
     opts =
       if opts[:quiet],
-        do: Keyword.put(opts, :log, false),
-        else: opts
-
-    opts =
-      if opts[:quiet],
-        do: Keyword.put(opts, :log_sql, false),
+        do: Keyword.merge(opts, [log: false, log_sql: false]),
         else: opts
 
     Enum.each repos, fn repo ->

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -44,6 +44,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     * `--quiet` - do not log migration commands
     * `--prefix` - the prefix to run migrations on
     * `--pool-size` - the pool size if the repository is started only for the task (defaults to 1)
+    * `--log-sql` - log the raw sql migrations are running
 
   """
 
@@ -53,7 +54,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
     {opts, _, _} = OptionParser.parse args,
       switches: [all: :boolean, step: :integer, to: :integer, quiet: :boolean,
-                 prefix: :string, pool_size: :integer],
+                 prefix: :string, pool_size: :integer, log_sql: :boolean],
       aliases: [n: :step, v: :to]
 
     opts =
@@ -64,6 +65,11 @@ defmodule Mix.Tasks.Ecto.Migrate do
     opts =
       if opts[:quiet],
         do: Keyword.put(opts, :log, false),
+        else: opts
+
+    opts =
+      if opts[:quiet],
+        do: Keyword.put(opts, :log_sql, false),
         else: opts
 
     Enum.each repos, fn repo ->

--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -64,12 +64,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
 
     opts =
       if opts[:quiet],
-        do: Keyword.put(opts, :log, false),
-        else: opts
-
-    opts =
-      if opts[:quiet],
-        do: Keyword.put(opts, :log_sql, false),
+        do: Keyword.merge(opts, [log: false, log_sql: false]),
         else: opts
 
     Enum.each repos, fn repo ->

--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -44,6 +44,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
     * `--quiet` - do not log migration commands
     * `--prefix` - the prefix to run migrations on
     * `--pool-size` - the pool size if the repository is started only for the task (defaults to 1)
+    * `--log-sql` - log the raw sql migrations are running
 
   """
 
@@ -53,7 +54,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
 
     {opts, _, _} = OptionParser.parse args,
       switches: [all: :boolean, step: :integer, to: :integer, start: :boolean,
-                 quiet: :boolean, prefix: :string, pool_size: :integer],
+                 quiet: :boolean, prefix: :string, pool_size: :integer, log_sql: :boolean],
       aliases: [n: :step, v: :to]
 
     opts =
@@ -64,6 +65,11 @@ defmodule Mix.Tasks.Ecto.Rollback do
     opts =
       if opts[:quiet],
         do: Keyword.put(opts, :log, false),
+        else: opts
+
+    opts =
+      if opts[:quiet],
+        do: Keyword.put(opts, :log_sql, false),
         else: opts
 
     Enum.each repos, fn repo ->

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -12,7 +12,7 @@ defmodule Ecto.MigrationTest do
 
   setup meta do
     {:ok, runner} =
-      Runner.start_link(self(), TestRepo, meta[:direction] || :forward, :up, false)
+      Runner.start_link(self(), TestRepo, meta[:direction] || :forward, :up, false, false)
     Runner.metadata(runner, meta)
     {:ok, runner: runner}
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -12,7 +12,7 @@ defmodule Ecto.MigrationTest do
 
   setup meta do
     {:ok, runner} =
-      Runner.start_link(self(), TestRepo, meta[:direction] || :forward, :up, [level: false, sql: false])
+      Runner.start_link(self(), TestRepo, meta[:direction] || :forward, :up, %{level: false, sql: false})
     Runner.metadata(runner, meta)
     {:ok, runner: runner}
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -12,7 +12,7 @@ defmodule Ecto.MigrationTest do
 
   setup meta do
     {:ok, runner} =
-      Runner.start_link(self(), TestRepo, meta[:direction] || :forward, :up, false, false)
+      Runner.start_link(self(), TestRepo, meta[:direction] || :forward, :up, [level: false, sql: false])
     Runner.metadata(runner, meta)
     {:ok, runner: runner}
   end


### PR DESCRIPTION
A small change but access to the raw SQL can be quite useful.