### PR TITLE
Update examples for like & ilike

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -80,7 +80,7 @@ defmodule Ecto.Query.API do
   @doc """
   Searches for `search` in `string`.
 
-      from p in Post, where: like(p.body, "Chapter%")
+      from p in Post, where: like(p.body, "%Chapter%")
 
   Translates to the underlying SQL LIKE query, therefore
   its behaviour is dependent on the database. In particular,
@@ -93,7 +93,7 @@ defmodule Ecto.Query.API do
   @doc """
   Searches for `search` in `string` in a case insensitive fashion.
 
-      from p in Post, where: ilike(p.body, "Chapter%")
+      from p in Post, where: ilike(p.body, "%Chapter%")
 
   Translates to the underlying SQL ILIKE query. This operation is
   only available on PostgreSQL.


### PR DESCRIPTION
The string being searched for using `like` or `ilike` must start and end with `%`.
For example, `"%Chapter%"` will work, but not `"Chapter%"` or `"%Chapter"`.