### PR TITLE
Backport 2a892ac to V2.1

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -130,7 +130,14 @@ defmodule Ecto.Migrator do
   end
 
   @doc """
-  Apply migrations in a directory to a repository with given strategy.
+  Apply migrations to a repository with a given strategy.
+
+  The second argument identifies where the migrations are sourced from. A file
+  path may be passed, in which case the migrations will be loaded from this
+  during the migration process. The other option is to pass a list of tuples
+  that identify the version number and migration modules to be run, for example:
+
+      Ecto.Migrator.run(Repo, [{0, MyApp.Migration1}, {1, MyApp.Migration2}, ...], :up, opts)
 
   A strategy must be given as an option.
 
@@ -143,17 +150,17 @@ defmodule Ecto.Migrator do
       Can be any of `Logger.level/0` values or `false`.
 
   """
-  @spec run(Ecto.Repo.t, binary, atom, Keyword.t) :: [integer]
-  def run(repo, directory, direction, opts) do
+  @spec run(Ecto.Repo.t, binary | [{integer, module}], atom, Keyword.t) :: [integer]
+  def run(repo, migration_source, direction, opts) do
     versions = migrated_versions(repo, opts)
 
     cond do
       opts[:all] ->
-        run_all(repo, versions, directory, direction, opts)
+        run_all(repo, versions, migration_source, direction, opts)
       to = opts[:to] ->
-        run_to(repo, versions, directory, direction, to, opts)
+        run_to(repo, versions, migration_source, direction, to, opts)
       step = opts[:step] ->
-        run_step(repo, versions, directory, direction, step, opts)
+        run_step(repo, versions, migration_source, direction, step, opts)
       true ->
         raise ArgumentError, "expected one of :all, :to, or :step strategies"
     end
@@ -176,7 +183,7 @@ defmodule Ecto.Migrator do
     end)
   end
 
-  defp run_to(repo, versions, directory, direction, target, opts) do
+  defp run_to(repo, versions, migration_source, direction, target, opts) do
     within_target_version? = fn
       {version, _, _}, target, :up ->
         version <= target
@@ -184,39 +191,45 @@ defmodule Ecto.Migrator do
         version >= target
     end
 
-    pending_in_direction(versions, directory, direction)
+    pending_in_direction(versions, migration_source, direction)
     |> Enum.take_while(&(within_target_version?.(&1, target, direction)))
     |> migrate(direction, repo, opts)
   end
 
-  defp run_step(repo, versions, directory, direction, count, opts) do
-    pending_in_direction(versions, directory, direction)
+  defp run_step(repo, versions, migration_source, direction, count, opts) do
+    pending_in_direction(versions, migration_source, direction)
     |> Enum.take(count)
     |> migrate(direction, repo, opts)
   end
 
-  defp run_all(repo, versions, directory, direction, opts) do
-    pending_in_direction(versions, directory, direction)
+  defp run_all(repo, versions, migration_source, direction, opts) do
+    pending_in_direction(versions, migration_source, direction)
     |> migrate(direction, repo, opts)
   end
 
-  defp pending_in_direction(versions, directory, :up) do
-    migrations_for(directory)
+  defp pending_in_direction(versions, migration_source, :up) do
+    migrations_for(migration_source)
     |> Enum.filter(fn {version, _name, _file} -> not (version in versions) end)
   end
 
-  defp pending_in_direction(versions, directory, :down) do
-    migrations_for(directory)
+  defp pending_in_direction(versions, migration_source, :down) do
+    migrations_for(migration_source)
     |> Enum.filter(fn {version, _name, _file} -> version in versions end)
     |> Enum.reverse
   end
 
-  defp migrations_for(directory) do
-    query = Path.join(directory, "*")
+  # This function will match directories passed into `Migrator.run`.
+  defp migrations_for(migration_source) when is_binary(migration_source) do
+    query = Path.join(migration_source, "*")
 
     for entry <- Path.wildcard(query),
         info = extract_migration_info(entry),
         do: info
+  end
+
+  # This function will match specific version/modules passed into `Migrator.run`.
+  defp migrations_for(migration_source) when is_list(migration_source) do
+    Enum.map migration_source, fn({version, module}) -> {version, module, :existing_module} end
   end
 
   defp extract_migration_info(file) do
@@ -240,17 +253,12 @@ defmodule Ecto.Migrator do
   defp migrate(migrations, direction, repo, opts) do
     ensure_no_duplication(migrations)
 
-    Enum.map migrations, fn {version, _name, file} ->
-      {mod, _bin} =
-        Enum.find(Code.load_file(file), fn {mod, _bin} ->
-          function_exported?(mod, :__migration__, 0)
-        end) || raise_no_migration_in_file(file)
-
+    Enum.map migrations, fn {version, name_or_mod, file} ->
+      mod = extract_module(file, name_or_mod)
       case direction do
         :up   -> do_up(repo, version, mod, opts)
         :down -> do_down(repo, version, mod, opts)
       end
-
       version
     end
   end
@@ -293,9 +301,27 @@ defmodule Ecto.Migrator do
     end
   end
 
+  defp is_migration_module?({mod, _bin}), do: function_exported?(mod, :__migration__, 0)
+  defp is_migration_module?(mod), do: function_exported?(mod, :__migration__, 0)
+
+  defp extract_module(:existing_module, mod) do
+    if is_migration_module?(mod), do: mod, else: raise_no_migration_in_module(mod)
+  end
+  defp extract_module(file, _name) do
+    modules = Code.load_file(file)
+    case Enum.find(modules, &is_migration_module?/1) do
+      {mod, _bin} -> mod
+      _otherwise -> raise_no_migration_in_file(file)
+    end
+  end
+
   defp raise_no_migration_in_file(file) do
     raise Ecto.MigrationError,
-          "file #{Path.relative_to_cwd(file)} does not contain any Ecto.Migration"
+          "file #{Path.relative_to_cwd(file)} is not an Ecto.Migration"
+  end
+  defp raise_no_migration_in_module(mod) do
+    raise Ecto.MigrationError,
+          "module #{inspect mod} is not an Ecto.Migration"
   end
 
   defp log(false, _msg), do: :ok

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -71,6 +71,8 @@ defmodule Ecto.MigratorTest do
     use Ecto.Migration
   end
 
+  defmodule EmptyModule do
+  end
 
   defmodule TestSchemaRepo do
     use Ecto.Repo, otp_app: :ecto, adapter: Ecto.TestAdapter
@@ -176,7 +178,7 @@ defmodule Ecto.MigratorTest do
   test "fails if there is no migration in file" do
     in_tmp fn path ->
       File.write! "13_sample.exs", ":ok"
-      assert_raise Ecto.MigrationError, "file 13_sample.exs does not contain any Ecto.Migration", fn ->
+      assert_raise Ecto.MigrationError, "file 13_sample.exs is not an Ecto.Migration", fn ->
         run(TestRepo, path, :up, all: true, log: false)
       end
     end
@@ -332,5 +334,63 @@ defmodule Ecto.MigratorTest do
       end
     end
     """
+  end
+
+  describe "alternate migration source format" do
+    test "fails if there is no migration in file" do
+      assert_raise Ecto.MigrationError, "module Ecto.MigratorTest.EmptyModule is not an Ecto.Migration", fn ->
+        run(TestRepo, [{13, EmptyModule}], :up, all: true, log: false)
+      end
+    end
+
+    test "fails if the module does not define migrations" do
+      assert_raise Ecto.MigrationError, "Ecto.MigratorTest.InvalidMigration does not implement a `up/0` or `change/0` function", fn ->
+        run(TestRepo, [{13, InvalidMigration}], :up, all: true, log: false)
+      end
+    end
+
+    test "fails if there are duplicated versions" do
+      assert_raise Ecto.MigrationError, "migrations can't be executed, migration version 13 is duplicated", fn ->
+        run(TestRepo, [{13, ChangeMigration}, {13, UpDownMigration}], :up, all: true, log: false)
+      end
+    end
+
+    test "fails if there are duplicated name" do
+      assert_raise Ecto.MigrationError, "migrations can't be executed, migration name Elixir.Ecto.MigratorTest.ChangeMigration is duplicated", fn ->
+        run(TestRepo, [{13, ChangeMigration}, {14, ChangeMigration}], :up, all: true, log: false)
+      end
+    end
+
+    test "upwards migrations skips migrations that are already up" do
+      assert run(TestRepo, [{1, ChangeMigration}], :up, all: true, log: false) == []
+    end
+
+    test "downwards migrations skips migrations that are already down" do
+      assert run(TestRepo, [{1, ChangeMigration}, {4, UpDownMigration}], :down, all: true, log: false) == [1]
+    end
+
+    test "stepwise migrations stop before all have been run" do
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, step: 1, log: false) == [13]
+    end
+
+    test "stepwise migrations stop at the number of available migrations" do
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, step: 2, log: false) == [13, 14]
+    end
+
+    test "stepwise migrations stop even if asked to exceed available" do
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, step: 3, log: false) == [13, 14]
+    end
+
+    test "version migrations stop before all have been run" do
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false) == [13]
+    end
+
+    test "version migrations stop at the number of available migrations" do
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 14, log: false) == [13, 14]
+    end
+
+    test "version migrations stop even if asked to exceed available" do
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 15, log: false) == [13, 14]
+    end
   end
 end


### PR DESCRIPTION
I got a commit in to master back in January (https://github.com/elixir-ecto/ecto/commit/2a892ac8c15d36516c5559cfab3c77b3ed0049f2), and I'm stuck using a github version of Ecto (not Hex) as my app relies on this behaviour.

@michalmuskala mentioned it might be ok to backport to v2.1.x so it can get in the next 2.1 release.  I'm not actually sure how to actually backport things... So I've cherry-picked the commit, and rebased onto the 2.1 branch hoping that is what's required :)

As far as I know this change is fully backwards compatible, so would be ok to go on 2.1.x.

There is a failing test when running with this code, but that test was already failing on the code I branched from (https://github.com/elixir-ecto/ecto/commit/0bbf06f078ac4015fb8469f9bfe7d11957cafaa0).

Let me know if this is what I'm supposed to be doing!