### PR TITLE
Add force update option for casting relations

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -669,6 +669,7 @@ defmodule Ecto.Changeset do
     * `:required` - if the association is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
+    * `:force_update_on_change` - if the update should mark the parent struct as updated
   """
   def cast_assoc(changeset, name, opts \\ []) when is_atom(name) do
     cast_relation(:assoc, changeset, name, opts)
@@ -695,6 +696,7 @@ defmodule Ecto.Changeset do
     * `:required` - if the embed is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
+    * `:force_update_on_change` - if the update should mark the parent struct as updated
   """
   def cast_embed(changeset, name, opts \\ []) when is_atom(name) do
     cast_relation(:embed, changeset, name, opts)
@@ -717,6 +719,13 @@ defmodule Ecto.Changeset do
         {update_in(changeset.required, &[key|&1]), true}
       else
         {changeset, false}
+      end
+
+    changeset =
+      if opts[:force_update_on_change] do
+        update_in(changeset.repo_opts, &Keyword.put(&1, :force, true))
+      else
+        changeset
       end
 
     on_cast  = Keyword.get_lazy(opts, :with, fn -> on_cast_default(type, related) end)

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -799,7 +799,7 @@ defmodule Ecto.Changeset do
 
   defp force_update(changeset, opts) do
     if Keyword.get(opts, :force_update_on_change, true) do
-      update_in(changeset.repo_opts, &Keyword.put(&1, :force, true))
+      put_in(changeset.repo_opts[:force], true)
     else
       changeset
     end

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -211,11 +211,15 @@ defmodule Ecto.Changeset.EmbeddedTest do
   end
 
   test "cast embeds_one with `:force_update_on_change` option" do
-    changeset = cast(%Author{profile: %Profile{id: "id"}}, %{"profile" => nil}, :profile,
+    changeset = cast(%Author{profile: %Profile{id: "id"}}, %{profile: nil}, :profile,
                      force_update_on_change: true)
     assert changeset.repo_opts[:force]
 
-    changeset = cast(%Author{profile: %Profile{id: "id"}}, %{"profile" => nil}, :profile)
+    changeset = cast(%Author{profile: %Profile{id: "id"}}, %{profile: nil}, :profile,
+                     force_update_on_change: false)
+    assert changeset.repo_opts == []
+
+    changeset = cast(%Author{profile: nil}, %{profile: nil}, :profile, force_update_on_change: true)
     assert changeset.repo_opts == []
   end
 
@@ -452,11 +456,15 @@ defmodule Ecto.Changeset.EmbeddedTest do
   end
 
   test "cast embeds_many with `:force_update_on_change` option" do
-    changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts,
-                     force_update_on_change: true)
+    params = [%{title: "hello"}]
+    changeset = cast(%Author{}, %{posts: params}, :posts, force_update_on_change: true)
     assert changeset.repo_opts[:force]
 
-    changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts)
+    changeset = cast(%Author{}, %{posts: params}, :posts, force_update_on_change: false)
+    assert changeset.repo_opts == []
+
+    changeset = cast(%Author{posts: [%Post{title: "hello"}]}, %{posts: params}, :posts,
+                     force_update_on_change: true)
     assert changeset.repo_opts == []
   end
 

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -210,6 +210,15 @@ defmodule Ecto.Changeset.EmbeddedTest do
     assert changeset.valid?
   end
 
+  test "cast embeds_one with `:force_update_on_change` option" do
+    changeset = cast(%Author{profile: %Profile{id: "id"}}, %{"profile" => nil}, :profile,
+                     force_update_on_change: true)
+    assert changeset.repo_opts[:force]
+
+    changeset = cast(%Author{profile: %Profile{id: "id"}}, %{"profile" => nil}, :profile)
+    assert changeset.repo_opts == []
+  end
+
   test "cast embeds_one with custom changeset" do
     changeset = cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile,
                      with: &Profile.optional_changeset/2)
@@ -440,6 +449,15 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{posts: []}, %{"posts" => nil}, :posts, required: true)
     assert changeset.changes == %{}
     assert changeset.errors == [posts: {"is invalid", [validation: :embed, type: {:array, :map}]}]
+  end
+
+  test "cast embeds_many with `:force_update_on_change` option" do
+    changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts,
+                     force_update_on_change: true)
+    assert changeset.repo_opts[:force]
+
+    changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts)
+    assert changeset.repo_opts == []
   end
 
   test "cast embeds_many with empty parameters" do

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -215,12 +215,17 @@ defmodule Ecto.Changeset.HasAssocTest do
   end
 
   test "cast has_one with `:force_update_on_change` option" do
-    changeset = cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile)
+    changeset = cast(%Author{}, %{profile: %{name: "michal"}}, :profile,
+                     force_update_on_change: true)
+    assert changeset.repo_opts[:force]
+
+    changeset = cast(%Author{}, %{profile: %{name: "michal"}}, :profile,
+                     force_update_on_change: false)
     assert changeset.repo_opts == []
 
-    changeset = cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile,
-      force_update_on_change: true)
-    assert changeset.repo_opts[:force]
+    changeset = cast(%Author{profile: %{name: "michal"}}, %{name: "michal"}, :profile,
+                     force_update_on_change: true)
+    assert changeset.repo_opts == []
   end
 
   test "cast has_one with optional" do
@@ -500,7 +505,11 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{posts: [%{title: "hello"}]}, :posts, force_update_on_change: true)
     assert changeset.repo_opts[:force]
 
-    changeset = cast(%Author{}, %{posts: [%{title: "hello"}]}, :posts)
+    changeset = cast(%Author{}, %{posts: [%{title: "hello"}]}, :posts, force_update_on_change: false)
+    assert changeset.repo_opts == []
+
+    changeset = cast(%Author{posts: [%Post{title: "hello"}]}, %{posts: [%{title: "hello"}]}, :posts,
+                     force_update_on_change: true)
     assert changeset.repo_opts == []
   end
 

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -214,6 +214,15 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
   end
 
+  test "cast has_one with `:force_update_on_change` option" do
+    changeset = cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile)
+    assert changeset.repo_opts == []
+
+    changeset = cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile,
+      force_update_on_change: true)
+    assert changeset.repo_opts[:force]
+  end
+
   test "cast has_one with optional" do
     changeset = cast(%Author{profile: %Profile{id: "id"}}, %{"profile" => nil}, :profile)
     assert changeset.changes.profile == nil
@@ -485,6 +494,14 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
     assert changeset.errors == [posts: {"is invalid", [validation: :assoc, type: {:array, :map}]}]
+  end
+
+  test "cast has_many with `:force_update_on_change` option" do
+    changeset = cast(%Author{}, %{posts: [%{title: "hello"}]}, :posts, force_update_on_change: true)
+    assert changeset.repo_opts[:force]
+
+    changeset = cast(%Author{}, %{posts: [%{title: "hello"}]}, :posts)
+    assert changeset.repo_opts == []
   end
 
   test "cast has_many with empty parameters" do


### PR DESCRIPTION
Adds an option on `cast_assoc/3` and `cast_embeds/3` to add `[force: true]` in the `repo_opts` on a changeset.

Addresses #2317.

Note: I wasn't quite sure how to validate that record's `updated_at` is updated in the test suite.