### PR TITLE
Fix type casting coalesce

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -80,6 +80,14 @@ defmodule Ecto.Query.Builder do
     escape_with_type(expr, type, params_acc, vars, env)
   end
 
+  def escape({:type, _, [{:coalesce, _, _} = expr, type]}, _type, params_acc, vars, env) do
+    escape_with_type(expr, type, params_acc, vars, env)
+  end
+
+  def escape({:type, _, [{:filter, _, _} = expr, type]}, _type, params_acc, vars, env) do
+    escape_with_type(expr, type, params_acc, vars, env)
+  end
+
   # fragments
   def escape({:fragment, _, [query]}, _type, params_acc, vars, env) when is_list(query) do
     {escaped, params_acc} =


### PR DESCRIPTION
I wasn't sure if we wanted to add a pattern there for *any* "function" that we are trying to escape, but it seems to me like it was designed to guard against escaping non-ecto-syntax functions, so I figured adding just an explicit check for coalesce would be desired. I also added a pattern to fix `filter` since that would be broken in the same way.