### PR TITLE
Add check in ecto.gen.migration for existing migration files

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -47,8 +47,15 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
         {opts, [name], _} ->
           ensure_repo(repo, args)
           path = migrations_path(repo)
-          file = Path.join(path, "#{timestamp()}_#{underscore(name)}.exs")
+          base_name = "#{underscore(name)}.exs"
+          file = Path.join(path, "#{timestamp()}_#{base_name}")
           create_directory path
+
+          fuzzy_path = Path.join(path, "*_#{base_name}")
+          unless [] == Path.wildcard(fuzzy_path) do
+            Mix.raise "migration can't be created," <>
+              " existing migration files for #{name} already exist."
+          end
 
           assigns = [mod: Module.concat([repo, Migrations, camelize(name)]),
                      change: opts[:change]]

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -52,13 +52,11 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
           create_directory path
 
           fuzzy_path = Path.join(path, "*_#{base_name}")
-          unless [] == Path.wildcard(fuzzy_path) do
-            Mix.raise "migration can't be created," <>
-              " existing migration files for #{name} already exist."
+          if Path.wildcard(fuzzy_path) != [] do
+            Mix.raise "migration can't be created, there is already a migration file with name #{name}."
           end
 
-          assigns = [mod: Module.concat([repo, Migrations, camelize(name)]),
-                     change: opts[:change]]
+          assigns = [mod: Module.concat([repo, Migrations, camelize(name)]), change: opts[:change]]
           create_file file, migration_template(assigns)
 
           if open?(file) and Mix.shell.yes?("Do you want to run this migration?") do

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -39,6 +39,13 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     assert String.match? name, ~r/^\d{14}_my_migration\.exs$/
   end
 
+  test "raises when existing migration exists" do
+    run ["-r", to_string(Repo), "my_migration"]
+    assert_raise Mix.Error, ~r"migration can't be created", fn ->
+      run ["-r", to_string(Repo), "my_migration"]
+    end
+  end
+
   test "raises when missing file" do
     assert_raise Mix.Error, fn -> run ["-r", to_string(Repo)] end
   end


### PR DESCRIPTION
 This PR is in reference to issue #2318 

 A simple check was added in Mix.Tasks.Ecto.Gen.Migration.run/1 that looks for ```"#{path}/*_#{migration_name}.exs"``` file(s), if one is found a Mix.Error is raised. 

 -  I'm not sure how opinionated we want to be in regard to naming conventions. To me it makes perfect sense to bail if we see ```"*_#{migration_name}.exs"```, per convention. However, maybe it might be better to perform a regex on the contents of the file instead of going by the file name itself?
-  I did not update moduledoc (yet...) as it doesn't seem like this was doc worthy and that it is most likely expected behavior. 
- Raising a Mix.Error felt right per the surrounding code, but not be not be the best choice