### PR TITLE
Get rid of extra 'to' in error message.

### DIFF
--- a/lib/mix/tasks/ecto.drop.ex
+++ b/lib/mix/tasks/ecto.drop.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Ecto.Drop do
     Enum.each repos, fn repo ->
       ensure_repo(repo, args)
       ensure_implements(repo.__adapter__, Ecto.Adapter.Storage,
-                                          "to drop storage for #{inspect repo}")
+                                          "drop storage for #{inspect repo}")
 
       if skip_safety_warnings?() or
          opts[:force] or


### PR DESCRIPTION
(this)[https://github.com/elixir-ecto/ecto/blob/master/lib/mix/ecto.ex#L206] line would cause the message to be printed as:

`Expected SomeAdapter to implement Ecto.Adapter.Storage in order to to drop storage for SomeRepo`

This change fixes the sentence so it reads: 

`Expected SomeAdapter to implement Ecto.Adapter.Storage in order to drop storage for SomeRepo`