### PR TITLE
Allow string without size on pg

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -837,6 +837,16 @@ if Code.ensure_loaded?(Postgrex) do
       end
     end
 
+    defp column_type(:string = type, opts) do
+      size      = Keyword.get(opts, :size, 255)
+      type_name = ecto_to_db(type)
+
+      case size do
+        nil -> type_name
+        _   -> [type_name, ?(, to_string(size), ?)]
+      end
+    end
+
     defp column_type(type, opts) do
       size      = Keyword.get(opts, :size)
       precision = Keyword.get(opts, :precision)
@@ -844,10 +854,9 @@ if Code.ensure_loaded?(Postgrex) do
       type_name = ecto_to_db(type)
 
       cond do
-        size            -> [type_name, ?(, to_string(size), ?)]
-        precision       -> [type_name, ?(, to_string(precision), ?,, to_string(scale || 0), ?)]
-        type == :string -> [type_name, "(255)"]
-        true            -> type_name
+        size      -> [type_name, ?(, to_string(size), ?)]
+        precision -> [type_name, ?(, to_string(precision), ?,, to_string(scale || 0), ?)]
+        true      -> type_name
       end
     end
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -744,6 +744,19 @@ defmodule Ecto.Adapters.PostgresTest do
     """ |> remove_newlines]
   end
 
+  test "string type with size: nil" do
+    create = {:create, table(:posts),
+              [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
+               {:add, :title, :string, []},
+               {:add, :body, :string, [size: nil]}]}
+
+    assert execute_ddl(create) == ["""
+    CREATE TABLE "posts" ("name" varchar(20) DEFAULT 'Untitled' NOT NULL,
+    "title" varchar(255),
+    "body" varchar)
+    """ |> remove_newlines]
+  end
+
   test "create table with prefix" do
     create = {:create, table(:posts, prefix: :foo),
               [{:add, :category_0, %Reference{table: :categories}, []}]}


### PR DESCRIPTION
Although there is no performance difference between `text` and `varchar` without
limit, users may want to use `:string`, not `:text`, in migrations.

The existing default size 255 for `:string` is preserved. However when
`nil` is given for `:size` on `:string`, do not set the length limit.