### PR TITLE
remove unnecessary cast in datetime_add

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -461,8 +461,8 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp expr({:datetime_add, _, [datetime, count, interval]}, sources, query) do
-      [?(, expr(datetime, sources, query), "::timestamp + ",
-       interval(count, interval, sources, query) | ")::timestamp"]
+      [expr(datetime, sources, query), "::timestamp + ",
+       interval(count, interval, sources, query)]
     end
 
     defp expr({:date_add, _, [date, count, interval]}, sources, query) do


### PR DESCRIPTION
In the commit https://github.com/elixir-ecto/ecto/commit/8388d4b148ae7e6a2d87fb4eb9617b8eafdfc361 that fixes `datetime_add` microseconds for MySQL, the surrounding cast was removed as it isn't needed — a great solution to the adding microseconds compatibility problem! This PR removes that cast for Postgres as well. Although there isn't a compatibility problem, there isn't a scenario where a timestamp +/- an interval returns anything other than a timestamp.

Postgres docs reference  
https://www.postgresql.org/docs/current/static/functions-datetime.html