### PR TITLE
Add missing parameter names in Repo.load/2 typespec

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1092,5 +1092,6 @@ defmodule Ecto.Repo do
       [%User{...}, ...]
 
   """
-  @callback load(Ecto.Schema.t | map(), map() | Keyword.t | {list, list}) :: Ecto.Schema.t | map()
+  @callback load(struct_or_map :: Ecto.Schema.t | map(), data :: map() | Keyword.t | {list, list}) ::
+            Ecto.Schema.t | map()
 end


### PR DESCRIPTION
Documentation refers to the second argument as `data`, but function signature shows `load(arg0, arg1)`.