### PR TITLE
Issue #2418: Adds reversible version of remove subcommand

### DIFF
--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -24,7 +24,7 @@ defmodule Ecto.Adapter.Migration  do
   @type table_subcommand ::
     {:add, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
     {:modify, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
-    {:remove, field :: atom}
+    {:remove, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t}
 
   @typedoc """
   A DDL object is a struct that represents a table or index in a database schema.

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -24,7 +24,8 @@ defmodule Ecto.Adapter.Migration  do
   @type table_subcommand ::
     {:add, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
     {:modify, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
-    {:remove, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t}
+    {:remove, field :: atom, type :: Ecto.Type.t | Reference.t, Keyword.t} |
+    {:remove, field :: atom}
 
   @typedoc """
   A DDL object is a struct that represents a table or index in a database schema.

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -820,6 +820,10 @@ defmodule Ecto.Migration do
     Runner.subcommand {:remove, column}
   end
 
+  def remove(column, type, opts \\ []) when is_atom(column) do
+    Runner.subcommand {:remove, column, type, opts}
+  end
+
   @doc ~S"""
   Defines a foreign key.
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -226,6 +226,10 @@ defmodule Ecto.Migration.Runner do
     do: {:drop, constraint}
   defp reverse(_command), do: false
 
+  defp table_reverse([{:remove, name, type, opts}| t], acc) do
+    table_reverse(t, [{:add, name, type, opts} | acc])
+  end
+
   defp table_reverse([{:add, name, _type, _opts} | t], acc) do
     table_reverse(t, [{:remove, name} | acc])
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -565,6 +565,22 @@ defmodule Ecto.MigrationTest do
     end
   end
 
+  test "backward: removing a column (remove/3 called)" do
+    alter table(:posts) do
+      remove :title, :string, []
+    end
+    flush()
+    assert {:alter, %Table{name: "posts"}, [{:add, :title, :string, []}]} = last_command()
+  end
+
+  test "backward: removing a column (remove/2 called)" do
+    alter table(:posts) do
+      remove :title, :string
+    end
+    flush()
+    assert {:alter, %Table{name: "posts"}, [{:add, :title, :string, []}]} = last_command()
+  end
+
   test "backward: rename column" do
     rename table(:posts), :given_name, to: :first_name
     flush()


### PR DESCRIPTION
An attempt to fix [#2416](https://github.com/elixir-ecto/ecto/pull/2416) - add reversible version of remove migration subcommand

I might miss something since I haven't submitted to OSS in a while %-)