### PR TITLE
make the `:otp_app` argument to a new Repo optional

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -42,7 +42,7 @@ defmodule Ecto.Repo.Supervisor do
   Retrieves the compile time configuration.
   """
   def compile_config(repo, opts) do
-    otp_app = Keyword.fetch!(opts, :otp_app)
+    otp_app = Keyword.get(opts, :otp_app)
     config  = Application.get_env(otp_app, repo, [])
     adapter = opts[:adapter] || config[:adapter]
 


### PR DESCRIPTION
if declaring repo options inline (via `using Ecto.Repo opts`) the
`:otp_app` option is unesscessary. using `Keyword.get/2` instead of
`Keyword.fetch!/2` returns `nil` if `:otp_app` is missing which
results in `[]` being returned from the `Application.get_env` call,
the same result as if `:otp_app` pointed to a missing config