### PR TITLE
Update hint for configuring supervisor for Elixir 1.4

### DIFF
--- a/lib/mix/tasks/ecto.gen.repo.ex
+++ b/lib/mix/tasks/ecto.gen.repo.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
 
     Mix.shell.info """
     Don't forget to add your new repo to your supervision tree
-    (typically in lib/#{app}.ex):
+    (typically in #{mixfile_loc(app)}):
 
         supervisor(#{inspect repo}, [])
 
@@ -72,6 +72,15 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
 
     """
   end
+
+  defp mixfile_loc(app) do
+    case Elixir.Version.compare(System.version, "1.4.0") do
+      :gt -> "lib/#{app}/application.ex"
+      :eq -> "lib/#{app}/application.ex"
+      :lt -> "lib/#{app}.ex"
+    end
+  end
+
 
   embed_template :repo, """
   defmodule <%= inspect @mod %> do

--- a/lib/mix/tasks/ecto.gen.repo.ex
+++ b/lib/mix/tasks/ecto.gen.repo.ex
@@ -81,7 +81,6 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
     end
   end
 
-
   embed_template :repo, """
   defmodule <%= inspect @mod %> do
     use Ecto.Repo, otp_app: <%= inspect @app %>


### PR DESCRIPTION
The "typical location" where the supervisor is defined changed with Elixir 1.4. This updates the task hints to the new location if the user is using Elixir ~> 1.4.0.