### PR TITLE
Raise error when not association passed to Ecto.assoc_loaded?/1

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -531,8 +531,8 @@ defmodule Ecto do
 
   """
   def assoc_loaded?(%Ecto.Association.NotLoaded{}), do: false
+  def assoc_loaded?(list) when is_list(list), do: true
   def assoc_loaded?(%_{}), do: true
-  def assoc_loaded?([]), do: true
   def assoc_loaded?(nil), do: true
   def assoc_loaded?(other), do: raise ArgumentError, "expected associated entries, got #{inspect other}"
 

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -534,7 +534,6 @@ defmodule Ecto do
   def assoc_loaded?(list) when is_list(list), do: true
   def assoc_loaded?(%_{}), do: true
   def assoc_loaded?(nil), do: true
-  def assoc_loaded?(other), do: raise ArgumentError, "expected associated entries, got #{inspect other}"
 
   @doc """
   Gets the metadata from the given struct.

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -530,12 +530,11 @@ defmodule Ecto do
       true
 
   """
-  def assoc_loaded?(association) do
-    case association do
-      %Ecto.Association.NotLoaded{} -> false
-      _ -> true
-    end
-  end
+  def assoc_loaded?(%Ecto.Association.NotLoaded{}), do: false
+  def assoc_loaded?(%_{}), do: true
+  def assoc_loaded?([]), do: true
+  def assoc_loaded?(nil), do: true
+  def assoc_loaded?(other), do: raise ArgumentError, "expected associated entries, got #{inspect other}"
 
   @doc """
   Gets the metadata from the given struct.

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -462,9 +462,16 @@ defmodule Ecto.AssociationTest do
     assert comment.__meta__.source == {nil, "comments"}
   end
 
-  test "sets association to loaded/not loaded" do
+  test "assoc_loaded?/1 sets association to loaded/not loaded" do
     refute Ecto.assoc_loaded?(%Post{}.comments)
     assert Ecto.assoc_loaded?(%Post{comments: []}.comments)
+    assert Ecto.assoc_loaded?(%Post{permalink: nil}.permalink)
+  end
+
+  test "assoc_loaded?/1 fails on not struct, list or nil" do
+    assert_raise ArgumentError, ~r"expected associated entries, got :whatever", fn ->
+      Ecto.assoc_loaded?(:whatever)
+    end
   end
 
   test "assoc/2" do

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -465,6 +465,7 @@ defmodule Ecto.AssociationTest do
   test "assoc_loaded?/1 sets association to loaded/not loaded" do
     refute Ecto.assoc_loaded?(%Post{}.comments)
     assert Ecto.assoc_loaded?(%Post{comments: []}.comments)
+    assert Ecto.assoc_loaded?(%Post{comments: [%Comment{}]}.comments)
     assert Ecto.assoc_loaded?(%Post{permalink: nil}.permalink)
   end
 

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -469,12 +469,6 @@ defmodule Ecto.AssociationTest do
     assert Ecto.assoc_loaded?(%Post{permalink: nil}.permalink)
   end
 
-  test "assoc_loaded?/1 fails on not struct, list or nil" do
-    assert_raise ArgumentError, ~r"expected associated entries, got :whatever", fn ->
-      Ecto.assoc_loaded?(:whatever)
-    end
-  end
-
   test "assoc/2" do
     assert inspect(assoc(%Post{id: 1}, :comments)) ==
            inspect(from c in Comment, where: c.post_id == ^1)


### PR DESCRIPTION
I noticed that `Ecto.assoc_loaded?/1` returns true on any input except `%Ecto.Association.NotLoaded{}`. I think it can be source of errors when somebody will try to put atom instead of entry `Ecto.assoc_loaded?(:assoc)` or something else.