### PR TITLE
Support selecting into structs

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -892,6 +892,10 @@ defmodule Ecto.Integration.RepoTest do
 
   ## Query syntax
 
+  defmodule Foo do
+    defstruct [:title]
+  end
+
   test "query select expressions" do
     %Post{} = TestRepo.insert!(%Post{title: "1", text: "hai"})
 
@@ -914,6 +918,9 @@ defmodule Ecto.Integration.RepoTest do
              p.title => p.text,
              "text"  => p.text
            })
+
+    assert [%Foo{title: "1"}] ==
+           TestRepo.all(from p in Post, select: %Foo{title: p.title})
   end
 
   test "query select map update" do
@@ -922,12 +929,19 @@ defmodule Ecto.Integration.RepoTest do
     assert [%Post{:title => "new title", text: "hai"}] =
            TestRepo.all(from p in Post, select: %{p | title: "new title"})
 
+    assert [%Post{title: "new title", text: "hai"}] =
+      TestRepo.all(from p in Post, select: %Post{p | title: "new title"})
+
     assert_raise KeyError, fn ->
       TestRepo.all(from p in Post, select: %{p | unknown: "new title"})
     end
 
     assert_raise BadMapError, fn ->
       TestRepo.all(from p in Post, select: %{p.title | title: "new title"})
+    end
+
+    assert_raise BadStructError, fn ->
+      TestRepo.all(from p in Post, select: %Foo{p | title: p.title})
     end
   end
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -684,6 +684,8 @@ defmodule Ecto.Query do
       from(c in City, select: {c.name, c.population})
       from(c in City, select: [c.name, c.county])
       from(c in City, select: %{n: c.name, answer: 42})
+      from(c in City, select: %{c | alternative_name: c.name})
+      from(c in City, select: %Data{name: c.name})
 
   It is also possible to select a struct and limit the returned
   fields at the same time:

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -44,6 +44,13 @@ defmodule Ecto.Query.Builder.Select do
     {expr, params_take}
   end
 
+  # Struct
+  defp escape({:%, _, [name, map]}, params_take, vars, env) do
+    name = Macro.expand(name, env)
+    {escaped_map, params_take} = escape(map, params_take, vars, env)
+    {{:{}, [], [:%, [], [name, escaped_map]]}, params_take}
+  end
+
   # Map
   defp escape({:%{}, _, [{:|, _, [data, pairs]}]}, params_take, vars, env) do
     {data, params_take} = escape(data, params_take, vars, env)

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -850,6 +850,8 @@ defmodule Ecto.Query.Planner do
     do: collect_fields([data|pairs], query, take, from)
   defp collect_fields({:%{}, _, pairs}, query, take, from),
     do: collect_fields(pairs, query, take, from)
+  defp collect_fields({:%, _, [_name, expr]}, query, take, from),
+    do: collect_fields(expr, query, take, from)
   defp collect_fields(list, query, take, from) when is_list(list),
     do: Enum.flat_map_reduce(list, from, &collect_fields(&1, query, take, &2))
   defp collect_fields(expr, _query, _take, from) when is_atom(expr) or is_binary(expr) or is_number(expr),

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -274,6 +274,17 @@ defmodule Ecto.Repo.Queryable do
     end
   end
 
+  defp transform_row({:%, _, [name, map]}, take, from, values) do
+    case transform_row(map, take, from, values) do
+      {%{__struct__: ^name} = struct, acc} ->
+        {struct, acc}
+      {%{__struct__: _} = struct, _acc} ->
+        raise BadStructError, struct: name, term: struct
+      {map, acc} when is_map(map) ->
+        {struct(name, map), acc}
+    end
+  end
+
   defp transform_row(list, take, from, values) when is_list(list) do
     Enum.map_reduce(list, values, &transform_row(&1, take, from, &2))
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -37,6 +37,9 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert {[{:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :y]]}, [], []]},
                {:{}, [], [:^, [], [0]]}], {%{0 => {1, :any}}, %{}}} ==
               escape(quote do [x.y, ^1] end, [x: 0], __ENV__)
+
+      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {%{}, %{}}} ==
+             escape(quote do %Foo{a: a} end, [a: 0], __ENV__)
     end
 
     @fields [:field]


### PR DESCRIPTION
This enables queries like `from(c in City, select: %Data{name: c.name})` to work, which might be especially interesting in case of complex joins or schemaless queries.