### PR TITLE
update travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: elixir
 elixir:
-  - 1.4.0
+  - 1.4.5
+  - 1.5.3
+  - 1.6.0
 otp_release:
-  - 18.2
-  - 19.1
+  - 18.3
+  - 19.3
+  - 20.2
 addons:
   apt:
     packages:
@@ -21,6 +24,10 @@ before_install:
 sudo: required
 dist: trusty
 cache: apt
+matrix:
+  exclude:
+    - elixir: 1.6.0
+      otp_release: 18.3
 env:
   global:
     - PGVERSION=9.6


### PR DESCRIPTION
The Travis build hasn't been updated for newer Erlang/Elixir versions, so I've added the most recent ones.

This increases the number of builds from 8 to 32 though.