### PR TITLE
Paramaterizing ChangeSet Type

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -248,10 +248,10 @@ defmodule Ecto.Changeset do
             constraints: [], filters: %{}, action: nil, types: nil,
             empty_values: @empty_values, repo: nil, repo_opts: []
 
-  @type t :: %Changeset{valid?: boolean(),
+  @type t(data_type) :: %Changeset{valid?: boolean(),
                         repo: atom | nil,
                         repo_opts: Keyword.t,
-                        data: Ecto.Schema.t | map | nil,
+                        data: data_type | nil,
                         params: %{String.t => term} | nil,
                         changes: %{atom => term},
                         required: [atom],
@@ -263,6 +263,7 @@ defmodule Ecto.Changeset do
                         action: action,
                         types: nil | %{atom => Ecto.Type.t}}
 
+  @type t :: t(Ecto.Schema.t | map)
   @type error :: {String.t, Keyword.t}
   @type action :: nil | :insert | :update | :delete | :replace | :ignore
   @type constraint :: %{type: :check | :exclusion | :foreign_key | :unique,

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -251,7 +251,7 @@ defmodule Ecto.Changeset do
   @type t(data_type) :: %Changeset{valid?: boolean(),
                         repo: atom | nil,
                         repo_opts: Keyword.t,
-                        data: data_type | nil,
+                        data: data_type,
                         params: %{String.t => term} | nil,
                         changes: %{atom => term},
                         required: [atom],
@@ -263,7 +263,7 @@ defmodule Ecto.Changeset do
                         action: action,
                         types: nil | %{atom => Ecto.Type.t}}
 
-  @type t :: t(Ecto.Schema.t | map)
+  @type t :: t(Ecto.Schema.t | map | nil)
   @type error :: {String.t, Keyword.t}
   @type action :: nil | :insert | :update | :delete | :replace | :ignore
   @type constraint :: %{type: :check | :exclusion | :foreign_key | :unique,


### PR DESCRIPTION
I often find myself wanting to be more specific in my functions when I say that a function takes a changeset. Our schemas pretty much all express a `.t()` that is usually just `@type t :: %__MODULE__{}`.

I think its nice and very informative to be able to say something like

```
@spec validate_author_permissions(Ecto.Changeset.t(Post.t())) :: Ecto.changeset.t(Post.t())
```

The only real question I have here is whether or not we should do the `| nil` in the paramaterized or non paramaterized version.