### PR TITLE
Allow casting binary UUIDs

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -13,10 +13,28 @@ defmodule Ecto.UUID do
   @doc """
   Casts to UUID.
   """
-  def cast(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
-              b1, b2, b3, b4, ?-,
-              c1, c2, c3, c4, ?-,
-              d1, d2, d3, d4, ?-,
+  def cast(<< a::64, ?-, b::32, ?-, c::32, ?-, d::32, ?-, e::96 >>) do
+    do_cast(<< a::64, b::32, c::32, d::32, e::96 >>)
+  end
+  def cast(<< _::128 >> = binary) do
+    binary |> Base.encode16(case: :lower) |> do_cast()
+  end
+  def cast(_), do: :error
+
+  @doc """
+  Same as `cast/1` but raises `Ecto.CastError` on invalid arguments.
+  """
+  def cast!(value) do
+    case cast(value) do
+      {:ok, uuid} -> uuid
+      :error -> raise Ecto.CastError, type: __MODULE__, value: value
+    end
+  end
+
+  defp do_cast(<< a1, a2, a3, a4, a5, a6, a7, a8,
+              b1, b2, b3, b4,
+              c1, c2, c3, c4,
+              d1, d2, d3, d4,
               e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
     << c(a1), c(a2), c(a3), c(a4),
        c(a5), c(a6), c(a7), c(a8), ?-,
@@ -29,19 +47,7 @@ defmodule Ecto.UUID do
   catch
     :error -> :error
   else
-    casted ->
-      {:ok, casted}
-  end
-  def cast(_), do: :error
-
-  @doc """
-  Same as `cast/1` but raises `Ecto.CastError` on invalid arguments.
-  """
-  def cast!(value) do
-    case cast(value) do
-      {:ok, uuid} -> uuid
-      :error -> raise Ecto.CastError, type: __MODULE__, value: value
-    end
+    casted -> {:ok, casted}
   end
 
   @compile {:inline, c: 1}

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -13,28 +13,10 @@ defmodule Ecto.UUID do
   @doc """
   Casts to UUID.
   """
-  def cast(<< a::64, ?-, b::32, ?-, c::32, ?-, d::32, ?-, e::96 >>) do
-    do_cast(<< a::64, b::32, c::32, d::32, e::96 >>)
-  end
-  def cast(<< _::128 >> = binary) do
-    binary |> Base.encode16(case: :lower) |> do_cast()
-  end
-  def cast(_), do: :error
-
-  @doc """
-  Same as `cast/1` but raises `Ecto.CastError` on invalid arguments.
-  """
-  def cast!(value) do
-    case cast(value) do
-      {:ok, uuid} -> uuid
-      :error -> raise Ecto.CastError, type: __MODULE__, value: value
-    end
-  end
-
-  defp do_cast(<< a1, a2, a3, a4, a5, a6, a7, a8,
-              b1, b2, b3, b4,
-              c1, c2, c3, c4,
-              d1, d2, d3, d4,
+  def cast(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
+              b1, b2, b3, b4, ?-,
+              c1, c2, c3, c4, ?-,
+              d1, d2, d3, d4, ?-,
               e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
     << c(a1), c(a2), c(a3), c(a4),
        c(a5), c(a6), c(a7), c(a8), ?-,
@@ -48,6 +30,18 @@ defmodule Ecto.UUID do
     :error -> :error
   else
     casted -> {:ok, casted}
+  end
+  def cast(<< _::128 >> = binary), do: binary |> encode() |> cast()
+  def cast(_), do: :error
+
+  @doc """
+  Same as `cast/1` but raises `Ecto.CastError` on invalid arguments.
+  """
+  def cast!(value) do
+    case cast(value) do
+      {:ok, uuid} -> uuid
+      :error -> raise Ecto.CastError, type: __MODULE__, value: value
+    end
   end
 
   @compile {:inline, c: 1}

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -31,7 +31,7 @@ defmodule Ecto.UUID do
   else
     casted -> {:ok, casted}
   end
-  def cast(<< _::128 >> = binary), do: binary |> encode() |> cast()
+  def cast(<< _::128 >> = binary), do: encode(binary)
   def cast(_), do: :error
 
   @doc """
@@ -145,14 +145,14 @@ defmodule Ecto.UUID do
   Converts a binary UUID into a string.
   """
   def load(<<_::128>> = uuid) do
-   {:ok, encode(uuid)}
+    encode(uuid)
   end
   def load(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = string) do
     raise "trying to load string UUID as Ecto.UUID: #{inspect string}. " <>
           "Maybe you wanted to declare :uuid as your database field?"
   end
   def load(%Ecto.Query.Tagged{type: :uuid, value: uuid}) do
-    {:ok, encode(uuid)}
+    encode(uuid)
   end
   def load(_), do: :error
 
@@ -160,7 +160,8 @@ defmodule Ecto.UUID do
   Generates a version 4 (random) UUID.
   """
   def generate do
-    bingenerate() |> encode
+    {:ok, uuid} = encode(bingenerate())
+    uuid
   end
 
   @doc """
@@ -185,10 +186,31 @@ defmodule Ecto.UUID do
                  e9::4, e10::4, e11::4, e12::4 >>) do
     << e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-,
        e(b1), e(b2), e(b3), e(b4), ?-,
-       e(c1), e(c2), e(c3), e(c4), ?-,
-       e(d1), e(d2), e(d3), e(d4), ?-,
+       encode_version(c1), e(c2), e(c3), e(c4), ?-,
+       encode_variant(d1), e(d2), e(d3), e(d4), ?-,
        e(e1), e(e2), e(e3), e(e4), e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12) >>
+  catch
+    :error -> :error
+  else
+    encoded -> {:ok, encoded}
   end
+
+  @compile {:inline, encode_version: 1}
+
+  defp encode_version(1), do: ?1
+  defp encode_version(2), do: ?2
+  defp encode_version(3), do: ?3
+  defp encode_version(4), do: ?4
+  defp encode_version(5), do: ?5
+  defp encode_version(_), do: throw(:error)
+
+  @compile {:inline, encode_variant: 1}
+
+  defp encode_variant(8), do: ?8
+  defp encode_variant(9), do: ?9
+  defp encode_variant(10), do: ?a
+  defp encode_variant(11), do: ?b
+  defp encode_variant(_), do: throw(:error)
 
   @compile {:inline, e: 1}
 

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -10,18 +10,15 @@ defmodule Ecto.UUIDTest do
 
   test "cast" do
     assert Ecto.UUID.cast(@test_uuid) == {:ok, @test_uuid}
+    assert Ecto.UUID.cast(@test_uuid_binary) == {:ok, @test_uuid}
     assert Ecto.UUID.cast(@test_uuid_upper_case) == {:ok, String.downcase(@test_uuid_upper_case)}
     assert Ecto.UUID.cast(@test_uuid_invalid_characters) == :error
     assert Ecto.UUID.cast(@test_uuid_invalid_shape) == :error
-    assert Ecto.UUID.cast(@test_uuid_binary) == :error
     assert Ecto.UUID.cast(nil) == :error
   end
 
   test "cast!" do
     assert Ecto.UUID.cast!(@test_uuid) == @test_uuid
-    assert_raise Ecto.CastError, "cannot cast <<96, 29, 116, 228, 168, 211, 75, 110, 131, 101, 237, 219, 76, 137, 51, 39>> to Ecto.UUID", fn ->
-      assert Ecto.UUID.cast!(@test_uuid_binary)
-    end
     assert_raise Ecto.CastError, "cannot cast nil to Ecto.UUID", fn ->
       assert Ecto.UUID.cast!(nil)
     end


### PR DESCRIPTION
Currently, only dash-separated strings are allowed in `UUID.cast/1`. This adds the ability to pass 16 byte binaries. The same validation rules apply to both binaries and dash-separated strings.

Closes #2045