### PR TITLE
feat(Numeric Type Casting): Allow trailing whitespace when casting bi…

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -523,6 +523,10 @@ defmodule Ecto.Type do
       {:ok, 1}
       iex> cast(:integer, "1")
       {:ok, 1}
+      iex> cast(:integer, "1 ")
+      {:ok, 1}
+      iex> cast(:integer, " 1")
+      :error
       iex> cast(:integer, "1.0")
       :error
 
@@ -530,6 +534,10 @@ defmodule Ecto.Type do
       {:ok, 1}
       iex> cast(:id, "1")
       {:ok, 1}
+      iex> cast(:id, "1 ")
+      {:ok, 1}
+      iex> cast(:id, " 1")
+      :error
       iex> cast(:id, "1.0")
       :error
 
@@ -541,6 +549,12 @@ defmodule Ecto.Type do
       {:ok, 1.0}
       iex> cast(:float, "1.0")
       {:ok, 1.0}
+      iex> cast(:float, "1.0 ")
+      {:ok, 1.0}
+      iex> cast(:float, "1.0f")
+      :error
+      iex> cast(:float, " 1.0")
+      :error
       iex> cast(:float, "1-foo")
       :error
 
@@ -600,7 +614,7 @@ defmodule Ecto.Type do
   end
 
   def cast(:float, term) when is_binary(term) do
-    case Float.parse(term) do
+    case term |> String.trim_trailing() |> Float.parse() do
       {float, ""} -> {:ok, float}
       _           -> :error
     end
@@ -655,7 +669,7 @@ defmodule Ecto.Type do
   end
 
   def cast(type, term) when type in [:id, :integer] and is_binary(term) do
-    case Integer.parse(term) do
+    case term |> String.trim_trailing() |> Integer.parse() do
       {int, ""} -> {:ok, int}
       _         -> :error
     end


### PR DESCRIPTION
…nary integers and floats

On occasion users of our app will accidentally type in a trailing space when dealing with numeric values which results in an "is invalid" error. I understand if you want to be extremely strict when parsing values but I believe this change is reasonable.