### PR TITLE
Support repo opts for Changeset.prepare_changes/2

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -204,6 +204,7 @@ defmodule Ecto.Changeset do
     * `action`       - The action to be performed with the changeset
     * `types`        - Cache of the data's field types
     * `repo`         - The repository applying the changeset (only set after a Repo function is called)
+    * `opts`         - The opts given to the repo function applying the changeset (only set after a Repo function is called)
     * `empty_values` - A list of values to be considered empty
 
   """
@@ -217,7 +218,7 @@ defmodule Ecto.Changeset do
   defstruct valid?: false, data: nil, params: nil, changes: %{}, repo: nil,
             errors: [], validations: [], required: [], prepare: [],
             constraints: [], filters: %{}, action: nil, types: nil,
-            empty_values: @empty_values
+            empty_values: @empty_values, opts: nil
 
   @type t :: %Changeset{valid?: boolean(),
                         repo: atom | nil,

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -176,7 +176,7 @@ defmodule Ecto.Repo.Schema do
 
     # On insert, we always merge the whole struct into the
     # changeset as changes, except the primary key if it is nil.
-    changeset = put_repo_and_action(changeset, :insert, repo)
+    changeset = put_repo_action_and_opts(changeset, :insert, repo, opts)
     changeset = surface_changes(changeset, struct, types, fields ++ assocs)
 
     wrap_in_transaction(repo, adapter, opts, assocs, prepare, fn ->
@@ -212,8 +212,8 @@ defmodule Ecto.Repo.Schema do
     end)
   end
 
-  defp do_insert(repo, _adapter, %Changeset{valid?: false} = changeset, _opts) do
-    {:error, put_repo_and_action(changeset, :insert, repo)}
+  defp do_insert(repo, _adapter, %Changeset{valid?: false} = changeset, opts) do
+    {:error, put_repo_action_and_opts(changeset, :insert, repo, opts)}
   end
 
   @doc """
@@ -242,7 +242,7 @@ defmodule Ecto.Repo.Schema do
     # Differently from insert, update does not copy the struct
     # fields into the changeset. All changes must be in the
     # changeset before hand.
-    changeset = put_repo_and_action(changeset, :update, repo)
+    changeset = put_repo_action_and_opts(changeset, :update, repo, opts)
 
     if changeset.changes != %{} or force? do
       wrap_in_transaction(repo, adapter, opts, assocs, prepare, fn ->
@@ -286,8 +286,8 @@ defmodule Ecto.Repo.Schema do
     end
   end
 
-  defp do_update(repo, _adapter, %Changeset{valid?: false} = changeset, _opts) do
-    {:error, put_repo_and_action(changeset, :update, repo)}
+  defp do_update(repo, _adapter, %Changeset{valid?: false} = changeset, opts) do
+    {:error, put_repo_action_and_opts(changeset, :update, repo, opts)}
   end
 
   @doc """
@@ -339,7 +339,7 @@ defmodule Ecto.Repo.Schema do
     schema  = struct.__struct__
     assocs = schema.__schema__(:associations)
 
-    changeset = put_repo_and_action(changeset, :delete, repo)
+    changeset = put_repo_action_and_opts(changeset, :delete, repo, opts)
     changeset = %{changeset | changes: %{}}
 
     wrap_in_transaction(repo, adapter, opts, assocs, prepare, fn ->
@@ -361,8 +361,8 @@ defmodule Ecto.Repo.Schema do
     end)
   end
 
-  defp do_delete(repo, _adapter, %Changeset{valid?: false} = changeset, _opts) do
-    {:error, put_repo_and_action(changeset, :delete, repo)}
+  defp do_delete(repo, _adapter, %Changeset{valid?: false} = changeset, opts) do
+    {:error, put_repo_action_and_opts(changeset, :delete, repo, opts)}
   end
 
   def load(adapter, schema_or_types, data) do
@@ -385,10 +385,10 @@ defmodule Ecto.Repo.Schema do
   defp struct_from_changeset!(_action, %{data: struct}),
     do: struct
 
-  defp put_repo_and_action(%{action: given}, action, repo) when given != nil and given != action,
+  defp put_repo_action_and_opts(%{action: given}, action, repo, _) when given != nil and given != action,
     do: raise(ArgumentError, "a changeset with action #{inspect given} was given to #{inspect repo}.#{action}/2")
-  defp put_repo_and_action(changeset, action, repo),
-    do: %{changeset | action: action, repo: repo}
+  defp put_repo_action_and_opts(changeset, action, repo, opts),
+    do: %{changeset | action: action, repo: repo, opts: opts}
 
   defp run_prepare(changeset, prepare) do
     Enum.reduce(Enum.reverse(prepare), changeset, fn fun, acc ->

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -172,7 +172,7 @@ defmodule Ecto.RepoTest do
   end
 
   test "insert, update, insert_or_update and delete errors on invalid changeset" do
-    invalid = %Ecto.Changeset{valid?: false, data: %MySchema{}}
+    invalid = %Ecto.Changeset{valid?: false, data: %MySchema{}, opts: []}
 
     insert = %{invalid | action: :insert, repo: TestRepo}
     assert {:error, ^insert} = TestRepo.insert(invalid)


### PR DESCRIPTION
In the example at https://hexdocs.pm/ecto/Ecto.Changeset.html#prepare_changes/2 it executes an additional query for updating the comment count. In my case this repo is a multi-tenant database using the `prefix` option when calling `Repo` functions.

When building models, it feels incorrect to have the changeset method require a prefix:

```Elixir
defmodule TestApp.Comment do
  ...
  def changeset(comment, params, prefix) do
    comment
    |> cast(params, [:body, :post_id])
    |> prepare_changes(fn changeset ->
      assoc(changeset.data, :post)
      |> changeset.repo.update_all([inc: [comment_count: 1]], prefix: prefix)
      changeset
    end)
  end
end

%TestApp.Comment{}
|> TestApp.Comment.changeset(..., prefix)
|> TestApp.Repo.insert(prefix: prefix)

```

Instead, I propose:

```Elixir
defmodule TestApp.Comment do
  ...
  def changeset(comment, params) do
    comment
    |> cast(params, [:body, :post_id])
    |> prepare_changes(fn changeset ->
      assoc(changeset.data, :post)
      |> changeset.repo.update_all([inc: [comment_count: 1]], changeset.repo.opts)
      changeset
    end)
  end
end

%TestApp.Comment{}
|> TestApp.Comment.changeset(...)
|> TestApp.Repo.insert(prefix: prefix)

```