### PR TITLE
Implementing infix mathematical operators

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -26,11 +26,13 @@ defmodule Ecto.Integration.TypeTest do
     # Integers
     assert [1] = TestRepo.all(from p in Post, where: p.visits == ^integer, select: p.visits)
     assert [1] = TestRepo.all(from p in Post, where: p.visits == 1, select: p.visits)
+    assert [3] = TestRepo.all(from p in Post, select: p.visits + 2)
 
     # Floats
     assert [0.1] = TestRepo.all(from p in Post, where: p.intensity == ^float, select: p.intensity)
     assert [0.1] = TestRepo.all(from p in Post, where: p.intensity == 0.1, select: p.intensity)
     assert [1500.0] = TestRepo.all(from p in Post, select: 1500.0)
+    assert [0.5] = TestRepo.all(from p in Post, select: p.intensity * 5)
 
     # Booleans
     assert [true] = TestRepo.all(from p in Post, where: p.public == ^true, select: p.public)
@@ -74,6 +76,12 @@ defmodule Ecto.Integration.TypeTest do
     # Custom types
     uuid = Ecto.UUID.generate()
     assert [^uuid] = TestRepo.all(from Post, select: type(^uuid, Ecto.UUID))
+
+    # Math operations
+    assert [4]   = TestRepo.all(from Post, select: type(2 + ^"2", :integer))
+    assert [4.0] = TestRepo.all(from Post, select: type(2 + ^"2", :float))
+    assert [4]   = TestRepo.all(from p in Post, select: type(2 + ^"2", p.visits))
+    assert [4.0] = TestRepo.all(from p in Post, select: type(2 + ^"2", p.intensity))
   end
 
   test "binary id type" do
@@ -228,6 +236,9 @@ defmodule Ecto.Integration.TypeTest do
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1, select: p.cost)
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1.0, select: p.cost)
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
+
+    assert [Decimal.new("2.0")] == TestRepo.all(from p in Post, select: p.cost * 2)
+    assert [Decimal.new("2.0")] == TestRepo.all(from p in Post, select: p.cost + p.cost)
   end
 
   @tag :decimal_type

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -238,7 +238,7 @@ defmodule Ecto.Integration.TypeTest do
     assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
 
     assert [Decimal.new("2.0")] == TestRepo.all(from p in Post, select: p.cost * 2)
-    assert [Decimal.new("2.0")] == TestRepo.all(from p in Post, select: p.cost + p.cost)
+    assert [Decimal.new("0.0")] == TestRepo.all(from p in Post, select: p.cost - p.cost)
   end
 
   @tag :decimal_type

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -179,6 +179,7 @@ if Code.ensure_loaded?(Mariaex) do
 
     binary_ops =
       [==: " = ", !=: " != ", <=: " <= ", >=: " >= ", <: " < ", >: " > ",
+       +: " + ", -: " - ", *: " * ", /: " / ",
        and: " AND ", or: " OR ", like: " LIKE "]
 
     @binary_ops Keyword.keys(binary_ops)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -237,6 +237,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     binary_ops =
       [==: " = ", !=: " != ", <=: " <= ", >=: " >= ", <: " < ", >: " > ",
+       +: " + ", -: " - ", *: " * ", /: " / ",
        and: " AND ", or: " OR ", ilike: " ILIKE ", like: " LIKE "]
 
     @binary_ops Keyword.keys(binary_ops)

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -201,7 +201,7 @@ defmodule Ecto.Query.Builder do
   end
 
   # mathematical operators
-  def escape({math_op, _, [left, right]}, type, params_acc, vars, env) 
+  def escape({math_op, _, [left, right]}, type, params_acc, vars, env)
       when math_op in ~w(+ - * /)a do
     {left,  params_acc} = escape(left, type, params_acc, vars, env)
     {right, params_acc} = escape(right, type, params_acc, vars, env)

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -860,7 +860,7 @@ defmodule Ecto.Type do
   # Checks if a value is of the given primitive type.
   defp of_base_type?(:any, _),         do: true
   defp of_base_type?(:id, term),       do: is_integer(term)
-  defp of_base_type?(:float, term),    do: is_float(term)
+  defp of_base_type?(:float, term),    do: is_float(term) or is_integer(term)
   defp of_base_type?(:integer, term),  do: is_integer(term)
   defp of_base_type?(:boolean, term),  do: is_boolean(term)
   defp of_base_type?(:binary, term),   do: is_binary(term)

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -197,6 +197,9 @@ defmodule Ecto.Adapters.MySQLTest do
 
     query = Schema |> select([r], r.x > 2) |> normalize
     assert all(query) == ~s{SELECT s0.`x` > 2 FROM `schema` AS s0}
+
+    query = Schema |> select([r], r.x + 2) |> normalize
+    assert all(query) == ~s{SELECT s0.`x` + 2 FROM `schema` AS s0}
   end
 
   test "is_nil" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -219,6 +219,9 @@ defmodule Ecto.Adapters.PostgresTest do
 
     query = Schema |> select([r], r.x > 2) |> normalize
     assert all(query) == ~s{SELECT s0."x" > 2 FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x + 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" + 2 FROM "schema" AS s0}
   end
 
   test "is_nil" do

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -20,6 +20,10 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do &0.y > &1.z end), %{}} ==
            escape(quote do x.y > y.z end, [x: 0, y: 1], __ENV__)
 
+    import Kernel, except: [+: 2]
+    assert {Macro.escape(quote do &0.y + &1.z end), %{}} ==
+           escape(quote do x.y + y.z end, [x: 0, y: 1], __ENV__)
+
     assert {Macro.escape(quote do avg(0) end), %{}} ==
            escape(quote do avg(0) end, [], __ENV__)
 


### PR DESCRIPTION
Closes #1757 

I tried to think about Ecto as a really thin layer over the database while implementing this. As a result, any kind of mathematical operation that the database supports (like dates and intervals on PostgreSQL) should work just fine.

I also changed the `type/2` macro to work with mathematical operations, so you can enforce return types and change how parameters will be casted to the database:

```elixir
# casts the parameter as a float and converts the result to float
from p in Post, select: type(p.visits / ^"2", :float)
```

The drawbacks I found in this implementation are:

- as it simply delegates the operations to the database, we don't have compile time errors (unless you try to do some crazy stuff, like `1 == 1 + (1 > 1)`);
- the queries are not fully portable between databases, as some operations can be fundamentally different in PostgreSQL, MySQL or whichever database you might use (e.g. `1 / 2` returns `0` in PostgreSQL and `#Decimal<0.5>` in MySQL).

There isn't much we can do for the second one without losing the "thin layer" status. As for the first one, maybe we could add some more checks (like allowing only some certain types in these operations) at the expense of increasing the distance to the database.

What do you guys think?