### PR TITLE
Warn about use of match operator in the query DSL

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -218,8 +218,8 @@ defmodule Ecto.Query.Builder do
   end
 
   def escape({:=, _, _}, _type, _params_acc, _vars, _env) do
-    error! "match operator is  not supported: `=`. " <>
-           "Instead use the comparison operator: `==`"
+    error! "match operator is not supported: `=`. " <>
+           "Did you mean to use `==` instead?"
   end
 
   def escape({op, _, _}, _type, _params_acc, _vars, _env) when op in ~w(|| && !)a do

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -217,6 +217,11 @@ defmodule Ecto.Query.Builder do
     {expr, params_acc}
   end
 
+  def escape({:=, _, _}, _type, _params_acc, _vars, _env) do
+    error! "match operator is  not supported: `=`. " <>
+           "Instead use the comparison operator: `==`"
+  end
+
   def escape({op, _, _}, _type, _params_acc, _vars, _env) when op in ~w(|| && !)a do
     error! "short-circuit operators are not supported: `#{op}`. " <>
            "Instead use boolean operators: `and`, `or`, and `not`"

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -217,7 +217,7 @@ defmodule Ecto.Query.Builder do
     {expr, params_acc}
   end
 
-  def escape(expr = {:=, _, _}, _type, _params_acc, _vars, _env) do
+  def escape({:=, _, _} = expr, _type, _params_acc, _vars, _env) do
     error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
             "The match operator is not supported: `=`. " <>
             "Did you mean to use `==` instead?"

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -217,9 +217,10 @@ defmodule Ecto.Query.Builder do
     {expr, params_acc}
   end
 
-  def escape({:=, _, _}, _type, _params_acc, _vars, _env) do
-    error! "match operator is not supported: `=`. " <>
-           "Did you mean to use `==` instead?"
+  def escape(expr = {:=, _, _}, _type, _params_acc, _vars, _env) do
+    error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
+            "The match operator is not supported: `=`. " <>
+            "Did you mean to use `==` instead?"
   end
 
   def escape({op, _, _}, _type, _params_acc, _vars, _env) when op in ~w(|| && !)a do

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -87,7 +87,7 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: true && false), [], __ENV__)
     end
 
-    assert_raise Ecto.Query.CompileError, ~r"match operator is  not supported: `=`", fn ->
+    assert_raise Ecto.Query.CompileError, ~r"match operator is not supported: `=`", fn ->
       escape(quote(do: 1 = 1), [], __ENV__)
     end
 

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -87,6 +87,10 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: true && false), [], __ENV__)
     end
 
+    assert_raise Ecto.Query.CompileError, ~r"match operator is  not supported: `=`", fn ->
+      escape(quote(do: 1 = 1), [], __ENV__)
+    end
+
     assert_raise Ecto.Query.CompileError, ~r"`unknown\(1, 2\)` is not a valid query expression", fn ->
       escape(quote(do: unknown(1, 2)), [], __ENV__)
     end

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -87,7 +87,7 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: true && false), [], __ENV__)
     end
 
-    assert_raise Ecto.Query.CompileError, ~r"match operator is not supported: `=`", fn ->
+    assert_raise Ecto.Query.CompileError, ~r"`1 = 1` is not a valid query expression. The match operator is not supported: `=`", fn ->
       escape(quote(do: 1 = 1), [], __ENV__)
     end
 


### PR DESCRIPTION
This change improves error handling when a match operator is used instead of a comparison operator.

See discussion:
https://groups.google.com/forum/#!topic/elixir-ecto/gYeF0jD8MPc