### PR TITLE
Support utc offset when casting string to utc_datetime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,9 @@
 language: elixir
 elixir:
-  - 1.3.2
   - 1.4.0
 otp_release:
   - 18.2
   - 19.1
-matrix:
-  # We are only interested on the newest/oldest pair
-  exclude:
-    - elixir: 1.4.0
-      otp_release: 18.2
-    - elixir: 1.3.2
-      otp_release: 19.1
 addons:
   apt:
     packages:

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -810,6 +810,13 @@ defmodule Ecto.Type do
       {:error, _} -> :error
     end
   end
+  defp cast_utc_datetime(%DateTime{time_zone: "Etc/UTC"} = datetime), do: {:ok, datetime}
+  defp cast_utc_datetime(%DateTime{} = datetime) do
+    case (datetime |> DateTime.to_unix() |> DateTime.from_unix()) do
+      {:ok, _} = ok -> ok
+      {:error, _} -> :error
+    end
+  end
   defp cast_utc_datetime(value) do
     case cast_naive_datetime(value) do
       {:ok, %NaiveDateTime{} = naive_datetime} ->

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -812,11 +812,8 @@ defmodule Ecto.Type do
   end
   defp cast_utc_datetime(value) do
     case cast_naive_datetime(value) do
-      {:ok, %NaiveDateTime{year: year, month: month, day: day,
-                           hour: hour, minute: minute, second: second, microsecond: microsecond}} ->
-        {:ok, %DateTime{year: year, month: month, day: day,
-                        hour: hour, minute: minute, second: second, microsecond: microsecond,
-                        std_offset: 0, utc_offset: 0, zone_abbr: "UTC", time_zone: "Etc/UTC"}}
+      {:ok, %NaiveDateTime{} = naive_datetime} ->
+        {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
       {:ok, _} = ok ->
         ok
       :error ->

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -799,6 +799,17 @@ defmodule Ecto.Type do
 
   ## UTC datetime
 
+  defp cast_utc_datetime(binary) when is_binary(binary) do
+    case DateTime.from_iso8601(binary) do
+      {:ok, datetime, _offset} -> {:ok, datetime}
+      {:error, :missing_offset} ->
+        case cast_naive_datetime(binary) do
+          {:ok, naive_datetime} -> {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
+          :error -> :error
+        end
+      {:error, _} -> :error
+    end
+  end
   defp cast_utc_datetime(value) do
     case cast_naive_datetime(value) do
       {:ok, %NaiveDateTime{year: year, month: month, day: day,

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Ecto.Mixfile do
   def project do
     [app: :ecto,
      version: @version,
-     elixir: "~> 1.3",
+     elixir: "~> 1.4",
      deps: deps(),
      build_per_environment: false,
      consolidate_protocols: false,

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -313,11 +313,13 @@ defmodule Ecto.TypeTest do
     assert Ecto.Type.cast(:utc_datetime, "2015-01-23 23:50:07") == {:ok, @datetime}
     assert Ecto.Type.cast(:utc_datetime, "2015-01-23T23:50:07") == {:ok, @datetime}
     assert Ecto.Type.cast(:utc_datetime, "2015-01-23T23:50:07Z") == {:ok, @datetime}
+    assert Ecto.Type.cast(:utc_datetime, "2015-01-24T09:50:07+10:00") == {:ok, @datetime}
     assert Ecto.Type.cast(:utc_datetime, "2000-02-29T23:50:07") == {:ok, @datetime_leapyear}
     assert Ecto.Type.cast(:utc_datetime, "2015-01-23P23:50:07") == :error
 
     assert Ecto.Type.cast(:utc_datetime, "2015-01-23T23:50:07.008000") == {:ok, @datetime_usec}
     assert Ecto.Type.cast(:utc_datetime, "2015-01-23T23:50:07.008000Z") == {:ok, @datetime_usec}
+    assert Ecto.Type.cast(:utc_datetime, "2015-01-23T17:50:07.008000-06:00") == {:ok, @datetime_usec}
 
     assert Ecto.Type.cast(:utc_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
                                            "hour" => "23", "minute" => "50", "second" => "07"}) ==

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -328,6 +328,12 @@ defmodule Ecto.TypeTest do
     assert Ecto.Type.cast(:utc_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07}) ==
            {:ok, @datetime}
 
+    assert Ecto.Type.cast(:utc_datetime, %DateTime{calendar: Calendar.ISO, year: 2015, month: 1, day: 24,
+                                                   hour: 9, minute: 50, second: 7, microsecond: {0, 0},
+                                                   std_offset: 0, utc_offset: 36000,
+                                                   time_zone: "Etc/GMT-10", zone_abbr: "+10"}) ==
+           {:ok, @datetime}
+
     assert Ecto.Type.cast(:utc_datetime, %{"year" => "", "month" => "", "day" => "",
                                            "hour" => "", "minute" => ""}) ==
            {:ok, nil}


### PR DESCRIPTION
Currently `utc_datetime` fields silently drops any offset present in a string when `cast`. This PR allows `utc_datetime` to support the same inputs as `DateTime.from_iso8601`.

Since `utc_datetime` also allows for strings without an offset, it will fall back to `NaiveDateTime.from_iso8601` then then convert to `DateTime` in `Etc/UTC` timezone.

The motivation for this PR is a bug that we experienced in our web application, where we are using `utc_datetime` with `embedded_schema` to validate and cast incoming query params:

```elixir
defmodule MyApp.ReportRequest do
  use Ecto.Schema
  alias Ecto.Changeset

  @primary_key false
  embedded_schema do
    field :start_date, :utc_datetime
    field :end_date, :utc_datetime
    field :customer_id, :string
  end

  def validate(params) do
    changeset = 
      %MyApp.ReportRequest{}
      |> Changeset.cast(params, [:start_date, :end_date, :customer_id])
      |> Changeset.validate_required([:start_date, :end_date, :customer_id])

    if changeset.valid? do 
      {:ok, Changeset.apply_changes(changeset)} 
    else 
      {:error, changeset}
    end
  end
end
```

Usage: 

```elixir
iex(2)> MyApp.ReportRequest.validate(%{
  "start_date" => "2001-01-01T12:00:00+10:00", 
  "end_date" => "2010-01-01T12:00:00+10:00", 
  "customer_id" => "abc"})
{:ok,
 %MyApp.ReportRequest{customer_id: "abc",
  end_date: %DateTime{calendar: Calendar.ISO, day: 1, hour: 12,
   microsecond: {0, 0}, minute: 0, month: 1, second: 0, std_offset: 0,
   time_zone: "Etc/UTC", utc_offset: 0, year: 2010, zone_abbr: "UTC"},
  start_date: %DateTime{calendar: Calendar.ISO, day: 1, hour: 12,
   microsecond: {0, 0}, minute: 0, month: 1, second: 0, std_offset: 0,
   time_zone: "Etc/UTC", utc_offset: 0, year: 2001, zone_abbr: "UTC"}}}
```

Notice that it silently dropped the `+10:00` offsets while converting to UTC.

With the changes in this PR, the new output is:

```elixir
iex(2)> MyApp.ReportRequest.validate(%{
  "start_date" => "2001-01-01T12:00:00+10:00", 
  "end_date" => "2010-01-01T12:00:00+10:00", 
  "customer_id" => "abc"})
{:ok,
 %MyApp.ReportRequest{customer_id: "abc",
  end_date: %DateTime{calendar: Calendar.ISO, day: 1, hour: 2,
   microsecond: {0, 0}, minute: 0, month: 1, second: 0, std_offset: 0,
   time_zone: "Etc/UTC", utc_offset: 0, year: 2010, zone_abbr: "UTC"},
  start_date: %DateTime{calendar: Calendar.ISO, day: 1, hour: 2,
   microsecond: {0, 0}, minute: 0, month: 1, second: 0, std_offset: 0,
   time_zone: "Etc/UTC", utc_offset: 0, year: 2001, zone_abbr: "UTC"}}}
```

