### PR TITLE
new "force" parameter to ecto.drop task

### DIFF
--- a/lib/mix/tasks/ecto.drop.ex
+++ b/lib/mix/tasks/ecto.drop.ex
@@ -20,13 +20,14 @@ defmodule Mix.Tasks.Ecto.Drop do
 
     * `-r`, `--repo` - the repo to drop
     * `--no-compile` - do not compile before stopping
+    * `--force` - do not ask for confirmation
 
   """
 
   @doc false
   def run(args) do
     repos = parse_repo(args)
-    {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean]
+    {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean, force: :boolean]
 
     Enum.each repos, fn repo ->
       ensure_repo(repo, args)
@@ -34,6 +35,7 @@ defmodule Mix.Tasks.Ecto.Drop do
                                           "to drop storage for #{inspect repo}")
 
       if skip_safety_warnings?() or
+         opts[:force] or
          Mix.shell.yes?("Are you sure you want to drop the database for repo #{inspect repo}?") do
         drop_database(repo, opts)
       end


### PR DESCRIPTION
It allows to skip the shell confirmation for a database drop.

The usecase, is mainly for staging environments, that run in a production like setup.

The fact that the skip_safety_warnings? is environment dependent tripped me over. If we are in a mix task, why making this decision indirect? from my point of view it should be either

A_ Always ask for confirmation
B_ Forced drop

where the user that runs the command is directly in control, not depending on "indirect" configuration

In my opinion, the `skip_safety_warnings?` should not exist (or depend solely on the tasks arguments). But that is not done in this PR (could be done, if you agree)