### PR TITLE
Support passing `on` to join/5 as option and soft-deprecate raw argument 

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -776,17 +776,17 @@ defmodule Ecto.Query do
   @join_opts [:on]
 
   defp parse_join_opts([]), do: {:opts, []}
-  defp parse_join_opts(lst) when is_list(lst) do
-    opts = Keyword.take(lst, @join_opts)
+  defp parse_join_opts(list) when is_list(list) do
+    opts = Keyword.take(list, @join_opts)
 
-    case {lst, opts} do
-      {lst, []} ->
-        {:expr, lst}
+    case {list, opts} do
+      {list, []} ->
+        {:expr, list}
       {opts, opts} ->
         {:opts, opts}
-      {lst, _} ->
+      {list, _} ->
         raise ArgumentError, "invalid option(s) passed to Ecto.Query.join/5: " <>
-          "#{inspect(Keyword.keys(lst) -- @join_opts)}. Valid options: #{inspect @join_opts}."
+          "#{inspect(Keyword.keys(list) -- @join_opts)}. Valid options: #{inspect @join_opts}."
     end
   end
   defp parse_join_opts(expr), do: {:expr, expr}

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -730,7 +730,7 @@ defmodule Ecto.Query do
   ## Expressions examples
 
       Comment
-      |> join(:inner, [c], p in Post, c.post_id == p.id)
+      |> join(:inner, [c], p in Post, on: c.post_id == p.id)
       |> select([c, p], {p.title, c.text})
 
       Post
@@ -738,7 +738,7 @@ defmodule Ecto.Query do
       |> select([p, c], {p, c})
 
       Post
-      |> join(:left, [p], c in Comment, c.post_id == p.id and c.is_visible == true)
+      |> join(:left, [p], c in Comment, on: c.post_id == p.id and c.is_visible == true)
       |> select([p, c], {p, c})
 
   ## Joining with fragments

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -119,4 +119,12 @@ defmodule Ecto.Query.Builder.JoinTest do
       escape(quote do assoc(join_var, field_var) end, nil, nil)
     end
   end
+
+  test "raises on mix of valid and invalid options passed to join/5" do
+    assert_raise ArgumentError, ~r/invalid option\(s\) passed/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in "comments", on: true, foo: :bar)
+      end, [], __ENV__)
+    end
+  end
 end

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -15,12 +15,12 @@ defmodule Ecto.Query.Builder.JoinTest do
   test "expands macros as sources" do
     left = "left"
     right = "right"
-    assert %{joins: [_]} = join("posts", :inner, [p], c in join_macro(^left, ^right), true)
+    assert %{joins: [_]} = join("posts", :inner, [p], c in join_macro(^left, ^right), on: true)
   end
 
   test "accepts keywords on :on" do
     assert %{joins: [join]} =
-            join("posts", :inner, [p], c in "comments", [post_id: p.id, public: true])
+            join("posts", :inner, [p], c in "comments", on: [post_id: p.id, public: true])
     assert Macro.to_string(join.on.expr) ==
            "&1.post_id() == &0.id() and &1.public() == %Ecto.Query.Tagged{tag: nil, type: {1, :public}, value: true}"
     assert join.on.params == []
@@ -30,63 +30,63 @@ defmodule Ecto.Query.Builder.JoinTest do
     qual = :left
     source = "comments"
     assert %{joins: [%{source: {"comments", nil}}]} =
-            join("posts", qual, [p], c in ^source, true)
+            join("posts", qual, [p], c in ^source, on: true)
 
     qual = :right
     source = Comment
     assert %{joins: [%{source: {nil, Comment}}]} =
-            join("posts", qual, [p], c in ^source, true)
+            join("posts", qual, [p], c in ^source, on: true)
 
     qual = :right
     source = {"user_comments", Comment}
     assert %{joins: [%{source: {"user_comments", Comment}}]} =
-            join("posts", qual, [p], c in ^source, true)
+            join("posts", qual, [p], c in ^source, on: true)
 
     qual = :inner
     source = from c in "comments", where: c.public
     assert %{joins: [%{source: %Ecto.Query{from: {"comments", nil}}}]} =
-            join("posts", qual, [p], c in ^source, true)
+            join("posts", qual, [p], c in ^source, on: true)
   end
 
   test "accepts interpolation on :on" do
     assert %{joins: [join]} =
-            join("posts", :inner, [p], c in "comments", ^[post_id: 1, public: true])
+            join("posts", :inner, [p], c in "comments", on: ^[post_id: 1, public: true])
     assert Macro.to_string(join.on.expr) == "&1.post_id() == ^0 and &1.public() == ^1"
     assert join.on.params == [{1, {1, :post_id}}, {true, {1, :public}}]
 
     dynamic = dynamic([p, c], c.post_id == p.id and c.public == ^true)
     assert %{joins: [join]} =
-            join("posts", :inner, [p], c in "comments", ^dynamic)
+            join("posts", :inner, [p], c in "comments", on: ^dynamic)
     assert Macro.to_string(join.on.expr) == "&1.post_id() == &0.id() and &1.public() == ^0"
     assert join.on.params == [{true, {1, :public}}]
   end
 
   test "accepts interpolation on assoc/2 field" do
     assoc = :comments
-    join("posts", :left, [p], c in assoc(p, ^assoc), true)
+    join("posts", :left, [p], c in assoc(p, ^assoc), on: true)
   end
 
   test "accepts subqueries" do
     subquery = "comments"
-    join("posts", :left, [p], c in subquery(subquery), true)
-    join("posts", :left, [p], c in subquery(subquery, prefix: "sample"), true)
+    join("posts", :left, [p], c in subquery(subquery), on: true)
+    join("posts", :left, [p], c in subquery(subquery, prefix: "sample"), on: true)
   end
 
   test "accepts interpolated binary as unsafe fragment" do
-    join("posts", :left, [p], c in unsafe_fragment(^"comments"), true)
-    join("posts", :left, [p], c in unsafe_fragment(^"?", 1), true)
+    join("posts", :left, [p], c in unsafe_fragment(^"comments"), on: true)
+    join("posts", :left, [p], c in unsafe_fragment(^"?", 1), on: true)
   end
 
   test "raises on non interpolated argument" do
     assert_raise Ecto.Query.CompileError, ~r/unsafe_fragment\(...\) expects the first argument/, fn ->
       escape(quote do
-        join("posts", :left, [p], c in unsafe_fragment("comments"), true)
+        join("posts", :left, [p], c in unsafe_fragment("comments"), on: true)
       end, [], __ENV__)
     end
 
     assert_raise Ecto.Query.CompileError, ~r/unsafe_fragment\(...\) expects the first argument/, fn ->
       escape(quote do
-        join("posts", :left, [p], c in unsafe_fragment(["$eq": "foo"]), true)
+        join("posts", :left, [p], c in unsafe_fragment(["$eq": "foo"]), on: true)
       end, [], __ENV__)
     end
   end
@@ -94,7 +94,7 @@ defmodule Ecto.Query.Builder.JoinTest do
   test "raises on invalid interpolated unsafe fragments" do
     frag = ["comments": "authors"]
     assert_raise ArgumentError, ~r/unsafe_fragment\(...\) expects the first argument/, fn ->
-      join("posts", :left, [p], c in unsafe_fragment(^frag), true)
+      join("posts", :left, [p], c in unsafe_fragment(^frag), on: true)
     end
   end
 
@@ -102,14 +102,14 @@ defmodule Ecto.Query.Builder.JoinTest do
     assert_raise ArgumentError,
                  ~r/invalid join qualifier `:whatever`/, fn ->
       qual = :whatever
-      join("posts", qual, [p], c in "comments", true)
+      join("posts", qual, [p], c in "comments", on: true)
     end
   end
 
   test "raises on invalid interpolation" do
     assert_raise Protocol.UndefinedError, fn ->
       source = 123
-      join("posts", :left, [p], c in ^source, true)
+      join("posts", :left, [p], c in ^source, on: true)
     end
   end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -138,11 +138,11 @@ defmodule Ecto.QueryTest do
 
     test "can be added through joins" do
       from(c in "comments", join: p in "posts", select: {p.title, c.text})
-      "comments" |> join(:inner, [c], p in "posts", true) |> select([c, p], {p.title, c.text})
+      "comments" |> join(:inner, [c], p in "posts", on: true) |> select([c, p], {p.title, c.text})
     end
 
     test "can be added through joins with a counter" do
-      base = join("comments", :inner, [c], p in "posts", true)
+      base = join("comments", :inner, [c], p in "posts", on: true)
       assert select(base, [{p, 1}], p) == select(base, [c, p], p)
     end
 
@@ -196,7 +196,7 @@ defmodule Ecto.QueryTest do
       query =
         "posts"
         |> join(:inner, [], "comments")
-        |> join(:inner, [..., c], v in "votes", c.id == v.id)
+        |> join(:inner, [..., c], v in "votes", on: c.id == v.id)
 
       assert hd(tl(query.joins)).on.expr ==
              {:==, [], [


### PR DESCRIPTION
Refs #2389 
Refs #2411 

This PR is attempt at stage one of plan to implement named joins in Ecto, as laid out by @josevalim in https://github.com/elixir-ecto/ecto/pull/2411#issuecomment-364642910.

The actual changes to the logic are implemented in the [first commit](https://github.com/elixir-ecto/ecto/commit/96d4c64b2fc544769c6395d88cb6082db076e41a). The [second commit](https://github.com/elixir-ecto/ecto/commit/ac84d0a2f9f99db71045c31679e07bd98627970f) contains exclusively updates to the new syntax across tests and docs.

Feedback appreciated.