### PR TITLE
Support setting the default of a :map type with a Map

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -185,4 +185,9 @@ defmodule Ecto.Adapter do
   @callback delete(repo, schema_meta, filters, options) ::
                      {:ok, fields} | {:invalid, constraints} |
                      {:error, :stale} | no_return
+
+  @doc false
+  def json_library do
+    Application.get_env(:ecto, :json_library, Poison)
+  end
 end

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -642,6 +642,10 @@ if Code.ensure_loaded?(Mariaex) do
       do: [" DEFAULT '", escape_string(literal), ?']
     defp default_expr({:ok, literal}) when is_number(literal) or is_boolean(literal),
       do: [" DEFAULT ", to_string(literal)]
+    defp default_expr({:ok, %{} = map}) do
+      default = Ecto.Adapter.json_library().encode!(map)
+      [" DEFAULT ", [?', escape_string(default), ?']]
+    end
     defp default_expr({:ok, {:fragment, expr}}),
       do: [" DEFAULT ", expr]
     defp default_expr(:error),

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -38,14 +38,10 @@ if Code.ensure_loaded?(Mariaex) do
         %{__struct__: _} = value ->
           value
         %{} = value ->
-          json_library().encode!(value)
+          Ecto.Adapter.json_library().encode!(value)
         value ->
           value
       end
-    end
-
-    defp json_library do
-      Application.fetch_env!(:ecto, :json_library)
     end
 
     def to_constraints(%Mariaex.Error{mariadb: %{code: 1062, message: message}}) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -785,11 +785,15 @@ if Code.ensure_loaded?(Postgrex) do
       do: [" DEFAULT '", escape_string(literal), ?']
     defp default_expr({:ok, literal}, _type) when is_number(literal) or is_boolean(literal),
       do: [" DEFAULT ", to_string(literal)]
+    defp default_expr({:ok, %{} = map}, :map) do
+      default = Ecto.Adapter.json_library().encode!(map)
+      [" DEFAULT ", single_quote(default)]
+    end
     defp default_expr({:ok, {:fragment, expr}}, _type),
       do: [" DEFAULT ", expr]
     defp default_expr({:ok, expr}, type),
       do: raise(ArgumentError, "unknown default `#{inspect expr}` for type `#{inspect type}`. " <>
-                               ":default may be a string, number, boolean, empty list or a fragment(...)")
+                               ":default may be a string, number, boolean, empty list, map (when type is Map), or a fragment(...)")
     defp default_expr(:error, _),
       do: []
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1,7 +1,7 @@
 if Code.ensure_loaded?(Postgrex) do
   Postgrex.Types.define(Ecto.Adapters.Postgres.TypeModule,
                         Ecto.Adapters.Postgres.extensions(),
-                        json: Application.get_env(:ecto, :json_library, Poison))
+                        json: Ecto.Adapter.json_library())
 
   defmodule Ecto.Adapters.Postgres.Connection do
     @moduledoc false

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -636,9 +636,7 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:add, :a, :map, [default: %{}]}
               ]
             }
-    assert execute_ddl(create) == ["""
-    CREATE TABLE `posts` (`a` text DEFAULT '{}') ENGINE = INNODB
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [~s|CREATE TABLE `posts` (`a` text DEFAULT '{}') ENGINE = INNODB|]
   end
 
   test "create table with a map column, and a map default with values" do
@@ -647,9 +645,7 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:add, :a, :map, [default: %{foo: "bar", baz: "boom"}]}
               ]
             }
-    assert execute_ddl(create) == ["""
-    CREATE TABLE `posts` (`a` text DEFAULT '{"foo":"bar","baz":"boom"}') ENGINE = INNODB
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [~s|CREATE TABLE `posts` (`a` text DEFAULT '{"foo":"bar","baz":"boom"}') ENGINE = INNODB|]
   end
 
   test "create table with a map column, and a string default" do
@@ -658,9 +654,7 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:add, :a, :map, [default: ~s|{"foo":"bar","baz":"boom"}|]}
               ]
             }
-    assert execute_ddl(create) == ["""
-    CREATE TABLE `posts` (`a` text DEFAULT '{"foo":"bar","baz":"boom"}') ENGINE = INNODB
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [~s|CREATE TABLE `posts` (`a` text DEFAULT '{"foo":"bar","baz":"boom"}') ENGINE = INNODB|]
   end
 
   test "drop table" do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -630,6 +630,39 @@ defmodule Ecto.Adapters.MySQLTest do
     """ |> remove_newlines]
   end
 
+  test "create table with a map column, and an empty map default" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, :map, [default: %{}]}
+              ]
+            }
+    assert execute_ddl(create) == ["""
+    CREATE TABLE `posts` (`a` text DEFAULT '{}') ENGINE = INNODB
+    """ |> remove_newlines]
+  end
+
+  test "create table with a map column, and a map default with values" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, :map, [default: %{foo: "bar", baz: "boom"}]}
+              ]
+            }
+    assert execute_ddl(create) == ["""
+    CREATE TABLE `posts` (`a` text DEFAULT '{"foo":"bar","baz":"boom"}') ENGINE = INNODB
+    """ |> remove_newlines]
+  end
+
+  test "create table with a map column, and a string default" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, :map, [default: ~s|{"foo":"bar","baz":"boom"}|]}
+              ]
+            }
+    assert execute_ddl(create) == ["""
+    CREATE TABLE `posts` (`a` text DEFAULT '{"foo":"bar","baz":"boom"}') ENGINE = INNODB
+    """ |> remove_newlines]
+  end
+
   test "drop table" do
     drop = {:drop, table(:posts)}
     assert execute_ddl(drop) == [~s|DROP TABLE `posts`|]

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -781,9 +781,7 @@ defmodule Ecto.Adapters.PostgresTest do
                 {:add, :a, :map, [default: %{}]}
               ]
             }
-    assert execute_ddl(create) == ["""
-    CREATE TABLE "posts" ("a" jsonb DEFAULT '{}')
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{}')|]
   end
 
   test "create table with a map column, and a map default with values" do
@@ -792,9 +790,7 @@ defmodule Ecto.Adapters.PostgresTest do
                 {:add, :a, :map, [default: %{foo: "bar", baz: "boom"}]}
               ]
             }
-    assert execute_ddl(create) == ["""
-    CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')|]
   end
 
   test "create table with a map column, and a string default" do
@@ -803,9 +799,7 @@ defmodule Ecto.Adapters.PostgresTest do
                 {:add, :a, :map, [default: ~s|{"foo":"bar","baz":"boom"}|]}
               ]
             }
-    assert execute_ddl(create) == ["""
-    CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')|]
   end
 
   test "drop table" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -775,6 +775,39 @@ defmodule Ecto.Adapters.PostgresTest do
     """ |> remove_newlines]
   end
 
+  test "create table with a map column, and an empty map default" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, :map, [default: %{}]}
+              ]
+            }
+    assert execute_ddl(create) == ["""
+    CREATE TABLE "posts" ("a" jsonb DEFAULT '{}')
+    """ |> remove_newlines]
+  end
+
+  test "create table with a map column, and a map default with values" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, :map, [default: %{foo: "bar", baz: "boom"}]}
+              ]
+            }
+    assert execute_ddl(create) == ["""
+    CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')
+    """ |> remove_newlines]
+  end
+
+  test "create table with a map column, and a string default" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, :map, [default: ~s|{"foo":"bar","baz":"boom"}|]}
+              ]
+            }
+    assert execute_ddl(create) == ["""
+    CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')
+    """ |> remove_newlines]
+  end
+
   test "drop table" do
     drop = {:drop, table(:posts)}
     assert execute_ddl(drop) == [~s|DROP TABLE "posts"|]


### PR DESCRIPTION
Currently, defining a :map type in a table can only have a default set with a literal string. Principle of least astonishment suggests that setting the default with an Elixir Map should be possible. With these changes this is now possible:

```
  def change do
    create table :testmap do
      add :map, :map, default: %{"foo" => "'bar'"}
    end
  end
```