### PR TITLE
[WIP] Add support for named joins

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -59,6 +59,17 @@ defmodule Ecto.Integration.JoinsTest do
     assert [{^p2, ^c1}] = TestRepo.all(query)
   end
 
+  test "named joins" do
+    _p = TestRepo.insert!(%Post{title: "1"})
+    p2 = TestRepo.insert!(%Post{title: "2"})
+    c1 = TestRepo.insert!(%Permalink{url: "1", post_id: p2.id})
+
+    query =
+      from(p in Post, join: {:permalink, c} in assoc(p, :permalink), order_by: p.id)
+      |> select([p, permalink: c], {p, c})
+    assert [{^p2, ^c1}] = TestRepo.all(query)
+  end
+
   test "joins with queries" do
     p1 = TestRepo.insert!(%Post{title: "1"})
     p2 = TestRepo.insert!(%Post{title: "2"})

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -332,7 +332,7 @@ defmodule Ecto.Query do
 
   defmodule JoinExpr do
     @moduledoc false
-    defstruct [:qual, :source, :on, :file, :line, :assoc, :ix, params: []]
+    defstruct [:name, :qual, :source, :on, :file, :line, :assoc, :ix, params: []]
   end
 
   defmodule Tagged do

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -550,6 +550,7 @@ defmodule Ecto.Query.Builder do
           quote do
             query = Ecto.Queryable.to_query(unquote(query))
             escape_count = Ecto.Query.Builder.count_binds(query)
+            bind_mappings = Ecto.Query.Builder.named_binds(query)
             query
           end
         tail_fn = fn tail ->
@@ -561,10 +562,6 @@ defmodule Ecto.Query.Builder do
           {tail, []} ->
             {query, vars ++ tail_fn.(tail)}
           {tail, named} ->
-            quote do
-              bind_mappings = Ecto.Query.Builder.named_binds(query)
-              query
-            end
             mapped_binds =
               Enum.map(named, fn {k, name} -> {k, quote(do: bind_mappings[unquote(name)])} end)
             {query, vars ++ tail_fn.(tail) ++ mapped_binds}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -811,7 +811,10 @@ defmodule Ecto.Query.Builder do
   def named_binds(%Query{joins: joins}) do
     joins
     |> Enum.with_index(1)
-    |> Enum.map(fn {%{name: name}, idx} -> {name, idx} end)
+    |> Enum.map(fn
+      {%{name: name}, idx} -> {name, idx}
+      {{name, _, _}, idx} -> {name, idx}
+    end)
     |> Enum.into(%{})
     |> Map.delete(nil)
   end

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -17,24 +17,41 @@ defmodule Ecto.Query.Builder.Join do
       iex> escape(quote(do: x in "foo"), [], __ENV__)
       {nil, :x, {"foo", nil}, nil, %{}}
 
+      iex> escape(quote(do: {:foo_name, x} in "foo"), [], __ENV__)
+      {:foo_name, :x, {"foo", nil}, nil, %{}}
+
       iex> escape(quote(do: "foo"), [], __ENV__)
       {nil, :_, {"foo", nil}, nil, %{}}
 
       iex> escape(quote(do: x in Sample), [], __ENV__)
       {nil, :x, {nil, {:__aliases__, [alias: false], [:Sample]}}, nil, %{}}
 
+      iex> escape(quote(do: {:sample_name, x} in Sample), [], __ENV__)
+      {:sample_name, :x, {nil, {:__aliases__, [alias: false], [:Sample]}}, nil, %{}}
+
       iex> escape(quote(do: x in {"foo", Sample}), [], __ENV__)
       {nil, :x, {"foo", {:__aliases__, [alias: false], [:Sample]}}, nil, %{}}
+
+      iex> escape(quote(do: {:sample_name, x} in {"foo", Sample}), [], __ENV__)
+      {:sample_name, :x, {"foo", {:__aliases__, [alias: false], [:Sample]}}, nil, %{}}
 
       iex> escape(quote(do: x in {"foo", :sample}), [], __ENV__)
       {nil, :x, {"foo", :sample}, nil, %{}}
 
+      iex> escape(quote(do: {:sample_name, x} in {"foo", :sample}), [], __ENV__)
+      {:sample_name, :x, {"foo", :sample}, nil, %{}}
+
       iex> escape(quote(do: c in assoc(p, :comments)), [p: 0], __ENV__)
       {nil, :c, nil, {0, :comments}, %{}}
+
+      iex> escape(quote(do: {:comments_name, c} in assoc(p, :comments)), [p: 0], __ENV__)
+      {:comments_name, :c, nil, {0, :comments}, %{}}
 
       iex> escape(quote(do: x in fragment("foo")), [], __ENV__)
       {nil, :x, {:{}, [], [:fragment, [], [raw: "foo"]]}, nil, %{}}
 
+      iex> escape(quote(do: {:foo_name, x} in fragment("foo")), [], __ENV__)
+      {:foo_name, :x, {:{}, [], [:fragment, [], [raw: "foo"]]}, nil, %{}}
   """
   @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {atom | nil, [atom], Macro.t | nil, Macro.t | nil, %{}}
   def escape({:in, _, [{var, _, context}, expr]}, vars, env)

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -96,7 +96,6 @@ defmodule Ecto.Query.Builder.Join do
   end
 
   def escape(join, vars, env) do
-    IO.inspect join
     case Macro.expand(join, env) do
       ^join ->
         Builder.error! "malformed join `#{Macro.to_string(join)}` in query expression"

--- a/test/ecto/query/builder/dynamic_test.exs
+++ b/test/ecto/query/builder/dynamic_test.exs
@@ -11,7 +11,9 @@ defmodule Ecto.Query.Builder.DynamicTest do
   end
 
   defp named_query do
-    from p in "posts", join: {:comments, c} in "comments", on: p.id == c.post_id
+    from p in "posts",
+      join: {:authors, a} in "authors", on: a.id == p.author_id,
+      join: {:comments, c} in "comments", on: p.id == c.post_id
   end
 
   describe "fully_expand/2" do
@@ -83,12 +85,12 @@ defmodule Ecto.Query.Builder.DynamicTest do
       dynamic = dynamic([comments: c], c.bar == ^"bar")
       assert {expr, _, params, _, _} = fully_expand(named_query(), dynamic)
       assert Macro.to_string(expr) ==
-        "&1.bar() == ^0"
-      assert params == [{"bar", {1, :bar}}]
+        "&2.bar() == ^0"
+      assert params == [{"bar", {2, :bar}}]
     end
 
     test "with ... and named join" do
-      dynamic = dynamic([p, ..., comments: c], p.foo == c.bar and c.baz == ^"baz")
+      dynamic = dynamic([p, ..., authors: a], p.foo == a.bar and a.baz == ^"baz")
       assert {expr, _, params, _, _} = fully_expand(named_query(), dynamic)
       assert Macro.to_string(expr) ==
         "&0.foo() == &1.bar() and &1.baz() == ^0"

--- a/test/ecto/query/builder/dynamic_test.exs
+++ b/test/ecto/query/builder/dynamic_test.exs
@@ -10,6 +10,10 @@ defmodule Ecto.Query.Builder.DynamicTest do
     from p in "posts", join: c in "comments", on: p.id == c.post_id
   end
 
+  defp named_query do
+    from p in "posts", join: {:comments, c} in "comments", on: p.id == c.post_id
+  end
+
   describe "fully_expand/2" do
     test "without params" do
       dynamic = dynamic([p], p.foo == true)
@@ -65,6 +69,30 @@ defmodule Ecto.Query.Builder.DynamicTest do
       assert Macro.to_string(expr) ==
              "&0.foo() == ^0 and &1.bar() == ^1 and &0.baz() == ^2"
       assert params == [{"foo", {0, :foo}}, {"bar", {1, :bar}}, {"baz", {0, :baz}}]
+    end
+
+    test "with ... binding in the middle" do
+      dynamic = dynamic([p, ..., c], p.foo == c.bar and c.baz == ^"baz")
+      assert {expr, _, params, _, _} = fully_expand(query(), dynamic)
+      assert Macro.to_string(expr) ==
+        "&0.foo() == &1.bar() and &1.baz() == ^0"
+      assert params == [{"baz", {1, :baz}}]
+    end
+
+    test "with named join" do
+      dynamic = dynamic([comments: c], c.bar == ^"bar")
+      assert {expr, _, params, _, _} = fully_expand(named_query(), dynamic)
+      assert Macro.to_string(expr) ==
+        "&1.bar() == ^0"
+      assert params == [{"bar", {1, :bar}}]
+    end
+
+    test "with ... and named join" do
+      dynamic = dynamic([p, ..., comments: c], p.foo == c.bar and c.baz == ^"baz")
+      assert {expr, _, params, _, _} = fully_expand(named_query(), dynamic)
+      assert Macro.to_string(expr) ==
+        "&0.foo() == &1.bar() and &1.baz() == ^0"
+      assert params == [{"baz", {1, :baz}}]
     end
   end
 end

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -124,6 +124,13 @@ defmodule Ecto.Query.BuilderTest do
            escape(quote(do: ^([] ++ [])), [], __ENV__)
   end
 
+  test "escape_binding with named binding in the input" do
+    assert {_, [x: 0,
+                y: 1,
+                z: {_, _, [{:bind_mappings, _, _}, :z_name]}]} =
+      escape_binding(%Ecto.Query{}, quote do: [x, y, z_name: z])
+  end
+
   defp params(quoted, type, vars \\ []) do
     {_, {params, :acc}} = escape(quoted, type, {%{}, :acc}, vars, __ENV__)
     params

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -286,7 +286,6 @@ defmodule Ecto.QueryTest do
       "posts"
       |> join(:inner, [p], {:comments, c} in "comments")
       |> where([comments: c], c.id == 0)
-      |> IO.inspect
     end
   end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -268,6 +268,21 @@ defmodule Ecto.QueryTest do
     end
   end
 
+  describe "named joins" do
+    test "assigns a name to a join" do
+      quoted =
+        quote do
+          from(p in Post,
+            join: b in Blog,
+            join: {:comment, c} in Comment)
+        end
+
+      assert {:%{}, _, list} = Macro.expand(quoted, __ENV__)
+      [_, {_, _, [_, {_, _, join_attrs}]}] = list[:joins]
+      assert join_attrs[:name] == :comment
+    end
+  end
+
   describe "exclude/2" do
     test "removes the given field" do
       base = %Ecto.Query{}

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -283,9 +283,24 @@ defmodule Ecto.QueryTest do
     end
 
     test "match on binding by name" do
-      "posts"
-      |> join(:inner, [p], {:comments, c} in "comments")
-      |> where([comments: c], c.id == 0)
+      query =
+        "posts"
+        |> join(:inner, [p], {:comments, c} in "comments")
+        |> where([comments: c], c.id == 0)
+
+      assert [%{name: :comments}] = query.joins
+      assert [%{expr: {_, _, [_, %{type: {1, :id}}]}}] = query.wheres
+    end
+
+    test "match on binding by name with ... in the middle" do
+      query =
+        "posts"
+        |> join(:inner, [p], c in "comments")
+        |> join(:inner, [], {:authors, a} in "comments")
+        |> where([p, ..., authors: a], a.id == 0)
+
+      assert [%{source: {"comments", _}}, %{name: :authors}] = query.joins
+      assert [%{expr: {_, _, [_, %{type: {2, :id}}]}}] = query.wheres
     end
   end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -281,6 +281,13 @@ defmodule Ecto.QueryTest do
       [_, {_, _, [_, {_, _, join_attrs}]}] = list[:joins]
       assert join_attrs[:name] == :comment
     end
+
+    test "match on binding by name" do
+      "posts"
+      |> join(:inner, [p], {:comments, c} in "comments")
+      |> where([comments: c], c.id == 0)
+      |> IO.inspect
+    end
   end
 
   describe "exclude/2" do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/2389

I took a stab at implementing support for named joins as discussed in #2389, using the ideas from initial post and https://github.com/elixir-ecto/ecto/issues/2389#issuecomment-359481044.

Example usage:

```elixir
query =
  Post
  |> join(:inner, [p], {:comment, c} in assoc(p, :comments))
  |> order_by([comment: c], c.id)
  |> select([p, comment: c], {p, c})
```

Marking it as work in progress because I'm definitely not sure whether 
  1. the API is acceptable 
  2. it's implemented optimally. 

Other than that, I'll want to refactor `Query.Builder.escape_binding` for sure, because there's a lot of redundancy and excessive nesting at the moment. Also, docs will need update eventually as well when/if the proposed change gets into acceptable shape.

Feedback appreciated.