### PR TITLE
Add type checking to put_change/3 and update_change/3

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -287,6 +287,8 @@ defmodule Ecto.Changeset do
   The function is meant for working with data internal to the application.
   Because of that neither validation nor casting is performed. This means
   `change/2` expects the keys in the `changes` map or keyword to be atoms.
+  If any value in the given `changes` does not match the
+  type for that key in the schema (or `types` map), an error is raised.
 
   When a changeset is passed as the first argument, the changes passed as the
   second argument are merged over the changes already in the changeset if they
@@ -999,6 +1001,9 @@ defmodule Ecto.Changeset do
   in the changeset data, it is not added to the list of changes.
 
   The function is meant for working with data internal to the application.
+  Because of that neither validation nor casting is performed. If `value`
+  does not match the type for the given `key` in the schema (or `types` map),
+  an error is raised.
 
   ## Examples
 
@@ -1037,10 +1042,12 @@ defmodule Ecto.Changeset do
 
   defp put_change(data, changes, errors, valid?, key, value, type) do
     case Ecto.Type.cast(type, value) do
-      {:ok, value} ->
+      {:ok, ^value} ->
         put_change(data, changes, errors, valid?, key, value)
+      {:ok, _} ->
+        raise Ecto.CastError, type: type, value: value
       :error ->
-        raise Ecto.CastError, "cannot cast #{inspect value} to type #{inspect type}"
+        raise Ecto.CastError, type: type, value: value
     end
   end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -974,6 +974,11 @@ defmodule Ecto.Changeset do
   is a change for the given `key`. Note that the value of the change
   can still be `nil` (unless the field was marked as required on `cast/4`).
 
+  The function is meant for working with data internal to the application.
+  Because of that neither validation nor casting is performed. If the return
+  value of the `function` does not match the type for the given `key` in the
+  schema (or `types` map), an error is raised.
+
   ## Examples
 
       iex> changeset = change(%Post{}, %{impressions: 1})
@@ -986,8 +991,7 @@ defmodule Ecto.Changeset do
   def update_change(%Changeset{changes: changes} = changeset, key, function) when is_atom(key) do
     case Map.fetch(changes, key) do
       {:ok, value} ->
-        changes = Map.put(changes, key, function.(value))
-        %{changeset | changes: changes}
+        put_change(changeset, key, function.(value))
       :error ->
         changeset
     end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1031,7 +1031,20 @@ defmodule Ecto.Changeset do
           "please use put_#{tag}/4 instead"
   end
 
-  defp put_change(data, changes, errors, valid?, key, value, _type) do
+  defp put_change(data, changes, errors, valid?, key, value, nil) do
+    put_change(data, changes, errors, valid?, key, value)
+  end
+
+  defp put_change(data, changes, errors, valid?, key, value, type) do
+    case Ecto.Type.cast(type, value) do
+      {:ok, value} ->
+        put_change(data, changes, errors, valid?, key, value)
+      :error ->
+        raise Ecto.CastError, "cannot cast #{inspect value} to type #{inspect type}"
+    end
+  end
+
+  defp put_change(data, changes, errors, valid?, key, value) do
     cond do
       Map.get(data, key) != value ->
         {Map.put(changes, key, value), errors, valid?}

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -20,7 +20,7 @@ defmodule Ecto.Changeset do
 
     * internal to the application - for example programatically generated,
       or coming from other subsystems. This use case is primarily covered
-      by the `change/2` and `put_change/3` functions.
+      by the `change/2`, `put_change/3`, and `update_change/3` functions.
 
     * external to the application - for example data provided by the user in
       a form that needs to be type-converted and properly validated. This use case

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -444,6 +444,11 @@ defmodule Ecto.ChangesetTest do
       changeset(%{})
       |> update_change(:title, & &1 || "bar")
     assert changeset.changes == %{}
+
+    assert_raise Ecto.CastError, fn ->
+      changeset(%{"upvotes" => nil})
+      |> update_change(:upvotes, & &1 || "10")
+    end
   end
 
   test "put_change/3 and delete_change/2" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -476,7 +476,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes.upvotes == nil
 
     assert_raise Ecto.CastError, "cannot cast \"42\" to :integer", fn ->
-     put_change(base_changeset, :upvotes, "42")
+      put_change(base_changeset, :upvotes, "42")
     end
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -469,6 +469,13 @@ defmodule Ecto.ChangesetTest do
 
     changeset = put_change(base_changeset, :upvotes, nil)
     assert changeset.changes.upvotes == nil
+
+    changeset = put_change(base_changeset, :upvotes, "42")
+    assert changeset.changes.upvotes == 42
+
+    assert_raise Ecto.CastError, fn ->
+      put_change(base_changeset, :title, 42)
+    end
   end
 
   test "force_change/3" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -470,11 +470,8 @@ defmodule Ecto.ChangesetTest do
     changeset = put_change(base_changeset, :upvotes, nil)
     assert changeset.changes.upvotes == nil
 
-    changeset = put_change(base_changeset, :upvotes, "42")
-    assert changeset.changes.upvotes == 42
-
-    assert_raise Ecto.CastError, fn ->
-      put_change(base_changeset, :title, 42)
+    assert_raise Ecto.CastError, "cannot cast \"42\" to :integer", fn ->
+     put_change(base_changeset, :upvotes, "42")
     end
   end
 


### PR DESCRIPTION
This will be especially useful if we introduce `:naive_datetime_usec` (https://github.com/elixir-ecto/ecto/issues/2018), as doing e.g.: `Changeset.change(accepted_at: NaiveDateTime.utc)` would cast to the correct type (with or without microseconds)