### PR TITLE
Add missing formatter file

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,32 @@
+locals_without_parens = [
+  # Query
+  from: 2,
+
+  # Schema
+  field: 1,
+  field: 2,
+  field: 3,
+  timestamps: 0,
+  timestamps: 1,
+  belongs_to: 2,
+  belongs_to: 3,
+  has_one: 2,
+  has_one: 3,
+  has_many: 2,
+  has_many: 3,
+  many_to_many: 2,
+  many_to_many: 3,
+  embeds_one: 2,
+  embeds_one: 3,
+  embeds_one: 4,
+  embeds_many: 2,
+  embeds_many: 3,
+  embeds_many: 4
+]
+
+[
+  locals_without_parens: locals_without_parens,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
+]


### PR DESCRIPTION
By doing `{"ecto", "~> 2.2.9", override: true}` in my mix.exs and  `import_deps: [:ecto]` in my own formatter, I was expecting to have the ecto rules set in my project.

However, it seems that the file `.formatter.exs` is missing from the package on hex. 

I then make the assumption that it should be present in the branch `v2.2`.
This commit aims to complete this one https://github.com/elixir-ecto/ecto/commit/9463e1c9564cd971754e3324033cdc5546ac428f