### PR TITLE
Pass the executing repo module as the first argument to Multi.run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ And should be rewritten as:
 
 This means Ecto no longer requires Ecto-specific extensions on databases such as Postgres which leads to better integration with 3rd party libraries and faster compilation times.
 
-## v3.0.0-dev (2017-08-18)
+## v3.0.0-dev (In Progress)
 
 ### Enhancements
 
@@ -40,6 +40,7 @@ This means Ecto no longer requires Ecto-specific extensions on databases such as
 
 ### Backwards incompatible changes
 
+  * [Ecto.Multi] `Ecto.Multi.run/3` and `Ecto.Multi.run/5` now receive the repo in which the transaction is executing as the first argument to functions, and the changes so far as the second argument.
   * [Ecto.DateTime] `Ecto.Date`, `Ecto.Time` and `Ecto.DateTime` were previously deprecated and have now been removed
   * [Ecto.Schema]`:time`, `:naive_datetime` and `:utc_datetime` no longer keep microseconds information. If you want to keep microseconds, use `:time_usec`, `:naive_datetime_usec`, `:utc_datetime_usec`
 

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -151,8 +151,8 @@ defmodule Ecto.Multi do
 
   ## Example
 
-      iex> lhs = Ecto.Multi.new |> Ecto.Multi.run(:left, fn _, _ -> {:ok, :ok} end)
-      iex> rhs = Ecto.Multi.new |> Ecto.Multi.run(:right, fn _, _ -> {:error, :error} end)
+      iex> lhs = Ecto.Multi.new |> Ecto.Multi.run(:left, fn _, changes -> {:ok, changes} end)
+      iex> rhs = Ecto.Multi.new |> Ecto.Multi.run(:right, fn _, changes -> {:error, changes} end)
       iex> Ecto.Multi.prepend(lhs, rhs) |> Ecto.Multi.to_list |> Keyword.keys
       [:right, :left]
 

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -100,7 +100,7 @@ defmodule Ecto.Multi do
 
   defstruct operations: [], names: MapSet.new
 
-  @type run :: (t -> {:ok | :error, any}) | {module, atom, [any]}
+  @type run :: ((Ecto.Repo.t, map) -> {:ok | :error, any}) | {module, atom, [any]}
   @type merge :: (map -> t) | {module, atom, [any]}
   @typep schema_or_source :: binary | {binary | nil, binary} | atom
   @typep operation :: {:changeset, Changeset.t, Keyword.t} |
@@ -307,7 +307,7 @@ defmodule Ecto.Multi do
   and receives the repo as the first argument, and the changes so far
   as the second argument.
   """
-  @spec run(t, name, (t -> {:ok | :error, any})) :: t
+  @spec run(t, name, run) :: t
   def run(multi, name, run) when is_function(run, 1) do
     IO.warn "Giving an anonymous function with 1 argument to Ecto.Multi.run/3 is deprecated. " <>
               "Please pass an anonymous function that receives the repository and the changes so far"

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -133,8 +133,8 @@ defmodule Ecto.Multi do
 
   ## Example
 
-      iex> lhs = Ecto.Multi.new |> Ecto.Multi.run(:left, fn _, _ -> {:ok, :ok} end)
-      iex> rhs = Ecto.Multi.new |> Ecto.Multi.run(:right, fn _, _ -> {:error, :error} end)
+      iex> lhs = Ecto.Multi.new |> Ecto.Multi.run(:left, fn _, changes -> {:ok, changes} end)
+      iex> rhs = Ecto.Multi.new |> Ecto.Multi.run(:right, fn _, changes -> {:error, changes} end)
       iex> Ecto.Multi.append(lhs, rhs) |> Ecto.Multi.to_list |> Keyword.keys
       [:left, :right]
 


### PR DESCRIPTION
Originating from forum post: https://groups.google.com/forum/#!topic/elixir-ecto/uqUkVCKhd7c

Passes the repo module through during execution to all run functions as the first argument.