### PR TITLE
Add apply_action to changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -251,6 +251,7 @@ defmodule Ecto.Changeset do
 
   @relations [:embed, :assoc]
   @match_types [:exact, :suffix]
+  @actions [:insert, :update, :delete, :replace]
 
   @doc """
   Wraps the given data in a changeset or adds changes to a changeset.
@@ -1134,6 +1135,35 @@ defmodule Ecto.Changeset do
           acc
       end
     end)
+  end
+
+  @doc """
+  Applies the changeset action only if the changes are valid.
+
+  If the changes are valid, all changes are applied to the changeset data.
+  If the changes are invalid, no changes are applied, and an error tuple
+  is returned with the changeset containing the action that was attempted
+  to be applied.
+
+  The action may be one of #{Enum.map_join(@actions, ", ", &"`#{inspect &1}`")}.
+
+  ## Examples
+
+      iex> {:ok, data} = apply_action(changeset, :update)
+
+      iex> {:error, changeset} = apply_action(changeset, :update)
+      %Ecto.Changeset{action: :update}
+  """
+  @spec apply_action(t, action) :: {:ok, Ecto.Schema.t | data} | {:error, t}
+  def apply_action(%Changeset{} = changeset, action) when action in @actions do
+    if changeset.valid? do
+      {:ok, apply_changes(changeset)}
+    else
+      {:error, %Changeset{changeset | action: action}}
+    end
+  end
+  def apply_action(%Changeset{}, action) do
+    raise ArgumentError, "unknown action #{inspect action}. The following values are allowed: #{inspect @actions}"
   end
 
   ## Validations

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -495,6 +495,37 @@ defmodule Ecto.ChangesetTest do
     assert changed_post.title == "foo"
   end
 
+  test "apply_action/2 with valid changeset" do
+    post = %Post{}
+    assert post.title == ""
+
+    changeset = changeset(post, %{"title" => "foo"})
+    assert changeset.valid?
+    assert {:ok, changed_post} = apply_action(changeset, :update)
+
+    assert changed_post.__struct__ == post.__struct__
+    assert changed_post.title == "foo"
+  end
+
+  test "apply_action/2 with invalid changeset" do
+    changeset =
+      %Post{}
+      |> changeset(%{"title" => "foo"})
+      |> validate_length(:title, min: 10)
+
+    refute changeset.valid?
+    changeset_new_action = %Ecto.Changeset{changeset | action: :update}
+    assert {:error, ^changeset_new_action} = apply_action(changeset, :update)
+  end
+
+  test "apply_action/2 with invalid action" do
+    assert_raise ArgumentError, ~r/unknown action/, fn ->
+      %Post{}
+      |> changeset(%{})
+      |> apply_action(:invalid_action)
+    end
+  end
+
   ## Validations
 
   test "add_error/3" do


### PR DESCRIPTION
Useful for composition in Ecto.Multi's to apply
changes only when valid and return an error
tuple in the event of invalid changes.
Additionally, an action may also be provied to
represent the action being peformed from the
changes. This is useful when working with embedded
schemas where operations on the changeset are
committed manually without relying on a Repo to
reflect failed operations on the changeset by
updating the action field.

/cc @josevalim 