### PR TITLE
Broaden typespecs for query and query!

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -181,7 +181,9 @@ defmodule Ecto.Adapters.SQL do
   Same as `query/4` but raises on invalid queries.
   """
   @spec query!(Ecto.Repo.t, String.t, [term], Keyword.t) ::
-               %{rows: nil | [[term] | binary], num_rows: non_neg_integer}
+               %{:rows => nil | [[term] | binary],
+                 :num_rows => non_neg_integer,
+                 optional(atom) => any}
                | no_return
   def query!(repo, sql, params \\ [], opts \\ []) do
     query!(repo, sql, map_params(params), fn x -> x end, opts)
@@ -223,7 +225,9 @@ defmodule Ecto.Adapters.SQL do
 
   """
   @spec query(Ecto.Repo.t, String.t, [term], Keyword.t) ::
-              {:ok, %{rows: nil | [[term] | binary], num_rows: non_neg_integer}}
+              {:ok, %{:rows => nil | [[term] | binary],
+                      :num_rows => non_neg_integer,
+                      optional(atom) => any}}
               | {:error, Exception.t}
   def query(repo, sql, params \\ [], opts \\ []) do
     query(repo, sql, map_params(params), fn x -> x end, opts)


### PR DESCRIPTION
`Ecto.Adapters.SQL.query/4` and `query!/4` can, at least for some adaptors, return more fields than just `rows` and `num_columns` (the example of `columns` appears in the docs). If you're relying on those fields, you'll get a dialyzer error because the typespec for the returned value doesn't allow for them. This patch fixes that.