### PR TITLE
Minor doc fixup: Update field name to reflect doc example code.

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1206,7 +1206,7 @@ defmodule Ecto.Schema do
         use Ecto.Schema
 
         embedded_schema do
-          field :name
+          field :title
         end
       end
 
@@ -1353,7 +1353,7 @@ defmodule Ecto.Schema do
         use Ecto.Schema
 
         embedded_schema do
-          field :name
+          field :title
         end
       end
 


### PR DESCRIPTION
The rest of the code in these docs refer to an `Item`'s `:title` but the field name was `:name` in the `schema`. Alternative is to change uses of `:title` to `:name` but this seems less invasive. 