### PR TITLE
Support nil field in Ecto.Changeset.optimistic lock

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -166,12 +166,24 @@ if Code.ensure_loaded?(Mariaex) do
 
     def update(prefix, table, fields, filters, _returning) do
       fields = intersperse_map(fields, ", ", &[quote_name(&1), " = ?"])
-      filters = intersperse_map(filters, " AND ", &[quote_name(&1), " = ?"])
+      filters = intersperse_map(filters, " AND ", fn
+        {field, nil} ->
+          [quote_name(field), " IS NULL"]
+
+        {field, _value} ->
+          [quote_name(field), " = ?"]
+      end)
       ["UPDATE ", quote_table(prefix, table), " SET ", fields, " WHERE " | filters]
     end
 
     def delete(prefix, table, filters, _returning) do
-      filters = intersperse_map(filters, " AND ", &[quote_name(&1), " = ?"])
+      filters = intersperse_map(filters, " AND ", fn
+        {field, nil} ->
+          [quote_name(field), " IS NULL"]
+
+        {field, _value} ->
+          [quote_name(field), " = ?"]
+      end)
       ["DELETE FROM ", quote_table(prefix, table), " WHERE " | filters]
     end
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -217,8 +217,12 @@ if Code.ensure_loaded?(Postgrex) do
         {[quote_name(field), " = $" | Integer.to_string(acc)], acc + 1}
       end)
 
-      {filters, _count} = intersperse_reduce(filters, " AND ", count, fn field, acc ->
-        {[quote_name(field), " = $" | Integer.to_string(acc)], acc + 1}
+      {filters, _count} = intersperse_reduce(filters, " AND ", count, fn
+        {field, nil}, acc ->
+          {[quote_name(field), " IS NULL"], acc}
+
+        {field, _value}, acc ->
+          {[quote_name(field), " = $" | Integer.to_string(acc)], acc + 1}
       end)
 
       ["UPDATE ", quote_table(prefix, table), " SET ",
@@ -226,8 +230,12 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     def delete(prefix, table, filters, returning) do
-      {filters, _} = intersperse_reduce(filters, " AND ", 1, fn field, acc ->
-        {[quote_name(field), " = $" | Integer.to_string(acc)], acc + 1}
+      {filters, _} = intersperse_reduce(filters, " AND ", 1, fn
+        {field, nil}, acc ->
+          {[quote_name(field), " IS NULL"], acc}
+
+        {field, _value}, acc ->
+          {[quote_name(field), " = $" | Integer.to_string(acc)], acc + 1}
       end)
 
       ["DELETE FROM ", quote_table(prefix, table), " WHERE ", filters | returning(returning)]

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -93,17 +93,17 @@ defmodule Ecto.Adapters.SQL do
 
       @doc false
       def update(repo, %{source: {prefix, source}}, fields, params, returning, opts) do
-        {fields, values1} = :lists.unzip(fields)
-        {filter, values2} = :lists.unzip(params)
-        sql = @conn.update(prefix, source, fields, filter, returning)
-        Ecto.Adapters.SQL.struct(repo, @conn, sql, {:update, source, params}, values1 ++ values2, :raise, returning, opts)
+        {fields, field_values} = :lists.unzip(fields)
+        filter_values = params |> Keyword.values() |> Enum.reject(&is_nil(&1))
+        sql = @conn.update(prefix, source, fields, params, returning)
+        Ecto.Adapters.SQL.struct(repo, @conn, sql, {:update, source, params}, field_values ++ filter_values, :raise, returning, opts)
       end
 
       @doc false
       def delete(repo, %{source: {prefix, source}}, params, opts) do
-        {filter, values} = :lists.unzip(params)
-        sql = @conn.delete(prefix, source, filter, [])
-        Ecto.Adapters.SQL.struct(repo, @conn, sql, {:delete, source, params}, values, :raise, [], opts)
+        filter_values = params |> Keyword.values() |> Enum.reject(&is_nil(&1))
+        sql = @conn.delete(prefix, source, params, [])
+        Ecto.Adapters.SQL.struct(repo, @conn, sql, {:delete, source, params}, filter_values, :raise, [], opts)
       end
 
       ## Transaction

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -552,11 +552,14 @@ defmodule Ecto.Adapters.MySQLTest do
   end
 
   test "delete" do
-    query = delete(nil, "schema", [:x, :y], [])
+    query = delete(nil, "schema", [x: 1, y: 2], [])
     assert query == ~s{DELETE FROM `schema` WHERE `x` = ? AND `y` = ?}
 
-    query = delete("prefix", "schema", [:x, :y], [])
+    query = delete("prefix", "schema", [x: 1, y: 2], [])
     assert query == ~s{DELETE FROM `prefix`.`schema` WHERE `x` = ? AND `y` = ?}
+
+    query = delete(nil, "schema", [x: nil, y: 1], [])
+    assert query == ~s{DELETE FROM `schema` WHERE `x` IS NULL AND `y` = ?}
   end
 
   # DDL

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -541,11 +541,14 @@ defmodule Ecto.Adapters.MySQLTest do
   end
 
   test "update" do
-    query = update(nil, "schema", [:id], [:x, :y], [])
+    query = update(nil, "schema", [:id], [x: 1, y: 2], [])
     assert query == ~s{UPDATE `schema` SET `id` = ? WHERE `x` = ? AND `y` = ?}
 
-    query = update("prefix", "schema", [:id], [:x, :y], [])
+    query = update("prefix", "schema", [:id], [x: 1, y: 2], [])
     assert query == ~s{UPDATE `prefix`.`schema` SET `id` = ? WHERE `x` = ? AND `y` = ?}
+
+    query = update("prefix", "schema", [:id], [x: 1, y: nil], [])
+    assert query == ~s{UPDATE `prefix`.`schema` SET `id` = ? WHERE `x` = ? AND `y` IS NULL}
   end
 
   test "delete" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -697,14 +697,17 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "update" do
-    query = update(nil, "schema", [:x, :y], [:id], [])
+    query = update(nil, "schema", [:x, :y], [id: 1], [])
     assert query == ~s{UPDATE "schema" SET "x" = $1, "y" = $2 WHERE "id" = $3}
 
-    query = update(nil, "schema", [:x, :y], [:id], [:z])
+    query = update(nil, "schema", [:x, :y], [id: 1], [:z])
     assert query == ~s{UPDATE "schema" SET "x" = $1, "y" = $2 WHERE "id" = $3 RETURNING "z"}
 
-    query = update("prefix", "schema", [:x, :y], [:id], [])
+    query = update("prefix", "schema", [:x, :y], [id: 1], [])
     assert query == ~s{UPDATE "prefix"."schema" SET "x" = $1, "y" = $2 WHERE "id" = $3}
+
+    query = update("prefix", "schema", [:x, :y], [id: 1, updated_at: nil], [])
+    assert query == ~s{UPDATE "prefix"."schema" SET "x" = $1, "y" = $2 WHERE "id" = $3 AND "updated_at" IS NULL}
   end
 
   test "delete" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -711,14 +711,17 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "delete" do
-    query = delete(nil, "schema", [:x, :y], [])
+    query = delete(nil, "schema", [x: 1, y: 2], [])
     assert query == ~s{DELETE FROM "schema" WHERE "x" = $1 AND "y" = $2}
 
-    query = delete(nil, "schema", [:x, :y], [:z])
+    query = delete(nil, "schema", [x: 1, y: 2], [:z])
     assert query == ~s{DELETE FROM "schema" WHERE "x" = $1 AND "y" = $2 RETURNING "z"}
 
-    query = delete("prefix", "schema", [:x, :y], [])
+    query = delete("prefix", "schema", [x: 1, y: 2], [])
     assert query == ~s{DELETE FROM "prefix"."schema" WHERE "x" = $1 AND "y" = $2}
+
+    query = delete("prefix", "schema", [x: nil, y: 1], [])
+    assert query == ~s{DELETE FROM "prefix"."schema" WHERE "x" IS NULL AND "y" = $1}
   end
 
   # DDL


### PR DESCRIPTION
I would like to propose a fix for #2277.

As described in the issue, if `Changeset.filters` has a nil `updated_at` field, the SQL query generated is `"updated_at" = $1` while the desired output would be `"updated_at" IS NULL`.

I suppose this change **WILL break other external adapters**, since it changes the input of [Ecto.Adapters.SQL.update/5](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/adapters/sql/connection.ex#L82), so I'm not sure this is the desired way to fix. I'm open for any suggestion.