### PR TITLE
Fix a few places that don't use `__schema__(:query)`

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -507,7 +507,7 @@ defmodule Ecto.Association.Has do
   def joins_query(%{queryable: queryable, related_key: related_key,
                     owner: owner, owner_key: owner_key}) do
     from o in owner,
-      join: q in ^queryable,
+      join: q in ^Ecto.Queryable.to_query(queryable),
       on: field(q, ^related_key) == field(o, ^owner_key)
   end
 
@@ -768,7 +768,7 @@ defmodule Ecto.Association.BelongsTo do
   def joins_query(%{queryable: queryable, related_key: related_key,
                     owner: owner, owner_key: owner_key}) do
     from o in owner,
-      join: q in ^queryable,
+      join: q in ^Ecto.Queryable.to_query(queryable),
       on: field(q, ^related_key) == field(o, ^owner_key)
   end
 
@@ -953,7 +953,7 @@ defmodule Ecto.Association.ManyToMany do
     [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
     from o in owner,
       join: j in ^join_through, on: field(j, ^join_owner_key) == field(o, ^owner_key),
-      join: q in ^queryable, on: field(j, ^join_related_key) == field(q, ^related_key)
+      join: q in ^Ecto.Queryable.to_query(queryable), on: field(j, ^join_related_key) == field(q, ^related_key)
   end
 
   @doc false

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -62,7 +62,7 @@ defmodule Ecto.Query.Builder.Join do
   end
 
   def escape({:__aliases__, _, _} = module, _vars, _env) do
-    {:_, {nil, module}, nil, %{}}
+    {:_, quote(do: Ecto.Queryable.to_query(unquote(module))), nil, %{}}
   end
 
   def escape(string, _vars, _env) when is_binary(string) do
@@ -70,7 +70,7 @@ defmodule Ecto.Query.Builder.Join do
   end
 
   def escape({string, {:__aliases__, _, _} = module}, _vars, _env) when is_binary(string) do
-    {:_, {string, module}, nil, %{}}
+    {:_, quote do from _ in {unquote(string), unquote(module)} end, nil, %{}}
   end
 
   def escape({string, atom}, _vars, _env) when is_binary(string) and is_atom(atom) do


### PR DESCRIPTION
I figured it was best to call into the protocol, but I could also do them just as `schema.__schema__(:query)` if necessary.

These changes basically seem like innocent changes that should be expected behavior, but also let me potentially implement workarounds for #2395. And if that actually gets implemented, then this is important too.