### PR TITLE
cast_assoc for required has_many allows empty list if assoc set to on_replace: :delete

### DIFF
--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -29,6 +29,7 @@ defmodule Ecto.Changeset.Relation do
   """
   def empty?(%{cardinality: _}, %NotLoaded{}), do: true
   def empty?(%{cardinality: :many}, []), do: true
+  def empty?(%{cardinality: :many}, changes), do: Enum.all?(changes, & &1.action == :replace)
   def empty?(%{cardinality: :one}, nil), do: true
   def empty?(%{}, _), do: false
 

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -29,7 +29,7 @@ defmodule Ecto.Changeset.Relation do
   """
   def empty?(%{cardinality: _}, %NotLoaded{}), do: true
   def empty?(%{cardinality: :many}, []), do: true
-  def empty?(%{cardinality: :many}, changes), do: Enum.all?(changes, & &1.action == :replace)
+  def empty?(%{cardinality: :many}, changes), do: Enum.all?(changes, & &1.action in [:replace, :delete])
   def empty?(%{cardinality: :one}, nil), do: true
   def empty?(%{}, _), do: false
 

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -444,6 +444,10 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert changeset.changes == %{posts: []}
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
+    changeset = cast(%Author{posts: [%Post{title: "hello", id: 1}]}, %{posts: []}, :posts, required: true)
+    assert changeset.required == [:posts]
+    assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
+
     changeset = cast(%Author{posts: []}, %{}, :posts, required: true)
     assert changeset.required == [:posts]
     assert changeset.changes == %{}


### PR DESCRIPTION
When

1. a struct's has_many assoc is required
2. that assoc is marked `on_replace: :delete`
3. that assoc is cast with an empty list

then: the `required` validation still passes, even though an empty list is invalid in other situations (`def empty?(%{cardinality: :many}, []), do: true`)

This PR adds a failing test for this as well as a fix.