### PR TITLE
added a pattern to schema_for_association_join! for map updates

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -427,6 +427,8 @@ defmodule Ecto.Query.Planner do
         schema
       %Ecto.SubQuery{query: %{select: %{expr: {:&, _, [ix]}}, sources: sources}} when is_integer(ix) ->
         schema_for_association_join!(query, join, elem(sources, ix))
+      %Ecto.SubQuery{query: %{select: %{expr: {:%{}, _, [{:|, _, [{:&, _, [ix]}, _fields]}]}}, sources: sources}} when is_integer(ix) ->
+        schema_for_association_join!(query, join, elem(sources, ix))
       %Ecto.SubQuery{} ->
         error! query, join, "can only perform association joins on subqueries " <>
                             "that return a single source in select"


### PR DESCRIPTION
Support was recently added for map updates in select statements from subqueries. In order to use `assoc/2` with the result of those subqueries, this pattern needs to be added to `schema_for_association_join!/3`