### PR TITLE
improvement on update_all doc

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -641,6 +641,8 @@ defmodule Ecto.Repo do
 
       MyRepo.update_all(Post, set: [title: "New title"])
 
+      MyRepo.update_all(Post, inc: [visits: 1])
+
       MyRepo.update_all(Post, [inc: [visits: 1]], [returning: [:visits]])
 
       from(p in Post, where: p.id < 10)

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -641,7 +641,7 @@ defmodule Ecto.Repo do
 
       MyRepo.update_all(Post, set: [title: "New title"])
 
-      MyRepo.update_all(Post, inc: [visits: 1])
+      MyRepo.update_all(Post, [inc: [visits: 1]], [returning: [:visits]])
 
       from(p in Post, where: p.id < 10)
       |> MyRepo.update_all(set: [title: "New title"])


### PR DESCRIPTION
since update and opts are both keyword, a novice user might make a
mistake and write the code like

    MyRepo.update_all(Post, inc: [visits: 1], returning: [:visits])

Which is wrong! and would get and error like

   ** (Ecto.Query.CompileError) unknown key `:returning` in update
       (ecto) lib/ecto/repo/queryable.ex:90:
       Ecto.Repo.Queryable.update_all/5

Which doesn't help the user to fix the problem

I hope this little tweak can save some debugging time