### PR TITLE
Allow validation of codepoint count in validate_length

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1622,7 +1622,7 @@ defmodule Ecto.Changeset do
         count_type = opts[:count] || :graphemes
         {type, length} = case {value, count_type} do
           {value, :codepoints} when is_binary(value) ->
-            {:string, length(String.codepoints(value))}
+            {:string, codepoints_length(value, 0)}
           {value, :graphemes} when is_binary(value) ->
             {:string, String.length(value)}
           {value, _} when is_list(value) ->
@@ -1636,6 +1636,10 @@ defmodule Ecto.Changeset do
         if error, do: [{field, error}], else: []
     end
   end
+
+  defp codepoints_length(<<_::utf8, rest::binary>>, acc), do: codepoints_length(rest, acc + 1)
+  defp codepoints_length(<<_, rest::binary>>, acc), do: codepoints_length(rest, acc + 1)
+  defp codepoints_length(<<>>, acc), do: acc
 
   defp wrong_length(_type, value, value, _opts), do: nil
   defp wrong_length(:string, _length, value, opts), do:

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1584,11 +1584,18 @@ defmodule Ecto.Changeset do
   @doc """
   Validates a change is a string or list of the given length.
 
+  Note that the length of a string is counted in graphemes. If using
+  this validation to match a character limit of a database backend,
+  it's likely that the limit ignores graphemes and limits the number
+  of unicode characters. Then consider using the `:count` option to
+  limit the number of codepoints.
+
   ## Options
 
     * `:is` - the length must be exactly this value
     * `:min` - the length must be greater than or equal to this value
     * `:max` - the length must be less than or equal to this value
+    * `:count` - what length to count for string, `:graphemes` (default) or `:codepoints`
     * `:message` - the message on failure, depending on the validation, is one of:
       * for strings:
         * "should be %{count} character(s)"
@@ -1612,10 +1619,13 @@ defmodule Ecto.Changeset do
   def validate_length(changeset, field, opts) when is_list(opts) do
     validate_change changeset, field, {:length, opts}, fn
       _, value ->
-        {type, length} = case value do
-          value when is_binary(value) ->
+        count_type = opts[:count] || :graphemes
+        {type, length} = case {value, count_type} do
+          {value, :codepoints} when is_binary(value) ->
+            {:string, length(String.codepoints(value))}
+          {value, :graphemes} when is_binary(value) ->
             {:string, String.length(value)}
-          value when is_list(value) ->
+          {value, _} when is_list(value) ->
             {:list, length(value)}
         end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -832,6 +832,13 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
     assert changeset.errors == [title: {"yada", count: 10, validation: :length, kind: :is}]
+
+    changeset = changeset(%{"title" => "\u0065\u0301"}) |> validate_length(:title, max: 1)
+    assert changeset.valid?
+
+    changeset = changeset(%{"title" => "\u0065\u0301"}) |> validate_length(:title, max: 1, count: :codepoints)
+    refute changeset.valid?
+    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 1, validation: :length, kind: :max}]
   end
 
   test "validate_length/3 with list" do


### PR DESCRIPTION
A common use case of validate_length is probably to check
that the given text will fit into a text field with a limited
size.

Most databases ignore graphemes in the size limit for char fields,
and only care about the number of code points.

This commit introduces the `:count` option for `validate_length`,
which will count codepoints instead of graphemes.