### PR TITLE
Clarify 'from' macro expected arguments

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -488,7 +488,7 @@ defmodule Ecto.Query do
   """
   defmacro from(expr, kw \\ []) do
     unless Keyword.keyword?(kw) do
-      raise ArgumentError, "second argument to `from` must be a keyword list"
+      raise ArgumentError, "second argument to `from` must be a compile time keyword list"
     end
 
     {quoted, binds, count_bind} = From.build(expr, __CALLER__)


### PR DESCRIPTION
It's quite confusing when you pass what will be a keyword list at runtime and get an error message saying it's not a keyword list.