### PR TITLE
Raise error when precision is missing

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -601,7 +601,7 @@ defmodule Ecto.Migration do
     * `:null` - when `false`, the column does not allow null values
     * `:size` - the size of the type (for example the numbers of characters).
       Default is no size, except for `:string` that defaults to 255.
-    * `:precision` - the precision for a numeric type. Default is no precision
+    * `:precision` - the precision for a numeric type. Required when `scale` is specified.
     * `:scale` - the scale of a numeric type. Default is 0 scale
 
   """
@@ -614,6 +614,10 @@ defmodule Ecto.Migration do
   end
 
   def add(column, type, opts) when is_atom(column) do
+    if opts[:scale] && !opts[:precision] do
+      raise ArgumentError, "Column #{Atom.to_string(column)} is missing precision option"
+    end
+
     validate_type!(type)
     Runner.subcommand {:add, column, type, opts}
   end
@@ -699,7 +703,7 @@ defmodule Ecto.Migration do
     * `:null` - sets to null or not null
     * `:default` - changes the default
     * `:size` - the size of the type (for example the numbers of characters). Default is no size.
-    * `:precision` - the precision for a numeric type. Default is no precision.
+    * `:precision` - the precision for a numeric type. Required when `scale` is specified.
     * `:scale` - the scale of a numeric type. Default is 0 scale.
   """
   def modify(column, type, opts \\ [])
@@ -711,6 +715,10 @@ defmodule Ecto.Migration do
   end
 
   def modify(column, type, opts) when is_atom(column) do
+    if opts[:scale] && !opts[:precision] do
+      raise ArgumentError, "Column #{Atom.to_string(column)} is missing precision option"
+    end
+
     Runner.subcommand {:modify, column, type, opts}
   end
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -128,6 +128,17 @@ defmodule Ecto.MigrationTest do
               [{:add, :title, :string, []}]}
   end
 
+  test "forward: creates a table without precision option for numeric type" do
+    assert_raise ArgumentError, "Column cost is missing precision option", fn ->
+      create(table(:posts)) do
+        add :title, :string
+        add :cost, :decimal, scale: 3
+        timestamps()
+      end
+      flush()
+    end
+  end
+
   test "forward: creates a table without updated_at timestamp" do
     create table = table(:posts, primary_key: false) do
       timestamps(inserted_at: :created_at, updated_at: false)
@@ -184,6 +195,15 @@ defmodule Ecto.MigrationTest do
               [{:add, :summary, :text, []},
                {:modify, :title, :text, []},
                {:remove, :views}]}
+  end
+
+  test "forward: alter numeric column without specifying precision" do
+    assert_raise ArgumentError, "Column cost is missing precision option", fn ->
+      alter table(:posts) do
+        modify :cost, :decimal, scale: 5
+      end
+      flush()
+    end
   end
 
   test "forward: rename column" do


### PR DESCRIPTION
Raise `ArgumentError` when `precision` is missing for `numeric` type.

Fix for #1946 