### PR TITLE
`execute/1` isn't specific to DB type

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -563,7 +563,7 @@ defmodule Ecto.Migration do
   end
 
   @doc """
-  Executes arbitrary SQL or a keyword command in NoSQL databases.
+  Executes arbitrary SQL or a keyword command.
 
   Reversible commands can be defined by calling `execute/2`.
 


### PR DESCRIPTION
This way the docs for `execute/1` is consistent with `execute/2` where DB type is also not mentioned.