### PR TITLE
Port select-only type validation logic to builder

### DIFF
--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -96,37 +96,12 @@ defmodule Ecto.Query.Builder.Select do
     {expr, params_take}
   end
 
-  defp escape({:type, _, [{{:., _, [{var, _, context}, field]}, _, []} = expr, type]},
-              params_take, vars, env) when is_atom(var) and is_atom(context) and is_atom(field) do
-    escape_with_type(expr, type, params_take, vars, env)
-  end
-
-  defp escape({:type, _, [{:fragment, _, [_ | _]} = expr, type]}, params_take, vars, env) do
-    escape_with_type(expr, type, params_take, vars, env)
-  end
-
-  defp escape({:type, _, [{:unsafe_fragment, _, [_ | _]} = expr, type]}, params_take, vars, env) do
-    escape_with_type(expr, type, params_take, vars, env)
-  end
-
-  defp escape({:type, _, [{agg, _, [_ | _]} = expr, type]}, params_take, vars, env)
-       when agg in ~w(avg count max min sum)a do
-    escape_with_type(expr, type, params_take, vars, env)
-  end
-
   defp escape(expr, params_take, vars, env) do
     Builder.escape(expr, :any, params_take, vars, {env, &escape_expansion/5})
   end
 
   defp escape_expansion(expr, _type, params_take, vars, env) do
     escape(expr, params_take, vars, env)
-  end
-
-  defp escape_with_type(expr, type, params_take, vars, env) do
-    type = Builder.validate_type!(type, vars)
-    {expr, params_take} =
-      Builder.escape(expr, type, params_take, vars, {env, &escape_expansion/5})
-    {{:{}, [], [:type, [], [expr, type]]}, params_take}
   end
 
   defp escape_pairs(pairs, params_take, vars, env) do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -231,11 +231,9 @@ defmodule Ecto.Adapters.MySQLTest do
         order_by: type(fragment("(?->>?)", field(e, ^:map), ^"value"), ^:decimal),
         select: true)
 
-    result =
-      "SELECT TRUE FROM `schema3` AS s0 " <>
-      "ORDER BY (s0.`map`->>?) + 0"
+    result = "SELECT TRUE FROM `schema3` AS s0 ORDER BY (s0.`map`->>?) + 0"
 
-    assert all(query) == String.trim(result)
+    assert all(query) == result
   end
 
   test "fragments" do

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -41,13 +41,6 @@ defmodule Ecto.Adapters.MySQLTest do
 
     schema "schema3" do
       field :binary, :binary
-    end
-  end
-
-  defmodule Schema4 do
-    use Ecto.Schema
-
-    schema "schema4" do
       embeds_one :map do
         field :value, :decimal
       end
@@ -234,12 +227,12 @@ defmodule Ecto.Adapters.MySQLTest do
 
   test "order_by and types" do
     query =
-      normalize from(e in "schema4",
+      normalize from(e in "schema3",
         order_by: type(fragment("(?->>?)", field(e, ^:map), ^"value"), ^:decimal),
         select: true)
 
     result =
-      "SELECT TRUE FROM `schema4` AS s0 " <>
+      "SELECT TRUE FROM `schema3` AS s0 " <>
       "ORDER BY (s0.`map`->>?) + 0"
 
     assert all(query) == String.trim(result)

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -43,13 +43,6 @@ defmodule Ecto.Adapters.PostgresTest do
       field :list1, {:array, :string}
       field :list2, {:array, :integer}
       field :binary, :binary
-    end
-  end
-
-  defmodule Schema4 do
-    use Ecto.Schema
-
-    schema "schema4" do
       embeds_one :map do
         field :value, :decimal
       end
@@ -407,12 +400,12 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "order_by and types" do
     query =
-      normalize from(e in "schema4",
+      normalize from(e in "schema3",
         order_by: type(fragment("(?->>?)", field(e, ^:map), ^"value"), ^:decimal),
         select: true)
 
     result =
-      "SELECT TRUE FROM \"schema4\" AS s0 " <>
+      "SELECT TRUE FROM \"schema3\" AS s0 " <>
       "ORDER BY (s0.\"map\"->>$1)::decimal"
 
     assert all(query) == String.trim(result)

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -404,11 +404,9 @@ defmodule Ecto.Adapters.PostgresTest do
         order_by: type(fragment("(?->>?)", field(e, ^:map), ^"value"), ^:decimal),
         select: true)
 
-    result =
-      "SELECT TRUE FROM \"schema3\" AS s0 " <>
-      "ORDER BY (s0.\"map\"->>$1)::decimal"
+    result = "SELECT TRUE FROM \"schema3\" AS s0 ORDER BY (s0.\"map\"->>$1)::decimal"
 
-    assert all(query) == String.trim(result)
+    assert all(query) == result
   end
 
   test "fragments and types" do


### PR DESCRIPTION
solves #2496

@josevalim I was not sure how to write tests well, so I created scenario for my case as described in issue, so I'm casting type of json value in `order_by` macro for both adapters.

Hope I did not missed anything.