### PR TITLE
Tag test that requires support for schemas without PK

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -143,6 +143,7 @@ defmodule Ecto.Integration.RepoTest do
     assert TestRepo.update!(changeset) == permalink
   end
 
+  @tag :no_primary_key
   test "insert with no primary key" do
     assert %Barebone{num: nil} = TestRepo.insert!(%Barebone{})
     assert %Barebone{num: 13} = TestRepo.insert!(%Barebone{num: 13})


### PR DESCRIPTION
There are some databases that require schemas to have a primary key. 

For this cases it’s useful to allow developers to skip this test.