### PR TITLE
[WIP] Implemented infix mathematical operators through abstract type `:number`

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -26,11 +26,16 @@ defmodule Ecto.Integration.TypeTest do
     # Integers
     assert [1] = TestRepo.all(from p in Post, where: p.visits == ^integer, select: p.visits)
     assert [1] = TestRepo.all(from p in Post, where: p.visits == 1, select: p.visits)
+    assert [3] = TestRepo.all(from p in Post, select: p.visits + 2)
 
     # Floats
     assert [0.1] = TestRepo.all(from p in Post, where: p.intensity == ^float, select: p.intensity)
     assert [0.1] = TestRepo.all(from p in Post, where: p.intensity == 0.1, select: p.intensity)
     assert [1500.0] = TestRepo.all(from p in Post, select: 1500.0)
+    assert [1.1] = TestRepo.all(from p in Post, select: p.intensity + ^integer)
+    assert [1.1] = TestRepo.all(from p in Post, select: p.visits + 0.1)
+    # FIXME There should be no need for typecasting (?)
+    assert [1.1] = TestRepo.all(from p in Post, select: p.visits + type(^float, :float))
 
     # Booleans
     assert [true] = TestRepo.all(from p in Post, where: p.public == ^true, select: p.public)
@@ -220,6 +225,12 @@ defmodule Ecto.Integration.TypeTest do
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1, select: p.cost)
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1.0, select: p.cost)
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
+
+    decimal_result = Decimal.new("2.0")
+    assert [^decimal_result] = TestRepo.all(from p in Post, select: p.cost + 1)
+    assert [2.0] = TestRepo.all(from p in Post, select: p.cost + 1.0)
+    assert [^decimal_result] = TestRepo.all(from p in Post, select: p.cost + ^decimal)
+    assert [^decimal_result] = TestRepo.all(from p in Post, select: p.cost * 2)
   end
 
   test "schemaless types" do

--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -4,7 +4,8 @@ Logger.configure(level: :info)
 # on MySQL 5.6 but that is not yet supported in travis.
 ExUnit.start exclude: [:array_type, :read_after_writes, :uses_usec, :uses_msec, :returning,
                        :strict_savepoint, :create_index_if_not_exists, :modify_column,
-                       :transaction_isolation, :rename_column, :with_conflict_target]
+                       :transaction_isolation, :rename_column, :with_conflict_target,
+                       :pg_decimal_casting]
 
 # Configure Ecto for support and tests
 Application.put_env(:ecto, :lock_for_update, "FOR UPDATE")

--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -34,7 +34,7 @@ defmodule Ecto.Integration.StorageTest do
   end
 
   def run_psql(sql, args \\ []) do
-    args = ["-U", params()[:username], "-c", sql | args]
+    args = ["-U", params()[:username], "-h", params()[:hostname], "-c", sql | args]
     System.cmd "psql", args
   end
 

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -77,10 +77,10 @@ _   = Ecto.Adapters.Postgres.storage_down(TestRepo.config)
 %{rows: [[version]]} = TestRepo.query!("SHOW server_version", [])
 
 if Version.match?(version, "~> 9.5") do
-  ExUnit.configure(exclude: [:without_conflict_target])
+  ExUnit.configure(exclude: [:without_conflict_target, :mysql_decimal_casting])
 else
   Application.put_env(:ecto, :postgres_map_type, "json")
-  ExUnit.configure(exclude: [:upsert, :upsert_all, :array_type])
+  ExUnit.configure(exclude: [:upsert, :upsert_all, :array_type, :mysql_decimal_casting])
 end
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -243,6 +243,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     binary_ops =
       [==: " = ", !=: " != ", <=: " <= ", >=: " >= ", <: " < ", >: " > ",
+       +: " + ", -: " - ", *: " * ", /: " / ",
        and: " AND ", or: " OR ", ilike: " ILIKE ", like: " LIKE "]
 
     @binary_ops Keyword.keys(binary_ops)

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -3,6 +3,8 @@ defmodule Ecto.Query.Builder do
 
   alias Ecto.Query
 
+  @number_types ~w(integer float decimal)a
+
   @typedoc """
   Quoted types store primitive types and types in the format
   {source, quoted}. The latter are handled directly in the planner,
@@ -176,6 +178,26 @@ defmodule Ecto.Query.Builder do
     {params, acc} = params_acc
     {{:{}, [], [comp_op, [], [left, right]]},
      {params |> wrap_nil(left) |> wrap_nil(right), acc}}
+  end
+
+  # mathematical operators
+  def escape({math_op, _, [left, right]} = expr, type, params_acc, vars, env)
+      when math_op in ~w(+ - * /)a do
+    assert_type!(expr, type, :number)
+    
+    args_type =
+      case Enum.map([left, right], &quoted_type(&1, vars)) do
+        [:float, _]                          -> :float
+        [_, :float]                          -> :float
+        [type, _] when type in @number_types -> type
+        [_, type] when type in @number_types -> type
+        _                                    -> :any
+      end
+
+    {left,  params_acc} = escape(left, args_type, params_acc, vars, env)
+    {right, params_acc} = escape(right, args_type, params_acc, vars, env)
+
+    {{:{}, [], [math_op, [], [left, right]]}, params_acc}
   end
 
   # in operator
@@ -352,6 +374,10 @@ defmodule Ecto.Query.Builder do
   defp call_type(_, _),                                           do: nil
 
   defp assert_type!(_expr, {int, _field}, _actual) when is_integer(int) do
+    :ok
+  end
+
+  defp assert_type!(_expr, type, :number) when type in @number_types do
     :ok
   end
 
@@ -660,6 +686,18 @@ defmodule Ecto.Query.Builder do
   def quoted_type(literal, _vars) when is_binary(literal),  do: :string
   def quoted_type(literal, _vars) when is_boolean(literal), do: :boolean
   def quoted_type(literal, _vars) when is_integer(literal), do: :integer
+
+  # Mathematical operations
+  def quoted_type({:/, _, [_, _]}, _vars), do: :float
+  def quoted_type({math_op, _, [_, _] = args}, vars) when math_op in ~w(+ - *)a do
+    case Enum.map(args, &quoted_type(&1, vars)) do
+      [:integer, :integer]           -> :integer
+      [:decimal, :decimal]           -> :decimal
+      [a, b] when a in @number_types 
+              and b in @number_types -> :float
+      _                              -> :any
+    end
+  end
 
   def quoted_type({name, _, args}, _vars) when is_atom(name) and is_list(args) do
     case call_type(name, length(args)) do

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -157,6 +157,14 @@ defmodule Ecto.Query.BuilderTest do
     assert quoted_type({:sigil_w, [], ["foo", []]}, []) == {:array, :string}
     assert quoted_type({:sigil_s, [], ["foo", []]}, []) == :string
 
+    assert quoted_type({:+, [], [1, 2]}, []) == :integer
+    assert quoted_type({:+, [], [1, 0.1]}, []) == :float
+    assert quoted_type({:-, [], [1, 2]}, []) == :integer
+    assert quoted_type({:-, [], [1, 0.1]}, []) == :float
+    assert quoted_type({:/, [], [1, 2]}, []) == :float
+    assert quoted_type({:*, [], [1, 2]}, []) == :integer
+    assert quoted_type({:*, [], [1, 0.1]}, []) == :float
+
     assert quoted_type({:==, [], [1, 2]}, []) == :boolean
     assert quoted_type({:like, [], [1, 2]}, []) == :boolean
     assert quoted_type({:and, [], [1, 2]}, []) == :boolean

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -94,6 +94,9 @@ defmodule Ecto.Query.PlannerTest do
 
     assert Exception.message(exception) =~ "value `1` in `where` cannot be cast to type :string"
     assert Exception.message(exception) =~ "where: p.title == ^1"
+
+    {_query, params, _key} = prepare(Post |> select([p], p.visits + ^0.1))
+    assert params == [0.1]
   end
 
   test "prepare: raises readable error on dynamic expressions/keyword lists" do


### PR DESCRIPTION
Fixes #1757 

I gave it a shot and came up with this.

Somethings I'd like to question:

- I needed to add a explicit type cast in the PG integration test (the `#FIXME` tag). Is it an expected behavior?
- I'm not very fond of how the number type checking was implemented at the builder stage. Do you have any tips on how it could be better implemented?
- I have a feeling that there are some missing test cases. Are there some edge cases you think I should test?

I decided to validate my approach first before implementing the MySQL driver.

I'm looking forward for your feedback! :smiley: 