### PR TITLE
Add .formatter.exs for from/2

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,6 @@
+[
+  locals_without_parens: [from: 2],
+  export: [
+    locals_without_parens: [from: 2]
+  ]
+]

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,8 @@ defmodule Ecto.Mixfile do
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => "https://github.com/elixir-ecto/ecto"},
       files: ~w(mix.exs README.md CHANGELOG.md lib) ++
-             ~w(integration_test/cases integration_test/sql integration_test/support)
+             ~w(integration_test/cases integration_test/sql integration_test/support) ++
+             ~w(.formatter.exs)
     ]
   end
 


### PR DESCRIPTION
As elixir 1.6 introduce format feature, the Ecto query with `from/2` will be formatted like
```elixir
from(
   p in Post,
   select: p.title
)
```

If we like to encourage the use of documented syntax, by default (which is my favorite part of Ecto, aesthetically)
```
from p in Post,
  select: p.title
```

I propose to add this `.formatter.exs`, for the library dependent on Ecto, like Phoenix, can then import it.