### PR TITLE
Added tag for test that uses SQL.query call

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1036,16 +1036,6 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.insert!(%Post{title: "1"}, [log: false])
   end
 
-  @tag :sql_query
-  test "load" do
-    inserted_at = ~N[2016-01-01 09:00:00.000000]
-    TestRepo.insert!(%Post{title: "title1", inserted_at: inserted_at, public: false})
-
-    result = Ecto.Adapters.SQL.query!(TestRepo, "SELECT * FROM posts", [])
-    posts = Enum.map(result.rows, &TestRepo.load(Post, {result.columns, &1}))
-    assert [%Post{title: "title1", inserted_at: ^inserted_at, public: false}] = posts
-  end
-
   describe "upsert via insert" do
     @describetag :upsert
 

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1036,6 +1036,7 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.insert!(%Post{title: "1"}, [log: false])
   end
 
+  @tag :sql_query
   test "load" do
     inserted_at = ~N[2016-01-01 09:00:00.000000]
     TestRepo.insert!(%Post{title: "title1", inserted_at: inserted_at, public: false})

--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -83,4 +83,13 @@ defmodule Ecto.Integration.SQLTest do
     TestRepo.delete_all(from(Post, where: "'" == "'"))
     assert [] == TestRepo.all(Post)
   end
+
+  test "load" do
+    inserted_at = ~N[2016-01-01 09:00:00.000000]
+    TestRepo.insert!(%Post{title: "title1", inserted_at: inserted_at, public: false})
+
+    result = Ecto.Adapters.SQL.query!(TestRepo, "SELECT * FROM posts", [])
+    posts = Enum.map(result.rows, &TestRepo.load(Post, {result.columns, &1}))
+    assert [%Post{title: "title1", inserted_at: ^inserted_at, public: false}] = posts
+  end
 end


### PR DESCRIPTION
There are test that uses raw SQL call that is not suitable for non-sql based adapters. 

Tag will help to exclude it when running integration tests.