### PR TITLE
Skip trim value for binary data type for required validation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1586,7 +1586,11 @@ defmodule Ecto.Changeset do
                              "that was not loaded. Please preload your associations " <>
                              "before calling validate_required/3 or pass the :required " <>
                              "option to Ecto.Changeset.cast_assoc/3"
-      value when is_binary(value) -> String.trim_leading(value) == ""
+      value when is_binary(value) ->
+        case Map.fetch!(changeset.types, field) do
+          :binary -> value == ""
+          _ -> String.trim_leading(value) == ""
+        end
       nil -> true
       _ -> false
     end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -41,6 +41,7 @@ defmodule Ecto.ChangesetTest do
       field :title, :string, default: ""
       field :body
       field :uuid, :binary_id
+      field :color, :binary
       field :decimal, :decimal
       field :upvotes, :integer, default: 0
       field :topics, {:array, :string}
@@ -55,7 +56,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defp changeset(schema \\ %Post{}, params) do
-    cast(schema, params, ~w(id token title body upvotes decimal topics virtual)a)
+    cast(schema, params, ~w(id token title body upvotes decimal color topics virtual)a)
   end
 
   ## cast/4
@@ -722,6 +723,13 @@ defmodule Ecto.ChangesetTest do
     assert changeset.required == [:title, :body]
     assert changeset.changes == %{}
     assert changeset.errors == [title: {"is blank", [validation: :required]}, body: {"is blank", [validation: :required]}]
+
+    # When type is binary skip value triming (byte 12 == emtpy character in strings)
+    changeset =
+        changeset(%{color: <<12, 12, 12>>})
+      |> validate_required(:color)
+    assert changeset.valid?
+    assert changeset.errors == []
 
     # When unknown field
     assert_raise ArgumentError, ~r/unknown field :bad for changeset on/, fn  ->

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -725,9 +725,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == [title: {"is blank", [validation: :required]}, body: {"is blank", [validation: :required]}]
 
     # When type is binary skip value triming (byte 12 == emtpy character in strings)
-    changeset =
-        changeset(%{color: <<12, 12, 12>>})
-      |> validate_required(:color)
+    changeset = changeset(%{color: <<12, 12, 12>>}) |> validate_required(:color)
     assert changeset.valid?
     assert changeset.errors == []
 


### PR DESCRIPTION
Fix for issue #2455 

When checking validate_required, get the data type of the field and skip trim value when the datatype is binary.