### PR TITLE
Fix macro invocation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1303,7 +1303,7 @@ defmodule Ecto.Changeset do
       [title: {"cannot be foo", []}]
 
   """
-  @spec validate_change(t, atom, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}])) :: t
+  @spec validate_change(t, atom, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}}])) :: t
   def validate_change(%Changeset{} = changeset, field, validator) when is_atom(field) do
     %{changes: changes, errors: errors} = changeset
     ensure_field_exists!(changeset, field)
@@ -1342,7 +1342,7 @@ defmodule Ecto.Changeset do
       [title: :useless_validator]
 
   """
-  @spec validate_change(t, atom, term, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}])) :: t
+  @spec validate_change(t, atom, term, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}}])) :: t
   def validate_change(%Changeset{validations: validations} = changeset,
                       field, metadata, validator) do
     changeset = %{changeset | validations: [{field, metadata}|validations]}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -469,7 +469,7 @@ defmodule Ecto.Query.Builder do
   end
 
   defp try_expansion(expr, type, params, vars, {env, fun} = env_fun) do
-    case Macro.expand(expr, env) do
+    case Macro.expand_once(expr, env) do
       ^expr ->
         error! """
         `#{Macro.to_string(expr)}` is not a valid query expression.

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -32,6 +32,13 @@ defmodule Ecto.QueryTest do
       from(p in "posts", select: [macro_map(^key)])
     end
 
+    defmacrop macrotest(x), do: quote(do: is_nil(unquote(x)) or unquote(x) == "A")
+    defmacrop deeper_macrotest(x), do: quote(do: macrotest(unquote(x)) or unquote(x) == "B")
+    test "allows macro in where" do
+      _ = from(p in "posts", where: p.title == "C" or macrotest(p.title))
+      _ = from(p in "posts", where: p.title == "C" or deeper_macrotest(p.title))
+    end
+
     test "does not allow nils in comparison at compile time" do
       assert_raise Ecto.Query.CompileError,
                    ~r"comparison with nil is forbidden as it is unsafe", fn ->


### PR DESCRIPTION
Fixed #2194.

This changed `Macro.expand` to be `Macro.expand_once` in the Ecto.Query.Builder expansion functions.  This function already recurses back in to itself if the expanded expression already matches.

Added a test to test using a macro in a when expression as well as a macro within a macro call to test recursion as well in the query expressions.

I also had to fix two specs in `changeset.ex` or the project would just not compile at all with the errors of:
```elixir
== Compilation error in file lib/ecto/changeset.ex ==
** (SyntaxError) lib/ecto/changeset.ex:1306: "{" is missing terminator "}". unexpected token: "]" at line 1306
    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
```
And:
```elixir
== Compilation error in file lib/ecto/changeset.ex ==
** (SyntaxError) lib/ecto/changeset.ex:1345: "{" is missing terminator "}". unexpected token: "]" at line 1345
    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
```
I'm unsure how master was compiling before this actually...

All tests pass:
```elixir
╰─➤  mix test                         
........................................................................................................................
........................................................................................................................
........................................................................................................................
........................................................................................................................
........................................................................................................................
........................................................................................................................
........................................................................................................................
........................................................................................................................
........................................................................................................................
...................

Finished in 12.8 seconds
1099 tests, 0 failures

Randomized with seed 697025
```