### PR TITLE
Improve validation performed by UUID.cast

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -11,7 +11,7 @@ defmodule Ecto.Integration.TypeTest do
     integer  = 1
     float    = 0.1
     text     = <<0,1>>
-    uuid     = "00010203-0405-0607-0809-0a0b0c0d0e0f"
+    uuid     = "00010203-0405-4607-8809-0a0b0c0d0e0f"
     datetime = ~N[2014-01-16 20:26:51.000000]
 
     TestRepo.insert!(%Post{text: text, public: true, visits: integer, uuid: uuid,

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -13,7 +13,25 @@ defmodule Ecto.UUID do
   @doc """
   Casts to UUID.
   """
-  def cast(<< _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = u), do: {:ok, u}
+  def cast(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
+              b1, b2, b3, b4, ?-,
+              c1, c2, c3, c4, ?-,
+              d1, d2, d3, d4, ?-,
+              e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
+    << c(a1), c(a2), c(a3), c(a4),
+       c(a5), c(a6), c(a7), c(a8), ?-,
+       c(b1), c(b2), c(b3), c(b4), ?-,
+       cast_version(c1), c(c2), c(c3), c(c4), ?-,
+       cast_variant(d1), c(d2), c(d3), c(d4), ?-,
+       c(e1), c(e2), c(e3), c(e4),
+       c(e5), c(e6), c(e7), c(e8),
+       c(e9), c(e10), c(e11), c(e12) >>
+  catch
+    :error -> :error
+  else
+    casted ->
+      {:ok, casted}
+  end
   def cast(_), do: :error
 
   @doc """
@@ -25,6 +43,51 @@ defmodule Ecto.UUID do
       :error -> raise Ecto.CastError, "cannot cast #{inspect value} to UUID"
     end
   end
+
+  @compile {:inline, c: 1}
+
+  defp c(?0), do: ?0
+  defp c(?1), do: ?1
+  defp c(?2), do: ?2
+  defp c(?3), do: ?3
+  defp c(?4), do: ?4
+  defp c(?5), do: ?5
+  defp c(?6), do: ?6
+  defp c(?7), do: ?7
+  defp c(?8), do: ?8
+  defp c(?9), do: ?9
+  defp c(?A), do: ?a
+  defp c(?B), do: ?b
+  defp c(?C), do: ?c
+  defp c(?D), do: ?d
+  defp c(?E), do: ?e
+  defp c(?F), do: ?f
+  defp c(?a), do: ?a
+  defp c(?b), do: ?b
+  defp c(?c), do: ?c
+  defp c(?d), do: ?d
+  defp c(?e), do: ?e
+  defp c(?f), do: ?f
+  defp c(_),  do: throw(:error)
+
+  @compile {:inline, cast_version: 1}
+
+  defp cast_version(?1), do: ?1
+  defp cast_version(?2), do: ?2
+  defp cast_version(?3), do: ?3
+  defp cast_version(?4), do: ?4
+  defp cast_version(?5), do: ?5
+  defp cast_version(_), do: throw(:error)
+
+  @compile {:inline, cast_variant: 1}
+
+  defp cast_variant(?8), do: ?8
+  defp cast_variant(?9), do: ?9
+  defp cast_variant(?a), do: ?a
+  defp cast_variant(?b), do: ?b
+  defp cast_variant(?A), do: ?a
+  defp cast_variant(?B), do: ?b
+  defp cast_variant(_), do: throw(:error)
 
   @doc """
   Converts a string representing a UUID into a binary.

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -109,13 +109,13 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "prepare: casts and dumps binary ids" do
-    uuid = "00010203-0405-0607-0809-0a0b0c0d0e0f"
+    uuid = "00010203-0405-4607-8809-0a0b0c0d0e0f"
     {_query, params, _key} = prepare(Comment |> where([c], c.uuid == ^uuid))
-    assert params == [<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>]
+    assert params == [<<0, 1, 2, 3, 4, 5, 70, 7, 136, 9, 10, 11, 12, 13, 14, 15>>]
 
     assert_raise Ecto.Query.CastError,
-                 ~r/`"00010203-0405-0607-0809"` cannot be dumped to type :binary_id/, fn ->
-      uuid = "00010203-0405-0607-0809"
+                 ~r/`"00010203-0405-4607-8809"` cannot be dumped to type :binary_id/, fn ->
+      uuid = "00010203-0405-4607-8809"
       prepare(Comment |> where([c], c.uuid == ^uuid))
     end
   end

--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -24,7 +24,7 @@ defmodule Ecto.Repo.AutogenerateTest do
 
   ## Autogenerate
 
-  @uuid "30313233-3435-3637-3839-616263646566"
+  @uuid "30313233-3435-4637-9839-616263646566"
 
   test "autogenerates values" do
     schema = TestRepo.insert!(%Company{})

--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -31,7 +31,7 @@ defmodule Ecto.Repo.EmbeddedTest do
     end
   end
 
-  @uuid "30313233-3435-3637-3839-616263646566"
+  @uuid "30313233-3435-4637-9839-616263646566"
 
   ## insert
 

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -2,11 +2,17 @@ defmodule Ecto.UUIDTest do
   use ExUnit.Case, async: true
 
   @test_uuid "601d74e4-a8d3-4b6e-8365-eddb4c893327"
+  @test_uuid_upper_case "601D74E4-A8D3-4B6E-8365-EDDB4C893327"
+  @test_uuid_invalid_characters "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  @test_uuid_invalid_shape "this is not UUID"
   @test_uuid_binary <<0x60, 0x1D, 0x74, 0xE4, 0xA8, 0xD3, 0x4B, 0x6E,
                       0x83, 0x65, 0xED, 0xDB, 0x4C, 0x89, 0x33, 0x27>>
 
   test "cast" do
     assert Ecto.UUID.cast(@test_uuid) == {:ok, @test_uuid}
+    assert Ecto.UUID.cast(@test_uuid_upper_case) == {:ok, String.downcase(@test_uuid_upper_case)}
+    assert Ecto.UUID.cast(@test_uuid_invalid_characters) == :error
+    assert Ecto.UUID.cast(@test_uuid_invalid_shape) == :error
     assert Ecto.UUID.cast(@test_uuid_binary) == :error
     assert Ecto.UUID.cast(nil) == :error
   end


### PR DESCRIPTION
Closes #1999.

On top of what was reported, I've realised that the function will actually accept any characters in place of `a-z0-9`. This is now fixed.
I've also limited which characters can be allowed at two specific positions:
```
xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
```
M is `[1-5]` and N is `[89ab]`. [Source](https://en.wikipedia.org/wiki/Universally_unique_identifier#Format).