### PR TITLE
convert subqueries to queries in preloader

### DIFF
--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -314,6 +314,7 @@ defmodule Ecto.Repo.Preloader do
 
   defp query!(query) when is_function(query, 1), do: query
   defp query!(%Ecto.Query{} = query), do: query
+  defp query!(%Ecto.SubQuery{} = query), do: Ecto.Queryable.to_query(query)
 
   defp take(take, field) do
     case Access.fetch(take, field) do

--- a/test/ecto/query/builder/preload_test.exs
+++ b/test/ecto/query/builder/preload_test.exs
@@ -44,4 +44,13 @@ defmodule Ecto.Query.Builder.PreloadTest do
     assert preload("posts", [{^:users, ^fun}]).preloads == [users: fun]
     assert preload("posts", [users: ^{fun, :comments}]).preloads == [users: {fun, :comments}]
   end
+
+  test "supports subqueries" do
+    query = from u in "users", limit: 10
+    assert preload("posts", [users: ^subquery(query)]).preloads == [users: subquery(query)]
+
+    subquery = subquery(from u in "users")
+    assert preload("posts", [{^:users, ^subquery}]).preloads == [users: subquery]
+    assert preload("posts", [users: ^{subquery, :comments}]).preloads == [users: {subquery, :comments}]
+  end
 end


### PR DESCRIPTION
This (perhaps too naively?) converts a passed in subquery to its query representation when its used in a preload.