### PR TITLE
Use stricter syntax for update_all with joins in MySQL adapter

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -102,9 +102,9 @@ if Code.ensure_loaded?(Mariaex) do
         update_fields(:update, query, sources)
       end
 
-      join   = join(query, sources)
+      {join, wheres} = using_join(query, :update_all, sources)
       prefix = prefix || ["UPDATE ", from, " AS ", name, join, " SET "]
-      where  = where(query, sources)
+      where  = where(%{query | wheres: wheres ++ query.wheres}, sources)
 
       [prefix, fields | where]
     end
@@ -244,6 +244,25 @@ if Code.ensure_loaded?(Mariaex) do
 
     defp update_op(command, _quoted_key, _value, _sources, query) do
       error!(query, "Unknown update operation #{inspect command} for MySQL")
+    end
+
+    defp using_join(%Query{joins: []}, _kind, _sources), do: {[], []}
+    defp using_join(%Query{joins: joins} = query, kind, sources) do
+      froms =
+        intersperse_map(joins, ", ", fn
+          %JoinExpr{qual: :inner, ix: ix, source: source} ->
+            {join, name} = get_source(query, sources, ix, source)
+            [join, " AS " | name]
+          %JoinExpr{qual: qual} ->
+            error!(query, "MySQL adapter supports only inner joins on #{kind}, got: `#{qual}`")
+        end)
+
+      wheres =
+        for %JoinExpr{on: %QueryExpr{expr: value} = expr} <- joins,
+            value != true,
+            do: expr |> Map.put(:__struct__, BooleanExpr) |> Map.put(:op, :and)
+
+      {[?, ,?\s | froms], wheres}
     end
 
     defp join(%Query{joins: []}, _sources), do: []

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -262,7 +262,7 @@ if Code.ensure_loaded?(Mariaex) do
             value != true,
             do: expr |> Map.put(:__struct__, BooleanExpr) |> Map.put(:op, :and)
 
-      {[?, ,?\s | froms], wheres}
+      {[?,, ?\s | froms], wheres}
     end
 
     defp join(%Query{joins: []}, _sources), do: []

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -355,13 +355,13 @@ defmodule Ecto.Adapters.MySQLTest do
     query = Schema |> join(:inner, [p], q in Schema2, p.x == q.z)
                   |> update([_], set: [x: 0]) |> normalize(:update_all)
     assert update_all(query) ==
-           ~s{UPDATE `schema` AS s0 INNER JOIN `schema2` AS s1 ON s0.`x` = s1.`z` SET s0.`x` = 0}
+           ~s{UPDATE `schema` AS s0, `schema2` AS s1 SET s0.`x` = 0 WHERE (s0.`x` = s1.`z`)}
 
     query = from(e in Schema, where: e.x == 123, update: [set: [x: 0]],
                              join: q in Schema2, on: e.x == q.z) |> normalize(:update_all)
     assert update_all(query) ==
-           ~s{UPDATE `schema` AS s0 INNER JOIN `schema2` AS s1 ON s0.`x` = s1.`z` } <>
-           ~s{SET s0.`x` = 0 WHERE (s0.`x` = 123)}
+           ~s{UPDATE `schema` AS s0, `schema2` AS s1 } <>
+           ~s{SET s0.`x` = 0 WHERE (s0.`x` = s1.`z`) AND (s0.`x` = 123)}
   end
 
   test "update all with prefix" do


### PR DESCRIPTION
Closes #2303 

Refs #2332 

This PR addresses the issue #2303 by way of supporting only a strict subset of `JOIN` syntax for `update_all` queries, as suggested in https://github.com/elixir-ecto/ecto/pull/2332#issuecomment-349582570.
