### PR TITLE
`validate_no_conflicts_unreliably/3`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1355,23 +1355,32 @@ defmodule Ecto.Changeset do
   @doc """
   Validates (unreliably) that conflicting records do not exist in the database.
 
-  This is not reliable because conflicting records could be inserted by another
-  process after this validation runs. Use a constraint for a reliable check.
+  The data in the changeset may conflict with existing records in the database.
+
+  For example:
+
+    - An existing user has this username
+    - An existing reservation overlaps this date range
+
+  Such conflicts cannot be reliably prevented with validations, because
+  conflicting records could be inserted by another process after validations
+  run. A uniqueness constraint would reliably prevent the first conflict, and an
+  exclusion constraint would reliably prevent the second.
 
   However, in most cases when there are conflicts, they will already exist by
-  the time of validation. Checking for them in the validation phase may allow
+  the time of validation. Checking for them in the validation phase allows
   users to fix errors like "username is already taken" at the same time as
-  errors like "email can't be blank", instead of fixing each constraint error
-  the database raises, one at a time, after the validations pass.
+  errors like "email can't be blank", instead of fixing the validation errors
+  first, then fixing each constraint error the database raises one at a time.
 
-  To use this, pass a function that finds existing records with which this
-  changeset would conflict, according to a unique or exclusion constraint. If
-  the function returns any an empty enumerable, there are no conflicts and the
-  validation passes. If the function returns an enumerable containing one
-  existing record, but the changeset is an update to that record (that is, the
+  To use this validation, pass a function that takes a changeset and finds
+  existing records with which the changeset would conflict. If the function
+  returns any an empty enumerable, there are no conflicts and the validation
+  passes. If the function returns an enumerable containing one existing
+  record, but the changeset is an update to that record (that is, the
   changeset and the existing record are for the same schema and have the same
-  primary key), the validation passes. Otherwise, the changeset would create a
-  conflict and the validation fails.
+  primary key), the validation passes. Otherwise, the changeset would create
+  a conflict and the validation fails.
 
   The `field_name` is where the error message (if any) will be placed.
 
@@ -1383,7 +1392,7 @@ defmodule Ecto.Changeset do
 
       validate_no_conflicts_unreliably(changeset, :title, &find_posts_with_title/1)
       validate_no_conflicts_unreliably(changeset, :title, &find_posts_with_title/1, message: "not original")
-      validate_no_conflicts_unreliably(changeset, :base, &find_overlapping_rentals/1, message: "an existing rental overlaps these dates")
+      validate_no_conflicts_unreliably(changeset, :start_date, &find_overlapping_rentals/1, message: "an existing rental overlaps these dates")
 
   A finder function might look like:
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1352,6 +1352,99 @@ defmodule Ecto.Changeset do
     end
   end
 
+  @doc """
+  Validates (unreliably) that conflicting records do not exist in the database.
+
+  This is not reliable because conflicting records could be inserted by another
+  process after this validation runs. Use a constraint for a reliable check.
+
+  However, in most cases when there are conflicts, they will already exist by
+  the time of validation. Checking for them in the validation phase may allow
+  users to fix errors like "username is already taken" at the same time as
+  errors like "email can't be blank", instead of fixing each constraint error
+  the database raises, one at a time, after the validations pass.
+
+  To use this, pass a function that finds existing records with which this
+  changeset would conflict, according to a unique or exclusion constraint. If
+  the function returns any an empty enumerable, there are no conflicts and the
+  validation passes. If the function returns an enumerable containing one
+  existing record, but the changeset is an update to that record (that is, the
+  changeset and the existing record are for the same schema and have the same
+  primary key), the validation passes. Otherwise, the changeset would create a
+  conflict and the validation fails.
+
+  The `field_name` is where the error message (if any) will be placed.
+
+  ## Options
+
+    * `:message` - the error message on failure; defaults to "has already been taken"
+
+  ## Examples
+
+      validate_no_conflicts_unreliably(changeset, :title, &find_posts_with_title/1)
+      validate_no_conflicts_unreliably(changeset, :title, &find_posts_with_title/1, message: "not original")
+      validate_no_conflicts_unreliably(changeset, :base, &find_overlapping_rentals/1, message: "an existing rental overlaps these dates")
+
+  A finder function might look like:
+
+  defp find_posts_with_title(changeset) do
+    title = get_field(changeset, :title)
+    if is_nil(title) do
+      # no title, so there can be no conflicting records
+      []
+    else
+      MyApp.Repo.all(from p in Post, where: e.title == ^title)
+    end
+  end
+  """
+  @spec validate_no_conflicts_unreliably(t, atom, (t -> list), String.t) :: t
+  def validate_no_conflicts_unreliably(changeset, field_name, conflict_finder_func, opts \\ []) do
+    conflicts = changeset
+    |> conflict_finder_func.()
+    |> Enum.reject(fn (apparent_conflict) ->
+      would_update?(changeset, apparent_conflict)
+    end)
+
+    if Enum.any?(conflicts) do
+      message = message(opts, "has already been taken")
+      add_error(
+                changeset,
+                field_name,
+                message,
+                [validation: :validate_no_conflicts_unreliably]
+              )
+    else
+      changeset
+    end
+  end
+
+  defp would_update?(changeset, record) do
+    source(record) == source(changeset) \
+      && primary_key(record) == primary_key(changeset)
+  end
+
+  defp source(changeset = %Changeset{}) do
+    changeset.data.__struct__.__schema__(:source)
+  end
+
+  defp source(record) do
+    record.__struct__.__schema__(:source)
+  end
+
+  defp primary_key(changeset = %Changeset{}) do
+    primary_key_fields = changeset.data.__struct__.__schema__(:primary_key)
+    Enum.map(primary_key_fields, fn(field) ->
+      get_field(changeset, field)
+    end)
+  end
+
+  defp primary_key(record) do
+    primary_key_fields = record.__struct__.__schema__(:primary_key)
+    Enum.map(primary_key_fields, fn(field) ->
+      Map.get(record, field)
+    end)
+  end
+
   defp ensure_field_exists!(%Changeset{types: types, data: data}, field) do
     unless Map.has_key?(types, field) do
       raise ArgumentError, "unknown field #{inspect field} for changeset on #{inspect data}"

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -14,6 +14,7 @@ defmodule Ecto.ChangesetTest do
     use Ecto.Schema
 
     schema "posts" do
+      field :id_part_2, :integer, primary_key: true
       field :title, :string, default: ""
       field :body
       field :uuid, :binary_id
@@ -28,7 +29,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defp changeset(schema \\ %Post{}, params) do
-    cast(schema, params, ~w(title body upvotes decimal topics virtual))
+    cast(schema, params, ~w(id id_part_2 title body upvotes decimal topics virtual))
   end
 
   ## cast/4
@@ -970,6 +971,37 @@ defmodule Ecto.ChangesetTest do
                 |> validate_acceptance(:terms_of_service, message: "must be abided")
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be abided", [validation: :acceptance]}]
+  end
+
+  test "validate_no_conflicts_unreliably/3" do
+    find_posts_with_title = fn(changeset) ->
+      name = get_field(changeset, :title)
+      if name == "Existing Title" do
+        [%Post{title: "Existing Title", id: 1, id_part_2: 2, body: "blah blah"}]
+      else
+        []
+      end
+    end
+
+    # conflicting insert with default error message
+    changeset = validate_no_conflicts_unreliably(changeset(%Post{}, %{"title" => "Existing Title"}), :title, find_posts_with_title)
+    refute changeset.valid?
+    assert changeset.errors == [title: {"has already been taken", [validation: :validate_no_conflicts_unreliably]}]
+
+    # conflicting insert with custom error message
+    changeset = validate_no_conflicts_unreliably(changeset(%Post{}, %{"title" => "Existing Title"}), :title, find_posts_with_title, message: "not original")
+    refute changeset.valid?
+    assert changeset.errors == [title: {"not original", [validation: :validate_no_conflicts_unreliably]}]
+
+    # changeset with same primary key is an update, therefore not a conflict
+    changeset = validate_no_conflicts_unreliably(changeset(%Post{title: "Existing Title", id: 1, id_part_2: 2}, %{"body" => "Update..."}), :title, find_posts_with_title)
+    assert changeset.valid?
+    assert changeset.errors == []
+
+    # an update that assigns a duplicate title to a different primary key is a conflict
+    changeset = validate_no_conflicts_unreliably(changeset(%Post{title: "Existing Title", id: 1, id_part_2: 3}, %{"body" => "Update..."}), :title, find_posts_with_title)
+    refute changeset.valid?
+    assert changeset.errors == [title: {"has already been taken", [validation: :validate_no_conflicts_unreliably]}]
   end
 
   ## Locks


### PR DESCRIPTION
## The Feature

I've [advocated](https://elixirforum.com/t/a-case-for-validating-uniqueness/3637) that Ecto support *validating* uniqueness, despite the fact that a constraint must also be used to prevent race conditions. My reasons are:

- If someone has taken the username I want, they *probably* took it yesterday or last year, not a few milliseconds ago
- In a server-rendered app, it's annoying to fix the "required" and "format" validations, etc, only to submit and get *another* error saying "username is taken" (and possibly another for each constraint we have). It's nice if we can tell the user "email is required and username is already taken" at the same time (except in the case of race conditions). This is what Rails does normally (although it doesn't handle the constraint violation gracefully, if it happens).

@josevalim [seemed OK with the concept](https://elixirforum.com/t/a-case-for-validating-uniqueness/3637/13) as long as it was named `unsafe_validate_unique` or something similar, to warn people that they still need a constraint for guaranteed uniqueness.

## The Implementation

This code allows calling:

- `unsafe_validate_unique(changeset, [:username], MyApp.Repo)`
- `unsafe_validate_unique(changeset, [:city, :state], MyApp.Repo)`
- `unsafe_validate_unique(changeset, [:city, :state], MyApp.Repo, :city, "not unique in state")`

I *think* this implementation is roughly OK, but I'm not sure the best way to test it. I think I should persist one changeset, then validate some other changesets given the existence of the first record in the database.

But no existing validation tests use a repo.

Suggestions on where / how to test this without ruining the existing test suite? :) Outright rejection of the feature?