### PR TITLE
Fix typo

### DIFF
--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -275,7 +275,7 @@ defmodule Ecto.MigratorTest do
     end
   end
 
-  test "version migrations work iside directories" do
+  test "version migrations work inside directories" do
     in_tmp fn path ->
       File.mkdir_p!("foo")
       create_migration "foo/13_version_in_dir.exs"


### PR DESCRIPTION
Fix typo in `test/ecto/migrator_test.exs`