### PR TITLE
Document using a fragment with order_by/3

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -966,6 +966,14 @@ defmodule Ecto.Query do
       values = [asc: :name, desc: :population]
       from(c in City, order_by: ^values)
 
+  A fragment can also be used:
+
+    from c in City, order_by: [
+      # a deterministic shuffled order
+      fragment("? % ? DESC", c.id, ^modulus),
+      desc: c.id,
+    ]
+
   ## Expressions example
 
       City |> order_by([c], asc: c.name, desc: c.population)

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -968,11 +968,11 @@ defmodule Ecto.Query do
 
   A fragment can also be used:
 
-    from c in City, order_by: [
-      # a deterministic shuffled order
-      fragment("? % ? DESC", c.id, ^modulus),
-      desc: c.id,
-    ]
+      from c in City, order_by: [
+        # a deterministic shuffled order
+        fragment("? % ? DESC", c.id, ^modulus),
+        desc: c.id,
+      ]
 
   ## Expressions example
 


### PR DESCRIPTION
The documentation didn't show that a fragment could be used with `order_by/3`, so I added my own use case.

Is it too weird? The idea is to have an order that's shuffled but stable for pagination (in the case where I'm using it, inserting and deleting records is fairly rare; such changes would change the ordering some because a new record might appear in the middle of the result set.)

The point is not to show this particular use case, it's just the example I have for why fragments might be needed.