### PR TITLE
Require JSON library to implement encode_to_iodata!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ And should be rewritten as:
     config :mariaex, :json_library, CustomJSONLib
 
 This means Ecto no longer requires Ecto-specific extensions on databases such as Postgres which leads to better integration with 3rd party libraries and faster compilation times.
+Ecto also now requires the json library to implement an `encode_to_iodata!/1` function instead of `encode!` in line
+with the interface required by Postgrex.
 
 ## v3.0.0-dev (In Progress)
 

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -807,7 +807,8 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     defp json_encode!(value) do
-      Application.get_env(:mariaex, :json_library, Poison).encode!(value)
+      library = Application.get_env(:mariaex, :json_library, Poison)
+      IO.iodata_to_binary(library.encode_to_iodata!(value))
     end
   end
 end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -792,7 +792,8 @@ if Code.ensure_loaded?(Postgrex) do
     defp default_expr({:ok, literal}, _type) when is_number(literal) or is_boolean(literal),
       do: [" DEFAULT ", to_string(literal)]
     defp default_expr({:ok, %{} = map}, :map) do
-      default = Application.get_env(:postgrex, :json_library, Poison).encode!(map)
+      library = Application.get_env(:postgrex, :json_library, Poison)
+      default = IO.iodata_to_binary(library.encode_to_iodata!(map))
       [" DEFAULT ", single_quote(default)]
     end
     defp default_expr({:ok, {:fragment, expr}}, _type),


### PR DESCRIPTION
This puts Ecto's requirements in line with Postgrex and Phoenix