### PR TITLE
Support `prefix` in subqueries.

### DIFF
--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -90,6 +90,18 @@ defmodule Ecto.QueryTest do
       assert subquery(subquery("posts")).query.from == {"posts", nil}
       assert subquery(subquery("posts").query).query.from == {"posts", nil}
     end
+
+    test "prefix is not applied if left blank" do
+      assert subquery("posts").query.prefix == nil
+      assert subquery(subquery("posts")).query.prefix == nil
+      assert subquery(subquery("posts").query).query.prefix == nil
+    end
+
+    test "applies prefix to the subquery's query if provided" do
+      assert subquery("posts", prefix: "my_prefix").query.prefix == "my_prefix"
+      assert subquery(subquery("posts", prefix: "my_prefix")).query.prefix == "my_prefix"
+      assert subquery(subquery("posts", prefix: "my_prefix").query).query.prefix == "my_prefix"
+    end
   end
 
   describe "bindings" do


### PR DESCRIPTION
I raised an issue a while back (https://github.com/elixir-ecto/ecto/issues/2036) regarding a lack of a `prefix` option in subqueries. I closed it at the time because I found a workaround, and assumed there was no good reason to include it.

I ran into another case where this was required, so attempted to add the required functionality.

Please review that this makes sense, I'm not very familiar with the rest of the code. All tests do still pass though.