### PR TITLE
Partial fix for subquery select parameter count

### DIFF
--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -533,7 +533,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "self join on subquery" do
-    subquery = Schema |> select([r], %{x: r.x, y: r.y})
+    subquery = select(Schema, [r], %{x: r.x, y: r.y})
     query = subquery |> join(:inner, [c], p in subquery(subquery), true) |> normalize
     assert SQL.all(query) ==
            ~s{SELECT s0."x", s0."y" FROM "schema" AS s0 INNER JOIN } <>
@@ -542,7 +542,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "self join on subquery with fragment" do
-    subquery = Schema |> select([r], %{string: fragment("downcase(?)", ^"string")})
+    subquery = select(Schema, [r], %{string: fragment("downcase(?)", ^"string")})
     query = subquery |> join(:inner, [c], p in subquery(subquery), true) |> normalize
     assert SQL.all(query) ==
            ~s{SELECT downcase($1) FROM "schema" AS s0 INNER JOIN } <>
@@ -551,7 +551,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "join on subquery with simple select" do
-    subquery = Schema |> select([r], %{x: ^999, w: ^888})
+    subquery = select(Schema, [r], %{x: ^999, w: ^888})
     query = Schema
             |> select([r], %{y: ^666})
             |> join(:inner, [c], p in subquery(subquery), true)


### PR DESCRIPTION
This PR addresses the issue in #2128, at least as far as the example test cases therein go. It still can't deal with the following case correctly:

```elixir
  test "join on subquery with simple select and multi element outer select" do
    subquery = Schema |> select([r], %{x: ^999})
    query = Schema
            |> select([r], %{y: ^666, w: ^777})
            |> join(:inner, [c], p in subquery(subquery), true)
            |> where([a, b], a.x == ^111)
            |> normalize

    assert SQL.all(query) ==
           ~s{SELECT $1, $2 FROM "schema" AS s0 INNER JOIN } <>
           ~s{(SELECT $3 AS "x" FROM "schema" AS s0) AS s1 ON TRUE } <>
           ~s{WHERE (s0."x" = $4)}
  end
```

As such I'm not actually sure if it's a) the right approach and I just need to figure out how to extend it a bit, or b) entirely the wrong approach. So while it solves my immediate issue, I'm happy to take pointers on how to fix it (more) properly.