### PR TITLE
Add unsafe_fragment/1 query API

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -272,6 +272,39 @@ defmodule Ecto.Query.API do
   def fragment(fragments), do: doc! [fragments]
 
   @doc """
+  Send an unsafe fragment directly to the database.
+
+  WARNING: sending an unsafe fragment may expose your application to sql
+  injection attacks. Think twice before using it and try to reach the same
+  result using the safe fragment/1 API.
+
+  Sometimes it is not possible to represent all possible databases queries
+  using Ecto's syntax or fragment/1, expecially when dealing with specific
+  database construct and dynamic fields.
+
+  To overcome this, it is possible to build the expression as a binary
+  outside the query expression and send it to the database by interpolating
+  the value in the query.
+
+      def window_sorting(field, dir) do
+        expr = "ROW_NUMBER() OVER(ORDER BY \#{field} \#{dir})"
+        from p in Post,
+          select: %{p | id: unsafe_fragment(^expr)}
+      end
+
+  In the example above, we are using the row_number() sql window function to
+  do a particular type of ordering.
+
+  It is very important to keep in mind that no input sanitization is done
+  by Ecto, so the application may be open to sql injection attacks if the
+  expression is not built properly.
+
+  Only an interpolated string (binary) is supported, any other value will
+  result into a compilation error or ArgumentError during runtime.
+  """
+  def unsafe_fragment(fragment), do: doc! [fragment]
+
+  @doc """
   Allows a field to be dynamically accessed.
 
       def at_least_four(doors_or_tires) do

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -271,7 +271,7 @@ defmodule Ecto.Query.API do
   """
   def fragment(fragments), do: doc! [fragments]
 
-  @doc """
+  @doc ~S"""
   Send an unsafe fragment directly to the database.
 
   WARNING: sending an unsafe fragment may expose your application to sql
@@ -292,11 +292,11 @@ defmodule Ecto.Query.API do
             :asc -> "ASC"
             :desc -> "DESC"
           end
-          "\#{key} \#{dir}"
+          "#{key} #{dir}"
         end
         |> Enum.join(",")
       
-        expr = "ROW_NUMBER() OVER(ORDER BY \#{sort})"
+        expr = "ROW_NUMBER() OVER(ORDER BY #{sort})"
         from p in Post,
           select: %{p | id: unsafe_fragment(^expr)}
       end

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -295,7 +295,7 @@ defmodule Ecto.Query.API do
           "#{key} #{dir}"
         end
         |> Enum.join(",")
-      
+
         expr = "ROW_NUMBER() OVER(ORDER BY #{sort})"
         from p in Post,
           select: %{p | id: unsafe_fragment(^expr)}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -553,8 +553,23 @@ defmodule Ecto.Query.Builder do
   """
   def keyword!(kw) do
     unless Keyword.keyword?(kw) do
-      raise ArgumentError, "to prevent sql injection, only a keyword list may be interpolated " <>
-                           "as the first argument to `fragment/1` with the `^` operator, got `#{inspect kw}`"
+      message = """
+      to prevent sql injection, only a keyword list may be interpolated
+      as the first argument to `fragment/1` with the `^` operator, got `#{inspect kw}`
+      """
+      message = if is_binary(kw) do
+        message <> """
+
+        For interpolated strings use `unsafe_fragment/1` to pass the argument
+        as-is to the database, paying attention to possible sql injection attack
+        vectors as no escaping is done by Ecto.
+        
+        Use `unsafe_fragment/1` only as last resort and wisely.
+        """
+      else
+        message
+      end
+      raise ArgumentError, message: message
     end
 
     kw

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -56,6 +56,11 @@ defmodule Ecto.Query.Builder.Join do
     {:_, expr, nil, params}
   end
 
+  def escape({:unsafe_fragment, _, [{:^, _, [_var]}]} = expr, vars, env) do
+    {expr, {params, :acc}} = Builder.escape(expr, :any, {%{}, :acc}, vars, env)
+    {:_, expr, nil, params}
+  end
+
   def escape({:__aliases__, _, _} = module, _vars, _env) do
     {:_, {nil, module}, nil, %{}}
   end

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -56,7 +56,7 @@ defmodule Ecto.Query.Builder.Join do
     {:_, expr, nil, params}
   end
 
-  def escape({:unsafe_fragment, _, [{:^, _, [_var]}]} = expr, vars, env) do
+  def escape({:unsafe_fragment, _, [_]} = expr, vars, env) do
     {expr, {params, :acc}} = Builder.escape(expr, :any, {%{}, :acc}, vars, env)
     {:_, expr, nil, params}
   end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -100,6 +100,10 @@ defmodule Ecto.Query.Builder.Select do
     escape_with_type(expr, type, params_take, vars, env)
   end
 
+  defp escape({:type, _, [{:unsafe_fragment, _, [_]} = expr, type]}, params_take, vars, env) do
+    escape_with_type(expr, type, params_take, vars, env)
+  end
+
   defp escape({:type, _, [{agg, _, [_ | _]} = expr, type]}, params_take, vars, env)
        when agg in ~w(avg count max min sum)a do
     escape_with_type(expr, type, params_take, vars, env)

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -77,6 +77,26 @@ defmodule Ecto.Query.Builder.JoinTest do
     join("posts", :left, [p], c in unsafe_fragment(^frag), true)
   end
 
+  test "raises on non interpolated argument" do
+    assert_raise Ecto.Query.CompileError, ~r/expects a single argument/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in unsafe_fragment("comments"), true)
+      end, [], __ENV__)
+    end
+
+    assert_raise Ecto.Query.CompileError, ~r/expects a single argument/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in unsafe_fragment(["post"]), true)
+      end, [], __ENV__)
+    end
+
+    assert_raise Ecto.Query.CompileError, ~r/expects a single argument/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in unsafe_fragment(["$eq": "foo"]), true)
+      end, [], __ENV__)
+    end
+  end
+
   test "raises on invalid interpolated unsafe fragments" do
     frag = ["comments", "authors"]
     assert_raise ArgumentError, ~r/expects only an interpolated string/, fn ->

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -72,6 +72,23 @@ defmodule Ecto.Query.Builder.JoinTest do
     join("posts", :left, [p], c in subquery(subquery, prefix: "sample"), true)
   end
 
+  test "accepts interpolated binary as unsafe fragment" do
+    frag = "comments"
+    join("posts", :left, [p], c in unsafe_fragment(^frag), true)
+  end
+
+  test "raises on invalid interpolated unsafe fragments" do
+    frag = ["comments", "authors"]
+    assert_raise ArgumentError, ~r/expects only an interpolated string/, fn ->
+      join("posts", :left, [p], c in unsafe_fragment(^frag), true)
+    end
+
+    frag = ["comments": "authors"]
+    assert_raise ArgumentError, ~r/expects only an interpolated string/, fn ->
+      join("posts", :left, [p], c in unsafe_fragment(^frag), true)
+    end
+  end
+
   test "raises on invalid qualifier" do
     assert_raise ArgumentError,
                  ~r/invalid join qualifier `:whatever`/, fn ->

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -378,7 +378,7 @@ defmodule Ecto.QueryTest do
 
   describe "unsafe_fragment/1" do
     test "raises with non interpolated binary fragment" do
-      message = ~r"expects only an interpolated string"
+      message = ~r"expects a single argument to be interpolated"
       assert_raise Ecto.Query.CompileError, message, fn ->
         quote_and_eval(
           from p in "posts", where: unsafe_fragment("1 = 1")
@@ -387,7 +387,7 @@ defmodule Ecto.QueryTest do
     end
 
     test "raises with non interpolated binary and params" do
-      message = ~r"expects only an interpolated string"
+      message = ~r"expects a single argument to be interpolated"
       assert_raise Ecto.Query.CompileError, message, fn ->
         quote_and_eval(
           from p in "posts", where: unsafe_fragment("1 = ?", 1)
@@ -395,8 +395,26 @@ defmodule Ecto.QueryTest do
       end
     end
 
+    test "raises with non interpolated, non empty list" do
+      message = ~r"expects a single argument to be interpolated"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        quote_and_eval(
+          from p in "posts", where: unsafe_fragment(["foo", "bar"])
+        )
+      end
+    end
+
+    test "raises with non interpolated, empty list" do
+      message = ~r"expects a single argument to be interpolated"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        quote_and_eval(
+          from p in "posts", where: unsafe_fragment([])
+        )
+      end
+    end
+
     test "raises with non interpolated keyword list" do
-      message = ~r"expects only an interpolated string"
+      message = ~r"expects a single argument to be interpolated"
       assert_raise Ecto.Query.CompileError, message, fn ->
         quote_and_eval(
           from p in "posts", where: unsafe_fragment(["foo": "bar"])
@@ -407,6 +425,20 @@ defmodule Ecto.QueryTest do
     test "raises at runtime when interpolation is a keyword list" do
       assert_raise ArgumentError, ~r"expects only an interpolated string", fn ->
         clause = ["foo": "bar"]
+        from p in "posts", where: unsafe_fragment(^clause)
+      end
+    end
+
+    test "raises at runtime when interpolation is a non empty list" do
+      assert_raise ArgumentError, ~r"expects only an interpolated string", fn ->
+        clause = ["foo", "bar"]
+        from p in "posts", where: unsafe_fragment(^clause)
+      end
+    end
+
+    test "raises at runtime when interpolation is an empty list" do
+      assert_raise ArgumentError, ~r"expects only an interpolated string", fn ->
+        clause = []
         from p in "posts", where: unsafe_fragment(^clause)
       end
     end

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -364,7 +364,14 @@ defmodule Ecto.QueryTest do
 
   describe "fragment/1" do
     test "raises at runtime when interpolation is not a keyword list" do
-      assert_raise ArgumentError, ~r/only a keyword list.*1 = \?/, fn ->
+      assert_raise ArgumentError, ~r/only a keyword list.*1 = \?/s, fn ->
+        clause = ["1 = ?"]
+        from p in "posts", where: fragment(^clause)
+      end
+    end
+
+    test "raises at runtime when interpolation is a binary string" do
+      assert_raise ArgumentError, ~r/unsafe_fragment\/1/, fn ->
         clause = "1 = ?"
         from p in "posts", where: fragment(^clause)
       end


### PR DESCRIPTION
This PR adds support for unsafe_fragment/1 query API.

This is meant to be used to insert fragments only from interpolated binaries, to handle cases that fragment/1 is not able to handle.

This API may open the app to injection attacks if not used wisely, but proper warnings are in the doc and errors.