### PR TITLE
put_assoc with params given as string keyed maps does behave correctly

### DIFF
--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -804,6 +804,21 @@ defmodule Ecto.Changeset.HasAssocTest do
     refute Map.has_key?(changeset.changes, :profile)
   end
 
+  test "put_assoc/4 with string map" do
+    ## test maps
+    base_changeset = Changeset.change(%Author{})
+
+    changeset = Changeset.put_assoc(base_changeset, :profile, %{name: "michal"})
+    assert %Ecto.Changeset{} = changeset.changes.profile
+    assert changeset.changes.profile.action == :insert
+    assert Changeset.get_field(changeset, :profile).name == "michal"
+
+    changeset = Changeset.put_assoc(base_changeset, :profile, %{"name" => "michal"})
+    assert %Ecto.Changeset{} = changeset.changes.profile
+    assert changeset.changes.profile.action == :insert
+    assert Changeset.get_field(changeset, :profile).name == "michal"
+  end
+
   test "put_assoc/4 when replacing" do
     profile = %Profile{id: 1, name: "michal"} |> Ecto.put_meta(state: :loaded)
     base_changeset = Changeset.change(%Author{profile: profile})


### PR DESCRIPTION
When you provide put_assoc with a map that is given with string keys, the changes are not resolved when converting the changeset to a struct.

See provided test case.