### PR TITLE
Add migration_lock repo configuration

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -606,10 +606,11 @@ defmodule Ecto.Adapters.SQL do
 
   @doc false
   def lock_for_migrations(repo, query, opts, fun) do
+    {_repo_mod, _pool, default_opts} = lookup_pool(repo)
     {:ok, result} =
       transaction(repo, opts ++ [log: false, timeout: :infinity], fn ->
         query
-        |> Map.put(:lock, "FOR UPDATE")
+        |> Map.put(:lock, Keyword.get(default_opts, :migration_lock, "FOR UPDATE"))
         |> repo.all()
         |> fun.()
       end)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -169,6 +169,11 @@ defmodule Ecto.Migration do
 
           config :app, App.Repo, migration_timestamps: [type: :utc_datetime]
 
+    * `:migration_lock` - Ecto will lock the migration table to handle concurrent
+      migrators using `FOR UPDATE` by default but you can configure it via:
+
+          config :app, App.Repo, migration_lock: nil
+
   """
 
   defmodule Index do


### PR DESCRIPTION
Added migration_lock repo configuration in order to override the lock that is being used by migrators to handle multiple concurrent migrators.

By default "FOR UPDATE" is being used.

Fixes #2233