### PR TITLE
WIP: Implement :returning option on insert

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -222,6 +222,19 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.insert!(%User{inserted_at: datetime})
     assert [%{inserted_at: ^datetime}] = TestRepo.all(User)
   end
+  
+  @tag :returning
+  @tag :with_conflict_target
+  test "insert with returning with schema" do
+    {:ok, c1} = TestRepo.insert(%Post{})
+    {:ok, c2} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: [:id, :uuid])
+    {:ok, c3} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: true)
+    {:ok, c4} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: false)
+    
+    assert c2.uuid == c1.uuid
+    assert c3.uuid == c1.uuid
+    assert c4.uuid != c1.uuid
+  end
 
   test "optimistic locking in update/delete operations" do
     import Ecto.Changeset, only: [cast: 3, optimistic_lock: 2]

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -222,19 +222,6 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.insert!(%User{inserted_at: datetime})
     assert [%{inserted_at: ^datetime}] = TestRepo.all(User)
   end
-  
-  @tag :returning
-  @tag :with_conflict_target
-  test "insert with returning with schema" do
-    {:ok, c1} = TestRepo.insert(%Post{})
-    {:ok, c2} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: [:id, :uuid])
-    {:ok, c3} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: true)
-    {:ok, c4} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: false)
-    
-    assert c2.uuid == c1.uuid
-    assert c3.uuid == c1.uuid
-    assert c4.uuid != c1.uuid
-  end
 
   test "optimistic locking in update/delete operations" do
     import Ecto.Changeset, only: [cast: 3, optimistic_lock: 2]
@@ -1161,6 +1148,19 @@ defmodule Ecto.Integration.RepoTest do
       assert updated.id == inserted.id
       assert updated.title != "second"
       assert TestRepo.get!(Post, inserted.id).title == "second"
+    end
+
+    @tag :returning
+    @tag :with_conflict_target
+    test "on conflict keyword list and conflict target and returning" do
+      {:ok, c1} = TestRepo.insert(%Post{})
+      {:ok, c2} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: [:id, :uuid])
+      {:ok, c3} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: true)
+      {:ok, c4} = TestRepo.insert(%Post{id: c1.id}, on_conflict: [set: [id: c1.id]], conflict_target: [:id], returning: false)
+
+      assert c2.uuid == c1.uuid
+      assert c3.uuid == c1.uuid
+      assert c4.uuid != c1.uuid
     end
 
     @tag :without_conflict_target

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -662,6 +662,11 @@ defmodule Ecto.Repo do
 
   ## Options
 
+    * `:returning` - selects which fields to return. When `true`, returns
+      all fields in the given struct. May be a list of fields, where a
+      struct is still returned but only with the given fields. In any case,
+      it will include fields with `read_after_writes` set to true.
+      This option is not supported by all databases.
     * `:prefix` - The prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). This overrides the prefix set
       in the struct.

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -169,11 +169,13 @@ defmodule Ecto.Repo.Schema do
     schema = struct.__struct__
     fields = schema.__schema__(:fields)
     assocs = schema.__schema__(:associations)
-    return = case opts[:returning] do
-      true                    -> schema.__schema__(:fields)
-      list when is_list(list) -> list
-      _                       -> schema.__schema__(:read_after_writes)
+    return = cond do
+      is_list(opts[:returning]) -> opts[:returning]
+      opts[:returning] == true -> schema.__schema__(:fields)
+      true -> []
     end
+    |> Enum.concat(schema.__schema__(:read_after_writes))
+    |> Enum.uniq
 
     {on_conflict, opts} = Keyword.pop(opts, :on_conflict, :raise)
     {conflict_target, opts} = Keyword.pop(opts, :conflict_target, [])


### PR DESCRIPTION
I've implemented the `:returning` option into the `insert` function, the `case` is to make the api the same as `insert_all` where true uses all fields, a list uses only the fields in the option and everything else uses the default `read_after_writes` (maybe I should check for `false` and return an empty list?

I've also inverted `extra` and `values` as values from the db has to have the precedence of values autogenerated from ecto, maybe as an improvement we should prioritize only values in the `return` list?

About the tests, I was trying to find a place where is correct to test this behavior, since it's database dependent if it has to check the input and the return value, since it must be run on postgresql only.

Related to #1966