### PR TITLE
Support coalesce

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -3,7 +3,7 @@ Code.require_file "../support/types.exs", __DIR__
 defmodule Ecto.Integration.TypeTest do
   use Ecto.Integration.Case, async: Application.get_env(:ecto, :async_integration_tests, true)
 
-  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag, Article}
+  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag}
   alias Ecto.Integration.TestRepo
   import Ecto.Query
 
@@ -69,21 +69,10 @@ defmodule Ecto.Integration.TypeTest do
   end
 
   test "coalesce type" do
-    TestRepo.insert!(%Article{published_at: nil})
-    datetime = ~N[2014-01-16 20:26:51.000000]
-    query = from a in Article, select: coalesce(a.published_at, ^datetime)
-    assert [^datetime] = TestRepo.all(query)
-
-    query = from a in "articles", select: coalesce(a.published_at, ^datetime)
-    assert [^datetime] = TestRepo.all(query)
-  end
-
-  test "coalesce type with unknown base type" do
-    TestRepo.insert!(%Article{published_at: nil})
-    datetime = ~N[2014-01-16 20:26:51.000000]
-
-    query = from a in "articles", select: coalesce(a.published_at, ^datetime)
-    assert [^datetime] = TestRepo.all(query)
+    TestRepo.insert!(%Post{text: nil})
+    text = <<0,1>>
+    query = from p in Post, select: coalesce(p.text, ^text)
+    assert [^text] = TestRepo.all(query)
   end
 
   test "tagged types" do

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -66,6 +66,23 @@ defmodule Ecto.Integration.TypeTest do
     datetime = ~N[2014-01-16 20:26:51]
     TestRepo.insert!(%Post{inserted_at: datetime})
     query = from p in Post, select: filter(max(p.inserted_at), p.public == ^true)
+  end
+
+  test "coalesce type" do
+    TestRepo.insert!(%Article{published_at: nil})
+    datetime = ~N[2014-01-16 20:26:51]
+    query = from a in Article, select: coalesce(a.published_at, ^datetime)
+    assert [^datetime] = TestRepo.all(query)
+
+    query = from a in "articles", select: coalesce(a.published_at, ^datetime)
+    assert [^datetime] = TestRepo.all(query)
+  end
+
+  test "coalesce type with unknown base type" do
+    TestRepo.insert!(%Article{published_at: nil})
+    datetime = ~N[2014-01-16 20:26:51]
+
+    query = from a in "articles", select: coalesce(a.published_at, ^datetime)
     assert [^datetime] = TestRepo.all(query)
   end
 

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -3,7 +3,7 @@ Code.require_file "../support/types.exs", __DIR__
 defmodule Ecto.Integration.TypeTest do
   use Ecto.Integration.Case, async: Application.get_env(:ecto, :async_integration_tests, true)
 
-  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag}
+  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag, Article}
   alias Ecto.Integration.TestRepo
   import Ecto.Query
 
@@ -70,7 +70,7 @@ defmodule Ecto.Integration.TypeTest do
 
   test "coalesce type" do
     TestRepo.insert!(%Article{published_at: nil})
-    datetime = ~N[2014-01-16 20:26:51]
+    datetime = ~N[2014-01-16 20:26:51.000000]
     query = from a in Article, select: coalesce(a.published_at, ^datetime)
     assert [^datetime] = TestRepo.all(query)
 
@@ -80,7 +80,7 @@ defmodule Ecto.Integration.TypeTest do
 
   test "coalesce type with unknown base type" do
     TestRepo.insert!(%Article{published_at: nil})
-    datetime = ~N[2014-01-16 20:26:51]
+    datetime = ~N[2014-01-16 20:26:51.000000]
 
     query = from a in "articles", select: coalesce(a.published_at, ^datetime)
     assert [^datetime] = TestRepo.all(query)

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -66,12 +66,21 @@ defmodule Ecto.Integration.TypeTest do
     datetime = ~N[2014-01-16 20:26:51]
     TestRepo.insert!(%Post{inserted_at: datetime})
     query = from p in Post, select: filter(max(p.inserted_at), p.public == ^true)
+    assert [^datetime] = TestRepo.all(query)
   end
 
-  test "coalesce type" do
+  test "coalesce type when default" do
     TestRepo.insert!(%Post{text: nil})
     text = <<0, 1>>
     query = from p in Post, select: coalesce(p.text, ^text)
+    assert [^text] = TestRepo.all(query)
+  end
+
+  test "coalesce type when value" do
+    text = <<0, 2>>
+    default_text = <<0, 1>>
+    TestRepo.insert!(%Post{text: text})
+    query = from p in Post, select: coalesce(p.text, ^default_text)
     assert [^text] = TestRepo.all(query)
   end
 

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -10,7 +10,7 @@ defmodule Ecto.Integration.TypeTest do
   test "primitive types" do
     integer  = 1
     float    = 0.1
-    text     = <<0,1>>
+    text     = <<0, 1>>
     uuid     = "00010203-0405-4607-8809-0a0b0c0d0e0f"
     datetime = ~N[2014-01-16 20:26:51]
 

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -70,7 +70,7 @@ defmodule Ecto.Integration.TypeTest do
 
   test "coalesce type" do
     TestRepo.insert!(%Post{text: nil})
-    text = <<0,1>>
+    text = <<0, 1>>
     query = from p in Post, select: coalesce(p.text, ^text)
     assert [^text] = TestRepo.all(query)
   end

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -158,6 +158,12 @@ defmodule Ecto.Query.API do
   """
   def count(value, :distinct), do: doc! [value, :distinct]
 
+
+  @doc """
+  Takes the first value provided that is non-null.
+  """
+  def coalesce(value, expr), do: doc! [value, expr]
+
   @doc """
   Applies the given expression as a FILTER clause against an
   aggregate. This is currently only supported by Postgres.

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -160,7 +160,13 @@ defmodule Ecto.Query.API do
 
 
   @doc """
-  Takes the first value provided that is non-null.
+  Takes whichever value is not null, or null if they both are.
+
+  In SQL, COALESCE takes any number of arguments, but in ecto
+  it only takes two, so it must be chained to achieve the same
+  effect.
+
+      from p in Payment, select: p.value |> coalesce(p.backup_value) |> coalesce(0)
   """
   def coalesce(value, expr), do: doc! [value, expr]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -158,7 +158,6 @@ defmodule Ecto.Query.API do
   """
   def count(value, :distinct), do: doc! [value, :distinct]
 
-
   @doc """
   Takes whichever value is not null, or null if they both are.
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -257,6 +257,11 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:filter, [], [aggregate, filter_expr]]}, params_acc}
   end
 
+  def escape({:coalesce, _, values}, type, params_acc, vars, env) do
+    {arg, params_acc} = escape(values, type, params_acc, vars, env)
+    {{:{}, [], [:coalesce, [], arg]}, params_acc}
+  end
+
   def escape({:=, _, _} = expr, _type, _params_acc, _vars, _env) do
     error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
             "The match operator is not supported: `=`. " <>

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -257,10 +257,6 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:filter, [], [aggregate, filter_expr]]}, params_acc}
   end
 
-  def escape({:coalesce, _, values}, type, params_acc, vars, env) do
-    {arg, params_acc} = escape(values, type, params_acc, vars, env)
-    {{:{}, [], [:coalesce, [], arg]}, params_acc}
-  end
   def escape({:coalesce, _, [left, right]}, type, params_acc, vars, env) do
     {left, params_acc} = escape(left, type, params_acc, vars, env)
     {right, params_acc} = escape(right, type, params_acc, vars, env)

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -261,6 +261,11 @@ defmodule Ecto.Query.Builder do
     {arg, params_acc} = escape(values, type, params_acc, vars, env)
     {{:{}, [], [:coalesce, [], arg]}, params_acc}
   end
+  def escape({:coalesce, _, [left, right]}, type, params_acc, vars, env) do
+    {left, params_acc} = escape(left, type, params_acc, vars, env)
+    {right, params_acc} = escape(right, type, params_acc, vars, env)
+    {{:{}, [], [:coalesce, [], [left, right]]}, params_acc}
+  end
 
   def escape({:=, _, _} = expr, _type, _params_acc, _vars, _env) do
     error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -952,6 +952,7 @@ defmodule Ecto.Query.Planner do
     {{:value, type}, [expr | fields], from}
   end
 
+<<<<<<< HEAD
   defp collect_fields({:filter, _, [call, _]} = expr, fields, from, query, take) do
     {type, _, _} = collect_fields(call, fields, from, query, take)
     {type, [expr | fields], from}
@@ -979,6 +980,21 @@ defmodule Ecto.Query.Planner do
 
   #   {{:value, coalesce_type}, [expr | fields], from}
   # end
+=======
+  defp collect_fields({:coalesce, _, [left, right]} = expr, fields, from, query, take) do
+    {left_type, _, _} = collect_fields(left, fields, from, query, take)
+    {right_type, _, _} = collect_fields(right, fields, from, query, take)
+
+    type =
+      case {left_type, right_type} do
+        {_, {:value, type}} when type != :any -> {:value, type}
+        {{:value, type}, _} when type != :any -> {:value, type}
+        _ -> {:value, :any}
+      end
+
+    {type, [expr | fields], from}
+  end
+>>>>>>> added testing, and simplified building/planning
 
   defp collect_fields({{:., _, [{:&, _, [ix]}, field]}, _, []} = expr,
                       fields, from, %{select: select} = query, _take) do
@@ -1092,13 +1108,6 @@ defmodule Ecto.Query.Planner do
   defp collect_assocs(exprs, fields, _query, _tag, _take, []) do
     {exprs, fields}
   end
-
-  # If they
-  defp value_type(literal) when is_integer(literal), do: :integer
-  defp value_type(literal) when is_float(literal), do: :float
-  defp value_type(literal) when is_binary(literal), do: :binary
-  defp value_type(literal) when is_bitstring(literal), do: :string
-  defp value_type(_), do: :any
 
   defp fetch_assoc(tag, take, assoc) do
     case Access.fetch(take, assoc) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -952,35 +952,11 @@ defmodule Ecto.Query.Planner do
     {{:value, type}, [expr | fields], from}
   end
 
-<<<<<<< HEAD
   defp collect_fields({:filter, _, [call, _]} = expr, fields, from, query, take) do
     {type, _, _} = collect_fields(call, fields, from, query, take)
     {type, [expr | fields], from}
   end
 
-  # defp collect_fields({:coalesce, _, values} = expr, fields, from, query, take) do
-  #   coalesce_type =
-  #     Enum.find_value(values, :any, fn value ->
-  #       case collect_fields(value, fields, from, query, take) do
-  #         {{:value, :any}, _, _} ->
-  #           false
-  #         {:any, _, _} ->
-  #           false
-  #         {{:value, type}, _, _} ->
-  #           type
-  #         {value, _, _} ->
-  #           value_type = value_type(value)
-  #           if value_type != :any do
-  #             value_type
-  #           else
-  #             false
-  #           end
-  #       end
-  #     end)
-
-  #   {{:value, coalesce_type}, [expr | fields], from}
-  # end
-=======
   defp collect_fields({:coalesce, _, [left, right]} = expr, fields, from, query, take) do
     {left_type, _, _} = collect_fields(left, fields, from, query, take)
     {right_type, _, _} = collect_fields(right, fields, from, query, take)
@@ -994,7 +970,6 @@ defmodule Ecto.Query.Planner do
 
     {type, [expr | fields], from}
   end
->>>>>>> added testing, and simplified building/planning
 
   defp collect_fields({{:., _, [{:&, _, [ix]}, field]}, _, []} = expr,
                       fields, from, %{select: select} = query, _take) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -957,6 +957,29 @@ defmodule Ecto.Query.Planner do
     {type, [expr | fields], from}
   end
 
+  # defp collect_fields({:coalesce, _, values} = expr, fields, from, query, take) do
+  #   coalesce_type =
+  #     Enum.find_value(values, :any, fn value ->
+  #       case collect_fields(value, fields, from, query, take) do
+  #         {{:value, :any}, _, _} ->
+  #           false
+  #         {:any, _, _} ->
+  #           false
+  #         {{:value, type}, _, _} ->
+  #           type
+  #         {value, _, _} ->
+  #           value_type = value_type(value)
+  #           if value_type != :any do
+  #             value_type
+  #           else
+  #             false
+  #           end
+  #       end
+  #     end)
+
+  #   {{:value, coalesce_type}, [expr | fields], from}
+  # end
+
   defp collect_fields({{:., _, [{:&, _, [ix]}, field]}, _, []} = expr,
                       fields, from, %{select: select} = query, _take) do
     type = source_type!(:select, query, select, ix, field)
@@ -1069,6 +1092,13 @@ defmodule Ecto.Query.Planner do
   defp collect_assocs(exprs, fields, _query, _tag, _take, []) do
     {exprs, fields}
   end
+
+  # If they
+  defp value_type(literal) when is_integer(literal), do: :integer
+  defp value_type(literal) when is_float(literal), do: :float
+  defp value_type(literal) when is_binary(literal), do: :binary
+  defp value_type(literal) when is_bitstring(literal), do: :string
+  defp value_type(_), do: :any
 
   defp fetch_assoc(tag, take, assoc) do
     case Access.fetch(take, assoc) do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -178,6 +178,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert all(query) == ~s{SELECT TRUE FROM `schema` AS s0 LOCK IN SHARE MODE}
   end
 
+  test "coalesce" do
+    query = Schema |> select([s], coalesce(s.x, 5)) |> nromalize
+    assert all(query) == ~s{SELECT coalesce(s0.x, 5) FROM `schema` AS s0}
+  end
+
   test "string escape" do
     query = "schema" |> where(foo: "'\\  ") |> select([], true) |> normalize
     assert all(query) == ~s{SELECT TRUE FROM `schema` AS s0 WHERE (s0.`foo` = '''\\\\  ')}

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -179,8 +179,8 @@ defmodule Ecto.Adapters.MySQLTest do
   end
 
   test "coalesce" do
-    query = Schema |> select([s], coalesce(s.x, 5)) |> nromalize
-    assert all(query) == ~s{SELECT coalesce(s0.x, 5) FROM `schema` AS s0}
+    query = Schema |> select([s], coalesce(s.x, 5)) |> normalize
+    assert all(query) == ~s{SELECT coalesce(s0.`x`, 5) FROM `schema` AS s0}
   end
 
   test "string escape" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -156,8 +156,8 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "coalesce" do
-    query = Schema |> select([s], coalesce(s.x, 5)) |> nromalize
-    assert all(query) == ~s{SELECT coalesce(s0.x, 5) FROM `schema` AS s0}
+    query = Schema |> select([s], coalesce(s.x, 5)) |> normalize
+    assert all(query) == ~s{SELECT coalesce(s0."x", 5) FROM "schema" AS s0}
   end
 
   test "where" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -155,6 +155,11 @@ defmodule Ecto.Adapters.PostgresTest do
     assert all(query) == ~s{SELECT DISTINCT ON (s0."x") s0."x" FROM "schema" AS s0 ORDER BY s0."x" DESC, s0."y"}
   end
 
+  test "coalesce" do
+    query = Schema |> select([s], coalesce(s.x, 5)) |> nromalize
+    assert all(query) == ~s{SELECT coalesce(s0.x, 5) FROM `schema` AS s0}
+  end
+
   test "where" do
     query = Schema |> where([r], r.x == 42) |> where([r], r.y != 43) |> select([r], r.x) |> normalize
     assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WHERE (s0."x" = 42) AND (s0."y" != 43)}


### PR DESCRIPTION
This PR adds support for `coalesce`. Per a discussion on a different PR, I opted not to make it variadic, even though it is in sql. It banks on the fact that `COALESCE(COALESCE(x, y), z)` is the same as `COALESCE(x, y, z)` With that in mind, it looks like:

```elixir
p.foo |> coalesce(p.bar) |> coalesce(5)
# or
coalesce(coalesce(p.foo, p.bar), 5)
```
I didn't really check if there is any kind of optimization to be done in the adapter or planner to unwrap these into a single `coalesce`. I wouldn't expect there to be any kind of performance difference in the two forms.

The only other thing I wasn't entirely sure about was determining the type for a coalesce call. It would seem to me that the best thing to do would be to take "the most specific type" of the two arguments. I wasn't really sure of a good way to do that aside from choosing whichever one is not `:any` if there is one. One thing I noticed is that the type of coalesce *could* be informed by a literal value, like
`from t in "table", select: coalece(t.field, 10)`. We could potentially return `{:value, :integer}` from `collect_fields` for that. I couldn't find any mapping of values -> type like that anywhere, so I figure it was best to leave it alone for now.