### PR TITLE
Move preprocessing out of adapters

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -19,7 +19,6 @@ defmodule Ecto.Adapter do
   @type returning :: [atom]
   @type prepared :: term
   @type cached :: term
-  @type process :: (term -> term)
   @type on_conflict :: {:raise, list(), []} |
                        {:nothing, list(), [atom]} |
                        {Ecto.Query.t, list(), [atom]}
@@ -128,13 +127,8 @@ defmodule Ecto.Adapter do
 
   The `meta` field is a map containing some of the fields found
   in the `Ecto.Query` struct.
-
-  It receives a process function that should be invoked for each
-  selected field in the query result in order to convert them to the
-  expected Ecto type. The `process` function will be nil if no
-  result set is expected from the query.
   """
-  @callback execute(repo, query_meta, query, params :: list(), process | nil, options) :: result when
+  @callback execute(repo, query_meta, query, params :: list(), options) :: result when
               result: {integer, [[term]] | nil} | no_return,
               query: {:nocache, prepared} |
                      {:cached, (prepared -> :ok), cached} |

--- a/lib/ecto/adapters/sql/stream.ex
+++ b/lib/ecto/adapters/sql/stream.ex
@@ -1,11 +1,10 @@
 defmodule Ecto.Adapters.SQL.Stream do
   @moduledoc false
 
-  defstruct [:repo, :statement, :params, :mapper, :opts]
+  defstruct [:repo, :statement, :params, :opts]
 
-  def __build__(repo, statement, params, mapper, opts) do
-    %__MODULE__{repo: repo, statement: statement, params: params, mapper: mapper,
-      opts: opts}
+  def __build__(repo, statement, params, opts) do
+    %__MODULE__{repo: repo, statement: statement, params: params, opts: opts}
   end
 end
 
@@ -18,16 +17,16 @@ defimpl Enumerable, for: Ecto.Adapters.SQL.Stream do
 
   def reduce(stream, acc, fun) do
     %Ecto.Adapters.SQL.Stream{repo: repo, statement: statement, params: params,
-                              mapper: mapper, opts: opts} = stream
-    Ecto.Adapters.SQL.reduce(repo, statement, params, mapper, opts, acc, fun)
+                              opts: opts} = stream
+    Ecto.Adapters.SQL.reduce(repo, statement, params, opts, acc, fun)
   end
 end
 
 defimpl Collectable, for: Ecto.Adapters.SQL.Stream do
   def into(stream) do
     %Ecto.Adapters.SQL.Stream{repo: repo, statement: statement, params: params,
-                              mapper: mapper, opts: opts} = stream
-    {state, fun} = Ecto.Adapters.SQL.into(repo, statement, params, mapper, opts)
+                              opts: opts} = stream
+    {state, fun} = Ecto.Adapters.SQL.into(repo, statement, params, opts)
     {state, make_into(fun, stream)}
   end
 

--- a/lib/ecto/repo/assoc.ex
+++ b/lib/ecto/repo/assoc.ex
@@ -7,20 +7,20 @@ defmodule Ecto.Repo.Assoc do
   Transforms a result set based on query assocs, loading
   the associations onto their parent schema.
   """
-  @spec query([Ecto.Schema.t], list, tuple) :: [Ecto.Schema.t]
-  def query(rows, assocs, sources)
+  @spec query([list], list, tuple, (list -> list)) :: [Ecto.Schema.t]
+  def query(rows, assocs, sources, fun)
 
-  def query([], _assocs, _sources), do: []
-  def query(rows, [], _sources), do: rows
+  def query([], _assocs, _sources, _fun), do: []
+  def query(rows, [], _sources, fun), do: Enum.map(rows, fun)
 
-  def query(rows, assocs, sources) do
+  def query(rows, assocs, sources, fun) do
     # Create rose tree of accumulator dicts in the same
     # structure as the fields tree
     accs = create_accs(0, assocs, sources, [])
 
     # Populate tree of dicts of associated entities from the result set
     {_keys, _cache, rows, sub_dicts} = Enum.reduce(rows, accs, fn row, acc ->
-      merge(row, acc, 0) |> elem(0)
+      merge(fun.(row), acc, 0) |> elem(0)
     end)
 
     # Create the reflections that will be loaded into memory.

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -122,7 +122,7 @@ defmodule Ecto.RepoTest do
   test "stream emits row values lazily" do
     stream = TestRepo.stream(MySchema)
     refute_received :stream_execute
-    assert Enum.to_list(stream) == [1]
+    assert [%MySchema{id: 1}] = Enum.to_list(stream)
     assert_received :stream_execute
     assert Enum.take(stream, 0) == []
     refute_received :stream_execute


### PR DESCRIPTION
Simplify execute (and stream) by removing processing argument. This is a breaking change but it is possible to get backwards compatibility from Ecto 2.2 for an adapter by defining a default preprocessing argument as `nil` or `fn x -> x end` depending on the adapter logic.
```elixir
def execute(repo, query_meta, query, params :: list(), process \\ fn x -> x end, options)
```
I am not aware of a noSQL adapter that has supported https://github.com/elixir-ecto/ecto/pull/2155 and this PR builds on top of that in a way.

This will fix the log entry result for SQL drivers. It would be possible to do this by just changing the SQL adapter.


