### PR TITLE
Support naming query `from` with `as`

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -47,6 +47,16 @@ defmodule Ecto.Integration.RepoTest do
     end
   end
 
+  test "fetch using named from" do
+    TestRepo.insert!(%Post{title: "hello"})
+
+    query =
+      from(p in Post, as: :post)
+      |> where([post: p], p.title == "hello")
+
+    assert [_] = TestRepo.all query
+  end
+
   test "fetch without schema" do
     %Post{} = TestRepo.insert!(%Post{title: "title1"})
     %Post{} = TestRepo.insert!(%Post{title: "title2"})

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -312,7 +312,7 @@ defmodule Ecto.Query do
 
   defmodule FromExpr do
     @moduledoc false
-    defstruct [:source]
+    defstruct [:source, :as]
   end
 
   defmodule DynamicExpr do
@@ -592,7 +592,8 @@ defmodule Ecto.Query do
       raise ArgumentError, "second argument to `from` must be a compile time keyword list"
     end
 
-    {quoted, binds, count_bind} = From.build(expr, __CALLER__)
+    {kw, as} = collect_as(kw)
+    {quoted, binds, count_bind} = From.build(expr, __CALLER__, as)
     from(kw, __CALLER__, count_bind, quoted, to_query_binds(binds))
   end
 
@@ -673,6 +674,9 @@ defmodule Ecto.Query do
     do: Builder.error! "`as` keyword was given more than once to the same join"
   defp collect_on_and_as(other, on, as),
     do: {other, on, as}
+
+  defp collect_as([{:as, as} | t]), do: {t, as}
+  defp collect_as(t), do: {t, nil}
 
   @doc """
   A join query expression.

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -69,7 +69,9 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp bound_from(nil, name), do: ["from #{name} in query"]
-  defp bound_from(%{source: source}, name), do: ["from #{name} in #{inspect_source source}"]
+  defp bound_from(%{source: source, as: as}, name) do
+    ["from #{name} in #{inspect_source source}"] ++ kw_inspect(:as, as)
+  end
 
   defp inspect_source(%Ecto.Query{} = query), do: "^" <> inspect(query)
   defp inspect_source(%Ecto.SubQuery{query: query}), do: "subquery(#{to_string query})"

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -221,6 +221,19 @@ defmodule Ecto.QueryTest do
       assert %{comment: 2, link: 3} == query.aliases
     end
 
+    test "assigns a name to query source" do
+      query = from p in "posts", as: :post
+
+      assert %{post: 0} == query.aliases
+    end
+
+    test "assign to source fails when non-atom name passed" do
+      message = ~r"`as` must be a compile time atom, got: `\"post\"`"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        quote_and_eval(from(p in "posts", as: "post"))
+      end
+    end
+
     test "crashes on duplicate as for keyword query" do
       message = ~r"`as` keyword was given more than once to the same join"
       assert_raise Ecto.Query.CompileError, message, fn ->
@@ -251,6 +264,15 @@ defmodule Ecto.QueryTest do
 
       assert inspect(query) ==
         ~s[#Ecto.Query<from p in \"posts\", join: c in \"comments\", as: :comment, on: true, where: c.id == 0>]
+    end
+
+    test "match on binding by name for source" do
+      query =
+        from(p in "posts", as: :post)
+        |> where([post: p], p.id == 0)
+
+      assert inspect(query) ==
+        ~s[#Ecto.Query<from p in \"posts\", as: :post, where: p.id == 0>]
     end
 
     test "match on binding by name with ... in the middle" do


### PR DESCRIPTION
Refs #2389 

This PR adds support for using `as` for naming query source.

Example:

```elixir
from(p in Post, as: :post)
|> where([post: p], p.title == "hello")
```