### PR TITLE
Allow default to be a map when type is {:map, type} in migrations

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -795,11 +795,15 @@ if Code.ensure_loaded?(Postgrex) do
       default = Application.get_env(:postgrex, :json_library, Poison).encode!(map)
       [" DEFAULT ", single_quote(default)]
     end
+    defp default_expr({:ok, %{} = map}, {:map, _type}) do
+      default = Application.get_env(:postgrex, :json_library, Poison).encode!(map)
+      [" DEFAULT ", single_quote(default)]
+    end
     defp default_expr({:ok, {:fragment, expr}}, _type),
       do: [" DEFAULT ", expr]
     defp default_expr({:ok, expr}, type),
       do: raise(ArgumentError, "unknown default `#{inspect expr}` for type `#{inspect type}`. " <>
-                               ":default may be a string, number, boolean, empty list, map (when type is Map), or a fragment(...)")
+                               ":default may be a string, number, boolean, empty list, map (when type is :map), or a fragment(...)")
     defp default_expr(:error, _),
       do: []
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -870,6 +870,33 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')|]
   end
 
+  test "create table with a typed map column, and an empty map default" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, {:map, :string}, [default: %{}]}
+              ]
+            }
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{}')|]
+  end
+
+  test "create table with a typed map column, and a map default with values" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, {:map, :string}, [default: %{foo: "bar", baz: "boom"}]}
+              ]
+            }
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')|]
+  end
+
+  test "create table with a typed map column, and a string default" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, {:map, :string}, [default: ~s|{"foo":"bar","baz":"boom"}|]}
+              ]
+            }
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("a" jsonb DEFAULT '{"foo":"bar","baz":"boom"}')|]
+  end
+
   test "drop table" do
     drop = {:drop, table(:posts)}
     assert execute_ddl(drop) == [~s|DROP TABLE "posts"|]


### PR DESCRIPTION
Allows to do this:

```elixir
add :field, {:map, :string}, default: %{}
```

Not sure if that makes sense since the `type` isn't actually used by any adapter (I think?) but since it's allowed in the migration it's nice to be able to add a default on these too.

