### PR TITLE
Add doc on setting adapter options in Repo configuration.

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -64,6 +64,21 @@ defmodule Ecto.Adapters.Postgres do
     * `:lc_ctype` - the character classification
     * `:dump_path` - where to place dumped structures
 
+  ### Adapter options
+
+  It should be noted that some adapter options may be set in your
+  repo configuration. For example, suppose you have a setup that
+  requires unnamed prepared statements. The Postgres adapter has
+  an option for this and can be set in your repo config.
+
+  config :my_app, MyApp.Repo,
+    adapter: Ecto.Adapters.Postgres,
+    database: "my_app_repo",
+    username: "user",
+    password: "pass",
+    hostname: "localhost"
+    prepare: :unnamed
+
   ## Extensions
 
   Both PostgreSQL and its adapter for Elixir, Postgrex, support an

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -16,10 +16,15 @@ defmodule Ecto.Adapters.Postgres do
   ## Options
 
   Postgres options split in different categories described
-  below. All options should be given via the repository
-  configuration. These options are also passed to the module
-  specified in the `:pool` option, so check that module's
-  documentation for more options.
+  below. All options can be given via the repository
+  configuration:
+  
+      config :your_app, YourApp.Repo,
+        adapter: Ecto.Adapters.Postgres,
+        ...
+
+  Non-compile time options can also be returned from the
+  repository `init/2` callback.
 
   ### Compile time options
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -41,6 +41,8 @@ defmodule Ecto.Adapters.Postgres do
     * `:ssl_opts` - A list of ssl options, see Erlang's `ssl` docs
     * `:parameters` - Keyword list of connection parameters
     * `:connect_timeout` - The timeout for establishing new connections (default: 5000)
+    * `:prepare` - How to prepare queries, either `:named` to use named queries
+      or `:unnamed` to force unnamed queries (default: `:named`)
     * `:socket_options` - Specifies socket configuration
 
   The `:socket_options` are particularly useful when configuring the size
@@ -63,21 +65,6 @@ defmodule Ecto.Adapters.Postgres do
     * `:lc_collate` - the collation order
     * `:lc_ctype` - the character classification
     * `:dump_path` - where to place dumped structures
-
-  ### Adapter options
-
-  It should be noted that some adapter options may be set in your
-  repo configuration. For example, suppose you have a setup that
-  requires unnamed prepared statements. The Postgres adapter has
-  an option for this and can be set in your repo config.
-
-  config :my_app, MyApp.Repo,
-    adapter: Ecto.Adapters.Postgres,
-    database: "my_app_repo",
-    username: "user",
-    password: "pass",
-    hostname: "localhost"
-    prepare: :unnamed
 
   ## Extensions
 


### PR DESCRIPTION
  I had to set the unamed prepared statements option for the postgres adapter earlier today and it was a bit confusing on how to do just that via config. So, here's some doc ❤️ 

  Notes: 

  - Not sure this is the best place for it, it felt right :)
  - Not sure if there needs to be more elaboration