### PR TITLE
Optimise Changeset.validate_inclusion/4 for MapSet

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1529,7 +1529,17 @@ defmodule Ecto.Changeset do
 
   """
   @spec validate_inclusion(t, atom, Enum.t, Keyword.t) :: t
-  def validate_inclusion(changeset, field, data, opts \\ []) do
+  def validate_inclusion(changeset, field, data, opts \\ [])
+
+  def validate_inclusion(changeset, field, set = %MapSet{}, opts) do
+    validate_change changeset, field, {:inclusion, set}, fn _, value ->
+      if MapSet.member?(set, value),
+        do: [],
+        else: [{field, {message(opts, "is invalid"), [validation: :inclusion]}}]
+    end
+  end
+
+  def validate_inclusion(changeset, field, data, opts) do
     validate_change changeset, field, {:inclusion, data}, fn _, value ->
       if value in data,
         do: [],

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -762,6 +762,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
     assert changeset.errors == [title: {"yada", [validation: :inclusion]}]
+
+    changeset =
+      changeset(%{"title" => "hello"})
+      |> validate_inclusion(:title, MapSet.new(~w(world)))
+    refute changeset.valid?
+    assert changeset.errors == [title: {"is invalid", [validation: :inclusion]}]
+    assert changeset.validations == [title: {:inclusion, MapSet.new(~w(world))}]
   end
 
   test "validate_subset/3" do


### PR DESCRIPTION
In the even that Changeset.validate_inclusion/4 is given a MapSet of
permitted values we can optimise the lookup to be less than O(n) for
larger collections.