### PR TITLE
Update docs for Ecto.Changeset where :on_replace is :nilify

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -123,7 +123,8 @@ defmodule Ecto.Changeset do
       embedded data via parent changeset - an error will be added to the parent
       changeset, and it will be marked as invalid
     * `:nilify` - sets owner reference column to `nil` (available only for
-      associations)
+      associations). Use this on a `belongs_to` column to allow the association
+      to be cleared out so that it can be set to a new value.
     * `:update` - updates the association, available only for `has_one` and `belongs_to`.
       This option will update all the fields given to the changeset including the id
       for the association


### PR DESCRIPTION
Even though I've previously read issue #1432 the knowledge did not stick and I didn't correctly set `on_replace` to `:nilify`. Hopefully this doc update will help.

The intent of this PR is to make it more clear what to set `on_replace` to if you want to allow updating a `belongs_to` association.