### PR TITLE
Use the "postgres" database for create/drop database commands

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -110,7 +110,7 @@ defmodule Ecto.Adapters.Postgres do
   def storage_up(opts) do
     database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
     encoding = opts[:encoding] || "UTF8"
-    opts     = Keyword.put(opts, :database, "template1")
+    opts     = Keyword.put(opts, :database, "postgres")
 
     command =
       ~s(CREATE DATABASE "#{database}" ENCODING '#{encoding}')
@@ -135,7 +135,7 @@ defmodule Ecto.Adapters.Postgres do
   def storage_down(opts) do
     database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
     command  = "DROP DATABASE \"#{database}\""
-    opts     = Keyword.put(opts, :database, "template1")
+    opts     = Keyword.put(opts, :database, "postgres")
 
     case run_query(command, opts) do
       {:ok, _} ->


### PR DESCRIPTION
Formerly, `mix ecto.create` or `mix ecto.drop` used the "template1" database.
However, other processes are not able to create new databases as long as there
is someone connected to the "template1" database. To fix that, we are now
connecting to the "postgres" database, which is also what PostgreSQL tools like
`createdb` do.

Fixes #1925 