### PR TITLE
Move errors to the top of the error message

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -87,6 +87,10 @@ defmodule Ecto.InvalidChangesetError do
     """
     could not perform #{action} because changeset is invalid.
 
+    Errors
+
+    #{pretty errors}
+
     Applied changes
 
     #{pretty changes}
@@ -94,10 +98,6 @@ defmodule Ecto.InvalidChangesetError do
     Params
 
     #{pretty changeset.params}
-
-    Errors
-
-    #{pretty errors}
 
     Changeset
 


### PR DESCRIPTION
Really long error messages can get truncated when written to things like
logs. This moves the most useful information about a changeset error to
the top, so that it won't get truncated in most cases.