### PR TITLE
Prepend the schema "public" when referring to the schema_migrations table

### DIFF
--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -91,6 +91,6 @@ defmodule Ecto.Integration.StorageTest do
   test "structure dump and load with migrations table" do
     {:ok, path} = Postgres.structure_dump(tmp_path(), TestRepo.config())
     contents = File.read!(path)
-    assert contents =~ ~s[INSERT INTO "schema_migrations" (version) VALUES (0)]
+    assert contents =~ ~s[INSERT INTO public."schema_migrations" (version) VALUES (0)]
   end
 end

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -176,7 +176,7 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp select_versions(table, config) do
-    case run_query(~s[SELECT version FROM "#{table}" ORDER BY version], config) do
+    case run_query(~s[SELECT version FROM public."#{table}" ORDER BY version], config) do
       {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, &hd/1)}
       {:error, %{postgres: %{code: :undefined_table}}} -> {:ok, []}
       {:error, _} = error -> error
@@ -199,11 +199,11 @@ defmodule Ecto.Adapters.Postgres do
   defp append_versions(_table, [], path) do
     {:ok, path}
   end
+
   defp append_versions(table, versions, path) do
     sql =
-      ~s[INSERT INTO "#{table}" (version) VALUES ] <>
-      Enum.map_join(versions, ", ", &"(#{&1})") <>
-      ~s[;\n\n]
+      ~s[INSERT INTO public."#{table}" (version) VALUES ] <>
+        Enum.map_join(versions, ", ", &"(#{&1})") <> ~s[;\n\n]
 
     File.open!(path, [:append], fn file ->
       IO.write(file, sql)


### PR DESCRIPTION
Resolves [Issue 2409](https://github.com/elixir-ecto/ecto/issues/2409).

This PR adds a _public_ prefix when referring to the `schema_migrations` table with PostgreSQL. 

Without the addition of this prefix, any statements within `structure.sql` that change the `search_path` will change the targeted schema of the `schema_migrations` table. This results in PostgreSQL giving an error message indicating that the table cannot be found. 

Full details and examples on the [GitHub Issue](https://github.com/elixir-ecto/ecto/issues/2409) page. 

### Changes

I have made the changes that @michalmuskala and @josevalim suggested to `select_versions/2` and `append_versions/3`.

I did notice that the Elixir 1.6 code formatter was wanting to adjust a few other lines in the file, but I have excluded those changes in this PR. 

### Testing

I have tested this change with a project that makes use of different PostgreSQL schemas, and the error that was being generated with Ecto version `2.2.8` no longer occurs. 