### PR TITLE
Update Ecto.Changeset.optimistic_lock/3 typespec

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1919,7 +1919,7 @@ defmodule Ecto.Changeset do
       iex> Ecto.Changeset.optimistic_lock(post, :lock_uuid, fn _ -> Ecto.UUID.generate end)
 
   """
-  @spec optimistic_lock(Ecto.Schema.t | t, atom, (integer -> integer)) :: t | no_return
+  @spec optimistic_lock(Ecto.Schema.t | t, atom, (term -> term)) :: t | no_return
   def optimistic_lock(data_or_changeset, field, incrementer \\ &(&1 + 1)) do
     changeset = change(data_or_changeset, %{})
     current = get_field(changeset, field)


### PR DESCRIPTION
As of right now, the function typespec defines that the incrementor must receive an integer and return an integer but that's not true; particularly, on the documentation of the function we have an example that receives a binary and returns a binary:

```elixir
iex> Ecto.Changeset.optimistic_lock(post, :lock_uuid, fn _ -> Ecto.UUID.generate end)
```

and another possible example would be
```elixir
iex> Ecto.Changeset.optimistic_lock(user, :last_update, fn _ -> NaiveDateTime.utc_now() end)
```

So, this PR corrects the typespec to consider correct any 1-arity function