### PR TITLE
Added notice about LIKE-injection

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -88,8 +88,8 @@ defmodule Ecto.Query.API do
   majority of other databases will be case-insensitive. For
   performing a case-insensitive `like` in PostgreSQL, see `ilike/2`.
 
-  You should be very careful when allowing user sent data to be used 
-  as part of LIKE query, since they allow to perform 
+  You should be very careful when allowing user sent data to be used
+  as part of LIKE query, since they allow to perform
   [LIKE-injections](https://githubengineering.com/like-injection/).
   """
   def like(string, search), do: doc! [string, search]

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -87,6 +87,10 @@ defmodule Ecto.Query.API do
   PostgreSQL will do a case-sensitive operation, while the
   majority of other databases will be case-insensitive. For
   performing a case-insensitive `like` in PostgreSQL, see `ilike/2`.
+  
+  You should be very careful when allowing user sent data to be used 
+  as part of LIKE query, since they allow to perform 
+  [LIKE-injections](https://githubengineering.com/like-injection/).
   """
   def like(string, search), do: doc! [string, search]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -87,7 +87,7 @@ defmodule Ecto.Query.API do
   PostgreSQL will do a case-sensitive operation, while the
   majority of other databases will be case-insensitive. For
   performing a case-insensitive `like` in PostgreSQL, see `ilike/2`.
-  
+
   You should be very careful when allowing user sent data to be used 
   as part of LIKE query, since they allow to perform 
   [LIKE-injections](https://githubengineering.com/like-injection/).


### PR DESCRIPTION
In general, I'm not sure that Ecto docs is a good place to give security advises. So closing this PR is ok. Maybe we can provide some security opts for `like/2`?

Test case:
```
iex(17)> var = "andrew@gryga.com"                                                  
"andrew@gryga.com"
iex(18)> Repo.all from t in "test_table", where: like(t.test, ^var), select: t.test
16:26:20.356 [debug] QUERY OK source="test_table" db=0.4ms
SELECT t0."test" FROM "test_table" AS t0 WHERE (t0."test" LIKE $1) ["andrew@gryga.com"]
["andrew@gryga.com"]
iex(19)> var = "a%@gryga.com"                                                      
"a%@gryga.com"
iex(20)> Repo.all from t in "test_table", where: like(t.test, ^var), select: t.test
16:26:23.573 [debug] QUERY OK source="test_table" db=0.5ms
SELECT t0."test" FROM "test_table" AS t0 WHERE (t0."test" LIKE $1) ["a%@gryga.com"]
["andrew@gryga.com", "a@gryga.com"]
```

Inspired by Github Engineering blogs post: https://githubengineering.com/like-injection/