### PR TITLE
Fix ANSI coloring on queries

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -641,10 +641,11 @@ defmodule Ecto.Adapters.SQL do
       pool_time: queue_time, result: result, query: query} = entry
     source = Keyword.get(opts, :source)
     caller_pid = Keyword.get(opts, :caller, self())
+    query_string = String.Chars.to_string(query)
     repo.__log__(%Ecto.LogEntry{query_time: query_time, decode_time: decode_time,
                                 queue_time: queue_time, result: log_result(result),
-                                params: params, query: String.Chars.to_string(query),
-                                ansi_color: sql_color(query), source: source,
+                                params: params, query: query_string,
+                                ansi_color: sql_color(query_string), source: source,
                                 caller_pid: caller_pid})
   end
 


### PR DESCRIPTION
The SQL adapter has several `sql_color` functions to apply color coding to different query types. However, because it's being passed a `%Postgrex.Query{}` (or `%Mariaex.Query{}`, etc.) instead of a string, it never matches and always falls back to `nil`. Passing the `String.Chars.to_string(query)` result instead matches properly and returns the correct colors.

I didn't see anything in the existing tests related to testing the logger, but if there's somewhere I should/can add a test for this, I'll gladly update the pull request.