### PR TITLE
correctly log validate_confirmation in Changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1792,7 +1792,7 @@ defmodule Ecto.Changeset do
           confirmation_missing(opts, error_field)
       end
 
-    %{changeset | validations: [{:confirmation, opts} | changeset.validations],
+    %{changeset | validations: [{field, {:confirmation, opts}} | changeset.validations],
                   errors: errors ++ changeset.errors,
                   valid?: changeset.valid? and errors == []}
   end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -971,48 +971,57 @@ defmodule Ecto.ChangesetTest do
                 |> validate_confirmation(:title)
     assert changeset.valid?
     assert changeset.errors == []
+    assert changeset.validations == [{:title, {:confirmation, []}}]
 
     changeset = changeset(%{"title" => "title"})
                 |> validate_confirmation(:title)
     assert changeset.valid?
     assert changeset.errors == []
+    assert changeset.validations == [{:title, {:confirmation, []}}]
 
     changeset = changeset(%{"title" => "title"})
                 |> validate_confirmation(:title, required: false)
     assert changeset.valid?
     assert changeset.errors == []
+    assert changeset.validations == [{:title, {:confirmation, [required: false]}}]
 
     changeset = changeset(%{"title" => "title"})
                 |> validate_confirmation(:title, required: true)
     refute changeset.valid?
     assert changeset.errors == [title_confirmation: {"can't be blank", [validation: :required]}]
+    assert changeset.validations == [{:title, {:confirmation, [required: true]}}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => nil})
                 |> validate_confirmation(:title)
     refute changeset.valid?
     assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+    assert changeset.validations == [{:title, {:confirmation, []}}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title)
     refute changeset.valid?
     assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+    assert changeset.validations == [{:title, {:confirmation, []}}]
 
     changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
                 |> validate_confirmation(:title, message: "doesn't match field below")
     refute changeset.valid?
     assert changeset.errors == [title_confirmation: {"doesn't match field below", [validation: :confirmation]}]
+    assert changeset.validations == [{:title, {:confirmation, [message: "doesn't match field below"]}}]
 
     # Skip when no parameter
     changeset = changeset(%{"title" => "title"})
                 |> validate_confirmation(:title, message: "password doesn't match")
     assert changeset.valid?
     assert changeset.errors == []
+    assert changeset.validations == [{:title, {:confirmation, [message: "password doesn't match"]}}]
 
     # With casting
     changeset = changeset(%{"upvotes" => "1", "upvotes_confirmation" => "1"})
                 |> validate_confirmation(:upvotes)
     assert changeset.valid?
     assert changeset.errors == []
+    assert changeset.validations == [{:upvotes, {:confirmation, []}}]
 
     # With blank change
     changeset = changeset(%{"password" => "", "password_confirmation" => "password"})
@@ -1031,6 +1040,7 @@ defmodule Ecto.ChangesetTest do
                 |> validate_confirmation(:password)
     refute changeset.valid?
     assert changeset.errors == []
+    assert changeset.validations == []
   end
 
   test "validate_acceptance/3" do


### PR DESCRIPTION
All other validations record `{field, {:validation_type, opts}}` in the Changeset's `validations` field, but `validate_confirmation` logs `{:validation, opts}` instead. I believe this is a regression introduced in #1739.