### PR TITLE
Put constraint name in error metadata for check & exclude constraints

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -281,7 +281,7 @@ defmodule Ecto.Integration.RepoTest do
       changeset
       |> Ecto.Changeset.unique_constraint(:uuid)
       |> TestRepo.insert()
-    assert changeset.errors == [uuid: {"has already been taken", [constraint: :unique]}]
+    assert changeset.errors == [uuid: {"has already been taken", [constraint: :unique, constraint_name: "posts_uuid_index"]}]
     assert changeset.data.__meta__.state == :built
   end
 
@@ -298,7 +298,7 @@ defmodule Ecto.Integration.RepoTest do
       }
 
     [_, p2, _] = changeset.changes.posts
-    assert p2.errors == [uuid: {"has already been taken", [constraint: :unique]}]
+    assert p2.errors == [uuid: {"has already been taken", [constraint: :unique, constraint_name: "posts_uuid_index"]}]
   end
 
   @tag :id_type
@@ -311,7 +311,7 @@ defmodule Ecto.Integration.RepoTest do
       changeset
       |> Ecto.Changeset.unique_constraint(:uuid)
       |> TestRepo.insert()
-    assert changeset.errors == [uuid: {"has already been taken", [constraint: :unique]}]
+    assert changeset.errors == [uuid: {"has already been taken", [constraint: :unique, constraint_name: "customs_uuid_index"]}]
     assert changeset.data.__meta__.state == :built
   end
 
@@ -418,7 +418,7 @@ defmodule Ecto.Integration.RepoTest do
       changeset
       |> Ecto.Changeset.foreign_key_constraint(:post_id)
       |> TestRepo.insert()
-    assert changeset.errors == [post_id: {"does not exist", [constraint: :foreign]}]
+    assert changeset.errors == [post_id: {"does not exist", [constraint: :foreign, constraint_name: "comments_post_id_fkey"]}]
   end
 
   @tag :foreign_key_constraint
@@ -448,7 +448,7 @@ defmodule Ecto.Integration.RepoTest do
       changeset
       |> Ecto.Changeset.assoc_constraint(:post)
       |> TestRepo.insert()
-    assert changeset.errors == [post: {"does not exist", [constraint: :assoc]}]
+    assert changeset.errors == [post: {"does not exist", [constraint: :assoc, constraint_name: "comments_post_id_fkey"]}]
   end
 
   @tag :foreign_key_constraint
@@ -492,7 +492,7 @@ defmodule Ecto.Integration.RepoTest do
       |> Ecto.Changeset.change
       |> Ecto.Changeset.no_assoc_constraint(:permalink)
       |> TestRepo.delete()
-    assert changeset.errors == [permalink: {"is still associated with this entry", [constraint: :no_assoc]}]
+    assert changeset.errors == [permalink: {"is still associated with this entry", [constraint: :no_assoc, constraint_name: "permalinks_user_id_fkey"]}]
   end
 
   @tag :foreign_key_constraint

--- a/integration_test/pg/constraints_test.exs
+++ b/integration_test/pg/constraints_test.exs
@@ -65,7 +65,7 @@ defmodule Ecto.Integration.ConstraintsTest do
       overlapping_changeset
       |> Ecto.Changeset.exclusion_constraint(:from, name: :cannot_overlap)
       |> PoolRepo.insert()
-    assert changeset.errors == [from: {"violates an exclusion constraint", [constraint: :exclude, constraint_name: "cannot_overlap"]}]
+    assert changeset.errors == [from: {"violates an exclusion constraint", [constraint: :exclusion, constraint_name: "cannot_overlap"]}]
     assert changeset.data.__meta__.state == :built
   end
 

--- a/integration_test/pg/constraints_test.exs
+++ b/integration_test/pg/constraints_test.exs
@@ -65,7 +65,7 @@ defmodule Ecto.Integration.ConstraintsTest do
       overlapping_changeset
       |> Ecto.Changeset.exclusion_constraint(:from, name: :cannot_overlap)
       |> PoolRepo.insert()
-    assert changeset.errors == [from: {"violates an exclusion constraint", [constraint: :exclusion]}]
+    assert changeset.errors == [from: {"violates an exclusion constraint", [constraint: :exclude, constraint_name: "cannot_overlap"]}]
     assert changeset.data.__meta__.state == :built
   end
 
@@ -85,7 +85,7 @@ defmodule Ecto.Integration.ConstraintsTest do
       changeset
       |> Ecto.Changeset.check_constraint(:price, name: :positive_price)
       |> PoolRepo.insert()
-    assert changeset.errors == [price: {"is invalid", [constraint: :check]}]
+    assert changeset.errors == [price: {"is invalid", [constraint: :check, constraint_name: "positive_price"]}]
     assert changeset.data.__meta__.state == :built
 
     # When the changeset does expect the db error and gives a custom message
@@ -94,7 +94,7 @@ defmodule Ecto.Integration.ConstraintsTest do
       changeset
       |> Ecto.Changeset.check_constraint(:price, name: :positive_price, message: "price must be greater than 0")
       |> PoolRepo.insert()
-    assert changeset.errors == [price: {"price must be greater than 0", [constraint: :check]}]
+    assert changeset.errors == [price: {"price must be greater than 0", [constraint: :check, constraint_name: "positive_price"]}]
     assert changeset.data.__meta__.state == :built
 
     # When the change does not violate the check constraint

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2272,7 +2272,7 @@ defmodule Ecto.Changeset do
     constraint_string = to_string(constraint)
     message    = message(opts, "violates an exclusion constraint")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :exclude, constraint_string, match_type, field, {message, [constraint: :exclude, constraint_name: constraint_string]})
+    add_constraint(changeset, :exclude, constraint_string, match_type, field, {message, [constraint: :exclusion, constraint_name: constraint_string]})
   end
 
   defp no_assoc_message(:one), do: "is still associated with this entry"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1990,9 +1990,10 @@ defmodule Ecto.Changeset do
   """
   def check_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || raise ArgumentError, "must supply the name of the constraint"
+    constraint_string = to_string(constraint)
     message    = message(opts, "is invalid")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :check, to_string(constraint), match_type, field, {message, [constraint: :check]})
+    add_constraint(changeset, :check, constraint_string, match_type, field, {message, [constraint: :check, constraint_name: constraint_string]})
   end
 
   @doc """
@@ -2264,9 +2265,10 @@ defmodule Ecto.Changeset do
   """
   def exclusion_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_exclusion"
+    constraint_string = to_string(constraint)
     message    = message(opts, "violates an exclusion constraint")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :exclude, to_string(constraint), match_type, field, {message, [constraint: :exclusion]})
+    add_constraint(changeset, :exclude, constraint_string, match_type, field, {message, [constraint: :exclude, constraint_name: constraint_string]})
   end
 
   defp no_assoc_message(:one), do: "is still associated with this entry"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1990,10 +1990,9 @@ defmodule Ecto.Changeset do
   """
   def check_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || raise ArgumentError, "must supply the name of the constraint"
-    constraint_string = to_string(constraint)
     message    = message(opts, "is invalid")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :check, constraint_string, match_type, field, message)
+    add_constraint(changeset, :check, to_string(constraint), match_type, field, message)
   end
 
   @doc """
@@ -2093,10 +2092,9 @@ defmodule Ecto.Changeset do
   @spec unique_constraint(t, atom, Keyword.t) :: t
   def unique_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_index"
-    constraint_string = to_string(constraint)
     message    = message(opts, "has already been taken")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :unique, constraint_string, match_type, field, message)
+    add_constraint(changeset, :unique, to_string(constraint), match_type, field, message)
   end
 
   @doc """
@@ -2142,9 +2140,8 @@ defmodule Ecto.Changeset do
   @spec foreign_key_constraint(t, atom, Keyword.t) :: t
   def foreign_key_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_fkey"
-    constraint_string = to_string(constraint)
     message    = message(opts, "does not exist")
-    add_constraint(changeset, :foreign_key, constraint_string, :exact, field, message, :foreign)
+    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, field, message, :foreign)
   end
 
   @doc """
@@ -2190,10 +2187,9 @@ defmodule Ecto.Changeset do
           raise ArgumentError,
             "assoc_constraint can only be added to belongs to associations, got: #{inspect other}"
       end
-    constraint_string = to_string(constraint)
 
     message = message(opts, "does not exist")
-    add_constraint(changeset, :foreign_key, constraint_string, :exact, assoc, message, :assoc)
+    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, assoc, message, :assoc)
   end
 
   @doc """
@@ -2242,9 +2238,8 @@ defmodule Ecto.Changeset do
           raise ArgumentError,
             "no_assoc_constraint can only be added to has one/many associations, got: #{inspect other}"
       end
-    constraint_string = to_string(constraint)
 
-    add_constraint(changeset, :foreign_key, constraint_string, :exact, assoc, message, :no_assoc)
+    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, assoc, message, :no_assoc)
   end
 
   @doc """
@@ -2269,10 +2264,9 @@ defmodule Ecto.Changeset do
   """
   def exclusion_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_exclusion"
-    constraint_string = to_string(constraint)
     message    = message(opts, "violates an exclusion constraint")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :exclude, constraint_string, match_type, field, message, :exclusion)
+    add_constraint(changeset, :exclude, to_string(constraint), match_type, field, message, :exclusion)
   end
 
   defp no_assoc_message(:one), do: "is still associated with this entry"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2093,9 +2093,10 @@ defmodule Ecto.Changeset do
   @spec unique_constraint(t, atom, Keyword.t) :: t
   def unique_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_index"
+    constraint_string = to_string(constraint)
     message    = message(opts, "has already been taken")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :unique, to_string(constraint), match_type, field, {message, [constraint: :unique]})
+    add_constraint(changeset, :unique, constraint_string, match_type, field, {message, [constraint: :unique, constraint_name: constraint_string]})
   end
 
   @doc """
@@ -2141,8 +2142,9 @@ defmodule Ecto.Changeset do
   @spec foreign_key_constraint(t, atom, Keyword.t) :: t
   def foreign_key_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_fkey"
+    constraint_string = to_string(constraint)
     message    = message(opts, "does not exist")
-    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, field, {message, [constraint: :foreign]})
+    add_constraint(changeset, :foreign_key, constraint_string, :exact, field, {message, [constraint: :foreign, constraint_name: constraint_string]})
   end
 
   @doc """
@@ -2188,9 +2190,10 @@ defmodule Ecto.Changeset do
           raise ArgumentError,
             "assoc_constraint can only be added to belongs to associations, got: #{inspect other}"
       end
+    constraint_string = to_string(constraint)
 
     message = message(opts, "does not exist")
-    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, assoc, {message, [constraint: :assoc]})
+    add_constraint(changeset, :foreign_key, constraint_string, :exact, assoc, {message, [constraint: :assoc, constraint_name: constraint_string]})
   end
 
   @doc """
@@ -2239,8 +2242,9 @@ defmodule Ecto.Changeset do
           raise ArgumentError,
             "no_assoc_constraint can only be added to has one/many associations, got: #{inspect other}"
       end
+    constraint_string = to_string(constraint)
 
-    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, assoc, {message, [constraint: :no_assoc]})
+    add_constraint(changeset, :foreign_key, constraint_string, :exact, assoc, {message, [constraint: :no_assoc, constraint_name: constraint_string]})
   end
 
   @doc """

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1304,12 +1304,12 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> exclusion_constraint(:title)
     assert changeset.constraints ==
            [%{type: :exclude, field: :title, constraint: "posts_title_exclusion", match: :exact,
-              error: {"violates an exclusion constraint", [constraint: :exclude, constraint_name: "posts_title_exclusion"]}}]
+              error: {"violates an exclusion constraint", [constraint: :exclusion, constraint_name: "posts_title_exclusion"]}}]
 
     changeset = change(%Post{}) |> exclusion_constraint(:title, name: :whatever, message: "is invalid")
     assert changeset.constraints ==
            [%{type: :exclude, field: :title, constraint: "whatever", match: :exact,
-              error: {"is invalid", [constraint: :exclude, constraint_name: "whatever"]}}]
+              error: {"is invalid", [constraint: :exclusion, constraint_name: "whatever"]}}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1148,12 +1148,12 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short)
     assert changeset.constraints ==
            [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
-              error: {"is invalid", [constraint: :check]}}]
+              error: {"is invalid", [constraint: :check, constraint_name: "title_must_be_short"]}}]
 
     changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short, message: "cannot be more than 15 characters")
     assert changeset.constraints ==
            [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
-              error: {"cannot be more than 15 characters", [constraint: :check]}}]
+              error: {"cannot be more than 15 characters", [constraint: :check, constraint_name: "title_must_be_short"]}}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> check_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
@@ -1304,12 +1304,12 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> exclusion_constraint(:title)
     assert changeset.constraints ==
            [%{type: :exclude, field: :title, constraint: "posts_title_exclusion", match: :exact,
-              error: {"violates an exclusion constraint", [constraint: :exclusion]}}]
+              error: {"violates an exclusion constraint", [constraint: :exclude, constraint_name: "posts_title_exclusion"]}}]
 
     changeset = change(%Post{}) |> exclusion_constraint(:title, name: :whatever, message: "is invalid")
     assert changeset.constraints ==
            [%{type: :exclude, field: :title, constraint: "whatever", match: :exact,
-              error: {"is invalid", [constraint: :exclusion]}}]
+              error: {"is invalid", [constraint: :exclude, constraint_name: "whatever"]}}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1169,19 +1169,19 @@ defmodule Ecto.ChangesetTest do
 
     assert changeset.constraints ==
            [%{type: :unique, field: :title, constraint: "posts_title_index", match: :exact,
-              error: {"has already been taken", [constraint: :unique]}}]
+              error: {"has already been taken", [constraint: :unique, constraint_name: "posts_title_index"]}}]
 
     changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, message: "is taken")
     assert changeset.constraints ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :exact, error: {"is taken", [constraint: :unique]}}]
+           [%{type: :unique, field: :title, constraint: "whatever", match: :exact, error: {"is taken", [constraint: :unique, constraint_name: "whatever"]}}]
 
     changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :suffix, message: "is taken")
     assert changeset.constraints ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :suffix, error: {"is taken", [constraint: :unique]}}]
+           [%{type: :unique, field: :title, constraint: "whatever", match: :suffix, error: {"is taken", [constraint: :unique, constraint_name: "whatever"]}}]
 
     changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :prefix, message: "is taken")
     assert changeset.constraints ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :prefix, error: {"is taken", [constraint: :unique]}}]
+           [%{type: :unique, field: :title, constraint: "whatever", match: :prefix, error: {"is taken", [constraint: :unique, constraint_name: "whatever"]}}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
@@ -1193,15 +1193,15 @@ defmodule Ecto.ChangesetTest do
 
     assert changeset.constraints ==
            [%{type: :unique, field: :permalink, constraint: "posts_url_index", match: :exact,
-              error: {"has already been taken", [constraint: :unique]}}]
+              error: {"has already been taken", [constraint: :unique, constraint_name: "posts_url_index"]}}]
 
     changeset = change(%Post{}) |> unique_constraint(:permalink, name: :whatever, message: "is taken")
     assert changeset.constraints ==
-           [%{type: :unique, field: :permalink, constraint: "whatever", match: :exact, error: {"is taken", [constraint: :unique]}}]
+           [%{type: :unique, field: :permalink, constraint: "whatever", match: :exact, error: {"is taken", [constraint: :unique, constraint_name: "whatever"]}}]
 
     changeset = change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :suffix, message: "is taken")
     assert changeset.constraints ==
-           [%{type: :unique, field: :permalink, constraint: "whatever", match: :suffix, error: {"is taken", [constraint: :unique]}}]
+           [%{type: :unique, field: :permalink, constraint: "whatever", match: :suffix, error: {"is taken", [constraint: :unique, constraint_name: "whatever"]}}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :invalid, message: "is taken")
@@ -1212,44 +1212,44 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Comment{}) |> foreign_key_constraint(:post_id)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :post_id, constraint: "comments_post_id_fkey", match: :exact,
-              error: {"does not exist", [constraint: :foreign]}}]
+              error: {"does not exist", [constraint: :foreign, constraint_name: "comments_post_id_fkey"]}}]
 
     changeset = change(%Comment{}) |> foreign_key_constraint(:post_id, name: :whatever, message: "is not available")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :post_id, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :foreign]}}]
+           [%{type: :foreign_key, field: :post_id, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :foreign, constraint_name: "whatever"]}}]
   end
 
   test "foreign_key_constraint/3 on field with :source" do
     changeset = change(%Post{}) |> foreign_key_constraint(:permalink)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :permalink, constraint: "posts_url_fkey", match: :exact,
-              error: {"does not exist", [constraint: :foreign]}}]
+              error: {"does not exist", [constraint: :foreign, constraint_name: "posts_url_fkey"]}}]
 
     changeset = change(%Post{}) |> foreign_key_constraint(:permalink, name: :whatever, message: "is not available")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :permalink, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :foreign]}}]
+           [%{type: :foreign_key, field: :permalink, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :foreign, constraint_name: "whatever"]}}]
   end
 
   test "assoc_constraint/3" do
     changeset = change(%Comment{}) |> assoc_constraint(:post)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :post, constraint: "comments_post_id_fkey", match: :exact,
-              error: {"does not exist", [constraint: :assoc]}}]
+              error: {"does not exist", [constraint: :assoc, constraint_name: "comments_post_id_fkey"]}}]
 
     changeset = change(%Comment{}) |> assoc_constraint(:post, name: :whatever, message: "is not available")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :assoc]}}]
+           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :assoc, constraint_name: "whatever"]}}]
   end
 
   test "assoc_constraint/3 on field with :source" do
     changeset = change(%Post{}) |> assoc_constraint(:category)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :category, constraint: "posts_category_id_fkey", match: :exact,
-              error: {"does not exist", [constraint: :assoc]}}]
+              error: {"does not exist", [constraint: :assoc, constraint_name: "posts_category_id_fkey"]}}]
 
     changeset = change(%Post{}) |> assoc_constraint(:category, name: :whatever, message: "is not available")
     assert changeset.constraints ==
-           [%{type: :foreign_key, field: :category, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :assoc]}}]
+           [%{type: :foreign_key, field: :category, constraint: "whatever", match: :exact, error: {"is not available", [constraint: :assoc, constraint_name: "whatever"]}}]
   end
 
   test "assoc_constraint/3 with errors" do
@@ -1268,24 +1268,24 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> no_assoc_constraint(:comments)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey", match: :exact,
-              error: {"are still associated with this entry", [constraint: :no_assoc]}}]
+              error: {"are still associated with this entry", [constraint: :no_assoc, constraint_name: "comments_post_id_fkey"]}}]
 
     changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: :whatever, message: "exists")
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :comments, constraint: "whatever", match: :exact,
-              error: {"exists", [constraint: :no_assoc]}}]
+              error: {"exists", [constraint: :no_assoc, constraint_name: "whatever"]}}]
   end
 
   test "no_assoc_constraint/3 with has_one" do
     changeset = change(%Post{}) |> no_assoc_constraint(:comment)
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :comment, constraint: "comments_post_id_fkey", match: :exact,
-              error: {"is still associated with this entry", [constraint: :no_assoc]}}]
+              error: {"is still associated with this entry", [constraint: :no_assoc, constraint_name: "comments_post_id_fkey"]}}]
 
     changeset = change(%Post{}) |> no_assoc_constraint(:comment, name: :whatever, message: "exists")
     assert changeset.constraints ==
            [%{type: :foreign_key, field: :comment, constraint: "whatever", match: :exact,
-              error: {"exists", [constraint: :no_assoc]}}]
+              error: {"exists", [constraint: :no_assoc, constraint_name: "whatever"]}}]
   end
 
   test "no_assoc_constraint/3 with errors" do

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -405,7 +405,7 @@ defmodule Ecto.MultiTest do
       assert {:messages, [{:insert, {nil, "comments"}}]} == Process.info(self(), :messages)
       assert %Comment{} = changes.insert
       assert "ok" == changes.run
-      assert error.errors == [x: {"has already been taken", [constraint: :unique]}]
+      assert error.errors == [x: {"has already been taken", [constraint: :unique, constraint_name: "comments_x_index"]}]
       refute Map.has_key?(changes, :update)
     end
 


### PR DESCRIPTION
In our project we have 2 check constraints on the same field. We want to be able to easily distinguish errors triggered by them without matching on error message strings.

We also propose to change other constraint functions to have this metadata shape, e.g.:

`[constraint: {type, constraint_name}`

Even though it's not common to e.g. have multiple unique constraints on the same field, the DB allows that.

This is obviously a breaking change.

An alternative for our use case is to be able to do e.g.:

```elixir
|> check_constraint(:price, name: :positive_price, metadata: [constraint: {:check, "positive_price"}])
```

(done pairing with @wojtekmach)