### PR TITLE
Ensure that Ecto.Repo.Queryable.transaction accepts function or multi

### DIFF
--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -14,7 +14,7 @@ defmodule Ecto.Repo.Queryable do
     adapter.transaction(repo, opts, fun)
   end
 
-  def transaction(adapter, repo, multi, opts) do
+  def transaction(adapter, repo, %Ecto.Multi{} = multi, opts) do
     wrap   = &adapter.transaction(repo, opts, &1)
     return = &adapter.rollback(repo, &1)
 


### PR DESCRIPTION
I accidentally passed changeset to Repo.transaction and got a weird error:

     ** (FunctionClauseError) no function clause matching in Ecto.Multi.__apply__/4
     stacktrace:
       (ecto) lib/ecto/multi.ex:392: Ecto.Multi.__apply__(#Ecto.Changeset<action: nil, ...>)
       (ecto) lib/ecto/repo/queryable.ex:21: Ecto.Repo.Queryable.transaction/4
       ...

FunctionClauseError on `Queryable.transaction/4` seems more appropriate (especially later with Exception.blame)?