### PR TITLE
updates the documentation of load and dump with shell command deps

### DIFF
--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -12,6 +12,13 @@ defmodule Mix.Tasks.Ecto.Dump do
   The repository must be set under `:ecto_repos` in the
   current app configuration or given via the `-r` option.
 
+  This task needs some shell utility to be present on the machine running the task.
+
+   Database   | Utility needed
+   :--------- | :-------------
+   PostgreSQL | pg_dump
+   MySQL      | mysqldump
+
   ## Example
 
       mix ecto.dump

--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -12,6 +12,13 @@ defmodule Mix.Tasks.Ecto.Load do
   The repository must be set under `:ecto_repos` in the
   current app configuration or given via the `-r` option.
 
+  This task needs some shell utility to be present on the machine running the task.
+
+   Database   | Utility needed
+   :--------- | :-------------
+   PostgreSQL | psql
+   MySQL      | mysql
+
   ## Example
 
       mix ecto.load


### PR DESCRIPTION
Following https://github.com/elixir-ecto/ecto/pull/1939, the only use of the shell client is for the Mix Tasks `ecto.load` and `ecto.dump`. This was no documented, leading to some problems. This updates these Tasks with information about this dependency.

I am open to any idea or change for the wording of course 😃 