### PR TITLE
Fixup docs for schemaless changesets

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -140,12 +140,11 @@ defmodule Ecto.Changeset do
   ## Schemaless changesets
 
   In the changeset examples so far, we have always used changesets to
-  validate and cast data backed up by a struct, such as the `%User{}`
+  validate and cast data contained in a struct, such as the `%User{}`
   struct defined by the `User` module.
 
-  However, changesets also run without a changeset, by passing a tuple
-  containing both the data and the supported types as a tuple instead
-  of a struct:
+  However, changesets can also be used with data in a plain map, by
+  passing a tuple containing both the data and the supported types:
 
       data  = %{}
       types = %{first_name: :string, last_name: :string, email: :string}


### PR DESCRIPTION
"However, changesets also run without a changeset" is a bit self-referential, so I've tried to distinguish between data in a struct and data in a map (which has no implied schema). Also, the "as a tuple instead of a struct" bit seems superfluous (it's like saying "pass a tuple as a tuple").