### PR TITLE
Support CTEs

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -112,21 +112,32 @@ if Code.ensure_loaded?(Postgrex) do
     alias Ecto.Query.{BooleanExpr, JoinExpr, QueryExpr}
 
     def all(query) do
+      IO.inspect(query)
       sources = create_names(query)
       {select_distinct, order_by_distinct} = distinct(query.distinct, sources, query)
 
-      from     = from(query, sources)
-      select   = select(query, select_distinct, sources)
-      join     = join(query, sources)
-      where    = where(query, sources)
-      group_by = group_by(query, sources)
-      having   = having(query, sources)
-      order_by = order_by(query, order_by_distinct, sources)
-      limit    = limit(query, sources)
-      offset   = offset(query, sources)
-      lock     = lock(query.lock)
+      with_ctes = with_ctes(query.with_ctes)
+      from      = from(query, sources)
+      select    = select(query, select_distinct, sources)
+      join      = join(query, sources)
+      where     = where(query, sources)
+      group_by  = group_by(query, sources)
+      having    = having(query, sources)
+      order_by  = order_by(query, order_by_distinct, sources)
+      limit     = limit(query, sources)
+      offset    = offset(query, sources)
+      lock      = lock(query.lock)
 
-      [select, from, join, where, group_by, having, order_by, limit, offset | lock]
+      [with_ctes, select, from, join, where, group_by, having, order_by, limit, offset | lock]
+    end
+
+    def with_ctes(query, current_with_statement \\ [])
+    def with_ctes([], statement), do: statement
+    def with_ctes([with_cte|rest], []) do
+      with_ctes(rest, ["WITH ", to_string(with_cte.as), " AS (", all(with_cte.query), ") "])
+    end
+    def with_ctes([with_cte|rest], current_with_statement) do
+      with_ctes(rest, current_with_statement ++ [", ", to_string(with_cte.as), " AS (", all(with_cte.query), ") "])
     end
 
     def update_all(%{from: from} = query, prefix \\ nil) do
@@ -892,14 +903,20 @@ if Code.ensure_loaded?(Postgrex) do
 
     ## Helpers
 
+    defp get_source(_, _, _, {:cte, cte}) do
+       string_name = to_string(cte)
+       {string_name, string_name}
+    end
     defp get_source(query, sources, ix, source) do
       {expr, name, _schema} = elem(sources, ix)
       {expr || paren_expr(source, sources, query), name}
     end
 
     defp quote_qualified_name(name, sources, ix) do
-      {_, source, _} = elem(sources, ix)
-      [source, ?. | quote_name(name)]
+      case elem(sources, ix) do
+        {[_, "cte", _], _, cte_alias} -> [to_string(cte_alias), ?. | quote_name(name)]
+        {_, source, _} -> [source, ?. | quote_name(name)]
+      end
     end
 
     defp quote_name(name) when is_atom(name) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -112,7 +112,6 @@ if Code.ensure_loaded?(Postgrex) do
     alias Ecto.Query.{BooleanExpr, JoinExpr, QueryExpr}
 
     def all(query) do
-      IO.inspect(query)
       sources = create_names(query)
       {select_distinct, order_by_distinct} = distinct(query.distinct, sources, query)
 

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -89,6 +89,10 @@ defmodule Ecto.Query.Builder.Join do
     {:_, quote(do: Ecto.Query.Builder.Join.join!(unquote(expr))), nil, %{}}
   end
 
+  def escape({:cte, _, [cte]} = expr, _vars, _env) do
+    {:_, {:cte, cte}, nil, %{}}
+  end
+
   def escape(join, vars, env) do
     case Macro.expand(join, env) do
       ^join ->


### PR DESCRIPTION
I'm primarily PR-ing this because I think the proposal only really makes sense to come along with an MVP (okay, its not *viable*, its just an MP). There are a lot of hacky workarounds for the things that I haven't taken the time to understand, especially the cache. But the point was to get a very minimal implementation of CTEs working for just one example.

Once I realized that there was minimal support for named joins, I realized that it was perhaps an entrypoint to using CTEs. If there are already efforts underway for this, or if this feature is just not desired, it is no big deal, it was just a few hours and was very educational anyway!

If we decide that we like it and should actually implement it, then I figured getting my earliest attempts at an implementation out there might be a good idea, to catch any misconceptions I might have and to avoid me spending too much time going down a bad path.

Testing locally, I was able to use this like so:
```elixir
iex(20)> cte = from row in "users", where: row.super, select: %{id: row.id}
#Ecto.Query<from u in "users", where: u.super, select: %{id: u.id}>
iex(6)> joined_to_cte = from row in "posts", with_cte: cte, as: :super_users, join: super_user in cte(:super_users), on: super_user.id == row.user_id, select: row.id
#Ecto.Query<with: :super_users as: #Ecto.Query<from u in "users", where: u.super, select: %{id: u.id}>,
 from p in "posts", join: s in cte(:super_users), on: s.id == p.user_id,
 select: p.id>
```

Which would result in the following SQL (formatted)
```sql
WITH super_users AS (
  SELECT u0."id" 
  FROM "users" AS u0 
  WHERE (u0."super")
) SELECT p0."id" FROM "posts" AS p0 
INNER JOIN super_users AS super_users 
ON super_users."id" = p0."user_id"
```

Personally I think having `WITH` in our toolbelt would be *great* especially for composability. For instance, lets say that if someone added a different `with` clause w/ the same alias, I think we would just override it, which allows for the quick swapping of certain contexts of the query very easily.

```
super_users_query = from row in "users", where: row.super
from row in query,
  with_cte: super_users_query,
  as: :users

# ...some time later...

from row in query,
  with_cte: (from row in "users"),
  as: :users
```