### PR TITLE
Handle `:invalid` params in validate_confirmation/3

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1613,14 +1613,15 @@ defmodule Ecto.Changeset do
 
   """
   @spec validate_confirmation(t, atom, Keyword.t) :: t
-  def validate_confirmation(changeset, field, opts \\ []) do
+  def validate_confirmation(changeset, field, opts \\ [])
+  def validate_confirmation(%{params: params} = changeset, field, opts) when is_map(params) do
     param = Atom.to_string(field)
     error_param = "#{param}_confirmation"
     error_field = String.to_atom(error_param)
-    value = Map.get(changeset.params, param)
+    value = Map.get(params, param)
 
     errors =
-      case Map.fetch(changeset.params, error_param) do
+      case Map.fetch(params, error_param) do
         {:ok, ^value} ->
           []
         {:ok, _} ->
@@ -1633,6 +1634,9 @@ defmodule Ecto.Changeset do
     %{changeset | validations: [{:confirmation, opts} | changeset.validations],
                   errors: errors ++ changeset.errors,
                   valid?: changeset.valid? and errors == []}
+  end
+  def validate_confirmation(%{params: nil} = changeset, _, _) do
+    changeset
   end
 
   defp confirmation_missing(opts, error_field) do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -922,6 +922,12 @@ defmodule Ecto.ChangesetTest do
                 |> validate_confirmation(:password)
     refute changeset.valid?
     assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+
+    # invalid params
+    changeset = changeset(:invalid)
+                |> validate_confirmation(:password)
+    refute changeset.valid?
+    assert changeset.errors == []
   end
 
   test "validate_acceptance/3" do


### PR DESCRIPTION
Solves the issue of error raised:
```
 ** (BadMapError) expected a map, got: nil
stacktrace:
   (stdlib) :maps.find("password", nil)
   (elixir) lib/map.ex:234: Map.get/3
   (ecto) lib/ecto/changeset.ex:1620: Ecto.Changeset.validate_confirmation/3
   test/ecto/changeset_test.exs:928: (test)
```

Inspired by #1818 
