### PR TITLE
Increase ecto pool size for running migrations

### DIFF
--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -98,7 +98,7 @@ defmodule Mix.Ecto do
 
     {:ok, apps} = repo.__adapter__.ensure_all_started(repo, :temporary)
 
-    pool_size = Keyword.get(opts, :pool_size, 1)
+    pool_size = Keyword.get(opts, :pool_size, 2)
     case repo.start_link(pool_size: pool_size) do
       {:ok, pid} ->
         {:ok, pid, apps}

--- a/test/mix/ecto_test.exs
+++ b/test/mix/ecto_test.exs
@@ -21,7 +21,7 @@ defmodule Mix.EctoTest do
 
   defmodule Repo do
     def start_link(opts) do
-      assert opts[:pool_size] == 1
+      assert opts[:pool_size] == 2
       Process.get(:start_link)
     end
 


### PR DESCRIPTION
closes #2256

This will fix the immediate issue. In addition, Ecto should probably warn when the pool size is too small or capture the connection checkout error and suggest increasing the pool size.