### PR TITLE
Deprecate use Ecto.Schema in favour of import

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ defmodule Sample.Repo do
 end
 
 defmodule Sample.Weather do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "weather" do
     field :city     # Defaults to type :string

--- a/examples/friends/lib/friends/person.ex
+++ b/examples/friends/lib/friends/person.ex
@@ -1,5 +1,5 @@
 defmodule Friends.Person do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "people" do
     field :first_name, :string

--- a/guides/Associations.md
+++ b/guides/Associations.md
@@ -114,7 +114,7 @@ And the following schema:
 ```elixir
 # lib/ecto_assoc/user.ex
 defmodule EctoAssoc.User do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "users" do
     field :name, :string
@@ -150,7 +150,7 @@ and the following schema:
 ```elixir
 # lib/ecto_assoc/avatar.ex
 defmodule EctoAssoc.Avatar do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "avatars" do
     field :nick_name, :string
@@ -304,7 +304,7 @@ and the following schema:
 ```elixir
 # lib/ecto_assoc/post.ex
 defmodule EctoAssoc.Post do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "posts" do
     field :header, :string
@@ -345,7 +345,7 @@ For the `Post` we add a `belongs_to` field to the schema:
 
 ```elixir
 defmodule EctoAssoc.Post do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "posts" do
     field :header, :string
@@ -361,7 +361,7 @@ For the `User` we add a `has_many` field to the schema:
 
 ```elixir
 defmodule EctoAssoc.User do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "users" do
     field :name, :string
@@ -473,7 +473,7 @@ and the following schema:
 
 ```elixir
 defmodule EctoAssoc.Tag do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "tags" do
     field :name, :string
@@ -524,7 +524,7 @@ new `posts_tags` table.
 ```elixir
 # lib/ecto_assoc/post.ex
 defmodule EctoAssoc.Post do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "posts" do
     field :header, :string
@@ -541,7 +541,7 @@ new `posts_tags` schema:
 ```elixir
 # lib/ecto_assoc/tag.ex
 defmodule EctoAssoc.Tag do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "tags" do
     field :name, :string
@@ -677,7 +677,7 @@ You should carefully read the documentation for [`Ecto.Schema.many_to_many/3`](E
 ```elixir
 # lib/ecto_assoc/post.ex
 defmodule EctoAssoc.Post do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "posts" do
     field :header, :string

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -193,7 +193,7 @@ Let's create the schema within our application at `lib/friends/person.ex`:
 
 ```elixir
 defmodule Friends.Person do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "people" do
     field :first_name, :string

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -173,7 +173,7 @@ defmodule Ecto.Integration.RepoTest do
   @tag :read_after_writes
   test "insert and update with changeset read after writes" do
     defmodule RAW do
-      use Ecto.Schema
+      import Ecto.Schema, only: [schema: 2]
 
       schema "comments" do
         field :text, :string
@@ -204,7 +204,7 @@ defmodule Ecto.Integration.RepoTest do
   @tag :id_type
   test "insert autogenerates for custom id type" do
     defmodule ID do
-      use Ecto.Schema
+      import Ecto.Schema, only: [schema: 2]
 
       @primary_key {:id, Elixir.Custom.Permalink, autogenerate: true}
       schema "posts" do

--- a/integration_test/sql/lock.exs
+++ b/integration_test/sql/lock.exs
@@ -7,7 +7,7 @@ defmodule Ecto.Integration.LockTest do
   alias Ecto.Integration.PoolRepo
 
   defmodule LockCounter do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "lock_counters" do
       field :count, :integer

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -243,7 +243,7 @@ defmodule Ecto.Integration.MigrationTest do
   end
 
   defmodule Parent do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "parent" do
     end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -19,7 +19,7 @@ defmodule Ecto.Integration.TransactionTest do
   end
 
   defmodule Trans do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "transactions" do
       field :text, :string

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -1,7 +1,7 @@
 defmodule Ecto.Integration.Schema do
   defmacro __using__(_) do
     quote do
-      use Ecto.Schema
+      import Ecto.Schema, only: [schema: 2, embedded_schema: 1]
       type =
         Application.get_env(:ecto, :primary_key_type) ||
         raise ":primary_key_type not set in :ecto application"
@@ -208,7 +208,7 @@ defmodule Ecto.Integration.Item do
     * Embedding
 
   """
-  use Ecto.Schema
+  import Ecto.Schema, only: [embedded_schema: 1]
 
   embedded_schema do
     field :price, :integer

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -61,7 +61,7 @@ defmodule Ecto do
 
   If your application was generated with a supervisor (by passing `--sup` to `mix new`)
   you will have a `lib/my_app/application.ex` file (or `lib/my_app.ex` for Elixir versions `< 1.4.0`)
-  containing the application start callback that defines and starts your supervisor. 
+  containing the application start callback that defines and starts your supervisor.
   You just need to edit the `start/2` function to start the repo as a supervisor on
   your application's supervisor:
 
@@ -82,7 +82,7 @@ defmodule Ecto do
   Let's see an example:
 
       defmodule Weather do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         # weather is the DB table
         schema "weather" do
@@ -147,7 +147,7 @@ defmodule Ecto do
   we apply them to the data. Imagine the given schema:
 
       defmodule User do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         import Ecto.Changeset
 
@@ -279,7 +279,7 @@ defmodule Ecto do
   Ecto supports defining associations on schemas:
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           has_many :comments, Comment
@@ -287,7 +287,7 @@ defmodule Ecto do
       end
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "comments" do
           field :title, :string

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -45,7 +45,7 @@ defmodule Ecto.Changeset do
   Let's see an example:
 
       defmodule User do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
         import Ecto.Changeset
 
         schema "users" do
@@ -136,7 +136,7 @@ defmodule Ecto.Changeset do
   you to manually mark it for deletion, as in the example below:
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
         import Ecto.Changeset
 
         schema "comments" do
@@ -1878,7 +1878,7 @@ defmodule Ecto.Changeset do
   a field to the schema too:
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           field :title, :string

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -1,7 +1,7 @@
 defmodule Ecto.Migration.SchemaMigration do
   # Define a schema that works with the a table, which is schema_migrations by default
   @moduledoc false
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   import Ecto.Query, only: [from: 2]
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -9,7 +9,7 @@ defmodule Ecto.Schema do
   ## Example
 
       defmodule User do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "users" do
           field :name, :string
@@ -71,7 +71,7 @@ defmodule Ecto.Schema do
       defmodule MyApp.Schema do
         defmacro __using__(_) do
           quote do
-            use Ecto.Schema
+            import Ecto.Schema, only: [schema: 2, embedded_schema: 1]
             @primary_key {:id, :binary_id, autogenerate: true}
             @foreign_key_type :binary_id
           end
@@ -600,7 +600,7 @@ defmodule Ecto.Schema do
   ## Examples
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
         schema "posts" do
           has_many :comments, Comment
         end
@@ -620,7 +620,7 @@ defmodule Ecto.Schema do
   via the `:through` option. Let's see an example:
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           has_many :comments, Comment
@@ -640,7 +640,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "comments" do
           belongs_to :author, Author
@@ -741,7 +741,7 @@ defmodule Ecto.Schema do
   ## Examples
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           has_one :permalink, Permalink
@@ -805,7 +805,7 @@ defmodule Ecto.Schema do
   ## Examples
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "comments" do
           belongs_to :post, Post
@@ -820,7 +820,7 @@ defmodule Ecto.Schema do
   field explicitly and then pass `define_field: false` to `belongs_to`:
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "comments" do
           field :post_id, :integer, ... # custom options
@@ -860,7 +860,7 @@ defmodule Ecto.Schema do
   and define a new Comment schema:
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "abstract table: comments" do
           # This will be used by associations on each "concrete" table
@@ -875,7 +875,7 @@ defmodule Ecto.Schema do
   Now in your Post and Task schemas:
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           has_many :comments, {"posts_comments", Comment}, foreign_key: :assoc_id
@@ -883,7 +883,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule Task do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "tasks" do
           has_many :comments, {"tasks_comments", Comment}, foreign_key: :assoc_id
@@ -922,7 +922,7 @@ defmodule Ecto.Schema do
   is a intermediary table responsible for associating the entries:
 
       defmodule Comment do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
         schema "comments" do
           # ...
         end
@@ -931,7 +931,7 @@ defmodule Ecto.Schema do
   In your posts and tasks:
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           many_to_many :comments, Comment, join_through: "posts_comments"
@@ -939,7 +939,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule Task do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "tasks" do
           many_to_many :comments, Comment, join_through: "tasks_comments"
@@ -1050,7 +1050,7 @@ defmodule Ecto.Schema do
   ## Examples
 
       defmodule Post do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
         schema "posts" do
           many_to_many :tags, Tag, join_through: "posts_tags"
         end
@@ -1084,7 +1084,7 @@ defmodule Ecto.Schema do
   In our example, a User has and belongs to many Organizations
 
       defmodule UserOrganization do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         @primary_key false
         schema "users_organizations" do
@@ -1102,7 +1102,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule User do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "users" do
           many_to_many :organizations, Organization, join_through: UserOrganization
@@ -1110,7 +1110,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule Organization do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "organizations" do
           many_to_many :users, User, join_through: UserOrganization
@@ -1159,7 +1159,7 @@ defmodule Ecto.Schema do
   ## Examples
 
       defmodule Order do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "orders" do
           embeds_one :item, Item
@@ -1167,7 +1167,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule Item do
-        use Ecto.Schema
+        import Ecto.Schema, only: [embedded_schema: 1]
 
         embedded_schema do
           field :name
@@ -1203,7 +1203,7 @@ defmodule Ecto.Schema do
   cases:
 
       defmodule Parent do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "parents" do
           field :name, :string
@@ -1306,7 +1306,7 @@ defmodule Ecto.Schema do
   ## Examples
 
       defmodule Order do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "orders" do
           embeds_many :items, Item
@@ -1314,7 +1314,7 @@ defmodule Ecto.Schema do
       end
 
       defmodule Item do
-        use Ecto.Schema
+        import Ecto.Schema, only: [embedded_schema: 1]
 
         embedded_schema do
           field :name
@@ -1377,7 +1377,7 @@ defmodule Ecto.Schema do
   cases:
 
       defmodule Parent do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "parents" do
           field :name, :string

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -65,7 +65,7 @@ defmodule Ecto.Type do
   Now we can use our new field type above in our schemas:
 
       defmodule ShortUrl do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "posts" do
           field :original_url, EctoURI

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -10,7 +10,7 @@ defmodule Ecto.Adapters.MySQLTest do
   alias Ecto.Migration.Reference
 
   defmodule Schema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schema" do
       field :x, :integer
@@ -27,7 +27,7 @@ defmodule Ecto.Adapters.MySQLTest do
   end
 
   defmodule Schema2 do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schema2" do
       belongs_to :post, Ecto.Adapters.MySQLTest.Schema,
@@ -37,7 +37,7 @@ defmodule Ecto.Adapters.MySQLTest do
   end
 
   defmodule Schema3 do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schema3" do
       field :binary, :binary

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -9,7 +9,7 @@ defmodule Ecto.Adapters.PostgresTest do
   alias Ecto.Adapters.Postgres.Connection, as: SQL
 
   defmodule Schema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schema" do
       field :x, :integer
@@ -27,7 +27,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   defmodule Schema2 do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schema2" do
       belongs_to :post, Ecto.Adapters.PostgresTest.Schema,
@@ -37,7 +37,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   defmodule Schema3 do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schema3" do
       field :list1, {:array, :string}

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -17,7 +17,7 @@ defmodule Ecto.AssociationTest do
   alias __MODULE__.AuthorPermalink
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "posts" do
       field :title, :string
@@ -31,7 +31,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule Comment do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "comments" do
       field :text, :string
@@ -44,7 +44,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule Permalink do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "permalinks" do
       field :url, :string
@@ -54,7 +54,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule PostWithPrefix do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
     @schema_prefix "my_prefix"
 
     schema "posts" do
@@ -64,7 +64,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule CommentWithPrefix do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
     @schema_prefix "my_prefix"
 
     schema "comments" do
@@ -73,7 +73,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :title, :string
@@ -91,7 +91,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule AuthorPermalink do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors_permalinks" do
       field :author_id
@@ -100,7 +100,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule Summary do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "summaries" do
       has_one :post, Post, defaults: [title: "default"], on_replace: :nilify
@@ -111,7 +111,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule Email do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "emails" do
       belongs_to :author, {"post_authors", Author}
@@ -119,7 +119,7 @@ defmodule Ecto.AssociationTest do
   end
 
   defmodule Profile do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "profiles" do
       field :name
@@ -616,7 +616,7 @@ defmodule Ecto.AssociationTest do
   describe "after_compile_validation/2" do
     defp after_compile_validation(assoc, name, opts) do
       defmodule Sample do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "sample" do
           opts = [cardinality: :one] ++ opts

--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -9,7 +9,7 @@ defmodule Ecto.Changeset.BelongsToTest do
   alias __MODULE__.Profile
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :title, :string
@@ -22,7 +22,7 @@ defmodule Ecto.Changeset.BelongsToTest do
   end
 
   defmodule Profile do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "profiles" do
       field :name

--- a/test/ecto/changeset/embedded_no_pk_test.exs
+++ b/test/ecto/changeset/embedded_no_pk_test.exs
@@ -10,7 +10,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   alias __MODULE__.Post
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :name, :string
@@ -25,7 +25,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
     import Ecto.Changeset
 
     @primary_key false
@@ -50,7 +50,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   defmodule Profile do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
     import Ecto.Changeset
 
     @primary_key false
@@ -234,7 +234,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
       "options are: `:raise`, `:mark_as_invalid`, `:delete`"
     assert_raise ArgumentError, error_message, fn ->
       defmodule Topic do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "topics" do
           embeds_many :tags, Tag, on_replace: :update

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -11,7 +11,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
   alias __MODULE__.Post
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :name, :string
@@ -32,7 +32,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
   end
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
     import Ecto.Changeset
 
     schema "posts" do
@@ -56,7 +56,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
   end
 
   defmodule Profile do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
     import Ecto.Changeset
 
     embedded_schema do
@@ -297,7 +297,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
       "options are: `:raise`, `:mark_as_invalid`, `:delete`"
     assert_raise ArgumentError, error_message, fn ->
       defmodule Topic do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "topics" do
           embeds_many :tags, Tag, on_replace: :update

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -10,7 +10,7 @@ defmodule Ecto.Changeset.HasAssocTest do
   alias __MODULE__.Profile
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "posts" do
       field :title, :string
@@ -29,7 +29,7 @@ defmodule Ecto.Changeset.HasAssocTest do
   end
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :title, :string
@@ -47,7 +47,7 @@ defmodule Ecto.Changeset.HasAssocTest do
   end
 
   defmodule Profile do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "profiles" do
       field :name
@@ -317,7 +317,7 @@ defmodule Ecto.Changeset.HasAssocTest do
       "options are: `:raise`, `:mark_as_invalid`, `:delete`, `:nilify`"
     assert_raise ArgumentError, error_message, fn ->
       defmodule Topic do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "topics" do
           has_many :tags, Tag, on_replace: :update

--- a/test/ecto/changeset/many_to_many_test.exs
+++ b/test/ecto/changeset/many_to_many_test.exs
@@ -8,7 +8,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
   alias __MODULE__.Post
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "posts" do
       field :title, :string
@@ -26,7 +26,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
   end
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :title, :string

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -3,7 +3,7 @@ defmodule Ecto.ChangesetTest do
   import Ecto.Changeset
 
   defmodule SocialSource do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
 
     @primary_key false
     embedded_schema do
@@ -17,7 +17,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defmodule Category do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "categories" do
       field :name, :string
@@ -26,7 +26,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defmodule Comment do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "comments" do
       belongs_to :post, Ecto.ChangesetTest.Post
@@ -34,7 +34,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "posts" do
       field :token, :integer, primary_key: true

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -5,7 +5,7 @@ defmodule Ecto.EmbeddedTest do
   alias Ecto.Embedded
 
   defmodule Author do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "authors" do
       field :name, :string

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -7,7 +7,7 @@ defmodule Ecto.MultiTest do
   alias Ecto.TestRepo
 
   defmodule Comment do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "comments" do
       field :x, :integer

--- a/test/ecto/poison_test.exs
+++ b/test/ecto/poison_test.exs
@@ -2,7 +2,7 @@ defmodule Ecto.PoisonTest do
   use ExUnit.Case, async: true
 
   defmodule User do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "users" do
       has_many :comments, Ecto.Comment

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -1,5 +1,5 @@
 defmodule Inspect.Post do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "posts" do
     field :visits, :integer
@@ -9,7 +9,7 @@ defmodule Inspect.Post do
 end
 
 defmodule Inspect.Comment do
-  use Ecto.Schema
+  import Ecto.Schema, only: [schema: 2]
 
   schema "comments" do
   end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -9,7 +9,7 @@ defmodule Ecto.Query.PlannerTest do
   alias Ecto.Query.JoinExpr
 
   defmodule Comment do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "comments" do
       field :text, :string
@@ -22,7 +22,7 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key {:id, Custom.Permalink, []}
     schema "posts" do

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -9,7 +9,7 @@ defmodule Ecto.Query.SubqueryTest do
   alias Ecto.Query.JoinExpr
 
   defmodule Comment do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "comments" do
       field :text, :string
@@ -20,7 +20,7 @@ defmodule Ecto.Query.SubqueryTest do
   end
 
   defmodule Post do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key {:id, Custom.Permalink, []}
     schema "posts" do

--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Repo.AutogenerateTest do
   use ExUnit.Case, async: true
 
   defmodule Manager do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @timestamps_opts [inserted_at: :created_on]
     schema "manager" do
@@ -13,7 +13,7 @@ defmodule Ecto.Repo.AutogenerateTest do
   end
 
   defmodule Company do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "default" do
       field :code, Ecto.UUID, autogenerate: true
@@ -23,7 +23,7 @@ defmodule Ecto.Repo.AutogenerateTest do
   end
 
   defmodule NaiveMod do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "naive_mod" do
       timestamps(type: :naive_datetime)
@@ -31,7 +31,7 @@ defmodule Ecto.Repo.AutogenerateTest do
   end
 
   defmodule NaiveUsecMod do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "naive_usec_mod" do
       timestamps(type: :naive_datetime_usec)
@@ -39,7 +39,7 @@ defmodule Ecto.Repo.AutogenerateTest do
   end
 
   defmodule UtcMod do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "utc_mod" do
       timestamps(type: :utc_datetime)
@@ -47,7 +47,7 @@ defmodule Ecto.Repo.AutogenerateTest do
   end
 
   defmodule UtcUsecMod do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "utc_usec_mod" do
       timestamps(type: :utc_datetime_usec)

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -5,7 +5,7 @@ defmodule Ecto.Repo.BelongsToTest do
   require Ecto.TestRepo, as: TestRepo
 
   defmodule SubAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "sub_assoc" do
       field :y, :string
@@ -14,7 +14,7 @@ defmodule Ecto.Repo.BelongsToTest do
   end
 
   defmodule MyAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_assoc" do
       field :x, :string
@@ -25,7 +25,7 @@ defmodule Ecto.Repo.BelongsToTest do
   end
 
   defmodule MySchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_schema" do
       field :x, :string

--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Repo.EmbeddedTest do
   alias Ecto.TestRepo, as: TestRepo
 
   defmodule SubEmbed do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
 
     @primary_key false
     embedded_schema do
@@ -13,7 +13,7 @@ defmodule Ecto.Repo.EmbeddedTest do
   end
 
   defmodule MyEmbed do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
 
     embedded_schema do
       field :x, :string
@@ -23,7 +23,7 @@ defmodule Ecto.Repo.EmbeddedTest do
   end
 
   defmodule MyAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_assocs" do
       field :x
@@ -32,7 +32,7 @@ defmodule Ecto.Repo.EmbeddedTest do
   end
 
   defmodule MySchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_schema" do
       embeds_one :embed, MyEmbed, on_replace: :delete

--- a/test/ecto/repo/has_assoc_test.exs
+++ b/test/ecto/repo/has_assoc_test.exs
@@ -5,7 +5,7 @@ defmodule Ecto.Repo.HasAssocTest do
   require Ecto.TestRepo, as: TestRepo
 
   defmodule SubAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "sub_assoc" do
       field :y, :string
@@ -14,7 +14,7 @@ defmodule Ecto.Repo.HasAssocTest do
   end
 
   defmodule MyAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_assoc" do
       field :x, :string
@@ -33,7 +33,7 @@ defmodule Ecto.Repo.HasAssocTest do
   end
 
   defmodule MySchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_schema" do
       field :x, :string

--- a/test/ecto/repo/many_to_many_test.exs
+++ b/test/ecto/repo/many_to_many_test.exs
@@ -5,7 +5,7 @@ defmodule Ecto.Repo.ManyToManyTest do
   require Ecto.TestRepo, as: TestRepo
 
   defmodule SubAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "sub_assoc" do
       field :y, :string
@@ -14,7 +14,7 @@ defmodule Ecto.Repo.ManyToManyTest do
   end
 
   defmodule MyAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_assoc" do
       field :x, :string
@@ -24,7 +24,7 @@ defmodule Ecto.Repo.ManyToManyTest do
   end
 
   defmodule MySchemaAssoc do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "schemas_assocs" do
       belongs_to :my_schema, MySchema
@@ -34,7 +34,7 @@ defmodule Ecto.Repo.ManyToManyTest do
   end
 
   defmodule MySchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_schema" do
       field :x, :string

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -6,7 +6,7 @@ defmodule Ecto.RepoTest do
   require Ecto.TestRepo, as: TestRepo
 
   defmodule MySchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my_schema" do
       field :x, :string
@@ -19,7 +19,7 @@ defmodule Ecto.RepoTest do
   end
 
   defmodule MySchemaNoPK do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key false
     schema "my_schema" do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -6,7 +6,7 @@ defmodule Ecto.SchemaTest do
   import ExUnit.CaptureIO
 
   defmodule Schema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "my schema" do
       field :name,  :string, default: "eric", autogenerate: {String, :upcase, ["eric"]}
@@ -102,7 +102,7 @@ defmodule Ecto.SchemaTest do
   end
 
   defmodule CustomSchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key {:perm, Custom.Permalink, autogenerate: true}
     @foreign_key_type :string
@@ -136,7 +136,7 @@ defmodule Ecto.SchemaTest do
   end
 
   defmodule EmbeddedSchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
 
     embedded_schema do
       field :name,  :string, default: "eric"
@@ -156,7 +156,7 @@ defmodule Ecto.SchemaTest do
   end
 
   defmodule CustomEmbeddedSchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [embedded_schema: 1]
 
     @primary_key false
     embedded_schema do
@@ -172,7 +172,7 @@ defmodule Ecto.SchemaTest do
   end
 
   defmodule InlineEmbeddedSchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "inline_embedded_schema" do
       embeds_one :one, One, primary_key: false do
@@ -194,7 +194,7 @@ defmodule Ecto.SchemaTest do
   end
 
   defmodule Timestamps do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "timestamps" do
       timestamps autogenerate: {:m, :f, [:a]}
@@ -211,7 +211,7 @@ defmodule Ecto.SchemaTest do
   ## Schema prefix
 
   defmodule SchemaWithPrefix do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @schema_prefix "tenant"
     schema "company" do
@@ -257,7 +257,7 @@ defmodule Ecto.SchemaTest do
   ## Composite primary keys
 
   defmodule SchemaCompositeKeys do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     # Extra key without disabling @primary_key
     schema "composite_keys" do
@@ -269,7 +269,7 @@ defmodule Ecto.SchemaTest do
   # Associative_entity map example:
   # https://en.wikipedia.org/wiki/Associative_entity
   defmodule AssocCompositeKeys do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key false
     schema "student_course_registers" do
@@ -295,7 +295,7 @@ defmodule Ecto.SchemaTest do
   test "field name clash" do
     assert_raise ArgumentError, "field/association :name is already set on schema", fn ->
       defmodule SchemaFieldNameClash do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "clash" do
           field :name, :string
@@ -308,7 +308,7 @@ defmodule Ecto.SchemaTest do
   test "invalid field type" do
     assert_raise ArgumentError, "invalid or unknown type {:apa} for field :name", fn ->
       defmodule SchemaInvalidFieldType do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "invalidtype" do
           field :name, {:apa}
@@ -318,7 +318,7 @@ defmodule Ecto.SchemaTest do
 
     assert_raise ArgumentError, "invalid or unknown type OMG for field :name", fn ->
       defmodule SchemaInvalidFieldType do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "invalidtype" do
           field :name, OMG
@@ -328,7 +328,7 @@ defmodule Ecto.SchemaTest do
 
     assert_raise ArgumentError, ~r/schema Ecto.SchemaTest.Schema is not a valid type for field :name/, fn ->
       defmodule SchemaInvalidFieldType do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "invalidtype" do
           field :name, Schema
@@ -340,7 +340,7 @@ defmodule Ecto.SchemaTest do
   test "fail invalid schema" do
     assert_raise ArgumentError, "schema source must be a string, got: :hello", fn ->
       defmodule SchemaFail do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema :hello do
           field :x, :string
@@ -354,7 +354,7 @@ defmodule Ecto.SchemaTest do
     assert_raise ArgumentError,
                  "field :x does not support :autogenerate because it uses a primitive type :string", fn ->
       defmodule AutogenerateFail do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "hello" do
           field :x, :string, autogenerate: true
@@ -366,7 +366,7 @@ defmodule Ecto.SchemaTest do
                  "only primary keys allow :autogenerate for type :id, " <>
                  "field :x is not a primary key", fn ->
       defmodule AutogenerateFail do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "hello" do
           field :x, :id, autogenerate: true
@@ -377,7 +377,7 @@ defmodule Ecto.SchemaTest do
     assert_raise ArgumentError,
                  "cannot mark the same field as autogenerate and read_after_writes", fn ->
       defmodule AutogenerateFail do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "hello" do
           field :x, Ecto.UUID, autogenerate: true, read_after_writes: true
@@ -389,7 +389,7 @@ defmodule Ecto.SchemaTest do
   ## Associations
 
   defmodule AssocSchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     schema "assocs" do
       has_many :posts, Post
@@ -517,7 +517,7 @@ defmodule Ecto.SchemaTest do
   end
 
   defmodule CustomAssocSchema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key {:pk, :integer, []}
     @foreign_key_type :string
@@ -557,7 +557,7 @@ defmodule Ecto.SchemaTest do
   test "has_* validates option" do
     assert_raise ArgumentError, "invalid option :unknown for has_many/3", fn ->
       defmodule InvalidHasOption do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "assoc" do
           has_many :posts, Post, unknown: :option
@@ -570,7 +570,7 @@ defmodule Ecto.SchemaTest do
     message = ~r"schema does not have the field :pk used by association :posts"
     assert_raise ArgumentError, message, fn ->
       defmodule PkAssocMisMatch do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "assoc" do
           has_many :posts, Post, references: :pk
@@ -583,7 +583,7 @@ defmodule Ecto.SchemaTest do
     message = ~r"association queryable must be a schema or {source, schema}, got: 123"
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "assoc" do
           has_many :posts, 123
@@ -596,7 +596,7 @@ defmodule Ecto.SchemaTest do
     message = ~r"schema does not have the association :whatever used by association :posts"
     assert_raise ArgumentError, message, fn ->
       defmodule PkAssocMisMatch do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "assoc" do
           has_many :posts, through: [:whatever, :works]
@@ -609,7 +609,7 @@ defmodule Ecto.SchemaTest do
     message = ~r"When using the :through option, the schema should not be passed as second argument"
     assert_raise ArgumentError, message, fn ->
       defmodule ThroughMatch do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "assoc" do
           has_many :posts, Post, through: [:whatever, :works]
@@ -623,7 +623,7 @@ defmodule Ecto.SchemaTest do
     message = ~r"foreign_key :#{name} must be distinct from corresponding association name"
     assert_raise ArgumentError, message, fn ->
       defmodule SchemaBadForeignKey do
-        use Ecto.Schema
+        import Ecto.Schema, only: [schema: 2]
 
         schema "fk_assoc_name_clash" do
           belongs_to name, User, foreign_key: name

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -18,7 +18,7 @@ defmodule Ecto.TypeTest do
   end
 
   defmodule Schema do
-    use Ecto.Schema
+    import Ecto.Schema, only: [schema: 2]
 
     @primary_key {:id, :binary_id, autogenerate: true}
     schema "" do


### PR DESCRIPTION
Importing the schema and embedded_schema macros is completely enough to
acheive what we need. Import is clearer for the end user and should be
preffered over use.

But I know this can be a controversial change, so I wanted to open a discussion before merging.

I split the change in two commits - the first one does the change in code required to make it happen, the second one replaces `use` with `import` in docs & tests.

\cc @josevalim @ericmj @chrismccord @wojtekmach 