### PR TITLE
Correct Default Message for validate_confirmation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1760,7 +1760,7 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:message` - the message on failure, defaults to "does not match"
+    * `:message` - the message on failure, defaults to "does not match confirmation"
     * `:required` - boolean, sets whether existence of confirmation parameter
       is required for addition of error. Defaults to false
 


### PR DESCRIPTION
The documentation for validate_confirmation contained the wrong message
for the default error message if no error message was provided. The
documentation indicated that the default error message was "does not
match," but the actual default error message in the code is "does not
match confirmation." I corrected the documentation to match the source
code.