### PR TITLE
Simplify embeds_one example to use embedded_schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1094,9 +1094,7 @@ defmodule Ecto.Schema do
       defmodule Item do
         use Ecto.Schema
 
-        # A required field for all embedded documents
-        @primary_key {:id, :binary_id, autogenerate: true}
-        schema "" do
+        embedded_schema do
           field :name
         end
       end


### PR DESCRIPTION
Seems like the examples were updated everywhere 2 years ago when the function was introduced, but this section was forgotten.