### PR TITLE
document --quiet and add -q shorthand

### DIFF
--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -4,6 +4,16 @@ defmodule Mix.Tasks.Ecto.Dump do
 
   @shortdoc "Dumps the repository database structure"
 
+  @aliases [
+    d: :dump_path,
+    q: :quiet
+  ]
+
+  @switches [
+    dump_path: :string,
+    quiet: :boolean
+  ]
+
   @moduledoc """
   Dumps the current environment's database structure for the
   given repository into a structure file.
@@ -26,11 +36,12 @@ defmodule Mix.Tasks.Ecto.Dump do
 
     * `-r`, `--repo` - the repo to load the structure info from
     * `-d`, `--dump-path` - the path of the dump file to create
+    * `-q`, `--quiet` - run the command quietly
   """
 
   def run(args) do
     {opts, _, _} =
-      OptionParser.parse args, switches: [dump_path: :string, quiet: :boolean], aliases: [d: :dump_path]
+      OptionParser.parse args, switches: @switches, aliases: @aliases
 
     Enum.each parse_repo(args), fn repo ->
       ensure_repo(repo, args)

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -3,6 +3,7 @@ defmodule Mix.Tasks.Ecto.Dump do
   import Mix.Ecto
 
   @shortdoc "Dumps the repository database structure"
+  @default_opts [quiet: false]
 
   @aliases [
     d: :dump_path,
@@ -42,6 +43,8 @@ defmodule Mix.Tasks.Ecto.Dump do
   def run(args) do
     {opts, _, _} =
       OptionParser.parse args, switches: @switches, aliases: @aliases
+
+    opts = Keyword.merge(@default_opts, opts)
 
     Enum.each parse_repo(args), fn repo ->
       ensure_repo(repo, args)

--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -3,7 +3,19 @@ defmodule Mix.Tasks.Ecto.Load do
   import Mix.Ecto
 
   @shortdoc "Loads previously dumped database structure"
-  @default_opts [force: false]
+  @default_opts [force: false, quiet: false]
+
+  @aliases [
+    d: :dump_path,
+    f: :force,
+    q: :quiet
+  ]
+
+  @switches [
+    dump_path: :string,
+    force: :boolean,
+    quiet: :boolean
+  ]
 
   @moduledoc """
   Loads the current environment's database structure for the
@@ -27,12 +39,13 @@ defmodule Mix.Tasks.Ecto.Load do
 
     * `-r`, `--repo` - the repo to load the structure info into
     * `-d`, `--dump-path` - the path of the dump file to load from
-    * `--force` - do not ask for confirmation
+    * `-f`, `--force` - do not ask for confirmation
+    * `-q`, `--quiet` - run the command quietly
   """
 
   def run(args) do
     {opts, _, _} =
-      OptionParser.parse args, switches: [dump_path: :string, quiet: :boolean, force: :boolean], aliases: [d: :dump_path]
+      OptionParser.parse args, switches: @switches, aliases: @aliases
 
     opts = Keyword.merge(@default_opts, opts)
 


### PR DESCRIPTION
This documents `--quiet` and adds a `-q` shorthand as well.