### PR TITLE
Stop using `__schema__` to resolve assocs in Ecto.Changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2154,15 +2154,10 @@ defmodule Ecto.Changeset do
   end
 
   defp raise_invalid_assoc(types, assoc) do
-    associations =
-      Enum.reduce(types, "", fn
-        {_key, {:assoc, %{field: field}}}, "" -> "`#{field}`"
-        {_key, {:assoc, %{field: field}}}, acc -> acc <> ", `#{field}`"
-        _, acc -> acc
-      end)
 
+    associations = for {_key, {:assoc, %{field: field}}} <- types, do: field
     raise ArgumentError, "cannot add constraint to changeset because association `#{assoc}` does not exist. " <>
-                         "Did you mean one of #{associations}?"
+                         "Did you mean one of `#{Enum.join(associations, "`, `")}`?"
   end
 
   @doc ~S"""

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2154,7 +2154,6 @@ defmodule Ecto.Changeset do
   end
 
   defp raise_invalid_assoc(types, assoc) do
-
     associations = for {_key, {:assoc, %{field: field}}} <- types, do: field
     raise ArgumentError, "cannot add constraint to changeset because association `#{assoc}` does not exist. " <>
                          "Did you mean one of `#{Enum.join(associations, "`, `")}`?"

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1064,7 +1064,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "assoc_constraint/3 with errors" do
-    message = ~r"cannot add constraint to changeset because association `unknown` does not exist. Did you mean one of `comments`, `comment`?"
+    message = ~r"cannot add constraint to changeset because association `unknown` does not exist. Did you mean one of `comment`, `comments`?"
     assert_raise ArgumentError, message, fn ->
       change(%Post{}) |> assoc_constraint(:unknown)
     end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -2,6 +2,20 @@ defmodule Ecto.ChangesetTest do
   use ExUnit.Case, async: true
   import Ecto.Changeset
 
+  defmodule SocialSource do
+    use Ecto.Schema
+
+    @primary_key false
+    embedded_schema do
+      field :origin
+      field :url
+    end
+
+    def changeset(schema \\ %SocialSource{}, params) do
+      cast(schema, params, ~w(origin url))
+    end
+  end
+
   defmodule Comment do
     use Ecto.Schema
 
@@ -22,6 +36,7 @@ defmodule Ecto.ChangesetTest do
       field :topics, {:array, :string}
       field :virtual, :string, virtual: true
       field :published_at, :naive_datetime
+      field :source, :map
       has_many :comments, Ecto.ChangesetTest.Comment, on_replace: :delete
       has_one :comment, Ecto.ChangesetTest.Comment
     end
@@ -97,6 +112,44 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == []
     assert changeset.valid?
     assert apply_changes(changeset) == %{title: "world", upvotes: 0}
+  end
+
+  test "cast/4: with dynamic embed" do
+    data = {
+      %{
+        title: "hello"
+      },
+      %{
+        title: :string,
+        source: {
+          :embed,
+          %Ecto.Embedded{
+            cardinality: :one,
+            field: :source,
+            on_cast: &SocialSource.changeset(&1, &2),
+            on_replace: :raise,
+            owner: nil,
+            related: SocialSource,
+            unique: true
+          }
+        }
+      }
+    }
+
+    params = %{"title" => "world", "source" => %{"origin" => "facebook", "url" => "http://example.com/social"}}
+
+    changeset =
+      data
+      |> cast(params, ~w(title))
+      |> cast_embed(:source, required: true)
+
+    assert changeset.params == params
+    assert changeset.data  == %{title: "hello"}
+    assert %{title: "world", source: %Ecto.Changeset{}} = changeset.changes
+    assert changeset.errors == []
+    assert changeset.valid?
+    assert apply_changes(changeset) ==
+      %{title: "world", source: %Ecto.ChangesetTest.SocialSource{origin: "facebook", url: "http://example.com/social"}}
   end
 
   test "cast/4: with changeset" do


### PR DESCRIPTION
Ecto.Changeset should use information from type when available.

This is a first step in implementing Dynamic Embeds as discussed in #1763. I'm splitting all work to have many small changes, rather than one big.

In next PR I'll try to reduce the number of `__schema__` calls in Ecto.Repo.Schema, so Changesets that were dynamically created will be able to be inserted into DB.