### PR TITLE
Lock migrations to support multiple concurrent migrators

### DIFF
--- a/integration_test/cases/migrator.exs
+++ b/integration_test/cases/migrator.exs
@@ -111,7 +111,7 @@ defmodule Ecto.Integration.MigratorTest do
   end
 
   defp count_entries() do
-    length Process.get(:migrations)
+    PoolRepo.aggregate(SchemaMigration, :count, :version)
   end
 
   defp create_migration(num) do

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -50,4 +50,6 @@ defmodule Ecto.Adapter.Migration  do
     * `:log` - When false, does not log begin/commit/rollback queries
   """
   @callback execute_ddl(repo :: Ecto.Repo.t, command, options :: Keyword.t) :: :ok | no_return
+
+  @callback lock_for_migrations(repo :: Ecto.Repo.t, options :: Keyword.t) :: :ok | no_return
 end

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -51,5 +51,6 @@ defmodule Ecto.Adapter.Migration  do
   """
   @callback execute_ddl(repo :: Ecto.Repo.t, command, options :: Keyword.t) :: :ok | no_return
 
-  @callback lock_for_migrations(repo :: Ecto.Repo.t, options :: Keyword.t, function :: fun) :: {:ok, any} | {:error, any}
+  @callback lock_for_migrations(repo :: Ecto.Repo.t, table :: String.t, options :: Keyword.t, function :: fun) ::
+    {:ok, any} | {:error, any}
 end

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -51,5 +51,5 @@ defmodule Ecto.Adapter.Migration  do
   """
   @callback execute_ddl(repo :: Ecto.Repo.t, command, options :: Keyword.t) :: :ok | no_return
 
-  @callback lock_for_migrations(repo :: Ecto.Repo.t, options :: Keyword.t) :: :ok | no_return
+  @callback lock_for_migrations(repo :: Ecto.Repo.t, options :: Keyword.t, function :: fun) :: {:ok, any} | {:error, any}
 end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -136,8 +136,14 @@ defmodule Ecto.Adapters.SQL do
         :ok
       end
 
+      @doc false
+      def lock_for_migrations(repo, opts) do
+        Ecto.Adapters.SQL.lock_for_migrations(repo, opts)
+      end
+
       defoverridable [prepare: 2, execute: 6, insert: 6, update: 6, delete: 4, insert_all: 7,
-                      execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1, ensure_all_started: 2]
+                      execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1, ensure_all_started: 2,
+                      lock_for_migrations: 2]
     end
   end
 
@@ -594,6 +600,13 @@ defmodule Ecto.Adapters.SQL do
       nil  -> raise "cannot call rollback outside of transaction"
       conn -> DBConnection.rollback(conn, value)
     end
+  end
+
+  ## Migrations
+
+  @doc false
+  def lock_for_migrations(repo, opts) do
+    # TODO: Figure out what should go here
   end
 
   ## Log

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -608,7 +608,7 @@ defmodule Ecto.Adapters.SQL do
   def lock_for_migrations(repo, table, opts, fun) do
     import Ecto.Query, only: [from: 2]
 
-    transaction(repo, [log: false, timeout: :infinity] ++ [opts], fn ->
+    transaction(repo, opts ++ [log: false, timeout: :infinity], fn ->
       versions =
         from(p in table, select: type(p.version, :integer))
         |> Map.put(:prefix, opts[:prefix])

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -608,7 +608,7 @@ defmodule Ecto.Adapters.SQL do
   def lock_for_migrations(repo, table, opts, fun) do
     import Ecto.Query, only: [from: 2]
 
-    transaction(repo, opts, fn ->
+    transaction(repo, [log: false, timeout: :infinity | opts], fn ->
       versions =
         from(p in table, select: type(p.version, :integer))
         |> Map.put(:prefix, opts[:prefix])

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -137,13 +137,13 @@ defmodule Ecto.Adapters.SQL do
       end
 
       @doc false
-      def lock_for_migrations(repo, opts, fun) do
-        Ecto.Adapters.SQL.lock_for_migrations(repo, opts, fun)
+      def lock_for_migrations(repo, table, opts, fun) do
+        Ecto.Adapters.SQL.lock_for_migrations(repo, table, opts, fun)
       end
 
       defoverridable [prepare: 2, execute: 6, insert: 6, update: 6, delete: 4, insert_all: 7,
                       execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1, ensure_all_started: 2,
-                      lock_for_migrations: 3]
+                      lock_for_migrations: 4]
     end
   end
 
@@ -605,17 +605,17 @@ defmodule Ecto.Adapters.SQL do
   ## Migrations
 
   @doc false
-  def lock_for_migrations(repo, opts, fun) do
-    alias Ecto.Migration.SchemaMigration
+  def lock_for_migrations(repo, table, opts, fun) do
     import Ecto.Query, only: [from: 2]
 
     transaction(repo, opts, fn ->
-      from(p in {SchemaMigration.get_source(repo), SchemaMigration}, select: p.version)
-      |> Map.put(:prefix, opts[:prefix])
-      |> Map.put(:lock, "FOR UPDATE")
-      |> repo.all(timeout: :infinity, log: false)
+      versions =
+        from(p in table, select: p.version)
+        |> Map.put(:prefix, opts[:prefix])
+        |> Map.put(:lock, "FOR UPDATE")
+        |> repo.all()
 
-      fun.()
+      fun.(versions)
     end)
   end
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -610,7 +610,7 @@ defmodule Ecto.Adapters.SQL do
 
     transaction(repo, opts, fn ->
       versions =
-        from(p in table, select: p.version)
+        from(p in table, select: type(p.version, :integer))
         |> Map.put(:prefix, opts[:prefix])
         |> Map.put(:lock, "FOR UPDATE")
         |> repo.all()

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -608,7 +608,7 @@ defmodule Ecto.Adapters.SQL do
   def lock_for_migrations(repo, table, opts, fun) do
     import Ecto.Query, only: [from: 2]
 
-    transaction(repo, [log: false, timeout: :infinity | opts], fn ->
+    transaction(repo, [log: false, timeout: :infinity] ++ [opts], fn ->
       versions =
         from(p in table, select: type(p.version, :integer))
         |> Map.put(:prefix, opts[:prefix])

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -18,12 +18,6 @@ defmodule Ecto.Migration.SchemaMigration do
     create_migrations_table(adapter, repo, prefix)
   end
 
-  def migrated_versions(repo, prefix) do
-    from(p in {get_source(repo), __MODULE__}, select: p.version)
-    |> Map.put(:prefix, prefix)
-    |> repo.all(@opts)
-  end
-
   def up(repo, version, prefix) do
     %__MODULE__{version: version}
     |> Ecto.put_meta(prefix: prefix, source: get_source(repo))

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -149,7 +149,8 @@ defmodule Ecto.Migrator do
       module.__migration__[:disable_ddl_transaction] ->
         fun.()
       repo.__adapter__.supports_ddl_transaction? ->
-        repo.transaction(fun, [log: false, timeout: :infinity])
+        {:ok, result} = repo.transaction(fun, [log: false, timeout: :infinity])
+        result
       true ->
         fun.()
     end

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -108,6 +108,11 @@ defmodule Ecto.TestAdapter do
 
   ## Migrations
 
+  def lock_for_migrations(repo, opts, fun) do
+    send self(), {:lock_for_migrations, fun}
+    {:ok, fun.()}
+  end
+
   def supports_ddl_transaction? do
     Process.get(:supports_ddl_transaction?) || false
   end

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -35,11 +35,6 @@ defmodule Ecto.TestAdapter do
 
   def prepare(operation, query), do: {:nocache, {operation, query}}
 
-  def execute(_repo, _, {:nocache, {:all, %{from: {_, SchemaMigration}}}}, _, _, _) do
-    {length(migrated_versions()),
-     Enum.map(migrated_versions(), &List.wrap/1)}
-  end
-
   def execute(_repo, _, {:nocache, {:all, _}}, _, _, _) do
     Process.get(:test_repo_all_results) || {1, [[1]]}
   end
@@ -108,9 +103,9 @@ defmodule Ecto.TestAdapter do
 
   ## Migrations
 
-  def lock_for_migrations(repo, opts, fun) do
+  def lock_for_migrations(repo, table, opts, fun) do
     send self(), {:lock_for_migrations, fun}
-    {:ok, fun.()}
+    {:ok, fun.(migrated_versions())}
   end
 
   def supports_ddl_transaction? do

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -36,7 +36,7 @@ defmodule Ecto.TestAdapter do
   def prepare(operation, query), do: {:nocache, {operation, query}}
 
   def execute(_repo, _, {:nocache, {:all, _}}, _, _, _) do
-    Process.get(:test_repo_all_results) || {1, [[1]]}
+    get_config(:test_repo_all_results, {1, [[1]]})
   end
 
   def execute(_repo, _meta, {:nocache, {:delete_all, %{from: {_, SchemaMigration}}}}, [version], _, _) do
@@ -45,13 +45,13 @@ defmodule Ecto.TestAdapter do
   end
 
   def execute(_repo, meta, {:nocache, {op, %{from: {source, _}}}}, _params, _preprocess, _opts) do
-    send self(), {op, {meta.prefix,source}}
+    send test_process(), {op, {meta.prefix,source}}
     {1, nil}
   end
 
   def stream(repo, meta, prepared, params, preprocess, opts) do
     Stream.map([:execute], fn(:execute) ->
-      send self(), :stream_execute
+      send test_process(), :stream_execute
       execute(repo, meta, prepared, params, preprocess, opts)
     end)
   end
@@ -59,7 +59,7 @@ defmodule Ecto.TestAdapter do
   ## Schema
 
   def insert_all(_repo, %{source: source}, _header, rows, _on_conflict, _returning, _opts) do
-    send self(), {:insert_all, source, rows}
+    send test_process(), {:insert_all, source, rows}
     {1, nil}
   end
 
@@ -70,24 +70,24 @@ defmodule Ecto.TestAdapter do
   end
 
   def insert(_repo, %{context: nil, source: source}, _fields, _on_conflict, return, _opts),
-    do: send(self(), {:insert, source}) && {:ok, Enum.zip(return, 1..length(return))}
+    do: send(test_process(), {:insert, source}) && {:ok, Enum.zip(return, 1..length(return))}
   def insert(_repo, %{context: {:invalid, _} = res}, _fields, _on_conflict, _return, _opts),
     do: res
 
   # Notice the list of changes is never empty.
   def update(_repo, %{context: nil, source: source}, [_|_], _filters, return, _opts),
-    do: send(self(), {:update, source}) && {:ok, Enum.zip(return, 1..length(return))}
+    do: send(test_process(), {:update, source}) && {:ok, Enum.zip(return, 1..length(return))}
   def update(_repo, %{context: {:invalid, _} = res}, [_|_], _filters, _return, _opts),
     do: res
 
   def delete(_repo, meta, _filter, _opts),
-    do: send(self(), {:delete, meta.source}) && {:ok, []}
+    do: send(test_process(), {:delete, meta.source}) && {:ok, []}
 
   ## Transactions
 
   def transaction(_repo, _opts, fun) do
     # Makes transactions "trackable" in tests
-    send self(), {:transaction, fun}
+    send test_process(), {:transaction, fun}
     try do
       {:ok, fun.()}
     catch
@@ -97,19 +97,19 @@ defmodule Ecto.TestAdapter do
   end
 
   def rollback(_repo, value) do
-    send self(), {:rollback, value}
+    send test_process(), {:rollback, value}
     throw {:ecto_rollback, value}
   end
 
   ## Migrations
 
-  def lock_for_migrations(repo, table, opts, fun) do
-    send self(), {:lock_for_migrations, fun}
+  def lock_for_migrations(_repo, _table, _opts, fun) do
+    send test_process(), {:lock_for_migrations, fun}
     {:ok, fun.(migrated_versions())}
   end
 
   def supports_ddl_transaction? do
-    Process.get(:supports_ddl_transaction?) || false
+    get_config(:supports_ddl_transaction?, false)
   end
 
   def execute_ddl(_repo, command, _) do
@@ -118,7 +118,17 @@ defmodule Ecto.TestAdapter do
   end
 
   defp migrated_versions do
-    Process.get(:migrated_versions) || []
+    get_config(:migrated_versions, [])
+  end
+
+  defp test_process do
+    get_config(:test_process, self())
+  end
+
+  defp get_config(name, default) do
+    :ecto
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(name, Process.get(name, default))
   end
 end
 


### PR DESCRIPTION
This is still a work in progress. I wanted to put this up for feedback.

* Locks migrations table in a transaction
* Wraps each migration in a Task, which may have its own transaction
* Propogates errors up, while ensure transactions are committed