### PR TITLE
Implement hint option to join for mysql

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -247,9 +247,9 @@ if Code.ensure_loaded?(Mariaex) do
     defp join(%Query{joins: []}, _sources), do: []
     defp join(%Query{joins: joins} = query, sources) do
       Enum.map(joins, fn
-        %JoinExpr{on: %QueryExpr{expr: expr}, qual: qual, ix: ix, source: source} ->
+        %JoinExpr{on: %QueryExpr{expr: expr}, qual: qual, ix: ix, source: source, hint: hint} ->
           {join, name} = get_source(query, sources, ix, source)
-          [join_qual(qual, query), join, " AS ", name, " ON " | expr(expr, sources, query)]
+          [join_qual(qual, query), join, " AS ", name, hint || "", " ON " | expr(expr, sources, query)]
       end)
     end
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -315,7 +315,7 @@ defmodule Ecto.Query do
 
   defmodule JoinExpr do
     @moduledoc false
-    defstruct [:qual, :source, :on, :file, :line, :assoc, :ix, params: []]
+    defstruct [:qual, :source, :on, :file, :line, :assoc, :ix, :hint, params: []]
   end
 
   defmodule Tagged do
@@ -581,7 +581,8 @@ defmodule Ecto.Query do
       end
 
     {t, on} = collect_on(t, nil)
-    {quoted, binds, count_bind} = Join.build(quoted, qual, binds, expr, on, count_bind, env)
+    {t, hint} = collect_hint(t, nil)
+    {quoted, binds, count_bind} = Join.build(quoted, qual, binds, expr, on, hint, count_bind, env)
     from(t, env, count_bind, quoted, binds)
   end
 
@@ -596,6 +597,11 @@ defmodule Ecto.Query do
   defp from([], _env, _count_bind, quoted, _binds) do
     quoted
   end
+
+  defp collect_hint([{:hint, expr}|t], nil),
+    do: collect_hint(t, expr)
+  defp collect_hint(other, acc),
+    do: {other, acc}
 
   defp collect_on([{:on, expr}|t], nil),
     do: collect_on(t, expr)
@@ -700,8 +706,8 @@ defmodule Ecto.Query do
       |> select([g, gs], {g.name, gs.sold_on})
 
   """
-  defmacro join(query, qual, binding \\ [], expr, on \\ nil) do
-    Join.build(query, qual, binding, expr, on, nil, __CALLER__)
+  defmacro join(query, qual, binding \\ [], expr, on \\ nil, hint \\ nil) do
+    Join.build(query, qual, binding, expr, on, hint, nil, __CALLER__)
     |> elem(0)
   end
 

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -108,9 +108,9 @@ defmodule Ecto.Query.Builder.Join do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, atom, [Macro.t], Macro.t, Macro.t, Macro.t, Macro.Env.t) ::
+  @spec build(Macro.t, atom, [Macro.t], Macro.t, Macro.t, Macro.t, Macro.t, Macro.Env.t) ::
               {Macro.t, Keyword.t, non_neg_integer | nil}
-  def build(query, qual, binding, expr, on, count_bind, env) do
+  def build(query, qual, binding, expr, on, hint, count_bind, env) do
     {query, binding} = Builder.escape_binding(query, binding)
     {join_bind, join_source, join_assoc, join_params} = escape(expr, binding, env)
     join_params = Builder.escape_params(join_params)
@@ -143,22 +143,23 @@ defmodule Ecto.Query.Builder.Join do
       end
 
     query = build_on(on || true, query, binding, count_bind, qual,
-                     join_source, join_assoc, join_params, env)
+                     join_source, join_assoc, join_params, hint, env)
     {query, binding, next_bind}
   end
 
   def build_on({:^, _, [var]}, query, _binding, count_bind,
-               join_qual, join_source, join_assoc, join_params, env) do
+               join_qual, join_source, join_assoc, join_params, hint, env) do
     quote do
       query = unquote(query)
-      Ecto.Query.Builder.Join.join!(query, unquote(var), unquote(count_bind),
-                                    unquote(join_qual), unquote(join_source), unquote(join_assoc),
-                                    unquote(join_params), unquote(env.file), unquote(env.line))
+      Ecto.Query.Builder.Join.join!(query,
+        unquote(var), unquote(count_bind), unquote(join_qual),
+        unquote(join_source), unquote(join_assoc), unquote(join_params),
+        unquote(hint), unquote(env.file), unquote(env.line))
     end
   end
 
   def build_on(on, query, binding, count_bind,
-               join_qual, join_source, join_assoc, join_params, env) do
+               join_qual, join_source, join_assoc, join_params, hint, env) do
     {on_expr, on_params} = Ecto.Query.Builder.Filter.escape(:on, on, count_bind, binding, env)
     on_params = Builder.escape_params(on_params)
 
@@ -167,11 +168,16 @@ defmodule Ecto.Query.Builder.Join do
         %JoinExpr{qual: unquote(join_qual), source: unquote(join_source),
                   assoc: unquote(join_assoc), file: unquote(env.file),
                   line: unquote(env.line), params: unquote(join_params),
+                  hint: unquote(hint),
                   on: %QueryExpr{expr: unquote(on_expr), params: unquote(on_params),
                                  line: unquote(env.line), file: unquote(env.file)}}
       end
 
     Builder.apply_query(query, __MODULE__, [join], env)
+  end
+
+  defmacro hint(expr) do
+    " " <> expr <> " "
   end
 
   @doc """
@@ -187,12 +193,13 @@ defmodule Ecto.Query.Builder.Join do
   @doc """
   Called at runtime to build a join.
   """
-  def join!(query, expr, count_bind, join_qual, join_source, join_assoc, join_params, file, line) do
+  def join!(query, expr, count_bind, join_qual, join_source, join_assoc, join_params, hint, file, line) do
     {on_expr, on_params, on_file, on_line} =
       Ecto.Query.Builder.Filter.filter!(:on, query, expr, count_bind, file, line)
 
     join = %JoinExpr{qual: join_qual, source: join_source, assoc: join_assoc,
                      file: file, line: line, params: join_params,
+                     hint: hint,
                      on: %QueryExpr{expr: on_expr, params: on_params,
                                     line: on_line, file: on_file}}
 

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -61,6 +61,12 @@ defmodule Ecto.Query.Builder.JoinTest do
     assert join.on.params == [{true, {1, :public}}]
   end
 
+  test "accepts hint option" do
+    assert %{joins: [join]} =
+      join("posts", :inner, [p], c in "comments", ^[post_id: 1, public: true], hint("force index (id)"))
+    assert Macro.to_string(join.hint) == "\" force index (id) \""
+  end
+
   test "accepts interpolation on assoc/2 field" do
     assoc = :comments
     join("posts", :left, [p], c in assoc(p, ^assoc), true)


### PR DESCRIPTION
Sometimes MySQL needs to specify which index to use.
However, current ecto does not option to specify such hints when we use join.
A user can specify any option with `hint` by hand, so not secure but convenient anyway.
