### PR TITLE
Corrected instruction for supervision tree under Ecto 1.5

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -99,7 +99,6 @@ def start(_type, _args) do
 `Elixir >= 1.5.0`:
 ```elixir
 def start(_type, _args) do
-  import Supervisor.Spec
 
   children = [
     Friends.Repo,


### PR DESCRIPTION
“import Supervisor.Spec” is not applicable when using Ecto 1.5.