### PR TITLE
WIP: Rename struct to schema struct

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -359,7 +359,7 @@ defmodule Ecto.Changeset do
   Applies the given `params` as changes for the given `data` according to
   the given set of keys. Returns a changeset.
 
-  The given `data` may be either a changeset, a struct or a `{data, types}`
+  The given `data` may be either a changeset, a schema struct or a `{data, types}`
   tuple. The second argument is a map of `params` that are cast according
   to the type information from `data`. `params` is a map with string keys
   or a map with atom keys containing potentially unsafe data.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -241,7 +241,7 @@ defmodule Ecto.Repo do
       def load(schema_or_types, data) do
         Ecto.Repo.Schema.load(@adapter, schema_or_types, data)
       end
-      
+
       defoverridable child_spec: 1
     end
   end
@@ -668,7 +668,7 @@ defmodule Ecto.Repo do
                        {integer, nil | [term]} | no_return
 
   @doc """
-  Inserts a struct or a changeset.
+  Inserts a struct defined via `Ecto.Schema` or a changeset.
 
   In case a struct is given, the struct is converted into a changeset
   with all non-nil fields as part of the changeset.


### PR DESCRIPTION
WIP for issue https://github.com/elixir-ecto/ecto/issues/2091

I am not sure if I should go ahead and rename every instance of `struct` where it technically means a `schema struct`?  In this PR I have replaced several instances of `struct` to `schema struct`. 
However, I haven't touched the variable names used in code. Should I this be also changed? I feel that would make it too verbose but not sure.

Any decision made here needs to be carried to other modules such as `Ecto.Repo` which also has references to `struct`.

Please advise.
