### PR TITLE
Support views in migrations #1805

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * [Ecto.Adapters.MySQL] Use Mariaex instead of MySQL client to create & drop database
   * [Ecto.Changeset] Add `apply_action/2`
   * [Ecto.Migrations] Add reversible `execute/2` to migrations
+  * [Ecto.Migrations] Add SQL views support
   * [Ecto.Migrator] Allow migration/rollback to log SQL commands via the `--log-sql` flag
   * [Ecto.LogEntry] Add `:caller_pid` to the Ecto.LogEntry struct
   * [Ecto.Repo] Implement `:returning` option on insert

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -7,6 +7,7 @@ defmodule Ecto.Migration.Runner do
   require Logger
 
   alias Ecto.Migration.Table
+  alias Ecto.Migration.View
   alias Ecto.Migration.Index
   alias Ecto.Migration.Constraint
   alias Ecto.Migration.Command
@@ -234,6 +235,15 @@ defmodule Ecto.Migration.Runner do
 
   defp command({:create, %Table{} = table, _}),
     do: "create table #{quote_name(table.prefix, table.name)}"
+  defp command({:create, %View{} = view}) do
+    "create view #{quote_name(view.prefix, view.name)}"
+  end
+  defp command({:create_or_replace, %View{} = view}) do
+    "create or replace view #{quote_name(view.prefix, view.name)}"
+  end
+  defp command({:create_if_not_exists, %View{} = view}) do
+    "create materialized view if not exists #{quote_name(view.prefix, view.name)}"
+  end
   defp command({:create_if_not_exists, %Table{} = table, _}),
     do: "create table if not exists #{quote_name(table.prefix, table.name)}"
   defp command({:alter, %Table{} = table, _}),
@@ -251,6 +261,10 @@ defmodule Ecto.Migration.Runner do
     do: "drop index #{quote_name(index.prefix, index.name)}"
   defp command({:drop_if_exists, %Index{} = index}),
     do: "drop index if exists #{quote_name(index.prefix, index.name)}"
+  defp command({:drop, %View{} = view}),
+    do: "drop view #{quote_name(view.prefix, view.name)}"
+  defp command({:drop_if_exists, %View{} = view}),
+    do: "drop view if exists #{quote_name(view.prefix, view.name)}"
   defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
     do: "rename table #{quote_name(current_table.prefix, current_table.name)} to #{quote_name(new_table.prefix, new_table.name)}"
   defp command({:rename, %Table{} = table, current_column, new_column}),


### PR DESCRIPTION
Can we somehow rewrite update_view_sql function? We need to convert our query to raw SQL and I'm not sure that my solution is the best one.