### PR TITLE
Set foreign key type to same used on primary keys

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -834,6 +834,8 @@ defmodule Ecto.Migration do
   end
 
   def references(table, opts) when is_binary(table) and is_list(opts) do
+    repo_opts = Keyword.take(Runner.repo_config(:migration_primary_key, []), [:type])
+    opts = Keyword.merge(repo_opts, opts)
     reference = struct(%Reference{table: table}, opts)
 
     unless reference.on_delete in [:nothing, :delete_all, :nilify_all] do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -7,6 +7,7 @@ defmodule Ecto.Adapters.MySQLTest do
 
   alias Ecto.Queryable
   alias Ecto.Adapters.MySQL.Connection, as: SQL
+  alias Ecto.Migration.Reference
 
   defmodule Schema do
     use Ecto.Schema
@@ -546,7 +547,7 @@ defmodule Ecto.Adapters.MySQLTest do
   # DDL
 
   import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3,
-                                references: 1, references: 2, constraint: 3]
+                                constraint: 3]
 
   test "executing a string during migration" do
     assert execute_ddl("example") == ["example"]
@@ -581,7 +582,7 @@ defmodule Ecto.Adapters.MySQLTest do
 
   test "create table with prefix" do
     create = {:create, table(:posts, prefix: :foo),
-               [{:add, :category_0, references(:categories, prefix: :foo), []}]}
+               [{:add, :category_0, %Reference{table: :categories}, []}]}
 
     assert execute_ddl(create) == ["""
     CREATE TABLE `foo`.`posts` (`category_0` BIGINT UNSIGNED,
@@ -599,11 +600,11 @@ defmodule Ecto.Adapters.MySQLTest do
   test "create table with references" do
     create = {:create, table(:posts),
                [{:add, :id, :serial, [primary_key: true]},
-                {:add, :category_0, references(:categories), []},
-                {:add, :category_1, references(:categories, name: :foo_bar), []},
-                {:add, :category_2, references(:categories, on_delete: :nothing), []},
-                {:add, :category_3, references(:categories, on_delete: :delete_all), [null: false]},
-                {:add, :category_4, references(:categories, on_delete: :nilify_all), []}]}
+                {:add, :category_0, %Reference{table: :categories}, []},
+                {:add, :category_1, %Reference{table: :categories, name: :foo_bar}, []},
+                {:add, :category_2, %Reference{table: :categories, on_delete: :nothing}, []},
+                {:add, :category_3, %Reference{table: :categories, on_delete: :delete_all}, [null: false]},
+                {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []}]}
 
     assert execute_ddl(create) == ["""
     CREATE TABLE `posts` (`id` bigint unsigned not null auto_increment,
@@ -688,10 +689,10 @@ defmodule Ecto.Adapters.MySQLTest do
   test "alter table" do
     alter = {:alter, table(:posts),
                [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
-                {:add, :author_id, references(:author), []},
+                {:add, :author_id, %Reference{table: :author}, []},
                 {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
                 {:modify, :cost, :integer, [null: false, default: nil]},
-                {:modify, :permalink_id, references(:permalinks), null: false},
+                {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
                 {:remove, :summary}]}
 
     assert execute_ddl(alter) == ["""
@@ -707,8 +708,8 @@ defmodule Ecto.Adapters.MySQLTest do
 
   test "alter table with prefix" do
     alter = {:alter, table(:posts, prefix: :foo),
-               [{:add, :author_id, references(:author), []},
-                {:modify, :permalink_id, references(:permalinks), null: false}]}
+               [{:add, :author_id, %Reference{table: :author}, []},
+                {:modify, :permalink_id, %Reference{table: :permalinks}, null: false}]}
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE `foo`.`posts` ADD `author_id` BIGINT UNSIGNED,

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -708,8 +708,9 @@ defmodule Ecto.Adapters.PostgresTest do
 
   # DDL
 
-  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3, references: 1,
-                                references: 2, constraint: 2, constraint: 3]
+  alias Ecto.Migration.Reference
+  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3,
+                                constraint: 2, constraint: 3]
 
   test "executing a string during migration" do
     assert execute_ddl("example") == ["example"]
@@ -736,7 +737,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "create table with prefix" do
     create = {:create, table(:posts, prefix: :foo),
-              [{:add, :category_0, references(:categories), []}]}
+              [{:add, :category_0, %Reference{table: :categories}, []}]}
 
     assert execute_ddl(create) == ["""
     CREATE TABLE "foo"."posts"
@@ -747,7 +748,7 @@ defmodule Ecto.Adapters.PostgresTest do
   test "create table with comment on columns and table" do
     create = {:create, table(:posts, comment: "comment"),
               [
-                {:add, :category_0, references(:categories), [comment: "column comment"]},
+                {:add, :category_0, %Reference{table: :categories}, [comment: "column comment"]},
                 {:add, :created_at, :timestamp, []},
                 {:add, :updated_at, :timestamp, [comment: "column comment 2"]}
               ]}
@@ -762,7 +763,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "create table with comment on table" do
     create = {:create, table(:posts, comment: "table comment", prefix: "foo"),
-              [{:add, :category_0, references(:categories), []}]}
+              [{:add, :category_0, %Reference{table: :categories}, []}]}
     assert execute_ddl(create) == [remove_newlines("""
     CREATE TABLE "foo"."posts"
     ("category_0" bigint CONSTRAINT "posts_category_0_fkey" REFERENCES "foo"."categories"("id"))
@@ -773,7 +774,7 @@ defmodule Ecto.Adapters.PostgresTest do
   test "create table with comment on columns" do
     create = {:create, table(:posts, prefix: "foo"),
               [
-                {:add, :category_0, references(:categories), [comment: "column comment"]},
+                {:add, :category_0, %Reference{table: :categories}, [comment: "column comment"]},
                 {:add, :created_at, :timestamp, []},
                 {:add, :updated_at, :timestamp, [comment: "column comment 2"]}
               ]}
@@ -788,15 +789,15 @@ defmodule Ecto.Adapters.PostgresTest do
   test "create table with references" do
     create = {:create, table(:posts),
               [{:add, :id, :serial, [primary_key: true]},
-               {:add, :category_0, references(:categories), []},
-               {:add, :category_1, references(:categories, name: :foo_bar), []},
-               {:add, :category_2, references(:categories, on_delete: :nothing), []},
-               {:add, :category_3, references(:categories, on_delete: :delete_all), [null: false]},
-               {:add, :category_4, references(:categories, on_delete: :nilify_all), []},
-               {:add, :category_5, references(:categories, on_update: :nothing), []},
-               {:add, :category_6, references(:categories, on_update: :update_all), [null: false]},
-               {:add, :category_7, references(:categories, on_update: :nilify_all), []},
-               {:add, :category_8, references(:categories, on_delete: :nilify_all, on_update: :update_all), [null: false]}]}
+               {:add, :category_0, %Reference{table: :categories}, []},
+               {:add, :category_1, %Reference{table: :categories, name: :foo_bar}, []},
+               {:add, :category_2, %Reference{table: :categories, on_delete: :nothing}, []},
+               {:add, :category_3, %Reference{table: :categories, on_delete: :delete_all}, [null: false]},
+               {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
+               {:add, :category_5, %Reference{table: :categories, on_update: :nothing}, []},
+               {:add, :category_6, %Reference{table: :categories, on_update: :update_all}, [null: false]},
+               {:add, :category_7, %Reference{table: :categories, on_update: :nilify_all}, []},
+               {:add, :category_8, %Reference{table: :categories, on_delete: :nilify_all, on_update: :update_all}, [null: false]}]}
 
     assert execute_ddl(create) == ["""
     CREATE TABLE "posts" ("id" serial,
@@ -872,10 +873,10 @@ defmodule Ecto.Adapters.PostgresTest do
   test "alter table" do
     alter = {:alter, table(:posts),
              [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
-              {:add, :author_id, references(:author), []},
+              {:add, :author_id, %Reference{table: :author}, []},
               {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
               {:modify, :cost, :integer, [null: false, default: nil]},
-              {:modify, :permalink_id, references(:permalinks), null: false},
+              {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
               {:remove, :summary}]}
 
     assert execute_ddl(alter) == ["""
@@ -898,7 +899,7 @@ defmodule Ecto.Adapters.PostgresTest do
     alter = {:alter, table(:posts, comment: "table comment"),
              [{:add, :title, :string, [default: "Untitled", size: 100, null: false, comment: "column comment"]},
               {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
-              {:modify, :permalink_id, references(:permalinks), [null: false, comment: "column comment"]},
+              {:modify, :permalink_id, %Reference{table: :permalinks}, [null: false, comment: "column comment"]},
               {:remove, :summary}]}
 
     assert execute_ddl(alter) == [remove_newlines("""
@@ -919,8 +920,8 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "alter table with prefix" do
     alter = {:alter, table(:posts, prefix: :foo),
-             [{:add, :author_id, references(:author, prefix: :foo), []},
-              {:modify, :permalink_id, references(:permalinks, prefix: :foo), null: false}]}
+             [{:add, :author_id, %Reference{table: :author}, []},
+              {:modify, :permalink_id, %Reference{table: :permalinks}, null: false}]}
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE "foo"."posts"

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -514,5 +514,16 @@ defmodule Ecto.MigrationTest do
     assert "SELECT 2" = last_command()
   end
 
+  test "references foreign keys types must be the same as primary defaults" do
+    %{runner: runner} = Process.get(:ecto_migration)
+    Agent.update(runner, fn state ->
+      config = Keyword.put(state.config, :migration_primary_key, [type: :binary_id])
+      Map.put(state, :config, config)
+    end)
+
+    assert references(:posts) ==
+           %Reference{table: "posts", column: :id, type: :binary_id}
+  end
+
   defp last_command(), do: Process.get(:last_command)
 end


### PR DESCRIPTION
User defined primary key types set on configuration also defines the
type for foreign keys.