### PR TITLE
Queries in Associations

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1048,8 +1048,18 @@ defmodule Ecto.Association.ManyToMany do
   defp validate_join_through(name, nil) do
     raise ArgumentError, "many_to_many #{inspect name} associations require the :join_through option to be given"
   end
-  defp validate_join_through(_, %Ecto.Query{}) do
-    :ok
+  defp validate_join_through(name, query = %Ecto.Query{}) do
+    allowed_keys = [:wheres, :sources, :from, :aliases]
+    default = %Ecto.Query{}
+    query
+    |> Map.from_struct()
+    |> Enum.each(fn {key, value} ->
+      unless (key in allowed_keys) or Map.get(default, key) == value do
+        raise ArgumentError,
+          "many_to_many #{inspect name} was given a query with a `#{inspect key}` statement. Associations " <>
+          "cannot accept queries with select `#{inspect key }` statements"
+      end
+    end)
   end
   defp validate_join_through(_, join_through) when is_atom(join_through) or is_binary(join_through) do
     :ok

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1048,7 +1048,7 @@ defmodule Ecto.Association.ManyToMany do
   defp validate_join_through(name, nil) do
     raise ArgumentError, "many_to_many #{inspect name} associations require the :join_through option to be given"
   end
-  defp validate_join_through(name, query = %Ecto.Query{}) do
+  defp validate_join_through(name, %Ecto.Query{} = query) do
     allowed_keys = [:wheres, :sources, :from, :aliases]
     default = %Ecto.Query{}
     query

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -256,7 +256,7 @@ defmodule Ecto.Association do
       Schema
 
       iex> Ecto.Association.related_from_query("wrong")
-      ** (ArgumentError) association queryable must be a schema or {source, schema}, got: "wrong"
+      ** (ArgumentError) association queryable must be a schema,  or {source, schema}, or a query. got: "wrong"
 
   """
   def related_from_query(atom) when is_atom(atom), do: atom
@@ -264,8 +264,8 @@ defmodule Ecto.Association do
   def related_from_query(%Ecto.Query{from: schema}) when is_atom(schema), do: schema
   def related_from_query(%Ecto.Query{from: {source, schema}}) when is_binary(source) and is_atom(schema), do: schema
   def related_from_query(queryable) do
-    raise ArgumentError, "association queryable must be a schema " <>
-      "or {source, schema}, got: #{inspect queryable}"
+    raise ArgumentError, "association queryable must be a schema, " <>
+      " or {source, schema}, or a query. got: #{inspect queryable}"
   end
 
   @doc """

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -277,7 +277,7 @@ defmodule Ecto.Association do
   def related_from_query(%Ecto.Query{from: {source, schema}}) when is_binary(source) and is_atom(schema), do: schema
   def related_from_query(queryable) do
     raise ArgumentError, "association queryable must be a schema, " <>
-      " or {source, schema}, or a query. got: #{inspect queryable}"
+      "a {source, schema}, or a query. got: #{inspect queryable}"
   end
 
   @doc """

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -650,10 +650,10 @@ defmodule Ecto.Schema do
         end
       end
 
-  A query with *only* where clauses can be provided, instead of a related schema, and the where clauses
-  on that query will be added as `on` clauses when using `assoc` query builders or when preloading.
-  Generally the query should not be defined in the association itself, but in a function elsewhere,
-  keeping your schema readable. Ensure that the provided query is sourced from the schema you wish to relate to.
+  ## Using Queries as Associations
+
+  A query can also be given instead of a schema. Querying, joining or preloading the association will
+  use the given query. Currently only where clauses can be provided in queries. Let's see an example:
 
       defmodule Comment do
         ...
@@ -669,6 +669,10 @@ defmodule Ecto.Schema do
           has_many :deleted_comments, Comment.deleted()
         end
       end
+
+  Note: building the association does not consider the query filters.
+  For example, if the given query requires the active field of the associated records to be true,
+  building such association won't automatically set the active field to true.
 
   ## has_many/has_one :through
 
@@ -811,10 +815,10 @@ defmodule Ecto.Schema do
       [post] = Repo.all(from(p in Post, where: p.id == 42, preload: :permalink))
       post.permalink #=> %Permalink{...}
 
-  A query with *only* where clauses can be provided, instead of a related schema, and the where clauses
-  on that query will be added as `on` clauses when using `assoc` query builders or when preloading.
-  Generally the query should not be defined in the association itself, but in a function elsewhere,
-  keeping your schema readable. Ensure that the provided query is sourced from the schema you wish to relate to.
+  ## Using Queries as Associations
+
+  A query can also be given instead of a schema. Querying, joining or preloading the association will
+  use the given query. Currently only where clauses can be provided in queries. Let's see an example:
 
       defmodule Post do
         ...
@@ -830,6 +834,10 @@ defmodule Ecto.Schema do
           has_one :post, Post.active()
         end
       end
+
+  Note: building the association does not consider the query filters.
+  For example, if the given query requires the active field of the associated records to be true,
+  building such association won't automatically set the active field to true.
   """
   defmacro has_one(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
@@ -903,10 +911,10 @@ defmodule Ecto.Schema do
         end
       end
 
-  A query with *only* where clauses can be provided, instead of a related schema, and the where clauses
-  on that query will be added as `on` clauses when using `assoc` query builders or when preloading.
-  Generally the query should not be defined in the association itself, but in a function elsewhere,
-  keeping your schema readable. Ensure that the provided query is sourced from the schema you wish to relate to.
+  ## Using Queries as Associations
+
+  A query can also be given instead of a schema. Querying, joining or preloading the association will
+  use the given query. Currently only where clauses can be provided in queries. Let's see an example:
 
       defmodule Post do
         ...
@@ -922,6 +930,10 @@ defmodule Ecto.Schema do
           belongs_to :post, Post.active()
         end
       end
+
+  Note: building the association does not consider the query filters.
+  For example, if the given query requires the active field of the associated records to be true,
+  building such association won't automatically set the active field to true.
 
   ## Polymorphic associations
 
@@ -1221,11 +1233,11 @@ defmodule Ecto.Schema do
         {:error, changeset} -> # Handle the error
       end
 
-  A query with *only* where clauses can be provided, instead of a related schema, and the where clauses
-  on that query will be added as `on` clauses when using `assoc` query builders or when preloading.
-  Many to many relationships additionally support providing a query for the `join_through`.
-  Generally the query should not be defined in the association itself, but in a function elsewhere,
-  keeping your schema readable. Ensure that the provided query is sourced from the schema you wish to relate to.
+  ## Using Queries as Associations
+
+  A query can also be given instead of a schema, both for the join_through and the destination.
+  Querying, joining or preloading the association will use the given query. Currently only where
+  clauses can be provided in queries. Let's see an example:
 
       defmodule UserOrganization do
         use Ecto.Schema
@@ -1266,6 +1278,10 @@ defmodule Ecto.Schema do
           many_to_many :users, User.not_banned(), join_through: UserOrganization.active()
         end
       end
+
+  Note: building the association does not consider the query filters.
+  For example, if the given query requires the active field of the associated records to be true,
+  building such association won't automatically set the active field to true.
   """
   defmacro many_to_many(name, queryable, opts \\ []) do
     quote do

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -21,12 +21,18 @@ defmodule Ecto.AssociationTest do
 
     schema "posts" do
       field :title, :string
+      field :upvotes, :integer
 
       has_many :comments, Comment
       has_one :permalink, Permalink
       has_many :permalinks, Permalink
       belongs_to :author, Author, defaults: [title: "World!"]
       belongs_to :summary, Summary
+    end
+
+    def awesome() do
+      from row in __MODULE__,
+        where: row.upvotes >= 1000
     end
   end
 
@@ -48,8 +54,14 @@ defmodule Ecto.AssociationTest do
 
     schema "permalinks" do
       field :url, :string
+      field :special, :boolean
       many_to_many :authors, Author, join_through: AuthorPermalink, defaults: [title: "m2m!"]
       has_many :author_emails, through: [:authors, :emails]
+    end
+
+    def special() do
+      from row in __MODULE__,
+        where: row.special
     end
   end
 
@@ -72,23 +84,6 @@ defmodule Ecto.AssociationTest do
     end
   end
 
-  defmodule Author do
-    use Ecto.Schema
-
-    schema "authors" do
-      field :title, :string
-      has_many :posts, Post, on_replace: :delete
-      has_many :posts_comments, through: [:posts, :comments]    # many -> many
-      has_many :posts_permalinks, through: [:posts, :permalink] # many -> one
-      has_many :emails, {"users_emails", Email}
-      has_one :profile, {"users_profiles", Profile},
-        defaults: [name: "default"], on_replace: :delete
-      many_to_many :permalinks, {"custom_permalinks", Permalink},
-        join_through: "authors_permalinks"
-      has_many :posts_with_prefix, PostWithPrefix
-      has_many :comments_with_prefix, through: [:posts_with_prefix, :comments_with_prefix]
-    end
-  end
 
   defmodule AuthorPermalink do
     use Ecto.Schema
@@ -96,6 +91,44 @@ defmodule Ecto.AssociationTest do
     schema "authors_permalinks" do
       field :author_id
       field :permalink_id
+      field :deleted, :boolean
+    end
+
+    def active() do
+      from row in __MODULE__,
+        where: not(row.deleted)
+    end
+  end
+
+  defmodule Author do
+    use Ecto.Schema
+
+    schema "authors" do
+      field :title, :string
+      field :super_user, :boolean
+      has_many :posts, Post, on_replace: :delete
+      has_many :posts_comments, through: [:posts, :comments]    # many -> many
+      has_many :posts_permalinks, through: [:posts, :permalink] # many -> one
+      has_many :emails, {"users_emails", Email}
+      has_many :awesome_posts, Post.awesome()
+      has_one :profile, {"users_profiles", Profile},
+        defaults: [name: "default"], on_replace: :delete
+      many_to_many :permalinks, {"custom_permalinks", Permalink},
+        join_through: "authors_permalinks"
+
+      many_to_many :active_special_permalinks, Permalink.special(),
+        join_through: AuthorPermalink.active()
+      many_to_many :special_permalinks, Permalink.special(),
+        join_through: AuthorPermalink
+      many_to_many :active_permalinks, Permalink,
+        join_through: AuthorPermalink.active()
+      has_many :posts_with_prefix, PostWithPrefix
+      has_many :comments_with_prefix, through: [:posts_with_prefix, :comments_with_prefix]
+    end
+
+    def super_users() do
+      from row in __MODULE__,
+        where: row.super_user
     end
   end
 
@@ -104,6 +137,7 @@ defmodule Ecto.AssociationTest do
 
     schema "summaries" do
       has_one :post, Post, defaults: [title: "default"], on_replace: :nilify
+      has_one :awesome_post, Post.awesome()
       has_many :posts, Post, on_replace: :nilify
       has_one :post_author, through: [:post, :author]        # one -> belongs
       has_many :post_comments, through: [:post, :comments]   # one -> many
@@ -115,6 +149,7 @@ defmodule Ecto.AssociationTest do
 
     schema "emails" do
       belongs_to :author, {"post_authors", Author}
+      belongs_to :super_user, Author.super_users(), foreign_key: :author_id, define_field: false
     end
   end
 
@@ -161,6 +196,25 @@ defmodule Ecto.AssociationTest do
            inspect(from c in Comment, where: c.post_id in ^[1, 2, 3], limit: 5)
   end
 
+  test "has many query-based assoc query" do
+    assoc = Author.__schema__(:association, :awesome_posts)
+    assert inspect(Ecto.Association.Has.joins_query(assoc)) ==
+           inspect(from a in Author, join: p in ^(from p in Post, where: p.upvotes >= 1000), on: p.author_id == a.id)
+
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
+           inspect(from p in Post, where: p.upvotes >= 1000, where: p.author_id in ^[])
+
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1, 2, 3])) ==
+           inspect(from p in Post, where: p.upvotes >= 1000, where: p.author_id in ^[1, 2, 3])
+  end
+
+  test "has many query-based assoc with custom query" do
+    assoc = Author.__schema__(:association, :awesome_posts)
+    query = from p in Post, limit: 5
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [1, 2, 3])) ==
+           inspect(from p in Post, where: p.upvotes >= 1000, where: p.author_id in ^[1, 2, 3], limit: 5)
+  end
+
   test "has one" do
     assoc = Post.__schema__(:association, :permalink)
 
@@ -195,6 +249,25 @@ defmodule Ecto.AssociationTest do
     query = from c in Permalink, limit: 5
     assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [1, 2, 3])) ==
            inspect(from c in Permalink, where: c.post_id in ^[1, 2, 3], limit: 5)
+  end
+
+  test "has one query-based assoc query" do
+    assoc = Summary.__schema__(:association, :awesome_post)
+    assert inspect(Ecto.Association.Has.joins_query(assoc)) ==
+           inspect(from s in Summary, join: p in ^(from p in Post, where: p.upvotes >= 1000), on: p.summary_id == s.id)
+
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [])) ==
+           inspect(from p in Post, where: p.upvotes >= 1000, where: p.summary_id in ^[])
+
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, nil, [1, 2, 3])) ==
+           inspect(from p in Post, where: p.upvotes >= 1000, where: p.summary_id in ^[1, 2, 3])
+  end
+
+  test "has one query-based assoc with custom query" do
+    assoc = Summary.__schema__(:association, :awesome_post)
+    query = from p in Post, limit: 5
+    assert inspect(Ecto.Association.Has.assoc_query(assoc, query, [1, 2, 3])) ==
+           inspect(from p in Post, where: p.upvotes >= 1000, where: p.summary_id in ^[1, 2, 3], limit: 5)
   end
 
   test "belongs to" do
@@ -234,6 +307,25 @@ defmodule Ecto.AssociationTest do
     query = from a in Author, limit: 5
     assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, query, [1, 2, 3])) ==
            inspect(from a in Author, where: a.id in ^[1, 2, 3], limit: 5)
+  end
+
+  test "belongs to query-based assoc query" do
+    assoc = Email.__schema__(:association, :super_user)
+    assert inspect(Ecto.Association.BelongsTo.joins_query(assoc)) ==
+           inspect(from e in Email, join: a in ^(from a in Author, where: a.super_user), on: a.id == e.author_id)
+
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [])) ==
+           inspect(from a in Author, where: a.super_user, where: a.id in ^[])
+
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, nil, [1, 2, 3])) ==
+           inspect(from a in Author, where: a.super_user, where: a.id in ^[1, 2, 3])
+  end
+
+  test "belongs to query-based assoc with custom query" do
+    assoc = Email.__schema__(:association, :super_user)
+    query = from a in Author, limit: 5
+    assert inspect(Ecto.Association.BelongsTo.assoc_query(assoc, query, [1, 2, 3])) ==
+           inspect(from a in Author, where: a.super_user, where: a.id in ^[1, 2, 3], limit: 5)
   end
 
   test "many to many" do
@@ -286,6 +378,125 @@ defmodule Ecto.AssociationTest do
                     join: p in Permalink, on: p.id in ^[1, 2, 3],
                     join: m in AuthorPermalink, on: m.permalink_id == p.id,
                     where: m.author_id == a.id, limit: 5)
+  end
+
+  test "many to many query-based assoc and query based join_through query" do
+    assoc = Author.__schema__(:association, :active_special_permalinks)
+    assert inspect(Ecto.Association.ManyToMany.joins_query(assoc)) ==
+           inspect(from a in Author,
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    join: p in ^(from p in Permalink, where: p.special),
+                    on: m.permalink_id == p.id)
+
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [])) ==
+           inspect(from p in Permalink, where: p.special,
+                    join: a in Author, on: a.id in ^[],
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id
+             )
+
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [1, 2, 3])) ==
+           inspect(from p in Permalink, where: p.special,
+                    join: a in Author, on: a.id in ^[1, 2, 3],
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id
+             )
+  end
+
+  test "many to many query-based assoc and query based join through with custom query" do
+    assoc = Author.__schema__(:association, :active_special_permalinks)
+    query = from p in Permalink, limit: 5
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, query, [1, 2, 3])) ==
+           inspect(from p in Permalink,
+                    join: a in Author,
+                    on: a.id in ^[1, 2, 3],
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    where: p.special(),
+                    where: m.permalink_id == p.id,
+                    limit: 5)
+  end
+
+  test "many to many query-based assoc query" do
+    assoc = Author.__schema__(:association, :special_permalinks)
+    assert inspect(Ecto.Association.ManyToMany.joins_query(assoc)) ==
+           inspect(from a in Author,
+                    join: m in AuthorPermalink,
+                    on: m.author_id == a.id,
+                    join: p in ^(from p in Permalink, where: p.special),
+                    on: m.permalink_id == p.id)
+
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [])) ==
+           inspect(from p in Permalink, where: p.special,
+                    join: a in Author, on: a.id in ^[],
+                    join: m in AuthorPermalink,
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id
+             )
+
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [1, 2, 3])) ==
+           inspect(from p in Permalink, where: p.special,
+                    join: a in Author, on: a.id in ^[1, 2, 3],
+                    join: m in AuthorPermalink,
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id
+             )
+  end
+
+  test "many to many query-based assoc query with custom query" do
+    assoc = Author.__schema__(:association, :special_permalinks)
+    query = from p in Permalink, limit: 5
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, query, [1, 2, 3])) ==
+           inspect(from p in Permalink,
+                    join: a in Author,
+                    on: a.id in ^[1, 2, 3],
+                    join: m in AuthorPermalink,
+                    on: m.author_id == a.id,
+                    where: p.special(),
+                    where: m.permalink_id == p.id,
+                    limit: 5)
+  end
+
+  test "many to many query-based join through query" do
+    assoc = Author.__schema__(:association, :active_permalinks)
+    assert inspect(Ecto.Association.ManyToMany.joins_query(assoc)) ==
+           inspect(from a in Author,
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    join: p in Permalink,
+                    on: m.permalink_id == p.id)
+
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [])) ==
+           inspect(from p in Permalink,
+                    join: a in Author, on: a.id in ^[],
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id
+             )
+
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, nil, [1, 2, 3])) ==
+           inspect(from p in Permalink,
+                    join: a in Author, on: a.id in ^[1, 2, 3],
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id
+             )
+  end
+
+  test "many to many query-based join through with custom query" do
+    assoc = Author.__schema__(:association, :active_permalinks)
+    query = from p in Permalink, limit: 5
+    assert inspect(Ecto.Association.ManyToMany.assoc_query(assoc, query, [1, 2, 3])) ==
+           inspect(from p in Permalink,
+                    join: a in Author,
+                    on: a.id in ^[1, 2, 3],
+                    join: m in ^(from m in AuthorPermalink, where: not(m.deleted)),
+                    on: m.author_id == a.id,
+                    where: m.permalink_id == p.id,
+                    limit: 5)
   end
 
   test "has many through many to many" do

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -84,7 +84,6 @@ defmodule Ecto.AssociationTest do
     end
   end
 
-
   defmodule AuthorPermalink do
     use Ecto.Schema
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -322,7 +322,7 @@ defmodule Ecto.Query.PlannerTest do
                    {:lock, "foo"},
                    {:prefix, "foo"},
                    {:where, [{:and, {:is_nil, [], [nil]}}, {:or, {:is_nil, [], [nil]}}]},
-                   {:join, [{:inner, {"comments", Comment, 6996781}, true}]},
+                   {:join, [{:inner, {"comments", Comment, 48293978}, true}]},
                    {"posts", Post, 27727487},
                    {:select, 1}]
   end
@@ -452,7 +452,7 @@ defmodule Ecto.Query.PlannerTest do
       |> normalize()
     assert query.select.fields ==
            select_fields([:id, :post_title, :text, :code, :posted, :visits, :links], 0) ++
-           select_fields([:id, :text, :posted, :uuid, :post_id], 1) ++
+           select_fields([:id, :text, :posted, :uuid, :special, :post_id], 1) ++
            [{{:., [], [{:&, [], [0]}, :post_title]}, [], []}]
   end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -16,8 +16,48 @@ defmodule Ecto.Query.PlannerTest do
       field :temp, :string, virtual: true
       field :posted, :naive_datetime
       field :uuid, :binary_id
+      field :special, :boolean
       belongs_to :post, Ecto.Query.PlannerTest.Post
       has_many :post_comments, through: [:post, :comments]
+    end
+
+    def special() do
+      from comment in __MODULE__,
+        where: comment.special
+    end
+  end
+
+  defmodule Author do
+    use Ecto.Schema
+
+    schema "authors" do
+      field :super_user, :boolean
+    end
+
+    def super() do
+      from author in __MODULE__,
+        where: author.super_user
+    end
+
+    def not_super() do
+      from author in __MODULE__,
+        where: not(author.super_user)
+    end
+  end
+
+  defmodule PostAuthors do
+    use Ecto.Schema
+
+    schema "post_authors" do
+      belongs_to :post, Post
+      belongs_to :author, Author
+
+      field :deleted, :boolean
+    end
+
+    def active() do
+      from join_row in __MODULE__,
+        where: not(join_row.deleted)
     end
   end
 
@@ -32,8 +72,12 @@ defmodule Ecto.Query.PlannerTest do
       field :posted, :naive_datetime
       field :visits, :integer
       field :links, {:array, Custom.Permalink}
+      belongs_to :author, Ecto.Query.PlannerTest.Author.not_super()
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment
+      has_many :special_comments, Ecto.Query.PlannerTest.Comment.special()
+
+      many_to_many :super_authors, Author.super(), join_through: PostAuthors.active()
     end
   end
 
@@ -227,6 +271,23 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(join1.on.expr) == "&3.id() == &0.post_id()"
     assert Macro.to_string(join2.on.expr) == "&1.post_id() == &3.id()"
     assert Macro.to_string(join3.on.expr) == "&2.id() == &0.post_id()"
+  end
+
+  test "prepare: joins associations with queries" do
+    query = from(p in Post, left_join: assoc(p, :special_comments)) |> prepare |> elem(0)
+
+    assert {{"posts", _}, {"comments", _}} = query.sources
+    assert [join] = query.joins
+    assert join.ix == 1
+    assert Macro.to_string(join.on.expr) == "&1.special() and &1.post_id() == &0.id()"
+
+    query = from(p in Post, left_join: assoc(p, :super_authors)) |> prepare |> elem(0)
+
+    assert {{"posts", _}, {"authors", _}, {"post_authors", _}} = query.sources
+    assert [join1, join2] = query.joins
+    assert Enum.map(query.joins, & &1.ix) == [2, 1]
+    assert Macro.to_string(join1.on.expr) == "not(&2.deleted()) and &2.post_id() == &0.id()"
+    assert Macro.to_string(join2.on.expr) == "&1.super_user() and &2.author_id() == &1.id()"
   end
 
   test "prepare: cannot associate without schema" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -39,9 +39,9 @@ defmodule Ecto.Query.PlannerTest do
       field :deleted, :boolean
     end
 
-    def active() do
+    def inactive() do
       from comment_post in __MODULE__,
-        where: not(comment_post.deleted)
+        where: comment_post.deleted
     end
   end
 
@@ -60,7 +60,7 @@ defmodule Ecto.Query.PlannerTest do
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment
       has_many :special_comments, Ecto.Query.PlannerTest.Comment.special()
 
-      many_to_many :shared_special_comments, Comment.special(), join_through: CommentPost.active()
+      many_to_many :shared_special_comments, Comment.special(), join_through: CommentPost.inactive()
     end
   end
 
@@ -269,7 +269,7 @@ defmodule Ecto.Query.PlannerTest do
     assert {{"posts", _}, {"comments", _}, {"comment_posts", _}} = query.sources
     assert [join1, join2] = query.joins
     assert Enum.map(query.joins, & &1.ix) == [2, 1]
-    assert Macro.to_string(join1.on.expr) == "not(&2.deleted()) and &2.post_id() == &0.id()"
+    assert Macro.to_string(join1.on.expr) == "&2.deleted() and &2.post_id() == &0.id()"
     assert Macro.to_string(join2.on.expr) == "&1.special() and &2.comment_id() == &1.id()"
   end
 
@@ -288,7 +288,7 @@ defmodule Ecto.Query.PlannerTest do
 
     assert Macro.to_string(join1.on.expr) == "&1.special() and &1.post_id() == &0.id()"
     assert Macro.to_string(join2.on.expr) == "&2.id() == &1.post_id()"
-    assert Macro.to_string(join3.on.expr) == "not(&6.deleted()) and &6.post_id() == &0.id()"
+    assert Macro.to_string(join3.on.expr) == "&6.deleted() and &6.post_id() == &0.id()"
     assert Macro.to_string(join4.on.expr) == "&3.special() and &6.comment_id() == &3.id()"
     assert Macro.to_string(join5.on.expr) == "&4.comment_id() == &3.id()"
     assert Macro.to_string(join6.on.expr) == "&5.special() and &5.id() == &4.special_comment_id()"

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -256,6 +256,23 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(join3.on.expr) == "&2.id() == &0.post_id()"
   end
 
+  test "prepare: joins associations with custom queries" do
+    query = from(p in Post, left_join: assoc(p, :special_comments)) |> prepare |> elem(0)
+
+    assert {{"posts", _}, {"comments", _}} = query.sources
+    assert [join] = query.joins
+    assert join.ix == 1
+    assert Macro.to_string(join.on.expr) == "&1.special() and &1.post_id() == &0.id()"
+
+    query = from(p in Post, left_join: assoc(p, :shared_special_comments)) |> prepare |> elem(0)
+
+    assert {{"posts", _}, {"comments", _}, {"comment_posts", _}} = query.sources
+    assert [join1, join2] = query.joins
+    assert Enum.map(query.joins, & &1.ix) == [2, 1]
+    assert Macro.to_string(join1.on.expr) == "not(&2.deleted()) and &2.post_id() == &0.id()"
+    assert Macro.to_string(join2.on.expr) == "&1.special() and &2.comment_id() == &1.id()"
+  end
+
   test "prepare: nested joins associations with custom queries" do
     query = from(p in Post,
                    join: c in assoc(p, :special_comments),
@@ -275,23 +292,6 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(join4.on.expr) == "&3.special() and &6.comment_id() == &3.id()"
     assert Macro.to_string(join5.on.expr) == "&4.comment_id() == &3.id()"
     assert Macro.to_string(join6.on.expr) == "&5.special() and &5.id() == &4.special_comment_id()"
-  end
-
-  test "prepare: joins associations with queries" do
-    query = from(p in Post, left_join: assoc(p, :special_comments)) |> prepare |> elem(0)
-
-    assert {{"posts", _}, {"comments", _}} = query.sources
-    assert [join] = query.joins
-    assert join.ix == 1
-    assert Macro.to_string(join.on.expr) == "&1.special() and &1.post_id() == &0.id()"
-
-    query = from(p in Post, left_join: assoc(p, :shared_special_comments)) |> prepare |> elem(0)
-
-    assert {{"posts", _}, {"comments", _}, {"comment_posts", _}} = query.sources
-    assert [join1, join2] = query.joins
-    assert Enum.map(query.joins, & &1.ix) == [2, 1]
-    assert Macro.to_string(join1.on.expr) == "not(&2.deleted()) and &2.post_id() == &0.id()"
-    assert Macro.to_string(join2.on.expr) == "&1.special() and &2.comment_id() == &1.id()"
   end
 
   test "prepare: cannot associate without schema" do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -388,95 +388,13 @@ defmodule Ecto.SchemaTest do
 
   ## Associations
 
-  defmodule Post do
-    use Ecto.Schema
-
-    import Ecto.Query, only: [from: 2]
-
-    schema "post_assoc" do
-      field :score, :integer
-    end
-
-    def low_score() do
-      from post in __MODULE__,
-        where: post.score < 25
-    end
-  end
-
-  defmodule Comment do
-    use Ecto.Schema
-
-    import Ecto.Query, only: [from: 2]
-
-    schema "comment_assoc" do
-      field :score, :integer
-    end
-
-    def high_score() do
-      from comment in __MODULE__,
-        where: comment.score > 100
-    end
-  end
-
-  defmodule User do
-    use Ecto.Schema
-
-    import Ecto.Query, only: [from: 2]
-
-    schema "user_assoc" do
-      field :score, :integer
-    end
-
-    def middle_range_score() do
-      from author in __MODULE__,
-        where: author.score > 25,
-        where: author.score < 75
-    end
-
-    def awesome() do
-      from author in __MODULE__,
-        where: author.score > 1000
-    end
-  end
-
-  defmodule AssocEditors do
-    use Ecto.Schema
-
-    import Ecto.Query, only: [from: 2]
-
-    schema "assoc_join_table" do
-      belongs_to :user, User
-      belongs_to :assoc, AssocSchema
-
-      field :deleted, :boolean
-    end
-
-    def active() do
-      from join_row in __MODULE__,
-        where: not(join_row.deleted)
-    end
-  end
-
-  ## Associations
-
   defmodule AssocSchema do
     use Ecto.Schema
 
     schema "assocs" do
       has_many :posts, Post
-      has_many :low_scoring_posts, Post.low_score()
       has_one :author, User
-
-      has_one :middle_range_author, User.middle_range_score()
-
       belongs_to :comment, Comment
-
-      belongs_to :high_scoring_comment, Comment.high_score(),
-        foreign_key: :comment_id,
-        define_field: false
-
-      many_to_many :awesome_editors, User.awesome(), join_through: AssocEditors.active(), on_replace: :delete
-
       has_many :comment_authors, through: [:comment, :authors]
       has_one :comment_main_author, through: [:comment, :main_author]
       has_many :emails, {"users_emails", Email}, on_replace: :delete
@@ -516,27 +434,6 @@ defmodule Ecto.SchemaTest do
     posts = (%AssocSchema{}).posts
     assert %Ecto.Association.NotLoaded{__cardinality__: :many} = posts
     assert inspect(posts) == "#Ecto.Association.NotLoaded<association :posts is not loaded>"
-  end
-
-  test "has_many association via query" do
-    struct = %Ecto.Association.Has{
-      field: :low_scoring_posts,
-      owner: AssocSchema,
-      cardinality: :many,
-      on_delete: :nothing,
-      related: Post,
-      owner_key: :id,
-      related_key: :assoc_schema_id,
-      queryable: Post.low_score(),
-      on_replace: :raise
-    }
-
-    assert AssocSchema.__schema__(:association, :low_scoring_posts) == struct
-    assert AssocSchema.__changeset__.low_scoring_posts == {:assoc, struct}
-
-    low_scoring_posts = (%AssocSchema{}).low_scoring_posts
-    assert %Ecto.Association.NotLoaded{__cardinality__: :many} = low_scoring_posts
-    assert inspect(low_scoring_posts) == "#Ecto.Association.NotLoaded<association :low_scoring_posts is not loaded>"
   end
 
   test "has_many through association" do
@@ -579,20 +476,6 @@ defmodule Ecto.SchemaTest do
     assert inspect(author) == "#Ecto.Association.NotLoaded<association :author is not loaded>"
   end
 
-  test "has_one association via query" do
-    struct =
-      %Ecto.Association.Has{field: :middle_range_author, owner: AssocSchema, cardinality: :one, on_delete: :nothing,
-                            related: User, owner_key: :id, related_key: :assoc_schema_id,
-                            queryable: User.middle_range_score(), on_replace: :raise}
-
-    assert AssocSchema.__schema__(:association, :middle_range_author) == struct
-    assert AssocSchema.__changeset__.middle_range_author == {:assoc, struct}
-
-    author = (%AssocSchema{}).middle_range_author
-    assert %Ecto.Association.NotLoaded{__cardinality__: :one} = author
-    assert inspect(author) == "#Ecto.Association.NotLoaded<association :middle_range_author is not loaded>"
-  end
-
   test "has_one through association" do
     assert AssocSchema.__schema__(:association, :comment_main_author) ==
            %Ecto.Association.HasThrough{field: :comment_main_author, owner: AssocSchema, cardinality: :one,
@@ -631,42 +514,6 @@ defmodule Ecto.SchemaTest do
     comment = (%AssocSchema{}).comment
     assert %Ecto.Association.NotLoaded{} = comment
     assert inspect(comment) == "#Ecto.Association.NotLoaded<association :comment is not loaded>"
-  end
-
-  test "belongs_to association via query" do
-    struct =
-      %Ecto.Association.BelongsTo{field: :high_scoring_comment, owner: AssocSchema, cardinality: :one,
-       related: Comment, owner_key: :comment_id, related_key: :id,
-       queryable: Comment.high_score(), on_replace: :raise, defaults: []}
-
-    assert AssocSchema.__schema__(:association, :high_scoring_comment) == struct
-    assert AssocSchema.__changeset__.high_scoring_comment == {:assoc, struct}
-
-    comment = (%AssocSchema{}).high_scoring_comment
-    assert %Ecto.Association.NotLoaded{} = comment
-    assert inspect(comment) == "#Ecto.Association.NotLoaded<association :high_scoring_comment is not loaded>"
-  end
-
-  test "many_to_many association via query" do
-    struct = %Ecto.Association.ManyToMany{
-      field: :awesome_editors,
-      owner: AssocSchema,
-      cardinality: :many,
-      on_delete: :nothing,
-      related: User,
-      owner_key: :id,
-      queryable: User.awesome(),
-      on_replace: :delete,
-      join_keys: [assoc_schema_id: :id, user_id: :id],
-      join_through: AssocEditors.active()
-    }
-
-    assert AssocSchema.__schema__(:association, :awesome_editors) == struct
-    assert AssocSchema.__changeset__.awesome_editors == {:assoc, struct}
-
-    awesome_editors = (%AssocSchema{}).awesome_editors
-    assert %Ecto.Association.NotLoaded{__cardinality__: :many} = awesome_editors
-    assert inspect(awesome_editors) == "#Ecto.Association.NotLoaded<association :awesome_editors is not loaded>"
   end
 
   defmodule CustomAssocSchema do
@@ -733,7 +580,7 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_* expects a queryable" do
-    message = ~r"association queryable must be a schema,  or {source, schema}, or a query. got: 123"
+    message = ~r"association queryable must be a schema or {source, schema}, got: 123"
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
         use Ecto.Schema

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -580,7 +580,7 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_* expects a queryable" do
-    message = ~r"association queryable must be a schema,  or {source, schema}, or a query. got: 123"
+    message = ~r"association :posts queryable must be a schema, a {source, schema}, or a query. got: 123"
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
         use Ecto.Schema

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -580,7 +580,7 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_* expects a queryable" do
-    message = ~r"association queryable must be a schema or {source, schema}, got: 123"
+    message = ~r"association queryable must be a schema,  or {source, schema}, or a query. got: 123"
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
         use Ecto.Schema

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -733,7 +733,7 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_* expects a queryable" do
-    message = ~r"association queryable must be a schema or {source, schema}, got: 123"
+    message = ~r"association queryable must be a schema,  or {source, schema}, or a query. got: 123"
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
         use Ecto.Schema


### PR DESCRIPTION
There wasn't much to do to make this work as expected, because everything aside from the validations was expecting associations to be expressed as queryables anyway (as far as I can tell). I have a few test failures that I'm not 100% sure on, but they appear to be due to changes I made to test schemas. I didn't want to just change them off hand though, because for all I know I broke something real. So I left those tests failing, and wrote new tests to express both the capability of building the query with queries for assocs, and the planning of it. I was going to write integration tests for it, but I figured that if the planner is breaking it out into the correct joins, that it would be unnecessary to have an integration test.

This is in service of providing a lot of the value #2395 was looking for, without having to introduce the larger change of default where clauses.