### PR TITLE
Custom Associations

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -497,14 +497,17 @@ defmodule Ecto do
     end
 
     schema = hd(structs).__struct__
-    assoc = %{owner_key: owner_key} =
+    assoc = %{owner_key: owner_key, assoc_query_receives_structs: structs?} =
       Ecto.Association.association_from_schema!(schema, assoc)
 
-    values =
+    values = if structs? do
+      structs
+    else
       Enum.uniq for(struct <- structs,
         assert_struct!(schema, struct),
         key = Map.fetch!(struct, owner_key),
         do: key)
+    end
 
     Ecto.Association.assoc_query(assoc, assocs, nil, values)
   end

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -464,7 +464,7 @@ defmodule Ecto do
   defp drop_meta([_|_] = attrs), do: Keyword.drop(attrs, [:__struct__, :__meta__])
 
   @doc """
-  Builds a query for the association in the given struct or structs.
+  Builds query/queries for the association in the given struct or structs.
 
   ## Examples
 
@@ -503,8 +503,8 @@ defmodule Ecto do
     values =
       Enum.uniq for(struct <- structs,
         assert_struct!(schema, struct),
-        key = Map.fetch!(struct, owner_key),
-        do: key)
+        _id = Map.get(struct, owner_key), # Filter out structs without owner_key data
+        do: struct)
 
     Ecto.Association.assoc_query(assoc, assocs, nil, values)
   end

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -497,17 +497,14 @@ defmodule Ecto do
     end
 
     schema = hd(structs).__struct__
-    assoc = %{owner_key: owner_key, assoc_query_receives_structs: structs?} =
+    assoc = %{owner_key: owner_key} =
       Ecto.Association.association_from_schema!(schema, assoc)
 
-    values = if structs? do
-      structs
-    else
+    values =
       Enum.uniq for(struct <- structs,
         assert_struct!(schema, struct),
         key = Map.fetch!(struct, owner_key),
         do: key)
-    end
 
     Ecto.Association.assoc_query(assoc, assocs, nil, values)
   end

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -490,13 +490,15 @@ defmodule Ecto.Association.Has do
   end
 
   @doc false
-  def assoc_query(%{queryable: queryable, related_key: related_key}, query, [value]) do
+  def assoc_query(%{queryable: queryable, related_key: related_key, owner_key: owner_key}, query, [value]) do
+    value = Map.get(value, owner_key)
     from x in (query || queryable),
       where: field(x, ^related_key) == ^value
   end
 
   @doc false
-  def assoc_query(%{queryable: queryable, related_key: related_key}, query, values) do
+  def assoc_query(%{queryable: queryable, related_key: related_key, owner_key: owner_key}, query, values) do
+    values = Enum.map(values, &(Map.get(&1, owner_key)))
     from x in (query || queryable),
       where: field(x, ^related_key) in ^values
   end
@@ -729,13 +731,15 @@ defmodule Ecto.Association.BelongsTo do
   end
 
   @doc false
-  def assoc_query(%{queryable: queryable, related_key: related_key}, query, [value]) do
+  def assoc_query(%{queryable: queryable, related_key: related_key, owner_key: owner_key}, query, [value]) do
+    value = Map.get(value, owner_key)
     from x in (query || queryable),
       where: field(x, ^related_key) == ^value
   end
 
   @doc false
-  def assoc_query(%{queryable: queryable, related_key: related_key}, query, values) do
+  def assoc_query(%{queryable: queryable, related_key: related_key, owner_key: owner_key}, query, values) do
+    values = Enum.map(values, &(Map.get(&1, owner_key)))
     from x in (query || queryable),
       where: field(x, ^related_key) in ^values
   end
@@ -897,6 +901,7 @@ defmodule Ecto.Association.ManyToMany do
                     queryable: queryable, owner: owner}, query, values) do
     [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
 
+    values = Enum.map(values, &(Map.get(&1, owner_key)))
     # We need to go all the way using owner and query so
     # Ecto has all the information necessary to cast fields.
     # This also helps validate the associated schema exists all the way.

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -31,7 +31,6 @@ defmodule Ecto.Association do
                owner: atom,
                owner_key: atom,
                field: atom,
-               assoc_query_receives_structs: true | false,
                unique: boolean}
 
   alias Ecto.Query.{BooleanExpr, QueryExpr}
@@ -98,18 +97,13 @@ defmodule Ecto.Association do
   values for the owner key.
 
   This callback is used by `Ecto.assoc/2` and when preloading.
-
-  If the `Ecto.Association.t` has `assoc_query_receives_structs` set to `true`,
-  instead of receiving a unique list of IDs, it will receive the list of all data
-  from which to fetch the association from. This flag allows customization of
-  associations beyond what Ecto can predict, Ecto itself does not use this flag.
   """
   @callback assoc_query(t, Ecto.Query.t | nil, values :: [term]) :: Ecto.Query.t
 
   @doc """
   Returns information used by the preloader.
   """
-  @callback preload_info(t, values :: [term]) ::
+  @callback preload_info(t) ::
               {:assoc, t, {integer, atom}} | {:through, t, [atom]}
 
   @doc """
@@ -413,7 +407,6 @@ defmodule Ecto.Association.Has do
     * `on_replace` - The action taken on associations when schema is replaced
     * `defaults` - Default fields used when building the association
     * `relationship` - The relationship to the specified schema, default is `:child`
-    * `assoc_query_receives_structs` - Always false
   """
 
   @behaviour Ecto.Association
@@ -421,8 +414,7 @@ defmodule Ecto.Association.Has do
   @on_replace_opts [:raise, :mark_as_invalid, :delete, :nilify]
   @has_one_on_replace_opts @on_replace_opts ++ [:update]
   defstruct [:cardinality, :field, :owner, :related, :owner_key, :related_key, :on_cast,
-             :queryable, :on_delete, :on_replace, unique: true, defaults: [], relationship: :child,
-             assoc_query_receives_structs: false]
+             :queryable, :on_delete, :on_replace, unique: true, defaults: [], relationship: :child]
 
   @doc false
   def struct(module, name, opts) do
@@ -510,7 +502,7 @@ defmodule Ecto.Association.Has do
   end
 
   @doc false
-  def preload_info(%{related_key: related_key} = refl, _structs) do
+  def preload_info(%{related_key: related_key} = refl) do
     {:assoc, refl, {0, related_key}}
   end
 
@@ -605,12 +597,11 @@ defmodule Ecto.Association.HasThrough do
     * `owner_key` - The key on the `owner` schema used for the association
     * `through` - The through associations
     * `relationship` - The relationship to the specified schema, default `:child`
-    * `assoc_query_receives_structs` - Always false
   """
 
   @behaviour Ecto.Association
   defstruct [:cardinality, :field, :owner, :owner_key, :through, :on_cast,
-             relationship: :child, unique: true, assoc_query_receives_structs: false]
+             relationship: :child, unique: true]
 
   @doc false
   def struct(module, name, opts) do
@@ -648,7 +639,7 @@ defmodule Ecto.Association.HasThrough do
   end
 
   @doc false
-  def preload_info(%{through: through} = refl, _structs) do
+  def preload_info(%{through: through} = refl) do
     {:through, refl, through}
   end
 
@@ -685,14 +676,12 @@ defmodule Ecto.Association.BelongsTo do
     * `defaults` - Default fields used when building the association
     * `relationship` - The relationship to the specified schema, default `:parent`
     * `on_replace` - The action taken on associations when schema is replaced
-    * `assoc_query_receives_structs` - Always false
   """
 
   @behaviour Ecto.Association
   @on_replace_opts [:raise, :mark_as_invalid, :delete, :nilify, :update]
   defstruct [:field, :owner, :related, :owner_key, :related_key, :queryable, :on_cast,
-             :on_replace, defaults: [], cardinality: :one, relationship: :parent, unique: true,
-             assoc_query_receives_structs: false]
+             :on_replace, defaults: [], cardinality: :one, relationship: :parent, unique: true]
 
   @doc false
   def struct(module, name, opts) do
@@ -752,7 +741,7 @@ defmodule Ecto.Association.BelongsTo do
   end
 
   @doc false
-  def preload_info(%{related_key: related_key} = refl, _structs) do
+  def preload_info(%{related_key: related_key} = refl) do
     {:assoc, refl, {0, related_key}}
   end
 
@@ -807,7 +796,6 @@ defmodule Ecto.Association.ManyToMany do
     * `join_keys` - The keyword list with many to many join keys
     * `join_through` - Atom (representing a schema) or a string (representing a table)
       for many to many associations
-    * `assoc_query_receives_structs` - Always false
   """
 
   @behaviour Ecto.Association
@@ -815,8 +803,7 @@ defmodule Ecto.Association.ManyToMany do
   @on_replace_opts [:raise, :mark_as_invalid, :delete]
   defstruct [:field, :owner, :related, :owner_key, :queryable, :on_delete,
              :on_replace, :join_keys, :join_through, :on_cast,
-             defaults: [], relationship: :child, cardinality: :many, unique: false,
-             assoc_query_receives_structs: false]
+             defaults: [], relationship: :child, cardinality: :many, unique: false]
 
   @doc false
   def struct(module, name, opts) do
@@ -927,7 +914,7 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   @doc false
-  def preload_info(%{join_keys: [{_, owner_key}, {_, _}]} = refl, _structs) do
+  def preload_info(%{join_keys: [{_, owner_key}, {_, _}]} = refl) do
     {:assoc, refl, {-2, owner_key}}
   end
 

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -57,7 +57,7 @@ defmodule Ecto.Repo.Preloader do
   defp preload_each([sample|_] = structs, repo, preloads, opts) do
     module = sample.__struct__
     prefix = preload_prefix(opts, sample)
-    {assocs, throughs} = expand(module, preloads, {%{}, %{}})
+    {assocs, throughs} = expand(module, preloads, structs, {%{}, %{}})
 
     assocs =
       maybe_pmap Map.values(assocs), repo, opts, fn
@@ -103,36 +103,44 @@ defmodule Ecto.Repo.Preloader do
     end
   end
 
-  defp preload_assoc(structs, module, repo, prefix, %{cardinality: card} = assoc,
+  defp preload_assoc(structs, module, repo, prefix, %{cardinality: card, assoc_query_receives_structs: structs?} = assoc,
                      related_key, query, preloads, take, opts) do
-    {fetch_ids, loaded_ids, loaded_structs} =
-      fetch_ids(structs, module, assoc, opts)
-    {fetch_ids, fetch_structs} =
-      fetch_query(fetch_ids, assoc, repo, query, prefix, related_key, take, opts)
+    {fetch_ids_or_structs, loaded_ids, loaded_structs} =
+      fetch_ids_or_structs(structs, module, assoc, Keyword.put(opts, :return_struct, structs?))
+    {fetch_ids_or_structs, fetch_structs} = if structs? do
+      fetch_query(fetch_ids_or_structs, assoc, repo, query, prefix, related_key, take, opts)
+    else
+      fetch_query(fetch_ids_or_structs, assoc, repo, query, prefix, related_key, take, opts)
+    end
 
     all = preload_each(Enum.reverse(loaded_structs, fetch_structs), repo, preloads, opts)
-    {:assoc, assoc, assoc_map(card, Enum.reverse(loaded_ids, fetch_ids), all)}
+    {:assoc, assoc, assoc_map(card, Enum.reverse(loaded_ids, fetch_ids_or_structs), all)}
   end
 
-  defp fetch_ids(structs, module, assoc, opts) do
+  defp fetch_ids_or_structs(structs, module, assoc, opts) do
     %{field: field, owner_key: owner_key, cardinality: card} = assoc
     force? = Keyword.get(opts, :force, false)
+    return_struct? = Keyword.get(opts, :return_struct, false)
 
-    Enum.reduce structs, {[], [], []}, fn struct, {fetch_ids, loaded_ids, loaded_structs} ->
+    Enum.reduce structs, {[], [], []}, fn struct, {fetch_ids_or_structs, loaded_ids, loaded_structs} ->
       assert_struct!(module, struct)
       %{^owner_key => id, ^field => value} = struct
 
       cond do
         card == :one and not is_nil(value) and Ecto.assoc_loaded?(value) and not force? ->
-          {fetch_ids, [id|loaded_ids], [value|loaded_structs]}
+          {fetch_ids_or_structs, [id|loaded_ids], [value|loaded_structs]}
         card == :many and Ecto.assoc_loaded?(value) and not force? ->
-          {fetch_ids,
+          {fetch_ids_or_structs,
            List.duplicate(id, length(value)) ++ loaded_ids,
            value ++ loaded_structs}
         is_nil(id) ->
-          {fetch_ids, loaded_ids, loaded_structs}
+          {fetch_ids_or_structs, loaded_ids, loaded_structs}
         true ->
-          {[id|fetch_ids], loaded_ids, loaded_structs}
+          if return_struct? do
+            {[struct|fetch_ids_or_structs], loaded_ids, loaded_structs}
+          else
+            {[id|fetch_ids_or_structs], loaded_ids, loaded_structs}
+          end
       end
     end
   end
@@ -146,8 +154,8 @@ defmodule Ecto.Repo.Preloader do
     unzip_ids data, [], []
   end
 
-  defp fetch_query(ids, %{cardinality: card} = assoc, repo, query, prefix, related_key, take, opts) do
-    query = assoc.__struct__.assoc_query(assoc, query, Enum.uniq(ids))
+  defp fetch_query(ids_or_structs, %{cardinality: card} = assoc, repo, query, prefix, related_key, take, opts) do
+    query = assoc.__struct__.assoc_query(assoc, query, Enum.uniq(ids_or_structs))
     field = related_key_to_field(query, related_key)
 
     # Normalize query
@@ -241,7 +249,7 @@ defmodule Ecto.Repo.Preloader do
 
   defp recur_through(field, {structs, owner}) do
     assoc = owner.__schema__(:association, field)
-    case assoc.__struct__.preload_info(assoc) do
+    case assoc.__struct__.preload_info(assoc, structs) do
       {:assoc, %{related: related}, _} ->
         pks = related.__schema__(:primary_key)
 
@@ -329,10 +337,10 @@ defmodule Ecto.Repo.Preloader do
 
   ## Expand
 
-  def expand(schema, preloads, acc) do
+  def expand(schema, preloads, structs \\ [], acc) do
     Enum.reduce(preloads, acc, fn {preload, {fields, query, sub_preloads}}, {assocs, throughs} ->
       assoc = Ecto.Association.association_from_schema!(schema, preload)
-      info  = assoc.__struct__.preload_info(assoc)
+      info  = assoc.__struct__.preload_info(assoc, structs)
 
       case info do
         {:assoc, _, _} ->

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -26,6 +26,13 @@ defmodule Ecto.Repo.Queryable do
     end
   end
 
+  def all(repo, adapter, queryables, opts) when is_list(opts) and is_list(queryables) do
+    queryables
+    |> Enum.map(fn queryable ->
+      all(repo, adapter, queryable, opts)
+    end)
+    |> List.flatten()
+  end
   def all(repo, adapter, queryable, opts) when is_list(opts) do
     query =
       queryable

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -135,10 +135,10 @@ defmodule Ecto.AssociationTest do
            inspect(from p in Post, join: c in Comment, on: c.post_id == p.id)
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
-           inspect(from c in Comment, where: c.post_id in ^[])
+           inspect([from(c in Comment, where: c.post_id in ^[])])
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
-           inspect(from c in Comment, where: c.post_id in ^[1, 2, 3])
+           inspect([from(c in Comment, where: c.post_id in ^[1, 2, 3])])
   end
 
   test "has many with specified source" do
@@ -148,17 +148,17 @@ defmodule Ecto.AssociationTest do
            inspect(from a in Author, join: e in {"users_emails", Email}, on: e.author_id == a.id)
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
-           inspect(from e in {"users_emails", Email}, where: e.author_id in ^[])
+           inspect([from(e in {"users_emails", Email}, where: e.author_id in ^[])])
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from e in {"users_emails", Email}, where: e.author_id in ^[1, 2, 3])
+           inspect([from(e in {"users_emails", Email}, where: e.author_id in ^[1, 2, 3])])
   end
 
   test "has many custom assoc query" do
     assoc = Post.__schema__(:association, :comments)
     query = from c in Comment, limit: 5
     assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
-           inspect(from c in Comment, where: c.post_id in ^[1, 2, 3], limit: 5)
+           inspect([from(c in Comment, where: c.post_id in ^[1, 2, 3], limit: 5)])
   end
 
   test "has one" do
@@ -168,13 +168,13 @@ defmodule Ecto.AssociationTest do
            inspect(from p in Post, join: c in Permalink, on: c.post_id == p.id)
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
-           inspect(from c in Permalink, where: c.post_id in ^[])
+           inspect([from(c in Permalink, where: c.post_id in ^[])])
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Post{id: 1}])) ==
-           inspect(from c in Permalink, where: c.post_id == ^1)
+           inspect([from(c in Permalink, where: c.post_id == ^1)])
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
-           inspect(from c in Permalink, where: c.post_id in ^[1, 2, 3])
+           inspect([from(c in Permalink, where: c.post_id in ^[1, 2, 3])])
   end
 
   test "has one with specified source" do
@@ -184,17 +184,17 @@ defmodule Ecto.AssociationTest do
            inspect(from a in Author, join: p in {"users_profiles", Profile}, on: p.author_id == a.id)
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
-           inspect(from p in {"users_profiles", Profile}, where: p.author_id in ^[])
+           inspect([from(p in {"users_profiles", Profile}, where: p.author_id in ^[])])
 
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from p in {"users_profiles", Profile}, where: p.author_id in ^[1, 2, 3])
+           inspect([from(p in {"users_profiles", Profile}, where: p.author_id in ^[1, 2, 3])])
   end
 
   test "has one custom assoc query" do
     assoc = Post.__schema__(:association, :permalink)
     query = from c in Permalink, limit: 5
     assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
-           inspect(from c in Permalink, where: c.post_id in ^[1, 2, 3], limit: 5)
+           inspect([from(c in Permalink, where: c.post_id in ^[1, 2, 3], limit: 5)])
   end
 
   test "belongs to" do
@@ -204,13 +204,13 @@ defmodule Ecto.AssociationTest do
            inspect(from p in Post, join: a in Author, on: a.id == p.author_id)
 
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [])) ==
-           inspect(from a in Author, where: a.id in ^[])
+           inspect([from(a in Author, where: a.id in ^[])])
 
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Post{author_id: 1}])) ==
-           inspect(from a in Author, where: a.id == ^1)
+           inspect([from(a in Author, where: a.id == ^1)])
 
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Post{author_id: 1}, %Post{author_id: 2}, %Post{author_id: 3}])) ==
-           inspect(from a in Author, where: a.id in ^[1, 2, 3])
+           inspect([from(a in Author, where: a.id in ^[1, 2, 3])])
   end
 
   test "belongs to with specified source" do
@@ -220,20 +220,20 @@ defmodule Ecto.AssociationTest do
            inspect(from e in Email, join: a in {"post_authors", Author}, on: a.id == e.author_id)
 
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [])) ==
-           inspect(from a in {"post_authors", Author}, where: a.id in ^[])
+           inspect([from(a in {"post_authors", Author}, where: a.id in ^[])])
 
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Email{author_id: 1}])) ==
-           inspect(from a in {"post_authors", Author}, where: a.id == ^1)
+           inspect([from(a in {"post_authors", Author}, where: a.id == ^1)])
 
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Email{author_id: 1}, %Email{author_id: 2}, %Email{author_id: 3}])) ==
-           inspect(from a in {"post_authors", Author}, where: a.id in ^[1, 2, 3])
+           inspect([from(a in {"post_authors", Author}, where: a.id in ^[1, 2, 3])])
   end
 
   test "belongs to custom assoc query" do
     assoc = Post.__schema__(:association, :author)
     query = from a in Author, limit: 5
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, query, [%Email{author_id: 1}, %Email{author_id: 2}, %Email{author_id: 3}])) ==
-           inspect(from a in Author, where: a.id in ^[1, 2, 3], limit: 5)
+           inspect([from(a in Author, where: a.id in ^[1, 2, 3], limit: 5)])
   end
 
   test "many to many" do
@@ -245,16 +245,16 @@ defmodule Ecto.AssociationTest do
                     join: a in Author, on: m.author_id == a.id)
 
     assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [])) ==
-           inspect(from a in Author,
+           inspect([from(a in Author,
                     join: p in Permalink, on: p.id in ^[],
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
-                    where: m.author_id == a.id)
+                    where: m.author_id == a.id)])
 
     assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [%Permalink{id: 1}, %Permalink{id: 2}, %Permalink{id: 3}])) ==
-           inspect(from a in Author,
+           inspect([from(a in Author,
                     join: p in Permalink, on: p.id in ^[1, 2, 3],
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
-                    where: m.author_id == a.id)
+                    where: m.author_id == a.id)])
   end
 
   test "many to many with specified source" do
@@ -266,26 +266,26 @@ defmodule Ecto.AssociationTest do
                     join: p in {"custom_permalinks", Permalink}, on: m.permalink_id == p.id)
 
     assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [])) ==
-           inspect(from p in {"custom_permalinks", Permalink},
+           inspect([from(p in {"custom_permalinks", Permalink},
                     join: a in Author, on: a.id in ^[],
                     join: m in "authors_permalinks", on: m.author_id == a.id,
-                    where: m.permalink_id == p.id)
+                    where: m.permalink_id == p.id)])
 
     assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from p in {"custom_permalinks", Permalink},
+           inspect([from(p in {"custom_permalinks", Permalink},
                     join: a in Author, on: a.id in ^[1, 2, 3],
                     join: m in "authors_permalinks", on: m.author_id == a.id,
-                    where: m.permalink_id == p.id)
+                    where: m.permalink_id == p.id)])
   end
 
   test "many to many custom assoc query" do
     assoc = Permalink.__schema__(:association, :authors)
     query = from a in Author, limit: 5
     assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, query, [%Permalink{id: 1}, %Permalink{id: 2}, %Permalink{id: 3}])) ==
-           inspect(from a in Author,
+           inspect([from(a in Author,
                     join: p in Permalink, on: p.id in ^[1, 2, 3],
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
-                    where: m.author_id == a.id, limit: 5)
+                    where: m.author_id == a.id, limit: 5)])
   end
 
   test "has many through many to many" do
@@ -295,8 +295,8 @@ defmodule Ecto.AssociationTest do
            inspect(from a in Author, join: p in assoc(a, :posts), join: c in assoc(p, :comments))
 
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from c in Comment, join: p in Post, on: p.author_id in ^[1, 2, 3],
-                        where: c.post_id == p.id, distinct: true)
+           inspect([from(c in Comment, join: p in Post, on: p.author_id in ^[1, 2, 3],
+                        where: c.post_id == p.id, distinct: true)])
   end
 
   test "has many through many to one" do
@@ -306,8 +306,8 @@ defmodule Ecto.AssociationTest do
            inspect(from a in Author, join: p in assoc(a, :posts), join: c in assoc(p, :permalink))
 
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from l in Permalink, join: p in Post, on: p.author_id in ^[1, 2, 3],
-                        where: l.post_id == p.id, distinct: true)
+           inspect([from(l in Permalink, join: p in Post, on: p.author_id in ^[1, 2, 3],
+                        where: l.post_id == p.id, distinct: true)])
   end
 
   test "has one through belongs to belongs" do
@@ -317,8 +317,8 @@ defmodule Ecto.AssociationTest do
            inspect(from c in Comment, join: p in assoc(c, :post), join: a in assoc(p, :author))
 
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Comment{post_id: 1}, %Comment{post_id: 2}, %Comment{post_id: 3}])) ==
-           inspect(from a in Author, join: p in Post, on: p.id in ^[1, 2, 3],
-                        where: a.id == p.author_id, distinct: true)
+           inspect([from(a in Author, join: p in Post, on: p.id in ^[1, 2, 3],
+                        where: a.id == p.author_id, distinct: true)])
   end
 
   test "has one through belongs to one" do
@@ -328,8 +328,8 @@ defmodule Ecto.AssociationTest do
            inspect(from c in Comment, join: p in assoc(c, :post), join: l in assoc(p, :permalink))
 
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Comment{post_id: 1}, %Comment{post_id: 2}, %Comment{post_id: 3}])) ==
-           inspect(from l in Permalink, join: p in Post, on: p.id in ^[1, 2, 3],
-                        where: l.post_id == p.id, distinct: true)
+           inspect([from(l in Permalink, join: p in Post, on: p.id in ^[1, 2, 3],
+                        where: l.post_id == p.id, distinct: true)])
   end
 
   test "has many through one to many" do
@@ -339,8 +339,8 @@ defmodule Ecto.AssociationTest do
            inspect(from s in Summary, join: p in assoc(s, :post), join: c in assoc(p, :comments))
 
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Summary{id: 1}, %Summary{id: 2}, %Summary{id: 3}])) ==
-           inspect(from c in Comment, join: p in Post, on: p.summary_id in ^[1, 2, 3],
-                        where: c.post_id == p.id, distinct: true)
+           inspect([from(c in Comment, join: p in Post, on: p.summary_id in ^[1, 2, 3],
+                        where: c.post_id == p.id, distinct: true)])
   end
 
   test "has one through one to belongs" do
@@ -350,42 +350,42 @@ defmodule Ecto.AssociationTest do
            inspect(from s in Summary, join: p in assoc(s, :post), join: a in assoc(p, :author))
 
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Summary{id: 1}, %Summary{id: 2}, %Summary{id: 3}])) ==
-           inspect(from a in Author, join: p in Post, on: p.summary_id in ^[1, 2, 3],
-                        where: a.id == p.author_id, distinct: true)
+           inspect([from(a in Author, join: p in Post, on: p.summary_id in ^[1, 2, 3],
+                        where: a.id == p.author_id, distinct: true)])
   end
 
   test "has many through custom assoc many to many query" do
     assoc = Author.__schema__(:association, :posts_comments)
     query = from c in Comment, where: c.text == "foo", limit: 5
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from c in Comment, join: p in Post,
+           inspect([from(c in Comment, join: p in Post,
                         on: p.author_id in ^[1, 2, 3],
                         where: c.post_id == p.id, where: c.text == "foo",
-                        distinct: true, limit: 5)
+                        distinct: true, limit: 5)])
 
     query = from c in {"custom", Comment}, where: c.text == "foo", limit: 5
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from c in {"custom", Comment}, join: p in Post,
+           inspect([from(c in {"custom", Comment}, join: p in Post,
                         on: p.author_id in ^[1, 2, 3],
                         where: c.post_id == p.id, where: c.text == "foo",
-                        distinct: true, limit: 5)
+                        distinct: true, limit: 5)])
 
     query = from c in Comment, join: p in assoc(c, :permalink), limit: 5
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
-           inspect(from c in Comment, join: p0 in Permalink, on: p0.comment_id == c.id,
+           inspect([from(c in Comment, join: p0 in Permalink, on: p0.comment_id == c.id,
                         join: p1 in Post, on: p1.author_id in ^[1, 2, 3],
                         where: c.post_id == p1.id,
-                        distinct: true, limit: 5)
+                        distinct: true, limit: 5)])
   end
 
   test "has many through many to many and has many" do
     assoc = Permalink.__schema__(:association, :author_emails)
     assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Permalink{id: 1}, %Permalink{id: 2}, %Permalink{id: 3}])) ==
-           inspect(from e in {"users_emails", Email},
+           inspect([from(e in {"users_emails", Email},
                         join: p in Permalink, on: p.id in ^[1, 2, 3],
                         join: ap in AuthorPermalink, on: ap.permalink_id == p.id,
                         join: a in Author, on: ap.author_id == a.id,
-                        where: e.author_id == a.id, distinct: true)
+                        where: e.author_id == a.id, distinct: true)])
   end
 
   ## Integration tests through Ecto
@@ -469,21 +469,21 @@ defmodule Ecto.AssociationTest do
 
   test "assoc/2" do
     assert inspect(assoc(%Post{id: 1}, :comments)) ==
-           inspect(from c in Comment, where: c.post_id == ^1)
+           inspect([from(c in Comment, where: c.post_id == ^1)])
 
     assert inspect(assoc([%Post{id: 1}, %Post{id: 2}], :comments)) ==
-           inspect(from c in Comment, where: c.post_id in ^[1, 2])
+           inspect([from(c in Comment, where: c.post_id in ^[1, 2])])
   end
 
   test "assoc/2 with prefixes" do
     author = %Author{id: 1}
-    assert Ecto.assoc(author, :posts_with_prefix).prefix == "my_prefix"
-    assert Ecto.assoc(author, :comments_with_prefix).prefix == "my_prefix"
+    assert (Ecto.assoc(author, :posts_with_prefix) |> hd).prefix == "my_prefix"
+    assert (Ecto.assoc(author, :comments_with_prefix) |> hd).prefix == "my_prefix"
   end
 
   test "assoc/2 filters nil ids" do
     assert inspect(assoc([%Post{id: 1}, %Post{id: 2}, %Post{id: nil}], :comments)) ==
-           inspect(from c in Comment, where: c.post_id in ^[1, 2])
+           inspect([from(c in Comment, where: c.post_id in ^[1, 2])])
   end
 
   test "assoc/2 fails on empty list" do

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -137,7 +137,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
            inspect(from c in Comment, where: c.post_id in ^[])
 
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
            inspect(from c in Comment, where: c.post_id in ^[1, 2, 3])
   end
 
@@ -150,14 +150,14 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
            inspect(from e in {"users_emails", Email}, where: e.author_id in ^[])
 
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from e in {"users_emails", Email}, where: e.author_id in ^[1, 2, 3])
   end
 
   test "has many custom assoc query" do
     assoc = Post.__schema__(:association, :comments)
     query = from c in Comment, limit: 5
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
            inspect(from c in Comment, where: c.post_id in ^[1, 2, 3], limit: 5)
   end
 
@@ -170,10 +170,10 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
            inspect(from c in Permalink, where: c.post_id in ^[])
 
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Post{id: 1}])) ==
            inspect(from c in Permalink, where: c.post_id == ^1)
 
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
            inspect(from c in Permalink, where: c.post_id in ^[1, 2, 3])
   end
 
@@ -186,14 +186,14 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
            inspect(from p in {"users_profiles", Profile}, where: p.author_id in ^[])
 
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from p in {"users_profiles", Profile}, where: p.author_id in ^[1, 2, 3])
   end
 
   test "has one custom assoc query" do
     assoc = Post.__schema__(:association, :permalink)
     query = from c in Permalink, limit: 5
-    assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [%Post{id: 1}, %Post{id: 2}, %Post{id: 3}])) ==
            inspect(from c in Permalink, where: c.post_id in ^[1, 2, 3], limit: 5)
   end
 
@@ -206,10 +206,10 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [])) ==
            inspect(from a in Author, where: a.id in ^[])
 
-    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [1])) ==
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Post{author_id: 1}])) ==
            inspect(from a in Author, where: a.id == ^1)
 
-    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Post{author_id: 1}, %Post{author_id: 2}, %Post{author_id: 3}])) ==
            inspect(from a in Author, where: a.id in ^[1, 2, 3])
   end
 
@@ -222,17 +222,17 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [])) ==
            inspect(from a in {"post_authors", Author}, where: a.id in ^[])
 
-    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [1])) ==
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Email{author_id: 1}])) ==
            inspect(from a in {"post_authors", Author}, where: a.id == ^1)
 
-    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [%Email{author_id: 1}, %Email{author_id: 2}, %Email{author_id: 3}])) ==
            inspect(from a in {"post_authors", Author}, where: a.id in ^[1, 2, 3])
   end
 
   test "belongs to custom assoc query" do
     assoc = Post.__schema__(:association, :author)
     query = from a in Author, limit: 5
-    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, query, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, query, [%Email{author_id: 1}, %Email{author_id: 2}, %Email{author_id: 3}])) ==
            inspect(from a in Author, where: a.id in ^[1, 2, 3], limit: 5)
   end
 
@@ -250,7 +250,7 @@ defmodule Ecto.AssociationTest do
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
                     where: m.author_id == a.id)
 
-    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [%Permalink{id: 1}, %Permalink{id: 2}, %Permalink{id: 3}])) ==
            inspect(from a in Author,
                     join: p in Permalink, on: p.id in ^[1, 2, 3],
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
@@ -271,7 +271,7 @@ defmodule Ecto.AssociationTest do
                     join: m in "authors_permalinks", on: m.author_id == a.id,
                     where: m.permalink_id == p.id)
 
-    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from p in {"custom_permalinks", Permalink},
                     join: a in Author, on: a.id in ^[1, 2, 3],
                     join: m in "authors_permalinks", on: m.author_id == a.id,
@@ -281,7 +281,7 @@ defmodule Ecto.AssociationTest do
   test "many to many custom assoc query" do
     assoc = Permalink.__schema__(:association, :authors)
     query = from a in Author, limit: 5
-    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, query, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, query, [%Permalink{id: 1}, %Permalink{id: 2}, %Permalink{id: 3}])) ==
            inspect(from a in Author,
                     join: p in Permalink, on: p.id in ^[1, 2, 3],
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
@@ -294,7 +294,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.HasThrough.joins_query(assoc)) ==
            inspect(from a in Author, join: p in assoc(a, :posts), join: c in assoc(p, :comments))
 
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from c in Comment, join: p in Post, on: p.author_id in ^[1, 2, 3],
                         where: c.post_id == p.id, distinct: true)
   end
@@ -305,7 +305,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.HasThrough.joins_query(assoc)) ==
            inspect(from a in Author, join: p in assoc(a, :posts), join: c in assoc(p, :permalink))
 
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from l in Permalink, join: p in Post, on: p.author_id in ^[1, 2, 3],
                         where: l.post_id == p.id, distinct: true)
   end
@@ -316,7 +316,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.HasThrough.joins_query(assoc)) ==
            inspect(from c in Comment, join: p in assoc(c, :post), join: a in assoc(p, :author))
 
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Comment{post_id: 1}, %Comment{post_id: 2}, %Comment{post_id: 3}])) ==
            inspect(from a in Author, join: p in Post, on: p.id in ^[1, 2, 3],
                         where: a.id == p.author_id, distinct: true)
   end
@@ -327,7 +327,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.HasThrough.joins_query(assoc)) ==
            inspect(from c in Comment, join: p in assoc(c, :post), join: l in assoc(p, :permalink))
 
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Comment{post_id: 1}, %Comment{post_id: 2}, %Comment{post_id: 3}])) ==
            inspect(from l in Permalink, join: p in Post, on: p.id in ^[1, 2, 3],
                         where: l.post_id == p.id, distinct: true)
   end
@@ -338,7 +338,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.HasThrough.joins_query(assoc)) ==
            inspect(from s in Summary, join: p in assoc(s, :post), join: c in assoc(p, :comments))
 
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Summary{id: 1}, %Summary{id: 2}, %Summary{id: 3}])) ==
            inspect(from c in Comment, join: p in Post, on: p.summary_id in ^[1, 2, 3],
                         where: c.post_id == p.id, distinct: true)
   end
@@ -349,7 +349,7 @@ defmodule Ecto.AssociationTest do
     assert inspect(Ecto.Association.HasThrough.joins_query(assoc)) ==
            inspect(from s in Summary, join: p in assoc(s, :post), join: a in assoc(p, :author))
 
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Summary{id: 1}, %Summary{id: 2}, %Summary{id: 3}])) ==
            inspect(from a in Author, join: p in Post, on: p.summary_id in ^[1, 2, 3],
                         where: a.id == p.author_id, distinct: true)
   end
@@ -357,21 +357,21 @@ defmodule Ecto.AssociationTest do
   test "has many through custom assoc many to many query" do
     assoc = Author.__schema__(:association, :posts_comments)
     query = from c in Comment, where: c.text == "foo", limit: 5
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from c in Comment, join: p in Post,
                         on: p.author_id in ^[1, 2, 3],
                         where: c.post_id == p.id, where: c.text == "foo",
                         distinct: true, limit: 5)
 
     query = from c in {"custom", Comment}, where: c.text == "foo", limit: 5
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from c in {"custom", Comment}, join: p in Post,
                         on: p.author_id in ^[1, 2, 3],
                         where: c.post_id == p.id, where: c.text == "foo",
                         distinct: true, limit: 5)
 
     query = from c in Comment, join: p in assoc(c, :permalink), limit: 5
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [1,2,3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, query, [%Author{id: 1}, %Author{id: 2}, %Author{id: 3}])) ==
            inspect(from c in Comment, join: p0 in Permalink, on: p0.comment_id == c.id,
                         join: p1 in Post, on: p1.author_id in ^[1, 2, 3],
                         where: c.post_id == p1.id,
@@ -380,7 +380,7 @@ defmodule Ecto.AssociationTest do
 
   test "has many through many to many and has many" do
     assoc = Permalink.__schema__(:association, :author_emails)
-    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [1, 2, 3])) ==
+    assert inspect(Ecto.Association.HasThrough.assoc_query(assoc, nil, [%Permalink{id: 1}, %Permalink{id: 2}, %Permalink{id: 3}])) ==
            inspect(from e in {"users_emails", Email},
                         join: p in Permalink, on: p.id in ^[1, 2, 3],
                         join: ap in AuthorPermalink, on: ap.permalink_id == p.id,
@@ -482,7 +482,7 @@ defmodule Ecto.AssociationTest do
   end
 
   test "assoc/2 filters nil ids" do
-    assert inspect(assoc([%Post{id: 1}, %Post{id: 2}, %Post{}], :comments)) ==
+    assert inspect(assoc([%Post{id: 1}, %Post{id: 2}, %Post{id: nil}], :comments)) ==
            inspect(from c in Comment, where: c.post_id in ^[1, 2])
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -436,4 +436,24 @@ defmodule Ecto.RepoTest do
     assert TestRepo.load(%{x: :string}, %{x: "abc", bad: "bad"}) ==
            %{x: "abc"}
   end
+
+  describe "Repo.one/1" do
+    test "accpets a queryable" do
+      assert TestRepo.one(MySchema) == 1
+    end
+
+    test "accpets a list of queryables" do
+      assert TestRepo.one([MySchema]) == 1
+    end
+  end
+
+  describe "Repo.all/1" do
+    test "accpets a queryable" do
+      assert TestRepo.all(MySchema) == [1]
+    end
+
+    test "accpets a list of queryables" do
+      assert TestRepo.all([MySchema]) == [1]
+    end
+  end
 end


### PR DESCRIPTION
Ecto has several association types which all implement via the `Ecto.Association` behavior. I'm not sure if this is intended to be something that external libraries can implement, but I've been trying.

My goal is to support a legacy Rails database with polymorphic relationships. I know, ecto has chosen not to support polymorphism and I'm fine with that, I agree its a problematic structure. However, I do believe that even if Ecto doesn't support it out of the box, **it should be supportable via a 3rd party library or a gist**. However, my attempts at doing so have proven to be problematic.

Following is my gist which with this pull request makes `Repo.one/1` fetches w/ preloading works with polymorphism, however `Repo.all/1` calls with polymorphism don't work since the code is expecting to execute a single query to get a single relationship (when polymorphic relationships can execute 1 or more queries). If we can make a list of queries get executed returned from `assoc_query/3` that will solve this issue.

https://gist.github.com/mgwidmann/ad2ef5138378dc3772a321567610520d

If you have any better ideas how to support this, I'm all ears. Again, I know Ecto does not intend to ever support polymorphism, I'm only asking for compatibility to allow it to be extended to do so. The purpose for this is only to support legacy systems.

