### PR TITLE
Add new test tags to support upcoming release of sqlite_ecto2.

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -479,6 +479,7 @@ defmodule Ecto.Integration.RepoTest do
     assert changeset.errors == [permalink: {"is still associated with this entry", []}]
   end
 
+  @tag :foreign_key_constraint
   test "insert and update with failing child foreign key" do
     defmodule Order do
       use Ecto.Integration.Schema
@@ -632,6 +633,7 @@ defmodule Ecto.Integration.RepoTest do
     assert TestRepo.aggregate(query, :count, :visits) == 3
   end
 
+  @tag :insert_cell_wise_defaults
   test "insert all" do
     assert {2, nil} = TestRepo.insert_all("comments", [[text: "1"], %{text: "2", lock_version: 2}])
     assert {2, nil} = TestRepo.insert_all({"comments", Comment}, [[text: "3"], %{text: "4", lock_version: 2}])
@@ -653,6 +655,7 @@ defmodule Ecto.Integration.RepoTest do
   end
 
   @tag :returning
+  @tag :insert_cell_wise_defaults
   test "insert all with returning with schema" do
     assert {0, []} = TestRepo.insert_all(Comment, [], returning: true)
     assert {0, nil} = TestRepo.insert_all(Comment, [], returning: false)
@@ -677,6 +680,7 @@ defmodule Ecto.Integration.RepoTest do
     end
   end
 
+  @tag :insert_cell_wise_defaults
   test "insert all with dumping" do
     datetime = ~N[2014-01-16 20:26:51.000000]
     assert {2, nil} = TestRepo.insert_all(Post, [%{inserted_at: datetime}, %{title: "date"}])
@@ -684,6 +688,7 @@ defmodule Ecto.Integration.RepoTest do
             %Post{inserted_at: nil, title: "date"}] = TestRepo.all(Post)
   end
 
+  @tag :insert_cell_wise_defaults
   test "insert all autogenerates for binary_id type" do
     custom = TestRepo.insert!(%Custom{bid: nil})
     assert custom.bid

--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -57,6 +57,7 @@ defmodule Ecto.Integration.SQLTest do
     assert ["'"] == TestRepo.all(query)
   end
 
+  @tag :insert_cell_wise_defaults
   test "Repo.insert_all escape" do
     TestRepo.insert_all(Post, [%{title: "'"}])
 

--- a/integration_test/sql/subquery.exs
+++ b/integration_test/sql/subquery.exs
@@ -18,6 +18,7 @@ defmodule Ecto.Integration.SubQueryTest do
            TestRepo.all(from p in subquery(query), select: p)
   end
 
+  @tag :map_boolean_in_subquery
   test "from: subqueries with select expression" do
     TestRepo.insert!(%Post{text: "hello", public: true})
 

--- a/integration_test/sql/subquery.exs
+++ b/integration_test/sql/subquery.exs
@@ -18,7 +18,6 @@ defmodule Ecto.Integration.SubQueryTest do
            TestRepo.all(from p in subquery(query), select: p)
   end
 
-  @tag :map_boolean_in_subquery
   test "from: subqueries with select expression" do
     TestRepo.insert!(%Post{text: "hello", public: true})
 


### PR DESCRIPTION
Each of the tagged tests needs to be disabled for sqlite_ecto2 because it makes use of features that can not be supported by SQLite.

(Note: Yes, I'm intentionally targeting the 2.1 branch, though I'd be grateful to see this carried forward to the master branch as well.)