### PR TITLE
Allows for a second migration source format.

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -131,7 +131,7 @@ defmodule Ecto.Migrator do
   during the migration process. The other option is to pass a list of tuples
   that identify the version number and migration modules to be run, for example:
 
-  `Ecto.Migrator.run(Repo, [{0, MyApp.Migration1}, {1, MyApp.Migration2}, ...], :up, opts)`
+      Ecto.Migrator.run(Repo, [{0, MyApp.Migration1}, {1, MyApp.Migration2}, ...], :up, opts)
 
   A strategy must be given as an option.
 
@@ -222,7 +222,7 @@ defmodule Ecto.Migrator do
   end
 
   # This function will match specific version/modules passed into `Migrator.run`.
-  defp migrations_for(migration_source) do
+  defp migrations_for(migration_source) when is_list(migration_source) do
     Enum.map migration_source, fn({version, module}) -> {version, module, :existing_module} end
   end
 
@@ -289,11 +289,11 @@ defmodule Ecto.Migrator do
 
   defp raise_no_migration_in_file(file) do
     raise Ecto.MigrationError,
-          "file #{Path.relative_to_cwd(file)} does not contain any Ecto.Migration"
+          "file #{Path.relative_to_cwd(file)} is not an Ecto.Migration"
   end
   defp raise_no_migration_in_module(mod) do
     raise Ecto.MigrationError,
-          "module #{mod} does not contain any Ecto.Migration"
+          "module #{inspect mod} is not an Ecto.Migration"
   end
 
   defp log(false, _msg), do: :ok

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -178,7 +178,7 @@ defmodule Ecto.MigratorTest do
   test "fails if there is no migration in file" do
     in_tmp fn path ->
       File.write! "13_sample.exs", ":ok"
-      assert_raise Ecto.MigrationError, "file 13_sample.exs does not contain any Ecto.Migration", fn ->
+      assert_raise Ecto.MigrationError, "file 13_sample.exs is not an Ecto.Migration", fn ->
         run(TestRepo, path, :up, all: true, log: false)
       end
     end
@@ -338,7 +338,7 @@ defmodule Ecto.MigratorTest do
 
   describe "alternate migration source format" do
     test "fails if there is no migration in file" do
-      assert_raise Ecto.MigrationError, "module Elixir.Ecto.MigratorTest.EmptyModule does not contain any Ecto.Migration", fn ->
+      assert_raise Ecto.MigrationError, "module Ecto.MigratorTest.EmptyModule is not an Ecto.Migration", fn ->
         run(TestRepo, [{13, EmptyModule}], :up, all: true, log: false)
       end
     end


### PR DESCRIPTION
My attempt to address #1894.

I'm not quite sure about the following line, as I haven't gotten into typespecs at all in Elixir yet:

`@spec run(Ecto.Repo.t, binary | [{integer, module}], atom, Keyword.t) :: [integer]`