### PR TITLE
Add unlogged option to create table

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -233,6 +233,16 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule UnloggedMigration do
+    use Ecto.Migration
+
+    def change do
+      create table(:default)
+      create table(:unlogged_true, unlogged: true)
+      create table(:unlogged_false, unlogged: false)
+    end
+  end
+
   defmodule NoSQLMigration do
     use Ecto.Migration
 
@@ -418,6 +428,11 @@ defmodule Ecto.Integration.MigrationTest do
   test "prefix" do
     assert :ok == up(PoolRepo, 20151012120000, PrefixMigration, log: false)
     assert :ok == down(PoolRepo, 20151012120000, PrefixMigration, log: false)
+  end
+
+  @tag :unlogged
+  test "unlogged" do
+    assert :ok == up(PoolRepo, 20181012120000, UnloggedMigration, log: false)
   end
 
   @tag :alter_primary_key

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -588,7 +588,9 @@ if Code.ensure_loaded?(Postgrex) do
 
     def execute_ddl({command, %Table{} = table, columns}) when command in [:create, :create_if_not_exists] do
       table_name = quote_table(table.prefix, table.name)
-      query = ["CREATE TABLE ",
+      query = ["CREATE ",
+               if_do(table.unlogged, "UNLOGGED "),
+               "TABLE ",
                if_do(command == :create_if_not_exists, "IF NOT EXISTS "),
                table_name, ?\s, ?(,
                column_definitions(table, columns), pk_definition(columns, ", "), ?),

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -195,9 +195,9 @@ defmodule Ecto.Migration do
 
     To define a table in a migration, see `Ecto.Migration.table/2`
     """
-    defstruct name: nil, prefix: nil, comment: nil, primary_key: true, engine: nil, options: nil
+    defstruct name: nil, prefix: nil, comment: nil, primary_key: true, engine: nil, options: nil, unlogged: false
     @type t :: %__MODULE__{name: String.t, prefix: atom | nil, comment: String.t | nil, primary_key: boolean,
-                           engine: atom, options: String.t}
+                           engine: atom, options: String.t, unlogged: boolean}
   end
 
   defmodule Reference do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -440,6 +440,7 @@ defmodule Ecto.Migration do
     * `:prefix` - the prefix for the table
     * `:options` - provide custom options that will be appended after generated
       statement, for example "WITH", "INHERITS" or "ON COMMIT" clauses
+    * `:unlogged` - Use Postgres UNLOGGED option to disable writes to WAL
 
   """
   def table(name, opts \\ [])

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -687,6 +687,14 @@ defmodule Ecto.Adapters.PostgresTest do
     """ |> remove_newlines]
   end
 
+  test "create table with unlogged" do
+    create = {:create, table(:posts, unlogged: :true), []}
+
+    assert execute_ddl(create) == ["""
+    CREATE UNLOGGED TABLE "posts" ()
+    """ |> remove_newlines]
+  end
+
   test "create table with comment on columns and table" do
     create = {:create, table(:posts, comment: "comment"),
               [

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -690,25 +690,25 @@ defmodule Ecto.Adapters.PostgresTest do
   test "create table with unlogged not present" do
     create = {:create, table(:posts), []}
 
-    assert execute_ddl(create) == ["""
+    assert execute_ddl(create) == [remove_newlines("""
     CREATE TABLE "posts" ()
-    """ |> remove_newlines]
+    """)]
   end
 
   test "create table with unlogged false" do
     create = {:create, table(:posts, unlogged: :false), []}
 
-    assert execute_ddl(create) == ["""
+    assert execute_ddl(create) == [remove_newlines("""
     CREATE TABLE "posts" ()
-    """ |> remove_newlines]
+    """)]
   end
 
   test "create table with unlogged true" do
     create = {:create, table(:posts, unlogged: :true), []}
 
-    assert execute_ddl(create) == ["""
+    assert execute_ddl(create) == [remove_newlines("""
     CREATE UNLOGGED TABLE "posts" ()
-    """ |> remove_newlines]
+    """)]
   end
 
   test "create table with comment on columns and table" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -687,7 +687,23 @@ defmodule Ecto.Adapters.PostgresTest do
     """ |> remove_newlines]
   end
 
-  test "create table with unlogged" do
+  test "create table with unlogged not present" do
+    create = {:create, table(:posts), []}
+
+    assert execute_ddl(create) == ["""
+    CREATE TABLE "posts" ()
+    """ |> remove_newlines]
+  end
+
+  test "create table with unlogged false" do
+    create = {:create, table(:posts, unlogged: :false), []}
+
+    assert execute_ddl(create) == ["""
+    CREATE TABLE "posts" ()
+    """ |> remove_newlines]
+  end
+
+  test "create table with unlogged true" do
     create = {:create, table(:posts, unlogged: :true), []}
 
     assert execute_ddl(create) == ["""


### PR DESCRIPTION
This is only applicable to Postgres adaptor.
UNLOGGED optiona prevents Postgres using the WAL :

> Data written to unlogged tables is not written to the write-ahead log
> which makes them considerably faster than ordinary tables.
-- https://www.postgresql.org/docs/9.1/static/sql-createtable.html

----

Problem with this commit is that by adding to Ecto.Migration.Table
means it needs to work on all adapters (I would guess).
We cannot use `options` either as that raises if keyword list is used
(as its used for generic text to add to column SQL commands).

Ideally this would work :

    create table(:test_unlogged, options: [unlogged: true])


I welcome feedback on direction this could go in to be accepted.