### PR TITLE
Parse URL query params

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -64,6 +64,12 @@ defmodule Ecto.Repo do
   The schema can be of any value. The path represents the database name
   while options are simply merged in.
 
+  URL can include query parameters to override shared and adapter-specific
+  options: `ssl`, `timeout`, `pool_timeout`, `pool_size`:
+
+    config :my_app, Repo,
+        url: "ecto://postgres:postgres@localhost/ecto_simple?ssl=true&pool_size=10"
+
   In case the URL needs to be dynamically configured, for example by
   reading a system environment variable, such can be done via the
   `c:init/2` repository callback:

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -65,7 +65,7 @@ defmodule Ecto.Repo do
   while options are simply merged in.
 
   URL can include query parameters to override shared and adapter-specific
-  options: `ssl`, `timeout`, `pool_timeout`, `pool_size`:
+  options `ssl`, `timeout`, `pool_timeout`, `pool_size`:
 
     config :my_app, Repo,
         url: "ecto://postgres:postgres@localhost/ecto_simple?ssl=true&pool_size=10"

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -107,13 +107,15 @@ defmodule Ecto.Repo.Supervisor do
     destructure [username, password], info.userinfo && String.split(info.userinfo, ":")
     "/" <> database = info.path
 
-    opts = [username: username,
-            password: password,
-            database: database,
-            hostname: info.host,
-            port:     info.port] ++ parse_uri_query(info)
+    url_opts = [username: username,
+                password: password,
+                database: database,
+                hostname: info.host,
+                port:     info.port]
 
-    for {k, v} <- opts, v, do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
+    query_opts = parse_uri_query(info)
+
+    for {k, v} <- url_opts ++ query_opts, v, do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
   end
 
   defp parse_uri_query(%URI{query: nil}),

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -134,7 +134,7 @@ defmodule Ecto.Repo.Supervisor do
         [{String.to_atom(key), parse_integer!(key, value, url)}] ++ acc
 
       {key, _value}, _acc ->
-        raise Ecto.InvalidURLError, url: url, message: "unsupported query parameter #{key}"
+        raise Ecto.InvalidURLError, url: url, message: "unsupported query parameter `#{key}`"
     end)
   end
 

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -84,7 +84,7 @@ defmodule Ecto.Repo.Supervisor do
 
   The format must be:
 
-      "ecto://username:password@hostname:port/database"
+      "ecto://username:password@hostname:port/database?ssl=true&timeout=1000"
 
   """
   def parse_url(""), do: []
@@ -115,7 +115,7 @@ defmodule Ecto.Repo.Supervisor do
 
     query_opts = parse_uri_query(info)
 
-    for {k, v} <- url_opts ++ query_opts, v, do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
+    for {k, v} <- url_opts ++ query_opts, not is_nil(v), do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
   end
 
   defp parse_uri_query(%URI{query: nil}),
@@ -126,6 +126,9 @@ defmodule Ecto.Repo.Supervisor do
     |> Enum.reduce([], fn
       {"ssl", "true"}, acc ->
         [{:ssl, true}] ++ acc
+
+      {"ssl", "false"}, acc ->
+        [{:ssl, false}] ++ acc
 
       {key, value}, acc when key in @integer_url_query_params ->
         [{String.to_atom(key), parse_integer!(key, value, url)}] ++ acc

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -142,13 +142,8 @@ defmodule Ecto.Repo.Supervisor do
     case Integer.parse(value) do
       {int, ""} ->
         int
-
-      {_int, remainder_of_binary} ->
-        raise Ecto.InvalidURLError, url: url, message: "can not parse value for parameter #{key} as an integer, " <>
-                                                       "binary remainder #{remainder_of_binary} should not be present"
-
-      :error ->
-        raise Ecto.InvalidURLError, url: url, message: "can not parse value #{value} for parameter #{key} as an integer"
+      _ ->
+        raise Ecto.InvalidURLError, url: url, message: "can not parse value `#{value}` for parameter `#{key}` as an integer"
     end
   end
 

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -60,7 +60,7 @@ defmodule Ecto.Repo.SupervisorTest do
   end
 
   test "parse_url query string" do
-    encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&pool_timeout=1000&timeout=1000")
+    encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&pool_timeout=1000&timeout=1000&pool_size=42")
     url = parse_url(encoded_url)
     assert {:password, "it+й"} in url
     assert {:username, "eric"} in url
@@ -70,6 +70,7 @@ defmodule Ecto.Repo.SupervisorTest do
     assert {:ssl, true} in url
     assert {:timeout, 1000} in url
     assert {:pool_timeout, 1000} in url
+    assert {:pool_size, 42} in url
   end
 
   test "parse_url returns no config when blank" do

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -102,5 +102,18 @@ defmodule Ecto.Repo.SupervisorTest do
     assert_raise Ecto.InvalidURLError, ~r"unsupported query parameter uknown_param", fn ->
       parse_url("ecto://eric:it+й@host:12345/mydb?uknown_param=value")
     end
+
+    for key <- ["timeout", "pool_size", "pool_timeout"] do
+      message = "can not parse value for parameter #{key} as an integer, " <>
+                "binary remainder binrem should not be present"
+
+      assert_raise Ecto.InvalidURLError, Regex.compile!(message), fn ->
+        parse_url("ecto://eric:it+й@host:12345/mydb?#{key}=123binrem")
+      end
+
+      assert_raise Ecto.InvalidURLError, ~r"can not parse value not_an_int for parameter #{key} as an integer", fn ->
+        parse_url("ecto://eric:it+й@host:12345/mydb?#{key}=not_an_int")
+      end
+    end
   end
 end

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -109,14 +109,7 @@ defmodule Ecto.Repo.SupervisorTest do
     end
 
     for key <- ["timeout", "pool_size", "pool_timeout"] do
-      message = "can not parse value for parameter #{key} as an integer, " <>
-                "binary remainder binrem should not be present"
-
-      assert_raise Ecto.InvalidURLError, Regex.compile!(message), fn ->
-        parse_url("ecto://eric:it+й@host:12345/mydb?#{key}=123binrem")
-      end
-
-      assert_raise Ecto.InvalidURLError, ~r"can not parse value not_an_int for parameter #{key} as an integer", fn ->
+      assert_raise Ecto.InvalidURLError, ~r"can not parse value `not_an_int` for parameter `#{key}` as an integer", fn ->
         parse_url("ecto://eric:it+й@host:12345/mydb?#{key}=not_an_int")
       end
     end

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -59,6 +59,19 @@ defmodule Ecto.Repo.SupervisorTest do
     assert {:port, 12345} in url
   end
 
+  test "parse_url query string" do
+    encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&pool_timeout=1000&timeout=1000")
+    url = parse_url(encoded_url)
+    assert {:password, "it+й"} in url
+    assert {:username, "eric"} in url
+    assert {:hostname, "host"} in url
+    assert {:database, "mydb"} in url
+    assert {:port, 12345} in url
+    assert {:ssl, true} in url
+    assert {:timeout, 1000} in url
+    assert {:pool_timeout, 1000} in url
+  end
+
   test "parse_url returns no config when blank" do
     assert parse_url("") == []
   end
@@ -84,6 +97,10 @@ defmodule Ecto.Repo.SupervisorTest do
 
     assert_raise Ecto.InvalidURLError, ~r"path should be a database name", fn ->
       parse_url("ecto://eric:hunter2@host:123")
+    end
+
+    assert_raise Ecto.InvalidURLError, ~r"unsupported query parameter uknown_param", fn ->
+      parse_url("ecto://eric:it+й@host:12345/mydb?uknown_param=value")
     end
   end
 end

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -104,7 +104,7 @@ defmodule Ecto.Repo.SupervisorTest do
       parse_url("ecto://eric:hunter2@host:123")
     end
 
-    assert_raise Ecto.InvalidURLError, ~r"unsupported query parameter uknown_param", fn ->
+    assert_raise Ecto.InvalidURLError, ~r"unsupported query parameter `uknown_param`", fn ->
       parse_url("ecto://eric:it+й@host:12345/mydb?uknown_param=value")
     end
 

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -77,6 +77,10 @@ defmodule Ecto.Repo.SupervisorTest do
     assert parse_url("") == []
   end
 
+  test "parse_url keeps false values" do
+    assert {:ssl, false} in parse_url("ecto://eric:it+й@host:12345/mydb?ssl=false")
+  end
+
   test "parse_urls empty username/password" do
     url = parse_url("ecto://host:12345/mydb")
     assert !Keyword.has_key?(url, :username)


### PR DESCRIPTION
It is common to use params in PostgreSQL connection URIs
(https://www.postgresql.org/docs/9.6/static/libpq-connect.html#AEN45575)
 and we can leverage them to set our shared params.

Change is inspired by our production issue, we had to enable SSL after upgrading database on Heroku without rebuilding the release artifact.