### PR TITLE
Fix IN query related bug

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -857,7 +857,7 @@ defmodule Ecto.Query.Planner do
   defp validate_in(meta, expr, param, acc) do
     {v, _t} = Enum.fetch!(expr.params, param)
     length  = length(v)
-    {{:^, meta, [acc, length]}, acc + 1}
+    {{:^, meta, [acc, length]}, acc + length}
   end
 
   defp normalize_select(%{select: nil} = query) do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -341,7 +341,7 @@ defmodule Ecto.Query.PlannerTest do
     {query, params} = where(Post, [p], p.title == ^"foo" and p.id in ^[1, 2, 3] and
                                        p.title == ^"bar") |> normalize_with_params()
     assert Macro.to_string(hd(query.wheres).expr) ==
-           "&0.post_title() == ^0 and &0.id() in ^(1, 3) and &0.post_title() == ^2"
+           "&0.post_title() == ^0 and &0.id() in ^(1, 3) and &0.post_title() == ^4"
     assert params == ["foo", 1, 2, 3, "bar"]
   end
 


### PR DESCRIPTION
The query `params` are assigned wrong counters whenever we have any `WHERE` query followed by an `IN` query. This results in wrong params assigned to the final query.

I believe this effects only those databases which do not support prepared statements, or queries which cannot be cached.

The fixed test case should explain the issue much better.

I was able to replicate the issue using Ecto  and MongoDB. If needed, i can provide a sample from the same.

Thanks