### PR TITLE
Fix ConstraintError message for exclude constraint

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -266,6 +266,7 @@ defmodule Ecto.Integration.RepoTest do
 
     assert exception.message =~ "posts_uuid_index (unique_constraint)"
     assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `unique_constraint/3`"
 
     message = ~r/constraint error when attempting to insert struct/
     exception =
@@ -403,6 +404,7 @@ defmodule Ecto.Integration.RepoTest do
 
     assert exception.message =~ "comments_post_id_fkey (foreign_key_constraint)"
     assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `foreign_key_constraint/3`"
 
     message = ~r/constraint error when attempting to insert struct/
     exception =

--- a/integration_test/pg/constraints_test.exs
+++ b/integration_test/pg/constraints_test.exs
@@ -51,6 +51,7 @@ defmodule Ecto.Integration.ConstraintsTest do
       end
     assert exception.message =~ "cannot_overlap (exclude_constraint)"
     assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `exclusion_constraint/3`"
 
     message = ~r/constraint error when attempting to insert struct/
     exception =
@@ -79,6 +80,7 @@ defmodule Ecto.Integration.ConstraintsTest do
 
     assert exception.message =~ "positive_price (check_constraint)"
     assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `check_constraint/3`"
 
     # When the changeset does expect the db error, but doesn't give a custom message
     {:error, changeset} =

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -280,13 +280,19 @@ defmodule Ecto.ConstraintError do
             Enum.map_join(constraints, "\n", &"    * #{&1.constraint} (#{&1.type}_constraint)")
       end
 
+    func =
+      case type do
+        :exclude -> "exclusion"
+        _ -> type
+      end
+
     msg = """
     constraint error when attempting to #{action} struct:
 
         * #{constraint} (#{type}_constraint)
 
     If you would like to convert this constraint into an error, please
-    call `#{type}_constraint/3` in your changeset with the constraint
+    call `#{func}_constraint/3` in your changeset with the constraint
     `:name` as an option.
 
     #{constraints}


### PR DESCRIPTION
Before the change, the error message was advising to call `exclude_constraint/3` but the function is named `exclusion_constraint/3`. I've tested messages for other constraints to be sure they match actual function name. I have also a suggestion about the message copy itself, what do you think about this:

If you would like to convert this **exception into a changeset error**,
please call `#{func}_constraint/3` **on** your changeset with the constraint
`:name` as an option.