### PR TITLE
Raise error when using where in on_conflict with MySQL

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -151,8 +151,11 @@ if Code.ensure_loaded?(Mariaex) do
          [quoted, " = VALUES(", quoted, ?)]
        end)]
     end
-    defp on_conflict({query, _, []}, _header) do
+    defp on_conflict({%{wheres: []} = query, _, []}, _header) do
       [" ON DUPLICATE KEY " | update_all(query, "UPDATE ")]
+    end
+    defp on_conflict({query, _, []}, _header) do
+      error!(nil, "Using a query with :where in combination with the :on_conflict option is not supported by MySQL")
     end
 
     defp insert_all(rows) do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -542,6 +542,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert_raise ArgumentError, "The :conflict_target option is not supported in insert/insert_all by MySQL", fn ->
       insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], [:x]}, [])
     end
+
+    assert_raise ArgumentError, "Using a query with :where in combination with the :on_conflict option is not supported by MySQL", fn ->
+      update = from("schema", update: [set: [x: ^"foo"]], where: [z: "bar"]) |> normalize(:update_all)
+      insert(nil, "schema", [:x, :y], [[:x, :y]], {update, [], []}, [])
+    end
   end
 
   test "update" do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -538,6 +538,10 @@ defmodule Ecto.Adapters.MySQLTest do
 
     query = insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], []}, [])
     assert query == ~s{INSERT INTO `schema` (`x`,`y`) VALUES (?,?) ON DUPLICATE KEY UPDATE `x` = VALUES(`x`),`y` = VALUES(`y`)}
+
+    assert_raise ArgumentError, "The :conflict_target option is not supported in insert/insert_all by MySQL", fn ->
+      insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], [:x]}, [])
+    end
   end
 
   test "update" do


### PR DESCRIPTION
Solution as discussed in #2450.

I also added a spec for `:conflict_target` on MySQL (which was otherwise untested) to build some confidence before adding my own spec for changed behaviour.