### PR TITLE
Improve transaction handling

### DIFF
--- a/integration_test/mysql/test_helper.exs
+++ b/integration_test/mysql/test_helper.exs
@@ -4,7 +4,8 @@ Logger.configure(level: :info)
 # but that is not yet supported in travis.
 ExUnit.start exclude: [:array_type, :read_after_writes, :returning, :modify_column,
                        :strict_savepoint, :create_index_if_not_exists,
-                       :transaction_isolation, :rename_column, :with_conflict_target]
+                       :transaction_error_status, :transaction_isolation,
+                       :rename_column, :with_conflict_target]
 
 # Configure Ecto for support and tests
 Application.put_env(:ecto, :lock_for_update, "FOR UPDATE")

--- a/integration_test/sql/sandbox.exs
+++ b/integration_test/sql/sandbox.exs
@@ -99,11 +99,9 @@ defmodule Ecto.Integration.SandboxTest do
     Sandbox.checkout(TestRepo)
 
     assert capture_log(fn ->
-      catch_error(
-        TestRepo.transaction fn ->
+      assert TestRepo.transaction(fn ->
           :timer.sleep(1000)
-        end, timeout: 0
-      )
+        end, timeout: 0) == {:error, :rollback}
     end) =~ "timed out"
 
     Sandbox.checkin(TestRepo)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -654,26 +654,24 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp flatten_transaction(repo, pool, conn, opts, fun) do
-    try do
-      fun.()
-    catch
-      :throw, {__MODULE__, :rollback, ^conn, reason} ->
-        fail_conn(pool, conn)
-        {:error, reason}
-      kind, reason ->
-        stack = System.stacktrace()
-        fail_conn(pool, conn)
-        :erlang.raise(kind, reason, stack)
-    else
-      result ->
-        case transaction_call(repo, :status, conn, opts) do
-          :transaction ->
-            {:ok, result}
-          _failure ->
-            fail_conn(pool, conn)
-            {:error, :rollback}
-        end
-    end
+    fun.()
+  catch
+    :throw, {__MODULE__, :rollback, ^conn, reason} ->
+      fail_conn(pool, conn)
+      {:error, reason}
+    kind, reason ->
+      stack = System.stacktrace()
+      fail_conn(pool, conn)
+      :erlang.raise(kind, reason, stack)
+  else
+    result ->
+      case transaction_call(repo, :status, conn, opts) do
+        :transaction ->
+          {:ok, result}
+        _failure ->
+          fail_conn(pool, conn)
+          {:error, :rollback}
+      end
   end
 
   defp transaction_call(repo, callback, conn, opts) do
@@ -691,7 +689,7 @@ defmodule Ecto.Adapters.SQL do
     {_repo_mod, pool, _default_opts} = lookup_pool(repo)
     case safe_get_conn(pool) do
       nil  -> raise "cannot call rollback outside of transaction"
-      {_, conn}-> throw({__MODULE__, :rollback, conn, value})
+      {_, conn} -> throw({__MODULE__, :rollback, conn, value})
     end
   end
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -250,13 +250,27 @@ defmodule Ecto.Adapters.SQL do
     conn = get_conn(pool) || pool
     opts = with_log(repo_mod, params, opts ++ default_opts)
     args = args ++ [params, opts]
+    sql_call(repo_mod, callback, [conn | args])
+  end
+
+  defp sql_call(repo_mod, callback, args) do
     try do
-      apply(repo_mod.__sql__, callback, [conn | args])
+      apply(repo_mod.__sql__, callback, args)
     rescue
-      err in DBConnection.OwnershipError ->
-        message = err.message <> "\nSee Ecto.Adapters.SQL.Sandbox docs for more information."
-        reraise %{err | message: message}, System.stacktrace
+      err in [DBConnection.OwnershipError] ->
+        stack = System.stacktrace()
+        reraise ownership_error(err), stack
+    else
+      {:error, %struct{} = err} when struct in [DBConnection.OwnershipError] ->
+        {:error, ownership_error(err)}
+      other ->
+        other
     end
+  end
+
+  defp ownership_error(%{message: message} = err) do
+    message = message <> "\nSee Ecto.Adapters.SQL.Sandbox docs for more information."
+    %{err | message: message}
   end
 
   defp put_source(opts, %{sources: sources}) when tuple_size(elem(sources, 0)) == 2 do
@@ -433,6 +447,9 @@ defmodule Ecto.Adapters.SQL do
     case sql_call(repo, :execute, [cached], params, opts) do
       {:ok, result} ->
         result
+      {:ok, query, result} ->
+        reset.({id, String.Chars.to_string(query)})
+        result
       {:error, err} ->
         raise err
       {:reset, err} ->
@@ -553,36 +570,128 @@ defmodule Ecto.Adapters.SQL do
   def transaction(repo, opts, fun) do
     {repo_mod, pool, default_opts} = lookup_pool(repo)
     opts = with_log(repo_mod, [], opts ++ default_opts)
-    case get_conn(pool) do
-      nil  -> do_transaction(pool, opts, fun)
-      conn -> DBConnection.transaction(conn, fn(_) -> fun.() end, opts)
+    case safe_get_conn(pool) do
+      nil  -> outter_transaction(repo, pool, opts, fun)
+      {:ok, conn} -> inner_transaction(repo, pool, conn, opts, fun)
+      {:error, _} -> {:error, :rollback}
     end
   end
 
-  defp do_transaction(pool, opts, fun) do
-    run = fn(conn) ->
-      try do
-        put_conn(pool, conn)
-        fun.()
-      after
-        delete_conn(pool)
-      end
+  defp outter_transaction(repo, pool, opts, fun) do
+    conn = begin_transaction(repo, pool, opts)
+    try do
+      put_conn(pool, conn)
+      transaction_call(repo, :status, conn, opts)
+      fun.()
+    catch
+      :throw, {__MODULE__, :rollback, ^conn, reason} ->
+        rollback_transaction(repo, conn, opts)
+        {:error, reason}
+      kind, reason ->
+        stack = System.stacktrace()
+        rollback_transaction(repo, conn, opts)
+        :erlang.raise(kind, reason, stack)
+    else
+      result ->
+        with {:ok, ^conn} <- safe_get_conn(pool) do
+          case commit_transaction(repo, conn, opts) do
+            :ok ->
+              {:ok, result}
+            {:error, _} = error ->
+              error
+          end
+        else
+          _ ->
+            rollback_transaction(repo, conn, opts)
+            {:error, :rollback}
+        end
+    after
+      delete_conn(pool)
     end
-    DBConnection.transaction(pool, run, opts)
+  end
+
+  defp begin_transaction(repo, pool, opts) do
+    case transaction_call(repo, :begin, pool, opts) do
+      {:ok, conn, _} ->
+        conn
+      {:error, err} ->
+        raise err
+    end
+  end
+
+  defp commit_transaction(repo, conn, opts) do
+    case transaction_call(repo, :commit, conn, opts) do
+      {:ok, _} ->
+        :ok
+      {:error, %struct{}}
+          when struct in [DBConnection.ConnectionError, DBConnection.TransactionError] ->
+        {:error, :rollback}
+      {:error, err} ->
+        raise err
+    end
+  end
+
+  defp rollback_transaction(repo, conn, opts) do
+    case transaction_call(repo, :rollback, conn, opts) do
+      {:ok, _} ->
+        :ok
+      {:error, %struct{}}
+          when struct in [DBConnection.ConnectionError, DBConnection.TransactionError] ->
+        :ok
+      {:error, err} ->
+        raise err
+    end
+  end
+
+  defp inner_transaction(repo, pool, conn, opts, fun) do
+    case transaction_call(repo, :status, conn, opts) do
+      :transaction ->
+        flatten_transaction(repo, pool, conn, opts, fun)
+      _failure ->
+        fail_conn(pool, conn)
+        {:error, :rollback}
+    end
+  end
+
+  defp flatten_transaction(repo, pool, conn, opts, fun) do
+    try do
+      fun.()
+    catch
+      :throw, {__MODULE__, :rollback, ^conn, reason} ->
+        fail_conn(pool, conn)
+        {:error, reason}
+      kind, reason ->
+        stack = System.stacktrace()
+        fail_conn(pool, conn)
+        :erlang.raise(kind, reason, stack)
+    else
+      result ->
+        case transaction_call(repo, :status, conn, opts) do
+          :transaction ->
+            {:ok, result}
+          _failure ->
+            fail_conn(pool, conn)
+            {:error, :rollback}
+        end
+    end
+  end
+
+  defp transaction_call(repo, callback, conn, opts) do
+    sql_call(repo, callback, [conn, opts])
   end
 
   @doc false
   def in_transaction?(repo) do
     {_repo_mod, pool, _default_opts} = lookup_pool(repo)
-    !!get_conn(pool)
+    !!safe_get_conn(pool)
   end
 
   @doc false
   def rollback(repo, value) do
     {_repo_mod, pool, _default_opts} = lookup_pool(repo)
-    case get_conn(pool) do
+    case safe_get_conn(pool) do
       nil  -> raise "cannot call rollback outside of transaction"
-      conn -> DBConnection.rollback(conn, value)
+      {_, conn}-> throw({__MODULE__, :rollback, conn, value})
     end
   end
 
@@ -666,12 +775,28 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp put_conn(pool, conn) do
-    _ = Process.put(key(pool), conn)
+    _ = Process.put(key(pool), {:ok, conn})
     :ok
   end
 
-  defp get_conn(pool) do
+  defp fail_conn(pool, conn) do
+    _ = Process.put(key(pool), {:error, conn})
+    :ok
+  end
+
+  defp safe_get_conn(pool) do
     Process.get(key(pool))
+  end
+
+  defp get_conn(pool) do
+    case Process.get(key(pool)) do
+      {:ok, conn} ->
+        conn
+      {:error, _conn} ->
+        raise DBConnection.ConnectionError, "transaction rolling back"
+      nil ->
+        nil
+    end
   end
 
   defp delete_conn(pool) do

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -27,7 +27,31 @@ defmodule Ecto.Adapters.SQL.Connection do
   @callback execute(connection :: DBConnection.t, prepared_query :: prepared, params :: [term], options :: Keyword.t) ::
             {:ok, term} | {:error, Exception.t}
   @callback execute(connection :: DBConnection.t, prepared_query :: cached, params :: [term], options :: Keyword.t) ::
-            {:ok, term} | {:error | :reset, Exception.t}
+            {:ok, term} | {:ok, replacement_query :: cached, term} | {:error | :reset, Exception.t}
+
+  @doc """
+  Begin a transaction with `DBConnection`.
+  """
+  @callback begin(connection :: DBConnection.t, options :: Keyword.t) ::
+            {:ok, DBConnection.conn, term} | {:error, Exception.t}
+
+  @doc """
+  Commit a transaction with `DBConnection`.
+  """
+  @callback commit(connection :: DBConnection.conn, options :: Keyword.t) ::
+            {:ok, term} | {:error, Exception.t}
+
+  @doc """
+  Begin a transaction with `DBConnection`.
+  """
+  @callback rollback(connection :: DBConnection.conn, options :: Keyword.t) ::
+            {:ok, term} | {:error, Exception.t}
+
+  @doc """
+  Get status of a connection with `DBConnection`.
+  """
+  @callback status(connection :: DBConnection.conn, options :: Keyword.t) ::
+            :transaction | :idle | :error
 
   @doc """
   Returns a stream that prepares and executes the given query with

--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -317,19 +317,32 @@ defmodule Ecto.Adapters.SQL.Sandbox do
       case conn_mod.handle_begin(opts, state) do
         {:ok, value, state} ->
           {:ok, value, {conn_mod, state, true}}
+        {status, state} ->
+          {status, {conn_mod, state, false}}
         {kind, err, state} ->
           {kind, err, {conn_mod, state, false}}
       end
     end
     def handle_commit(opts, {conn_mod, state, true}) do
       opts = [mode: :savepoint] ++ opts
-      proxy(:handle_commit, {conn_mod, state, false}, [opts])
+      case conn_mod.handle_commit(opts, state) do
+        {:ok, value, state} ->
+          {:ok, value, {conn_mod, state, false}}
+        {:idle, state} ->
+          {:idle, {conn_mod, state. false}}
+        {status, state} ->
+            {status, {conn_mod, state, true}}
+        {kind, err, state} ->
+          {kind, err, {conn_mod, state, false}}
+      end
     end
     def handle_rollback(opts, {conn_mod, state, true}) do
       opts = [mode: :savepoint] ++ opts
       proxy(:handle_rollback, {conn_mod, state, false}, [opts])
     end
 
+    def handle_status(opts, state),
+      do: proxy(:handle_status, state, [maybe_savepoint(opts, state)])
     def handle_prepare(query, opts, state),
       do: proxy(:handle_prepare, state, [query, maybe_savepoint(opts, state)])
     def handle_execute(query, params, opts, state),
@@ -338,6 +351,8 @@ defmodule Ecto.Adapters.SQL.Sandbox do
       do: proxy(:handle_close, state, [query, maybe_savepoint(opts, state)])
     def handle_declare(query, params, opts, state),
       do: proxy(:handle_declare, state, [query, params, maybe_savepoint(opts, state)])
+    def handle_fetch(query, cursor, opts, state),
+      do: proxy(:handle_fetch, state, [query, cursor, maybe_savepoint(opts, state)])
     def handle_first(query, cursor, opts, state),
       do: proxy(:handle_first, state, [query, cursor, maybe_savepoint(opts, state)])
     def handle_next(query, cursor, opts, state),

--- a/mix.exs
+++ b/mix.exs
@@ -44,9 +44,9 @@ defmodule Ecto.Mixfile do
       {:decimal, "~> 1.2"},
 
       # Drivers
-      {:db_connection, "~> 1.1", optional: true},
-      {:postgrex, "~> 0.14.0-dev", optional: true, github: "elixir-ecto/postgrex"},
-      {:mariaex, "~> 0.9.0-dev", optional: true, github: "xerions/mariaex"},
+      {:db_connection, "~> 1.1", optional: true, override: true, github: "elixir-ecto/db_connection", ref: "eb45ccd"},
+      {:postgrex, "~> 0.14.0-dev", optional: true, github: "elixir-ecto/postgrex", ref: "1d0a766"},
+      {:mariaex, "~> 0.9.0-dev", optional: true, github: "fishcakez/mariaex", ref: "cf37d53"},
 
       # Optional
       {:sbroker, "~> 1.0", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -1,13 +1,11 @@
-%{
-  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "eb45ccdd12d00a42ebc1e91293de26bb768fac40", [ref: "eb45ccd"]},
   "decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.17.1", "39f777415e769992e6732d9589dc5846ea587f01412241f4a774664c746affbb", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
-  "mariaex": {:git, "https://github.com/xerions/mariaex.git", "59d7ae0ab21212bf3434b573c07e4fd2385ec0c8", []},
+  "mariaex": {:git, "https://github.com/fishcakez/mariaex.git", "cf37d5324879f9c90a481a6f8bcaee25be516a13", [ref: "cf37d53"]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
-  "postgrex": {:git, "https://github.com/elixir-ecto/postgrex.git", "a6c1f1936851101b1fe6c340ab1e79c315b7388a", []},
-  "sbroker": {:hex, :sbroker, "1.0.0", "28ff1b5e58887c5098539f236307b36fe1d3edaa2acff9d6a3d17c2dcafebbd0", [:rebar3], [], "hexpm"},
-}
+  "postgrex": {:git, "https://github.com/elixir-ecto/postgrex.git", "1d0a766349c9e38cfd04b1c5900bab0cac7f39eb", [ref: "1d0a766"]},
+  "sbroker": {:hex, :sbroker, "1.0.0", "28ff1b5e58887c5098539f236307b36fe1d3edaa2acff9d6a3d17c2dcafebbd0", [:rebar3], [], "hexpm"}}


### PR DESCRIPTION
This is the first step towards upgrading to take advantage of the latest DBConnection. This change ensures we rely fully on the database's status to get a transaction's state. There are 3 main benefits.

Transactions now mark SQL transactions as failed if attempt to begin, rollback or commit a transaction when SQL status does not allow it. For example we will reject connections that have an open transaction when we checkout from the pool and disconnect them. Similarly if we try to commit or rollback a transaction but there isn't a transaction we will return an error. This could apply if a query manually committed or rolled back the transaction.

Nested transaction now mark SQL transactions as failed if a nested transaction starts or ends outside a transaction. This works in a similar way to previous benefit, except we can detect at the start and end of a nested transaction whether we are inside a transaction. This ensures we have a strict flattened transaction.

Nested transactions now mark pg transactions as failed when a SQL error occurs that put transaction in error state without an uncaught exception or explicit rollback to notify Ecto. This means we can detect a query error causing PostgreSQL to enter the error state where all queries fail and the transaction would rollback on commit. On error for nested and outter transactions an error forces a rollback of the whole transaction. Previously we could log these as commits!

Unfortunately there is a bug in DBConnection (https://github.com/elixir-ecto/db_connection/issues/106) that is blocking this.