### PR TITLE
Added a notice about nil comparison in Ecto.Query module doc

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -95,6 +95,13 @@ defmodule Ecto.Query do
   For this reason, we will use schemas on the remaining examples but
   remember Ecto does not require them in order to write queries.
 
+  ## `nil` comparison
+
+  Comparison with a infix operators with `nil` is forbidden as it is unsafe
+  and would expose security risks. To check that value is `nil` use `is_nil/1`.
+
+  If you want to dynamically extend your query, use a query composition.
+
   ## Composition
 
   Ecto queries are composable. For example, the query above can

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -97,8 +97,17 @@ defmodule Ecto.Query do
 
   ## `nil` comparison
 
-  `nil` comparison is forbidden as it is unsafe and would expose
-  security risks. To check that value is `nil` use `is_nil/1`.
+  `nil` comparison in filters, such as where and having, is forbidden
+  and it will raise an error:
+  
+      # Raises if age is nil
+      from u in User, where: u.age == ^age
+  
+  This is done as a security measure to avoid attacks that attempt
+  to traverse entries with nil columns. To check that value is `nil`,
+  use `is_nil/1` instead:
+  
+      from u in User, where: is_nil(u.age)
 
   ## Composition
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -97,10 +97,8 @@ defmodule Ecto.Query do
 
   ## `nil` comparison
 
-  Nil comparison with a infix operators is forbidden as it is unsafe
-  and would expose security risks. To check that value is `nil` use `is_nil/1`.
-
-  If you want to dynamically extend your query, use a query composition.
+  `nil` comparison is forbidden as it is unsafe and would expose
+  security risks. To check that value is `nil` use `is_nil/1`.
 
   ## Composition
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -97,7 +97,7 @@ defmodule Ecto.Query do
 
   ## `nil` comparison
 
-  Comparison with a infix operators with `nil` is forbidden as it is unsafe
+  Nil comparison with a infix operators is forbidden as it is unsafe
   and would expose security risks. To check that value is `nil` use `is_nil/1`.
 
   If you want to dynamically extend your query, use a query composition.


### PR DESCRIPTION
Due to a fact that questions about Ecto handling of `nil` comparison are common, I want to add a notice about it in `Ecto.Query` module doc.

Discussion thread on this addition is started in issue #1961.