### PR TITLE
Default virtual? to false when calling check_type!

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1727,9 +1727,9 @@ defmodule Ecto.Schema do
 
   @doc false
   def __field__(mod, name, type, opts) do
-    check_type!(name, type, opts[:virtual])
-    pk? = opts[:primary_key] || false
     virtual? = opts[:virtual] || false
+    check_type!(name, type, virtual?)
+    pk? = opts[:primary_key] || false
 
     default = default_for_type(type, opts)
     Module.put_attribute(mod, :changeset_fields, {name, type})


### PR DESCRIPTION
The compiler printed
```
Erlang/OTP 20 [erts-9.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]
Compiling 1 file (.ex)
== Compilation error in file lib/my_schema.ex ==
** (ArgumentError) argument error
    :erlang.not(nil)
    lib/ecto/schema.ex:1869: Ecto.Schema.check_type!/3
    lib/ecto/schema.ex:1508: Ecto.Schema.__field__/4
    lib/my_schema.ex:5: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```
instead of the more helpful error message defined in `check_type!` when trying to use a the type `:any` on a field that wasn't virtual.