### PR TITLE
Update docs for mix ecto.migrate task and custom priv path.

### DIFF
--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -10,7 +10,10 @@ defmodule Mix.Tasks.Ecto.Migrate do
   Migrations are expected at "priv/YOUR_REPO/migrations" directory
   of the current application but it can be configured to be any
   subdirectory of `priv` by specifying the `:priv` key under the
-  repository configuration.
+  repository configuration.  When building the migrations path,
+  "migrations" is appended to the path specified in the `:priv` key.
+  For example, if `:priv` is set to "priv/YOUR_REPO/my_migrations",
+  the migrations path will be "priv/YOUR_REPO/my_migrations/migrations".
 
   Runs all pending migrations by default. To migrate up to a specific
   version number, supply `--to version_number`. To migrate a specific


### PR DESCRIPTION
Hello!  Thank you so much for the work on Ecto.  It's a wonderful library!

This is a result of debugging a custom `priv` path with my repo.  I didn't realize `migrations` was getting appended to the specified path.  I'm happy to put a PR up to fix the `migrations_path` function if you'd prefer, but in the meantime, I wanted to update the documentation so no one else gets confused.  

Thanks again!