### PR TITLE
Add comment on table prefix usage with constraints

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -872,6 +872,7 @@ defmodule Ecto.Migration do
 
     * `:check` - A check constraint expression. Required when creating a check constraint.
     * `:exclude` - An exclusion constraint expression. Required when creating an exclusion constraint.
+    * `:prefix` - The prefix for the table.
 
   """
   def constraint(table, name, opts \\ [])


### PR DESCRIPTION
Make clear on how to use schema prefixes with adding constraints. Ran into this when I tried to add a constraint in a non-default postgres schema and could not find it immediately in the documentation.