### PR TITLE
Add trim option for validate_required

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1464,8 +1464,8 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:message` - the message on failure, defaults to "can't be blank"
-    * `:trim` - boolean, sets whether leading whitespaces are removed
-                before running the validation, defaults to true
+    * `:trim` - a boolean that sets whether whitespaces are removed before
+      running the validation on binaries/strings, defaults to true
 
   ## Examples
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1464,7 +1464,8 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:message` - the message on failure, defaults to "can't be blank"
-    * `:trim` - trims value before required check to remove whitespace, defaults to true
+    * `:trim` - boolean, sets whether leading whitespaces are removed
+                before running the validation, defaults to true
 
   ## Examples
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -41,6 +41,7 @@ defmodule Ecto.ChangesetTest do
       field :title, :string, default: ""
       field :body
       field :uuid, :binary_id
+      field :color, :binary
       field :decimal, :decimal
       field :upvotes, :integer, default: 0
       field :topics, {:array, :string}
@@ -55,7 +56,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defp changeset(schema \\ %Post{}, params) do
-    cast(schema, params, ~w(id token title body upvotes decimal topics virtual)a)
+    cast(schema, params, ~w(id token title body upvotes decimal color topics virtual)a)
   end
 
   ## cast/4
@@ -722,6 +723,15 @@ defmodule Ecto.ChangesetTest do
     assert changeset.required == [:title, :body]
     assert changeset.changes == %{}
     assert changeset.errors == [title: {"is blank", [validation: :required]}, body: {"is blank", [validation: :required]}]
+
+    # When :trim option is false
+    changeset = changeset(%{title: " "}) |> validate_required(:title, trim: false)
+    assert changeset.valid?
+    assert changeset.errors == []
+
+    changeset = changeset(%{color: <<12, 12, 12>>}) |> validate_required(:color, trim: false)
+    assert changeset.valid?
+    assert changeset.errors == []
 
     # When unknown field
     assert_raise ArgumentError, ~r/unknown field :bad for changeset on/, fn  ->


### PR DESCRIPTION
Fix for issue #2455 
Discussed in #2457

A new option for `validate_required` to skip the `String.trim_leading` before the check if the value is empty. The default is `true` to ensure backwards compatibility.