### PR TITLE
[WIP] Always log from the main process in parallel preloads

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -190,4 +190,13 @@ defmodule Ecto.Adapter do
   def json_library do
     Application.get_env(:ecto, :json_library, Poison)
   end
+
+  def log(repo, log, opts) do
+    case Keyword.fetch(opts, :forward_logs) do
+      {:ok, pid} when is_pid(pid) ->
+        send(pid, {:ecto_log, repo, log})
+      :error ->
+        repo.__log__(log)
+    end
+  end
 end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -642,11 +642,12 @@ defmodule Ecto.Adapters.SQL do
     source = Keyword.get(opts, :source)
     caller_pid = Keyword.get(opts, :caller, self())
     query_string = String.Chars.to_string(query)
-    repo.__log__(%Ecto.LogEntry{query_time: query_time, decode_time: decode_time,
-                                queue_time: queue_time, result: log_result(result),
-                                params: params, query: query_string,
-                                ansi_color: sql_color(query_string), source: source,
-                                caller_pid: caller_pid})
+    log = %Ecto.LogEntry{query_time: query_time, decode_time: decode_time,
+                         queue_time: queue_time, result: log_result(result),
+                         params: params, query: query_string,
+                         ansi_color: sql_color(query_string), source: source,
+                         caller_pid: caller_pid}
+    Ecto.Adapter.log(repo, log, opts)
   end
 
   defp log_result({:ok, _query, res}), do: {:ok, res}


### PR DESCRIPTION
This allows preserving process metadata when logging

---

This is just a proof of concept. It requires some tests and probably additional documentation. To be honest, I'm not 100% sure how to test this.

\cc @josevalim @fishcakez 
