### PR TITLE
Fix crash ecto.create/drop on log: false for mysql adapter

### DIFF
--- a/integration_test/mysql/storage_test.exs
+++ b/integration_test/mysql/storage_test.exs
@@ -8,9 +8,9 @@ defmodule Ecto.Integration.StorageTest do
   alias Ecto.Integration.TestRepo
 
   def params do
-    Ecto.Repo.Supervisor.parse_url(
-      Application.get_env(:ecto, :mysql_test_url) <> "/storage_mgt"
-    )
+    # Pass log false to ensure we can still create/drop.
+    url = Application.get_env(:ecto, :mysql_test_url) <> "/storage_mgt"
+    [log: false] ++ Ecto.Repo.Supervisor.parse_url(url)
   end
 
   def wrong_params do

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -284,7 +284,7 @@ defmodule Ecto.Adapters.MySQL do
 
     opts =
       opts
-      |> Keyword.delete(:name)
+      |> Keyword.drop([:name, :log])
       |> Keyword.put(:pool, DBConnection.Connection)
       |> Keyword.put(:backoff_type, :stop)
 


### PR DESCRIPTION
Fixed crash on ecto.create/drop with mysql.

I referred to https://github.com/elixir-ecto/ecto/commit/4d4f1cc5e586bbeb80e0c1b0eb2a3e1a8a1fa7f4 for this pull request.
