### PR TITLE
Add `FromExpr` and use it instead of a tuple in `Ecto.Query.from`

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -527,7 +527,7 @@ if Code.ensure_loaded?(Mariaex) do
     defp create_names(prefix, sources, pos, limit) when pos < limit do
       current =
         case elem(sources, pos) do
-          {table, schema} ->
+          %Ecto.Query.FromExpr{source: table, schema: schema} ->
             name = [create_alias(table) | Integer.to_string(pos)]
             {quote_table(prefix, table), name, schema}
           {:fragment, _, _} ->

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -585,7 +585,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp create_names(prefix, sources, pos, limit) when pos < limit do
       current =
         case elem(sources, pos) do
-          {table, schema} ->
+          %Ecto.Query.FromExpr{source: table, schema: schema} ->
             name = [create_alias(table) | Integer.to_string(pos)]
             {quote_table(prefix, table), name, schema}
           {:fragment, _, _} ->

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -260,7 +260,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp put_source(opts, %{sources: sources}) when tuple_size(elem(sources, 0)) == 2 do
-    {source, _} = elem(sources, 0)
+    %Ecto.Query.FromExpr{source: source} = elem(sources, 0)
     Keyword.put(opts, :source, source)
   end
   defp put_source(opts, _) do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -310,6 +310,11 @@ defmodule Ecto.Query do
              havings: [], preloads: [], assocs: [], distinct: nil, lock: nil]
   @type t :: %__MODULE__{}
 
+  defmodule FromExpr do
+    @moduledoc false
+    defstruct [:source, :schema]
+  end
+
   defmodule DynamicExpr do
     @moduledoc false
     defstruct [:fun, :binding, :file, :line]
@@ -1442,7 +1447,7 @@ defmodule Ecto.Query do
     %QueryExpr{expr: expr, file: __ENV__.file, line: __ENV__.line}
   end
 
-  defp assert_schema!(%{from: {_source, schema}}) when schema != nil, do: schema
+  defp assert_schema!(%{from: %Ecto.Query.FromExpr{schema: schema}}) when schema != nil, do: schema
   defp assert_schema!(query) do
     raise Ecto.QueryError, query: query, message: "expected a from expression with a schema"
   end

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -54,7 +54,7 @@ defmodule Ecto.Query.Builder.From do
     {query, binds} = escape(query, env)
 
     {count_bind, quoted} =
-      case expand_from(query, env) do
+      case Macro.expand(query, env) do
         schema when is_atom(schema) ->
           # Get the source at runtime so no unnecessary compile time
           # dependencies between modules are added
@@ -79,14 +79,12 @@ defmodule Ecto.Query.Builder.From do
   end
 
   defp query(prefix, source, schema) do
-    {:%, [], [Ecto.Query, {:%{}, [], [from: {source, schema}, prefix: prefix, aliases: {:%{}, [], []}]}]}
-  end
-
-  defp expand_from({left, right}, env) do
-    {left, Macro.expand(right, env)}
-  end
-  defp expand_from(other, env) do
-    Macro.expand(other, env)
+    {:%, [], [Ecto.Query,
+              {:%{}, [],
+               [from: {:%, [], [Ecto.Query.FromExpr,
+                                {:%{}, [], [source: source, schema: schema]}]},
+                prefix: prefix,
+                aliases: {:%{}, [], []}]}]}
   end
 
   @doc """

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -250,7 +250,6 @@ defmodule Ecto.Query.Planner do
   defp prepare_source(_query, {:fragment, _, _} = source, _adapter),
     do: source
 
-
   defp assert_no_subquery_assocs!(%{assocs: assocs, preloads: preloads} = query)
        when assocs != [] or preloads != [] do
     error!(query, "cannot preload associations in subquery")

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2,7 +2,7 @@ defmodule Ecto.Query.Planner do
   # Normalizes a query and its parameters.
   @moduledoc false
 
-  alias Ecto.Query.{BooleanExpr, DynamicExpr, JoinExpr, QueryExpr, SelectExpr}
+  alias Ecto.Query.{BooleanExpr, DynamicExpr, JoinExpr, QueryExpr, SelectExpr, FromExpr}
 
   if map_size(%Ecto.Query{}) != 18 do
     raise "Ecto.Query match out of date in builder"
@@ -243,12 +243,13 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp prepare_source(_query, {nil, schema}, _adapter) when is_atom(schema) and schema != nil,
-    do: {schema.__schema__(:source), schema}
-  defp prepare_source(_query, {source, schema}, _adapter) when is_binary(source) and is_atom(schema),
-    do: {source, schema}
+  defp prepare_source(_query, %FromExpr{source: nil, schema: schema}, _adapter) when is_atom(schema) and schema != nil,
+    do: %FromExpr{source: schema.__schema__(:source), schema: schema}
+  defp prepare_source(_query, %FromExpr{source: source, schema: schema}, _adapter) when is_binary(source) and is_atom(schema),
+    do: %FromExpr{source: source, schema: schema}
   defp prepare_source(_query, {:fragment, _, _} = source, _adapter),
     do: source
+
 
   defp assert_no_subquery_assocs!(%{assocs: assocs, preloads: preloads} = query)
        when assocs != [] or preloads != [] do
@@ -317,7 +318,7 @@ defmodule Ecto.Query.Planner do
     error!(query, "subquery must select a source (t), a field (t.field) or a map, got: `#{Macro.to_string(expr)}`")
   end
 
-  defp subquery_struct_and_fields({:source, {_, schema}, types}) do
+  defp subquery_struct_and_fields({:source, %FromExpr{schema: schema}, types}) do
     {schema, Keyword.keys(types)}
   end
   defp subquery_struct_and_fields({:struct, name, types}) do
@@ -461,10 +462,10 @@ defmodule Ecto.Query.Planner do
 
   defp schema_for_association_join!(query, join, source) do
     case source do
-      {source, nil} ->
+      %FromExpr{source: source, schema: nil} ->
           error! query, join, "cannot perform association join on #{inspect source} " <>
                               "because it does not have a schema"
-      {_, schema} ->
+      %FromExpr{schema: schema} ->
         schema
       %Ecto.SubQuery{select: {:struct, schema, _}} ->
         schema
@@ -576,9 +577,9 @@ defmodule Ecto.Query.Planner do
   defp prepend_if(cache, true, prepend), do: prepend ++ cache
   defp prepend_if(cache, false, _prepend), do: cache
 
-  defp source_cache({_, nil} = source, params),
-    do: {source, params}
-  defp source_cache({bin, schema}, params),
+  defp source_cache(%FromExpr{source: source, schema: nil}, params),
+    do: {{source, nil}, params}
+  defp source_cache(%FromExpr{source: bin, schema: schema}, params),
     do: {{bin, schema, schema.__schema__(:hash)}, params}
   defp source_cache({:fragment, _, _} = source, params),
     do: {source, params}
@@ -624,7 +625,7 @@ defmodule Ecto.Query.Planner do
   defp prepare_assocs(_query, _ix, []), do: :ok
   defp prepare_assocs(query, ix, assocs) do
     # We validate the schema exists when preparing joins above
-    {_, parent_schema} = get_source!(:preload, query, ix)
+    %FromExpr{schema: parent_schema} = get_source!(:preload, query, ix)
 
     Enum.each assocs, fn {assoc, {child_ix, child_assocs}} ->
       refl = parent_schema.__schema__(:association, assoc)
@@ -876,8 +877,8 @@ defmodule Ecto.Query.Planner do
     # In from, if there is a schema and we have a map tag with preloads,
     # it needs to be converted to a map in a later pass.
     {take, from_tag} =
-      case tag do
-        :map when is_tuple(source) and elem(source, 1) != nil and preloads != [] ->
+      case {tag, source} do
+        {:map, %FromExpr{schema: schema}} when schema != nil and preloads != [] ->
           {Map.put(take, 0, {:struct, from_take}), :map}
         _ ->
           {take, :any}
@@ -1067,7 +1068,7 @@ defmodule Ecto.Query.Planner do
 
   defp collect_assocs(exprs, fields, query, tag, take, [{assoc, {ix, children}}|tail]) do
     case get_source!(:preload, query, ix) do
-      {_, schema} = source when schema != nil ->
+      %FromExpr{schema: schema} = source when schema != nil ->
         {fetch, take_children} = fetch_assoc(tag, take, assoc)
         {expr, taken} = take!(source, query, fetch, assoc, ix)
         exprs = [expr | exprs]
@@ -1098,17 +1099,17 @@ defmodule Ecto.Query.Planner do
 
   defp take!(source, query, fetched, field, ix) do
     case {fetched, source} do
-      {{:ok, {_, []}}, {_, _}} ->
+      {{:ok, {_, []}}, %FromExpr{}} ->
         error! query, "at least one field must be selected for binding `#{field}`, got an empty list"
 
-      {{:ok, {:struct, _}}, {_, nil}} ->
+      {{:ok, {:struct, _}}, %FromExpr{schema: nil}} ->
         error! query, "struct/2 in select expects a source with a schema"
 
-      {{:ok, {kind, fields}}, {source, schema}} ->
+      {{:ok, {kind, fields}}, %FromExpr{schema: schema} = from} ->
         dumper = if schema, do: schema.__schema__(:dump), else: %{}
         schema = if kind == :map, do: nil, else: schema
         {types, fields} = select_dump(List.wrap(fields), dumper, ix)
-        {{:source, {source, schema}, types}, fields}
+        {{:source, %{from | schema: schema}, types}, fields}
 
       {{:ok, {_, _}}, {:fragment, _, _}} ->
         error! query, "it is not possible to return a map/struct subset of a fragment, " <>
@@ -1118,10 +1119,10 @@ defmodule Ecto.Query.Planner do
         error! query, "it is not possible to return a map/struct subset of a subquery, " <>
                       "you must explicitly select the whole subquery or individual fields only"
 
-      {:error, {_, nil}} ->
+      {:error, %FromExpr{schema: nil}} ->
         {{:value, :map}, [{:&, [], [ix]}]}
 
-      {:error, {_, schema}} ->
+      {:error, %FromExpr{schema: schema}} ->
         {types, fields} = select_dump(schema.__schema__(:fields), schema.__schema__(:dump), ix)
         {{:source, source, types}, fields}
 
@@ -1197,7 +1198,7 @@ defmodule Ecto.Query.Planner do
   defp type!(_kind, _lookup, _query, _expr, nil, _field), do: :any
   defp type!(kind, lookup, query, expr, ix, field) when is_integer(ix) do
     case get_source!(kind, query, ix) do
-      {_, schema} ->
+      %FromExpr{schema: schema} ->
         type!(kind, lookup, query, expr, schema, field)
       {:fragment, _, _} ->
         :any
@@ -1257,7 +1258,7 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp field_source({_, schema}, field) when schema != nil do
+  defp field_source(%FromExpr{schema: schema}, field) when schema != nil do
     # If the field is not found we return the field itself
     # which will be checked and raise later.
     schema.__schema__(:field_source, field) || field

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -19,7 +19,7 @@ end
 
 defimpl Ecto.Queryable, for: BitString do
   def to_query(source) when is_binary(source),
-    do: %Ecto.Query{from: %Ecto.Query.FromExpr{source: source, schema: nil}}
+    do: %Ecto.Query{from: %Ecto.Query.FromExpr{source: source}}
 end
 
 defimpl Ecto.Queryable, for: Atom do

--- a/lib/ecto/repo/assoc.ex
+++ b/lib/ecto/repo/assoc.ex
@@ -89,7 +89,7 @@ defmodule Ecto.Repo.Assoc do
   defp maybe_first(list, _), do: list
 
   defp create_refls(idx, fields, dicts, sources) do
-    {_source, schema} = elem(sources, idx)
+    %Ecto.Query.FromExpr{schema: schema} = elem(sources, idx)
 
     Enum.map(:lists.zip(dicts, fields), fn
       {{_primary_keys, _cache, dict, sub_dicts}, {field, {child_idx, child_fields}}} ->
@@ -103,7 +103,7 @@ defmodule Ecto.Repo.Assoc do
       create_accs(child_idx, child_fields, sources, %{})
     end)
 
-    {_source, schema} = elem(sources, idx)
+    %Ecto.Query.FromExpr{schema: schema} = elem(sources, idx)
     {schema.__schema__(:primary_key), %{}, initial_dict, acc}
   end
 end

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -7,8 +7,7 @@ defmodule Ecto.Repo.Queryable do
 
   alias Ecto.Query
   alias Ecto.Queryable
-  alias Ecto.Query.Planner
-  alias Ecto.Query.SelectExpr
+  alias Ecto.Query.{Planner, SelectExpr, FromExpr}
 
   require Ecto.Query
 
@@ -303,7 +302,7 @@ defmodule Ecto.Repo.Queryable do
     {data, row}
   end
 
-  defp process_source({source, schema}, types, row, all_nil?, prefix, adapter) do
+  defp process_source(%FromExpr{source: source, schema: schema}, types, row, all_nil?, prefix, adapter) do
     case split_values(types, row, [], all_nil?) do
       {nil, row} ->
         {nil, row}
@@ -413,7 +412,7 @@ defmodule Ecto.Repo.Queryable do
     {{:., [], [{:&, [], [ix]}, field]}, [], []}
   end
 
-  defp assert_schema!(%{from: {_source, schema}}) when schema != nil, do: schema
+  defp assert_schema!(%{from: %FromExpr{schema: schema}}) when schema != nil, do: schema
   defp assert_schema!(query) do
     raise Ecto.QueryError,
       query: query,

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -5,6 +5,7 @@ defmodule Ecto.Repo.Schema do
 
   alias Ecto.Changeset
   alias Ecto.Changeset.Relation
+  alias Ecto.Query.FromExpr
   require Ecto.Query
 
   @doc """
@@ -511,11 +512,11 @@ defmodule Ecto.Repo.Schema do
       :replace_all_except_primary_key ->
         {header -- schema.__schema__(:primary_key), [], conflict_target}
       [_ | _] = on_conflict ->
-        from = if schema, do: {source, schema}, else: source
+        from = if schema, do: %FromExpr{source: source, schema: schema}, else: source
         query = Ecto.Query.from from, update: ^on_conflict
-        on_conflict_query(query, {source, schema}, prefix, counter_fun, adapter, conflict_target)
+        on_conflict_query(query, %FromExpr{source: source, schema: schema}, prefix, counter_fun, adapter, conflict_target)
       %Ecto.Query{} = query ->
-        on_conflict_query(query, {source, schema}, prefix, counter_fun, adapter, conflict_target)
+        on_conflict_query(query, %FromExpr{source: source, schema: schema}, prefix, counter_fun, adapter, conflict_target)
       other ->
         raise ArgumentError, "unknown value for :on_conflict, got: #{inspect other}"
     end

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -4,6 +4,7 @@ defmodule Ecto.Query.Builder.JoinTest do
   import Ecto.Query.Builder.Join
   doctest Ecto.Query.Builder.Join
 
+  alias Ecto.Query.FromExpr
   import Ecto.Query
 
   defmacro join_macro(left, right) do
@@ -29,22 +30,22 @@ defmodule Ecto.Query.Builder.JoinTest do
   test "accepts queries on interpolation" do
     qual = :left
     source = "comments"
-    assert %{joins: [%{source: {"comments", nil}}]} =
+    assert %{joins: [%{source: %FromExpr{source: "comments", schema: nil}}]} =
             join("posts", qual, [p], c in ^source, on: true)
 
     qual = :right
     source = Comment
-    assert %{joins: [%{source: {nil, Comment}}]} =
+    assert %{joins: [%{source: %FromExpr{source: nil, schema: Comment}}]} =
             join("posts", qual, [p], c in ^source, on: true)
 
     qual = :right
-    source = {"user_comments", Comment}
-    assert %{joins: [%{source: {"user_comments", Comment}}]} =
+    source = %FromExpr{source: "user_comments", schema: Comment}
+    assert %{joins: [%{source: %FromExpr{source: "user_comments", schema: Comment}}]} =
             join("posts", qual, [p], c in ^source, on: true)
 
     qual = :inner
     source = from c in "comments", where: c.public
-    assert %{joins: [%{source: %Ecto.Query{from: {"comments", nil}}}]} =
+    assert %{joins: [%{source: %Ecto.Query{from: %FromExpr{source: "comments", schema: nil}}}]} =
             join("posts", qual, [p], c in ^source, on: true)
   end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -6,6 +6,7 @@ defmodule Ecto.QueryTest do
   import Support.EvalHelpers
   import Ecto.Query
   alias Ecto.Query
+  alias Ecto.Query.FromExpr
 
   defmacrop macro_equal(column, value) do
     quote do
@@ -80,15 +81,15 @@ defmodule Ecto.QueryTest do
     test "can override the source for existing queries" do
       query = %Query{from: {"posts", nil}}
       query = from q in {"new_posts", query}, where: true
-      assert query.from == {"new_posts", nil}
+      assert query.from == %FromExpr{source: "new_posts", schema: nil}
     end
   end
 
   describe "subqueries" do
     test "builds a subquery struct" do
-      assert subquery("posts").query.from == {"posts", nil}
-      assert subquery(subquery("posts")).query.from == {"posts", nil}
-      assert subquery(subquery("posts").query).query.from == {"posts", nil}
+      assert subquery("posts").query.from == %FromExpr{source: "posts", schema: nil}
+      assert subquery(subquery("posts")).query.from == %FromExpr{source: "posts", schema: nil}
+      assert subquery(subquery("posts").query).query.from == %FromExpr{source: "posts", schema: nil}
     end
 
     test "prefix is not applied if left blank" do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -415,7 +415,7 @@ defmodule Ecto.SchemaTest do
     struct =
       %Ecto.Association.Has{field: :emails, owner: AssocSchema, cardinality: :many, on_delete: :nothing,
                             related: Email, owner_key: :id, related_key: :assoc_schema_id,
-                            queryable: {"users_emails", Email}, on_replace: :delete}
+                            queryable: %Ecto.Query.FromExpr{source: "users_emails", schema: Email}, on_replace: :delete}
 
     assert AssocSchema.__schema__(:association, :emails) == struct
     assert AssocSchema.__changeset__.emails == {:assoc, struct}
@@ -455,7 +455,7 @@ defmodule Ecto.SchemaTest do
     struct =
       %Ecto.Association.Has{field: :profile, owner: AssocSchema, cardinality: :one, on_delete: :nothing,
                             related: Profile, owner_key: :id, related_key: :assoc_schema_id,
-                            queryable: {"users_profiles", Profile}, on_replace: :raise}
+                            queryable: %Ecto.Query.FromExpr{source: "users_profiles", schema: Profile}, on_replace: :raise}
 
     assert AssocSchema.__schema__(:association, :profile) == struct
     assert AssocSchema.__changeset__.profile == {:assoc, struct}
@@ -495,7 +495,7 @@ defmodule Ecto.SchemaTest do
     struct =
       %Ecto.Association.BelongsTo{field: :summary, owner: AssocSchema, cardinality: :one,
        related: Summary, owner_key: :summary_id, related_key: :id,
-       queryable: {"post_summary", Summary}, on_replace: :raise, defaults: []}
+       queryable: %Ecto.Query.FromExpr{source: "post_summary", schema: Summary}, on_replace: :raise, defaults: []}
 
     assert AssocSchema.__schema__(:association, :summary) == struct
     assert AssocSchema.__changeset__.summary == {:assoc, struct}

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -45,12 +45,12 @@ defmodule Ecto.TestAdapter do
     Process.get(:test_repo_all_results, {1, [[]]})
   end
 
-  def execute(_repo, _meta, {:nocache, {:delete_all, %{from: {_, SchemaMigration}}}}, [version], _) do
+  def execute(_repo, _meta, {:nocache, {:delete_all, %{from: %{schema: SchemaMigration}}}}, [version], _) do
     Process.put(:migrated_versions, List.delete(migrated_versions(), version))
     {1, nil}
   end
 
-  def execute(_repo, meta, {:nocache, {op, %{from: {source, _}}}}, _params, _opts) do
+  def execute(_repo, meta, {:nocache, {op, %{from: %{source: source}}}}, _params, _opts) do
     send test_process(), {op, {meta.prefix, source}}
     {1, nil}
   end


### PR DESCRIPTION
Refs #2389 

This PR introduces `Ecto.Query.FromExpr` which replaces `{source, schema}` tuple for holding query source data in the `from` field of `Ecto.Query`. The user facing API still accepts the from expression as `{source, schema}`, although it's internally converted to the new dedicated struct. That is at least my intent - I could have missed something, though as far as test coverage is concerned, it seems to be working (and again, I could have incidentally mangled tests while refactoring).

Notes about particular changes will follow in separate comments.

