### PR TITLE
Doc addition. is_nil - show not is_nil

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -108,6 +108,10 @@ defmodule Ecto.Query.API do
   Checks if the given value is nil.
 
       from p in Post, where: is_nil(p.published_at)
+
+  To check if a given value is not nil use:
+
+      from p in Post, where: not is_nil(p.published_at)
   """
   def is_nil(value), do: doc! [value]
 


### PR DESCRIPTION
There have been a couple requests on Slack where people were confused about how to do IS NOT NULL. This adds to is_nil doc to point out how to do that.