### PR TITLE
Fixes missing space on error message

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -301,7 +301,7 @@ defmodule Ecto.Migrator do
     rescue
       error ->
         Logger.error "Could not #{reason}. This error typically happens when the " <>
-                     "\"schema_migrations\" table, which Ecto uses for storing migration" <>
+                     "\"schema_migrations\" table, which Ecto uses for storing migration " <>
                      "information, is already used by another library or for other purposes.\n\n" <>
                      "You can fix this by running `mix ecto.drop` in the appropriate `MIX_ENV` " <>
                      "to drop the existing database and let Ecto start a new one with a proper " <>


### PR DESCRIPTION
Fixes a small typo in `lib/ecto/migrator.ex`.