### PR TITLE
Use `Task.async_stream` to preload associations.

### DIFF
--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -105,7 +105,7 @@ defmodule Ecto.Repo.Preloader do
       opts = Keyword.put_new(opts, :caller, self())
       assocs
       |> Task.async_stream(&fun.(&1, opts), timeout: :infinity)
-      |> Stream.map(fn {:ok, assoc} -> assoc end)
+      |> Enum.map(fn {:ok, assoc} -> assoc end)
     else
       Enum.map(assocs, &fun.(&1, opts))
     end

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -104,8 +104,8 @@ defmodule Ecto.Repo.Preloader do
       # set the proper timeouts.
       opts = Keyword.put_new(opts, :caller, self())
       assocs
-      |> Enum.map(&Task.async(:erlang, :apply, [fun, [&1, opts]]))
-      |> Enum.map(&Task.await(&1, :infinity))
+      |> Task.async_stream(&fun.(&1, opts), timeout: :infinity)
+      |> Stream.map(fn {:ok, assoc} -> assoc end)
     else
       Enum.map(assocs, &fun.(&1, opts))
     end


### PR DESCRIPTION
This fixes #2246.