### PR TITLE
Remove hard-coded "Ecto.Association.NotLoaded"

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -16,7 +16,7 @@ defmodule Ecto.Association.NotLoaded do
   defimpl Inspect do
     def inspect(not_loaded, _opts) do
       msg = "association #{inspect not_loaded.__field__} is not loaded"
-      ~s(#Ecto.Association.NotLoaded<#{msg}>)
+      ~s(##{inspect @for}<#{msg}>)
     end
   end
 end


### PR DESCRIPTION
I thought it was a little weird seeing the string `"Ecto.Association.NotLoaded"` in that module's Inspect implementation. This change calls `inspect @for` to get the module name dynamically.
It looks like the Inspect implementation for this module already has test coverage in test/ecto/schema_test.exs.