### PR TITLE
Fix Ecto.Migration.drop documentation

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -378,7 +378,7 @@ defmodule Ecto.Migration do
 
       drop index(:posts, [:name])
       drop table(:posts)
-      drop constraint(:products, name: "price_must_be_positive")
+      drop constraint(:products, "price_must_be_positive")
 
   """
   def drop(%{} = index_or_table_or_constraint) do


### PR DESCRIPTION
`Ecto.Migration.constraint/{2,3}` uses the second argument as the name of the constraint, so, the code that was in the `drop/1` documentation would return a `%Constraint{name: [name: "price_must_be_positive"]}` struct that would fail the operation