### PR TITLE
Fix link to associations code samples

### DIFF
--- a/guides/Associations.md
+++ b/guides/Associations.md
@@ -3,8 +3,7 @@
 This guide assumes you worked through the [Getting Started guide](Getting%20Started.md) and want to learn more about associations.
 
 If you want to see the code from this guide, you can view it [at
-ecto/examples/ecto_assoc on GitHub](https://github.com/elixir-
-lang/ecto/tree/master/examples/ecto_assoc).
+ecto/examples/ecto_assoc on GitHub](https://github.com/elixir-lang/ecto/tree/master/examples/ecto_assoc).
 
 There are three kinds of associations:
 


### PR DESCRIPTION
Hello!

I found a broken link while reading about Ecto associations.

I'm guessing it happened cause of a word-wrap setting and the placement of the `-`. I'm not sure if this would prevent it from happening in the future, but I can reformat this to something like the following if you'd like!

```
If you want to see the code from this guide, you can view it [at
ecto/examples/ecto_assoc on 
GitHub](https://github.com/elixir-lang/ecto/tree/master/examples/ecto_assoc).
```

Hope this tiny change helps! :p