### PR TITLE
Prompt user to confirm before running load mix task, fixes #2144

### DIFF
--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Ecto.Load do
       OptionParser.parse args, switches: [dump_path: :string, quiet: :boolean, force: :boolean], aliases: [d: :dump_path]
 
     opts = Keyword.merge(@default_opts, opts)
-    
+
     Enum.each parse_repo(args), fn repo ->
       ensure_repo(repo, args)
       ensure_implements(repo.__adapter__, Ecto.Adapter.Structure,

--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -37,18 +37,22 @@ defmodule Mix.Tasks.Ecto.Load do
       ensure_repo(repo, args)
       ensure_implements(repo.__adapter__, Ecto.Adapter.Structure,
                                           "to load structure for #{inspect repo}")
-      config = Keyword.merge(repo.config, opts)
+      load_structure(repo, opts)
+    end
+  end
 
-      case repo.__adapter__.structure_load(source_repo_priv(repo), config) do
-        {:ok, location} ->
-          unless opts[:quiet] do
-            Mix.shell.info "The structure for #{inspect repo} has been loaded from #{location}"
-          end
-        {:error, term} when is_binary(term) ->
-          Mix.raise "The structure for #{inspect repo} couldn't be loaded: #{term}"
-        {:error, term} ->
-          Mix.raise "The structure for #{inspect repo} couldn't be loaded: #{inspect term}"
-      end
+  defp load_structure(repo, opts) do
+    config = Keyword.merge(repo.config, opts)
+
+    case repo.__adapter__.structure_load(source_repo_priv(repo), config) do
+      {:ok, location} ->
+        unless opts[:quiet] do
+          Mix.shell.info "The structure for #{inspect repo} has been loaded from #{location}"
+        end
+      {:error, term} when is_binary(term) ->
+        Mix.raise "The structure for #{inspect repo} couldn't be loaded: #{term}"
+      {:error, term} ->
+        Mix.raise "The structure for #{inspect repo} couldn't be loaded: #{inspect term}"
     end
   end
 end


### PR DESCRIPTION
As discussed in #2144, the `ecto.load` mix task will typically drop and recreate tables thereby deleting data if run against a populated database. Running `ecto.load` in production could be equally problematic as running `ecto.drop`. This PR adds the same [safeguard that `ecto.drop` has](https://github.com/elixir-ecto/ecto/blob/master/lib/mix/tasks/ecto.drop.ex#L39) to `ecto.load`. Specifically it checks the project configuration to see if `:start_permanent` is `true`, this is an indication that we are likely not in dev or test environments and that we should ask the user to confirm their intention to run the task. If `:start_permanent` is `true` we prompt the user for confirmation. The user can suppress the prompt, regardless of environment settings by passing the `--force` flag like so: `mix ecto.load --force`.

I've tested this in a project I'm working on. I tried with true and false values for `start_permanent:` in my project's `mix.exs` and I've tried running `mix.load` with and without the `--force` flag. All behaves as expected.

Does anyone have suggestions on how to write a test for this? The challenge is that unless `Mix.Project.config[:start_permanent]` evaluates to `true` in the test environment, the code to be tested won't be reached. As I understand `Mix.Project.config` can't be changed at runtime. I could add a parameter to `run/1` that would allow a calling process such as a test to replace `skip_safety_warnings?` with a function that doesn't depend on `Mix.Project.config[:start_permanent]` , something like this:
`def run(args, skip_safety_warnings_function \\ &skip_safety_warnings?/0) do`

Maybe a test will add more complexity than it's worth? Any thoughts on that?