### PR TITLE
Add functions that specify version of UUID being generated.

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -160,6 +160,13 @@ defmodule Ecto.UUID do
   Generates a version 4 (random) UUID.
   """
   def generate do
+    generate_v4()
+  end
+
+  @doc """
+  Generates a version 4 (random) UUID.
+  """
+  def generate_v4 do
     {:ok, uuid} = encode(bingenerate())
     uuid
   end
@@ -168,6 +175,13 @@ defmodule Ecto.UUID do
   Generates a version 4 (random) UUID in the binary format.
   """
   def bingenerate do
+    bingenerate_v4()
+  end
+
+  @doc """
+  Generates a version 4 (random) UUID in the binary format.
+  """
+  def bingenerate_v4 do
     <<u0::48, _::4, u1::12, _::2, u2::62>> = :crypto.strong_rand_bytes(16)
     <<u0::48, 4::4, u1::12, 2::2, u2::62>>
   end

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -40,4 +40,8 @@ defmodule Ecto.UUIDTest do
   test "generate" do
     assert << _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = Ecto.UUID.generate
   end
+
+  test "generate_v4" do
+    assert << _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = Ecto.UUID.generate_v4
+  end
 end


### PR DESCRIPTION
Since there are multiple methods/versions of UUID generation, I thought it would be useful to specify the version of UUID being generated. I kept the existing `generate` function for backwards compatibility.

Alternatively, this could also be implemented like so:
```elixir
def generate(version \\ :v4) do
  ...
end
```

Instead of creating an additional function, but I'm not sure which you guys would prefer.

Let me know if you think this is useful.