### PR TITLE
suggesting valid associations when raising on non-existent association in get_assoc

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2127,8 +2127,15 @@ defmodule Ecto.Changeset do
     raise(ArgumentError, "cannot add constraint to changeset because it does not have a source, got: #{inspect data}")
 
   defp get_assoc(%{data: %{__struct__: schema}}, assoc) do
-    schema.__schema__(:association, assoc) ||
-      raise(ArgumentError, "cannot add constraint to changeset because association `#{assoc}` does not exist")
+    schema.__schema__(:association, assoc) || raise_invalid_assoc(schema, assoc)
+  end
+
+  defp raise_invalid_assoc(schema, assoc) do
+    associations = Enum.map_join(schema.__schema__(:associations), ", ", fn(association) ->
+      "`#{association}`"
+    end)
+    msg = "cannot add constraint to changeset because association `#{assoc}` does not exist. Did you mean one of #{associations}?"
+    raise(ArgumentError, msg)
   end
 
   @doc ~S"""

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1060,7 +1060,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "assoc_constraint/3 with errors" do
-    message = ~r"cannot add constraint to changeset because association `unknown` does not exist"
+    message = ~r"cannot add constraint to changeset because association `unknown` does not exist. Did you mean one of `comments`, `comment`?"
     assert_raise ArgumentError, message, fn ->
       change(%Post{}) |> assoc_constraint(:unknown)
     end


### PR DESCRIPTION
I noticed a few people asking questions in the Elixir slack recently about receiving the error for `cannot add constraint to changeset because association ``#{assoc}`` does not exist` when using `Ecto.Changeset.assoc_constraint`.  Most of the time, they were doing something like `assoc_constraint(:user_id)` when it should have been `assoc_constraint(:user)`.

It isn't necessarily clear in the error why `user` is correct and `user_id` isn't, and since the valid associations are available to suggest, I thought it could be helpful to suggest one.  I borrowed heavily from https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/exceptions.ex#L24-L34 to suggest a likely option.  It would also be possible and simpler to just list all of the associations, but I wasn't sure if that was preferable.