### PR TITLE
Make `from` named binding attempt crash when source is query

### DIFF
--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -74,8 +74,11 @@ defmodule Ecto.Query.Builder.From do
           prefix = quote do: unquote(schema).__schema__(:prefix)
           {1, query(prefix, source, schema, as)}
 
-        other ->
+        other when is_nil(as) ->
           {nil, other}
+
+        _other ->
+          Builder.error! "`as` can't be used with query in `from`"
       end
 
     quoted = Builder.apply_query(quoted, __MODULE__, [length(binds)], env)

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -227,6 +227,13 @@ defmodule Ecto.QueryTest do
       assert %{post: 0} == query.aliases
     end
 
+    test "assign to source fails for query source" do
+      message = ~r"`as` can't be used with query in `from`"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        quote_and_eval(from p in query, as: :post2)
+      end
+    end
+
     test "assign to source fails when non-atom name passed" do
       message = ~r"`as` must be a compile time atom, got: `\"post\"`"
       assert_raise Ecto.Query.CompileError, message, fn ->


### PR DESCRIPTION
Refs #2389 

This PR makes named binding for a query source fail explicitly, instead of being silently ignored, as discussed in https://github.com/elixir-ecto/ecto/pull/2499#issuecomment-379499803.