### PR TITLE
change comment in schema has_many :through docs

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -662,7 +662,7 @@ defmodule Ecto.Schema do
   This `:through` association will return all authors for all comments
   that belongs to that post:
 
-      # Get all comments for a given post
+      # Get all comments authors for a given post
       post = Repo.get(Post, 42)
       authors = Repo.all assoc(post, :comments_authors)
 


### PR DESCRIPTION
I find the current comment confusing. It does not describe what's happening in the code. I'd either change it to this one or remove it.

edit: I know it does describe what happens underneath, but I think the placement is unfortunate. Code comments describe the purpose of code and neither of these two lines' purpose is getting comments. It is a side effect of (or the means of getting the value of) the second line, and if we want to mention that side effect, I think it should be noted that it is a side effect.