### PR TITLE
Add missing variable assignment for clarity

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -222,7 +222,7 @@ person = %Friends.Person{age: 28}
 Or with syntax like this:
 
 ```elixir
-%{person | age: 28}
+person = %{person | age: 28}
 ```
 
 We can retrieve values using this syntax:


### PR DESCRIPTION
Under the `Creating the schema` section, there is a part where we say to do this:
```
person = %Friends.Person{age: 28}
```
And then we say that we can also write the above like so:
```
%{person | age: 28}
```
I updated it to look like this:
```
person = %{person | age: 28}
```
It was missing the variable assignment of `person` that we were using in the previous example. This keeps our code uniform for our examples and also keeps people from running into issues if they see both and try the second without ever typing the first. If they never type the first and just write the second, the return value is never set to `person` which means if they are following along with the guide they will hit an error because `person` was never reassigned with the new change.