### PR TITLE
Simple integer to string

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -302,6 +302,10 @@ defmodule Ecto.Type do
     {:ok, value}
   end
 
+  def dump(:string, value, _dumper) when is_integer(value) do
+    {:ok, "#{value}"}
+  end
+
   def dump(:any, value, _dumper) do
     {:ok, value}
   end
@@ -431,6 +435,10 @@ defmodule Ecto.Type do
 
   def load(:binary_id, value, _loader) when is_binary(value) do
     {:ok, value}
+  end
+
+  def load(:string, value, _loader) when is_integer(value) do
+    {:ok, "#{value}"}
   end
 
   def load({:array, type}, value, loader) when is_list(value) do
@@ -585,6 +593,10 @@ defmodule Ecto.Type do
 
   def cast(:binary_id, value) when is_binary(value) do
     {:ok, value}
+  end
+
+  def cast(:string, value) when is_integer(value) do
+    {:ok, "#{value}"}
   end
 
   def cast({:array, type}, term) when is_list(term) do


### PR DESCRIPTION
Issue [here](https://stackoverflow.com/questions/40613577/why-does-ectos-cast-not-convert-an-integer-to-a-string)

The same case for me too, I use [paper_trail](https://github.com/izelnakri/paper_trail) for tracing records, the type of ```item_id``` is one of ```string```,

```uuid```, ```integer```, and fetch them through ecto reflections, save as ```text``` type.

```uuid``` to ```string``` is automatic well done, but ```integer``` to ```string``` blocked me.

The PR  helps  simplify similar works.