### PR TITLE
Keep double underscores on index names

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -583,9 +583,10 @@ defmodule Ecto.Migration do
   defp default_index_name(index) do
     [index.table, index.columns, "index"]
     |> List.flatten
+    |> Enum.map(&to_string(&1))
+    |> Enum.map(&String.replace(&1, ~r"[^\w_]", "_"))
+    |> Enum.map(&String.replace_trailing(&1, "_", ""))
     |> Enum.join("_")
-    |> String.replace(~r"[^\w_]", "_")
-    |> String.replace("__", "_")
     |> String.to_atom
   end
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -58,6 +58,8 @@ defmodule Ecto.MigrationTest do
            %Index{table: "posts", unique: true, name: :foo, columns: [:title]}
     assert unique_index(:posts, :title, name: :foo) ==
            %Index{table: "posts", unique: true, name: :foo, columns: [:title]}
+    assert unique_index(:table_one__table_two, :title) ==
+           %Index{table: "table_one__table_two", unique: true, name: :table_one__table_two_title_index, columns: [:title]}
   end
 
   test "creates a reference" do


### PR DESCRIPTION
# Summary
Index names are composed of index.table name, index.columns names and
the "index" suffix. If index.table or index.columns names cointained two
underscores, they were replaced by a single underscore. This caused
issues when applying unique index constraints on changesets.

## Additional info
Fixes #2311