### PR TITLE
Raise MultipleResultsError when primary key is not unique on DB side

### DIFF
--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -55,8 +55,7 @@ defmodule Ecto.Integration.SQLTest do
 
     assert %CorruptedPk{a: "abc"} = TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
 
-    assert_raise Ecto.MultipleResultsError, ~s/expected at most one result but got 10 in query:\n\n/ <>
-                                            ~s/DELETE FROM "corrupted_pk" WHERE "a" = $1\n/, fn ->
+    assert_raise Ecto.MultipleResultsError, ~s/expected at most one result but got 10 in query:\n\n/ <> _, fn ->
       TestRepo.delete!(schema)
     end
   end

--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -4,6 +4,7 @@ defmodule Ecto.Integration.SQLTest do
   alias Ecto.Integration.TestRepo
   alias Ecto.Integration.Barebone
   alias Ecto.Integration.Post
+  alias Ecto.Integration.CorruptedPk
   import Ecto.Query, only: [from: 2]
 
   test "fragmented types" do
@@ -40,6 +41,24 @@ defmodule Ecto.Integration.SQLTest do
     {sql, []} = Ecto.Adapters.SQL.to_sql(:delete_all, TestRepo, Barebone)
     assert sql =~ "DELETE"
     assert sql =~ "barebones"
+  end
+
+  test "struct/7 raises when primary key is not unique" do
+    schema = %CorruptedPk{a: "abc"}
+    for _ <- 1..10, do: TestRepo.insert!(schema)
+
+    assert_raise Ecto.MultipleResultsError, ~s|expected at most one result but got 10 in query:\n\n| <>
+                                            ~s|from c in Ecto.Integration.CorruptedPk,\n| <>
+                                            ~s|  where: c.a == ^\"abc\"\n|, fn ->
+      TestRepo.get(CorruptedPk, "abc")
+    end
+
+    assert %CorruptedPk{a: "abc"} = TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
+
+    assert_raise Ecto.MultipleResultsError, ~s/expected at most one result but got 10 in query:\n\n/ <>
+                                            ~s/DELETE FROM "corrupted_pk" WHERE "a" = $1\n/, fn ->
+      TestRepo.delete!(schema)
+    end
   end
 
   test "Repo.insert! escape" do

--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -53,7 +53,7 @@ defmodule Ecto.Integration.SQLTest do
       TestRepo.get(CorruptedPk, "abc")
     end
 
-    assert %CorruptedPk{a: "abc"} = TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
+    assert %CorruptedPk{a: "abc"} = schema |> Ecto.Changeset.change(force: true) |> TestRepo.update!()
 
     assert_raise Ecto.MultipleResultsError, fn ->
       TestRepo.delete!(schema)

--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -55,7 +55,7 @@ defmodule Ecto.Integration.SQLTest do
 
     assert %CorruptedPk{a: "abc"} = TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
 
-    assert_raise Ecto.MultipleResultsError, ~s/expected at most one result but got 10 in query:\n\n/ <> _, fn ->
+    assert_raise Ecto.MultipleResultsError, fn ->
       TestRepo.delete!(schema)
     end
   end

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -97,6 +97,10 @@ defmodule Ecto.Integration.Migration do
       add :name, :string
     end
 
+    create table(:corrupted_pk, primary_key: false) do
+      add :a, :string
+    end
+
     create table(:posts_users_composite_pk) do
       add :post_id, references(:posts), primary_key: true
       add :user_id, references(:users), primary_key: true

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -257,6 +257,21 @@ defmodule Ecto.Integration.CompositePk do
   end
 end
 
+defmodule Ecto.Integration.CorruptedPk do
+  @moduledoc """
+  This module is used to test:
+
+    * Primary keys that is not unique on a DB side
+
+  """
+  use Ecto.Integration.Schema
+
+  @primary_key false
+  schema "corrupted_pk" do
+    field :a, :string, primary_key: true
+  end
+end
+
 defmodule Ecto.Integration.PostUserCompositePk do
   @moduledoc """
   This module is used to test:

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -555,6 +555,8 @@ defmodule Ecto.Adapters.SQL do
         {:ok, Enum.zip(returning, values)}
       {:ok, %{num_rows: 0}} ->
         if on_conflict == :nothing, do: {:ok, []}, else: {:error, :stale}
+      {:ok, %{rows: nil, num_rows: num_rows}} when num_rows > 1 ->
+        raise Ecto.MultipleResultsError, sql_query: sql, count: num_rows
       {:error, err} ->
         case conn.to_constraints(err) do
           []          -> raise err

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -204,13 +204,17 @@ defmodule Ecto.MultipleResultsError do
   defexception [:message]
 
   def exception(opts) do
-    query = Keyword.fetch!(opts, :queryable) |> Ecto.Queryable.to_query
+    sql_query = Keyword.get(opts, :sql_query)
     count = Keyword.fetch!(opts, :count)
+    query =
+      if sql_query,
+       do: sql_query,
+     else: opts |> Keyword.fetch!(:queryable) |> Ecto.Queryable.to_query() |> Inspect.Ecto.Query.to_string()
 
     msg = """
     expected at most one result but got #{count} in query:
 
-    #{Inspect.Ecto.Query.to_string(query)}
+    #{query}
     """
 
     %__MODULE__{message: msg}

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -207,9 +207,14 @@ defmodule Ecto.MultipleResultsError do
     sql_query = Keyword.get(opts, :sql_query)
     count = Keyword.fetch!(opts, :count)
     query =
-      if sql_query,
-       do: sql_query,
-     else: opts |> Keyword.fetch!(:queryable) |> Ecto.Queryable.to_query() |> Inspect.Ecto.Query.to_string()
+      if sql_query do
+        sql_query
+      else
+        opts
+        |> Keyword.fetch!(:queryable)
+        |> Ecto.Queryable.to_query()
+        |> Inspect.Ecto.Query.to_string()
+      end
 
     msg = """
     expected at most one result but got #{count} in query:


### PR DESCRIPTION
Related to #2132.

Also, it looks like `Repo.update!/1` does not check how many rows are actually affected. Should we do something with it?