### PR TITLE
[docs] Document that Changeset.validate_required drops fields

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1353,8 +1353,9 @@ defmodule Ecto.Changeset do
   Validates that one or more fields are present in the changeset.
 
   If the value of a field is `nil` or a string made only of whitespace,
-  the changeset is marked as invalid and an error is added. Note the
-  error won't be added though if the field already has an error.
+  the changeset is marked as invalid, the field is removed from the changeset's
+  changes, and an error is added. Note the error won't be added though if the
+  field already has an error.
 
   You can pass a single field name or a list of field names that
   are required.


### PR DESCRIPTION
This functionality is mentioned in the documentation for `update_change/3`, but since there's nothing about it in `validate_required` I wasn't sure what to believe =)  

>Note that the value of the change  can still be `nil` (unless the field was marked as required on `validate_required/3`).

Dug into the code and saw that it was the case. Thought this was an important functionality and that it should be documented.