### PR TITLE
allow more options for migration_primary_key config

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -308,7 +308,12 @@ defmodule Ecto.Migration do
 
       if table.primary_key do
         opts = Runner.repo_config(:migration_primary_key, [])
-        add(opts[:name] || :id, opts[:type] || :bigserial, primary_key: true)
+        opts = Keyword.put(opts, :primary_key, true)
+
+        {name, opts} = Keyword.pop(opts, :name, :id)
+        {type, opts} = Keyword.pop(opts, :type, :bigserial)
+
+        add(name, type, opts)
       end
 
       unquote(block)

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -156,6 +156,16 @@ defmodule Ecto.MigrationTest do
            {:create, table, [{:add, :uuid, :uuid, [primary_key: true]}]}
   end
 
+  @tag repo_config: [migration_primary_key: [type: :uuid, default: {:fragment, "gen_random_uuid()"}]]
+  test "forward: create a table with custom primary key options" do
+    create(table = table(:posts)) do
+    end
+    flush()
+
+    assert last_command() ==
+           {:create, table, [{:add, :id, :uuid, [primary_key: true, default: {:fragment, "gen_random_uuid()"}]}]}
+  end
+
   @tag repo_config: [migration_timestamps: [type: :utc_datetime, null: true]]
   test "forward: create a table with timestamps" do
     create(table = table(:posts)) do


### PR DESCRIPTION
Right now configuration for `:migration_primary_key` doesn't allow passing any additional options to the `add` function. This PR allows other options to be passed. Of the available options the only one that makes sense right now would be `default` but this change will keep things flexible for different options that might be rolled out in the future.

An example of how this might be utilized:
On a product my team is working on, sometimes it's convenient for our client-side developers to add a record directly to the dev database. We like to add a default to the `id` fields to make that manual entry easier.

`config :app, App.Repo, migration_primary_key: [id: :uuid, type: :binary_id, default: {:fragment, "gen_random_uuid()"}]`

used the `timestamps` function as a style reference