### PR TITLE
Add :caller_pid to the Ecto.LogEntry struct.

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -640,10 +640,12 @@ defmodule Ecto.Adapters.SQL do
     %{connection_time: query_time, decode_time: decode_time,
       pool_time: queue_time, result: result, query: query} = entry
     source = Keyword.get(opts, :source)
+    caller_pid = Keyword.get(opts, :caller, self())
     repo.__log__(%Ecto.LogEntry{query_time: query_time, decode_time: decode_time,
                                 queue_time: queue_time, result: log_result(result),
                                 params: params, query: String.Chars.to_string(query),
-                                ansi_color: sql_color(query), source: source})
+                                ansi_color: sql_color(query), source: source,
+                                caller_pid: caller_pid})
   end
 
   defp log_result({:ok, _query, res}), do: {:ok, res}

--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -12,6 +12,7 @@ defmodule Ecto.LogEntry do
     * decode_time - the time spent decoding the result in native units (it may be nil);
     * queue_time - the time spent to check the connection out in native units (it may be nil);
     * connection_pid - the connection process that executed the query;
+    * caller_pid - the application process that executed the query;
     * ansi_color - the color that should be used when logging the entry.
 
   Notice all times are stored in native unit. You must convert them to
@@ -24,10 +25,10 @@ defmodule Ecto.LogEntry do
                        params: [term], query_time: integer, decode_time: integer | nil,
                        queue_time: integer | nil, connection_pid: pid | nil,
                        result: {:ok, term} | {:error, Exception.t},
-                       ansi_color: IO.ANSI.ansicode | nil}
+                       ansi_color: IO.ANSI.ansicode | nil, caller_pid: pid | nil}
 
   defstruct query: nil, source: nil, params: [], query_time: nil, decode_time: nil,
-            queue_time: nil, result: nil, connection_pid: nil, ansi_color: nil
+            queue_time: nil, result: nil, connection_pid: nil, caller_pid: nil, ansi_color: nil
 
   require Logger
 


### PR DESCRIPTION
This will allow a way to reconnect the log entry with other already
accumulated state for use in e.g. metric collection of larger overall
request latency. Must check if `:caller` is already set in the case of
`preload`, which may load results in parallel and explicitly sets the
`:caller` opt.