### PR TITLE
Use MariaEx typed binary and string if supported

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -443,6 +443,10 @@ if Code.ensure_loaded?(Mariaex) do
     defp expr(true, _sources, _query),  do: "TRUE"
     defp expr(false, _sources, _query), do: "FALSE"
 
+    defp expr(%{__struct__: Mariaex.TypedValue, value: bin}, sources, query) when is_binary(bin) do
+      expr(bin, sources, query)
+    end
+
     defp expr(literal, _sources, _query) when is_binary(literal) do
       [?', escape_string(literal), ?']
     end


### PR DESCRIPTION
By default, MariaEx doesn't distinguish between raw binaries and text strings. MariaEx `query` features an option `binary_as` that makes the library either treat *all* Elixir strings as raw binaries or as text. This option, however, is not easily accessible from Ecto and is not a solution when a query features both a raw binary and text string.

I've created a pull request https://github.com/xerions/mariaex/pull/198 that allows passing Elixir string parameters wrapped in `%Mariaex.TypedValue` with an explicit `type` field (with a value of either `:binary` or `:string`) to remove ambiguity.

This PR leverages Ecto's knowledge of the model to inform MariaEx of the exact types of Elixir string parameters. The change is made in a backward-compatible way; Travis tests using updated MariaEx can be found [here](https://travis-ci.org/kzemek/ecto/builds/268303373).