### PR TITLE
Multi.error skips transaction and directly returns error

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -292,8 +292,8 @@ defmodule Ecto.Multi do
   Causes the multi to fail with the given value.
 
   Running the multi in a transaction will execute
-  all previous steps until this operation which
-  halt with the given `value`.
+  no previous steps and returns the value of the first
+  error added.
   """
   @spec error(t, name, error :: term) :: t
   def error(multi, name, value) do
@@ -410,6 +410,8 @@ defmodule Ecto.Multi do
 
   defp invalid_operation({name, {:changeset, %{valid?: false} = changeset, _}}),
     do: {:error, {name, changeset, %{}}}
+  defp invalid_operation({name, {:error, value}}),
+    do: {:error, {name, value, %{}}}
   defp invalid_operation(_operation),
     do: nil
 


### PR DESCRIPTION
Implementation of issue #2507 

If a error operation is part of the multi operations no transaction will get started and the error gets returned. The tests got changed to reflect the new behaviour.
I only changed the docs for `Multi.error`, the documentation for `Repo.transaction` could get changed too but I think that's not necessary.

Just give me a feedback if additional changes have to be made e.g. in the documentation.