### PR TITLE
Correct spec on Repo.transaction: Multi.name, not atom

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1029,7 +1029,7 @@ defmodule Ecto.Repo do
 
   """
   @callback transaction(fun_or_multi :: fun | Ecto.Multi.t, opts :: Keyword.t) ::
-    {:ok, any} | {:error, any} | {:error, atom, any, %{atom => any}}
+    {:ok, any} | {:error, any} | {:error, Ecto.Multi.name, any, %{Ecto.Multi.name => any}}
   @optional_callbacks [transaction: 2]
 
   @doc """


### PR DESCRIPTION
A multi's name can is type `any()`, so `atom` is misleading here.