### PR TITLE
Remove queries as an association source, add `where` and `join_through_where` keywords

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -38,7 +38,7 @@ defmodule Ecto.Association do
                owner_key: atom,
                field: atom,
                unique: boolean,
-               where: mfa | Ecto.Query.DynamicExpr.t() | Keyword.t()}
+               where: mfa | Ecto.Query.dynamic() | Keyword.t()}
 
   alias Ecto.Query.{BooleanExpr, QueryExpr, FromExpr}
 

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -222,7 +222,7 @@ defmodule Ecto.Association do
   def combine_assoc_query(%{where: nil}, queryable), do: queryable
   def combine_assoc_query(%{where: []}, queryable), do: queryable
   def combine_assoc_query(%{where: {module, function, args}} = assoc, queryable) do
-    combine_assoc_query(%{assoc | where: apply(Macro.expand(module, __ENV__), function, args)}, queryable)
+    combine_assoc_query(%{assoc | where: apply(module, function, args)}, queryable)
   end
   def combine_assoc_query(%{where: where}, queryable) do
     Ecto.Query.where(queryable, _, ^where)
@@ -984,7 +984,7 @@ defmodule Ecto.Association.ManyToMany do
   defp join_through_query(queryable, []), do: queryable
   defp join_through_query(queryable, nil), do: queryable
   defp join_through_query(queryable, {module, function, args}) do
-    join_through_query(queryable, apply(Macro.expand(module, __ENV__), function, args))
+    join_through_query(queryable, apply(module, function, args))
   end
   defp join_through_query(queryable, where) do
     from row in queryable,

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -328,7 +328,6 @@ defmodule Ecto.Query do
   defstruct [prefix: nil, sources: nil, from: nil, joins: [], aliases: %{}, wheres: [], select: nil,
              order_bys: [], limit: nil, offset: nil, group_bys: [], updates: [],
              havings: [], preloads: [], assocs: [], distinct: nil, lock: nil]
-  @type t :: %__MODULE__{}
 
   defmodule FromExpr do
     @moduledoc false
@@ -339,8 +338,6 @@ defmodule Ecto.Query do
     @moduledoc false
     defstruct [:fun, :binding, :file, :line]
   end
-
-  @opaque dynamic :: %DynamicExpr{}
 
   defmodule QueryExpr do
     @moduledoc false
@@ -369,6 +366,9 @@ defmodule Ecto.Query do
     # * type is the underlying tag type, like :string
     defstruct [:value, :tag, :type]
   end
+
+  @type t :: %__MODULE__{}
+  @opaque dynamic :: %DynamicExpr{}
 
   alias Ecto.Query.Builder
   alias Ecto.Query.Builder.{Distinct, Dynamic, Filter, From, GroupBy, Join,

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -337,6 +337,9 @@ defmodule Ecto.Query do
 
   defmodule DynamicExpr do
     @moduledoc false
+
+    @type t :: %__MODULE__{}
+
     defstruct [:fun, :binding, :file, :line]
   end
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -337,11 +337,10 @@ defmodule Ecto.Query do
 
   defmodule DynamicExpr do
     @moduledoc false
-
-    @type t :: %__MODULE__{}
-
     defstruct [:fun, :binding, :file, :line]
   end
+
+  @opaque dynamic :: %DynamicExpr{}
 
   defmodule QueryExpr do
     @moduledoc false

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -765,7 +765,6 @@ defmodule Ecto.Schema do
   """
   defmacro has_many(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
-    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
     quote do
       Ecto.Schema.__has_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -846,7 +845,6 @@ defmodule Ecto.Schema do
   """
   defmacro has_one(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
-    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
     quote do
       Ecto.Schema.__has_one__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1063,7 +1061,6 @@ defmodule Ecto.Schema do
   """
   defmacro belongs_to(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
-    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
     quote do
       Ecto.Schema.__belongs_to__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1291,11 +1288,6 @@ defmodule Ecto.Schema do
   building such association won't automatically set the active field to true.
   """
   defmacro many_to_many(name, queryable, opts \\ []) do
-    opts =
-      opts
-      |> Keyword.update(:where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
-      |> Keyword.update(:join_through_where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
-
     quote do
       Ecto.Schema.__many_to_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1627,23 +1619,6 @@ defmodule Ecto.Schema do
     struct = association.struct(schema, name, opts)
     Module.put_attribute(schema, :ecto_assocs, {name, struct})
     struct
-  end
-
-  @spec escape_association_where(any, Macro.env) :: any
-  def escape_association_where({{:., _, [module = {:__aliases__, _, _}, function]}, _, args}, caller) do
-    Macro.escape({expand_alias(module, caller), function, args})
-  end
-  # This doesn't work
-  def escape_association_where({:dynamic, _, args}, _) do
-    Macro.escape({Ecto.Query, :dynamic, args})
-  end
-  def escape_association_where(keyword, _) when is_list(keyword) do
-    keyword
-  end
-  def escape_association_where(other, _) do
-    IO.inspect(other)
-    raise "Only keyword lists, remote function calls and `dynamic` expressions allowed in `where`" <>
-      "and `join_through_where`: got #{Macro.to_string(other)}"
   end
 
   ## Callbacks

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -765,7 +765,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_many(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
-    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_mfa(&1, __CALLER__))
+    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
     quote do
       Ecto.Schema.__has_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -846,7 +846,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_one(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
-    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_mfa(&1, __CALLER__))
+    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
     quote do
       Ecto.Schema.__has_one__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1063,7 +1063,7 @@ defmodule Ecto.Schema do
   """
   defmacro belongs_to(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
-    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_mfa(&1, __CALLER__))
+    opts = Keyword.update(opts, :where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
     quote do
       Ecto.Schema.__belongs_to__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1293,8 +1293,8 @@ defmodule Ecto.Schema do
   defmacro many_to_many(name, queryable, opts \\ []) do
     opts =
       opts
-      |> Keyword.update(:where, nil, &Ecto.Schema.escape_mfa(&1, __CALLER__))
-      |> Keyword.update(:join_through_where, nil, &Ecto.Schema.escape_mfa(&1, __CALLER__))
+      |> Keyword.update(:where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
+      |> Keyword.update(:join_through_where, nil, &Ecto.Schema.escape_association_where(&1, __CALLER__))
 
     quote do
       Ecto.Schema.__many_to_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
@@ -1629,11 +1629,22 @@ defmodule Ecto.Schema do
     struct
   end
 
-  @spec escape_mfa(any, Macro.env) :: any
-  def escape_mfa({{:., _, [module = {:__aliases__, _, _}, function]}, _, args}, caller) do
+  @spec escape_association_where(any, Macro.env) :: any
+  def escape_association_where({{:., _, [module = {:__aliases__, _, _}, function]}, _, args}, caller) do
     Macro.escape({expand_alias(module, caller), function, args})
   end
-  def escape_mfa(other), do: other
+  # This doesn't work
+  def escape_association_where({:dynamic, _, args}, _) do
+    Macro.escape({Ecto.Query, :dynamic, args})
+  end
+  def escape_association_where(keyword, _) when is_list(keyword) do
+    keyword
+  end
+  def escape_association_where(other, _) do
+    IO.inspect(other)
+    raise "Only keyword lists, remote function calls and `dynamic` expressions allowed in `where`" <>
+      "and `join_through_where`: got #{Macro.to_string(other)}"
+  end
 
   ## Callbacks
 

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -106,7 +106,7 @@ defmodule Ecto.AssociationTest do
       has_many :posts_comments, through: [:posts, :comments]    # many -> many
       has_many :posts_permalinks, through: [:posts, :permalink] # many -> one
       has_many :emails, {"users_emails", Email}
-      has_many :awesome_posts, Post, where: Post.awesome()
+      has_many :awesome_posts, Post, where: {Post, :awesome, []}
       has_one :profile, {"users_profiles", Profile},
         defaults: [name: "default"], on_replace: :delete
       many_to_many :permalinks, {"custom_permalinks", Permalink},
@@ -114,16 +114,16 @@ defmodule Ecto.AssociationTest do
 
       many_to_many :active_special_permalinks, Permalink,
         join_through: AuthorPermalink,
-        join_through_where: AuthorPermalink.active(),
-        where: Permalink.special()
+        join_through_where: {AuthorPermalink, :active, []},
+        where: {Permalink, :special, []}
 
       many_to_many :special_permalinks, Permalink,
         join_through: AuthorPermalink,
-        where: Permalink.special()
+        where: {Permalink, :special, []}
 
       many_to_many :active_permalinks, Permalink,
         join_through: AuthorPermalink,
-        join_through_where: AuthorPermalink.active()
+        join_through_where: {AuthorPermalink, :active, []}
 
       has_many :posts_with_prefix, PostWithPrefix
       has_many :comments_with_prefix, through: [:posts_with_prefix, :comments_with_prefix]
@@ -139,7 +139,7 @@ defmodule Ecto.AssociationTest do
 
     schema "summaries" do
       has_one :post, Post, defaults: [title: "default"], on_replace: :nilify
-      has_one :awesome_post, Post, where: Post.awesome()
+      has_one :awesome_post, Post, where: {Post, :awesome, []}
       has_many :posts, Post, on_replace: :nilify
       has_one :post_author, through: [:post, :author]        # one -> belongs
       has_many :post_comments, through: [:post, :comments]   # one -> many
@@ -151,7 +151,7 @@ defmodule Ecto.AssociationTest do
 
     schema "emails" do
       belongs_to :author, {"post_authors", Author}
-      belongs_to :super_user, Author, where: Author.super_users(), foreign_key: :author_id, define_field: false
+      belongs_to :super_user, Author, where: {Author, :super_users, []}, foreign_key: :author_id, define_field: false
     end
   end
 

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -3,7 +3,7 @@ defmodule Ecto.AssociationTest do
   doctest Ecto.Association
 
   import Ecto
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, dynamic: 2]
 
   alias __MODULE__.Author
   alias __MODULE__.Comment
@@ -31,8 +31,7 @@ defmodule Ecto.AssociationTest do
     end
 
     def awesome() do
-      from row in __MODULE__,
-        where: row.upvotes >= 1000
+      dynamic([row], row.upvotes >= 1000)
     end
   end
 
@@ -60,8 +59,7 @@ defmodule Ecto.AssociationTest do
     end
 
     def special() do
-      from row in __MODULE__,
-        where: row.special
+      dynamic([row], row.special)
     end
   end
 
@@ -94,8 +92,7 @@ defmodule Ecto.AssociationTest do
     end
 
     def active() do
-      from row in __MODULE__,
-        where: not(row.deleted)
+      dynamic([row], not(row.deleted))
     end
   end
 
@@ -109,25 +106,31 @@ defmodule Ecto.AssociationTest do
       has_many :posts_comments, through: [:posts, :comments]    # many -> many
       has_many :posts_permalinks, through: [:posts, :permalink] # many -> one
       has_many :emails, {"users_emails", Email}
-      has_many :awesome_posts, Post.awesome()
+      has_many :awesome_posts, Post, where: Post.awesome()
       has_one :profile, {"users_profiles", Profile},
         defaults: [name: "default"], on_replace: :delete
       many_to_many :permalinks, {"custom_permalinks", Permalink},
         join_through: "authors_permalinks"
 
-      many_to_many :active_special_permalinks, Permalink.special(),
-        join_through: AuthorPermalink.active()
-      many_to_many :special_permalinks, Permalink.special(),
-        join_through: AuthorPermalink
+      many_to_many :active_special_permalinks, Permalink,
+        join_through: AuthorPermalink,
+        join_through_where: AuthorPermalink.active(),
+        where: Permalink.special()
+
+      many_to_many :special_permalinks, Permalink,
+        join_through: AuthorPermalink,
+        where: Permalink.special()
+
       many_to_many :active_permalinks, Permalink,
-        join_through: AuthorPermalink.active()
+        join_through: AuthorPermalink,
+        join_through_where: AuthorPermalink.active()
+
       has_many :posts_with_prefix, PostWithPrefix
       has_many :comments_with_prefix, through: [:posts_with_prefix, :comments_with_prefix]
     end
 
     def super_users() do
-      from row in __MODULE__,
-        where: row.super_user
+      dynamic([row], row.super_user)
     end
   end
 
@@ -136,7 +139,7 @@ defmodule Ecto.AssociationTest do
 
     schema "summaries" do
       has_one :post, Post, defaults: [title: "default"], on_replace: :nilify
-      has_one :awesome_post, Post.awesome()
+      has_one :awesome_post, Post, where: Post.awesome()
       has_many :posts, Post, on_replace: :nilify
       has_one :post_author, through: [:post, :author]        # one -> belongs
       has_many :post_comments, through: [:post, :comments]   # one -> many
@@ -148,7 +151,7 @@ defmodule Ecto.AssociationTest do
 
     schema "emails" do
       belongs_to :author, {"post_authors", Author}
-      belongs_to :super_user, Author.super_users(), foreign_key: :author_id, define_field: false
+      belongs_to :super_user, Author, where: Author.super_users(), foreign_key: :author_id, define_field: false
     end
   end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -23,8 +23,7 @@ defmodule Ecto.Query.PlannerTest do
     end
 
     def special() do
-      from comment in __MODULE__,
-        where: comment.special
+      dynamic([row], row.special)
     end
   end
 
@@ -34,14 +33,13 @@ defmodule Ecto.Query.PlannerTest do
     schema "comment_posts" do
       belongs_to :comment, Comment
       belongs_to :post, Post
-      belongs_to :special_comment, Comment.special()
+      belongs_to :special_comment, Comment, where: Comment.special()
 
       field :deleted, :boolean
     end
 
     def inactive() do
-      from comment_post in __MODULE__,
-        where: comment_post.deleted
+      dynamic([row], row.deleted)
     end
   end
 
@@ -58,9 +56,9 @@ defmodule Ecto.Query.PlannerTest do
       field :links, {:array, Custom.Permalink}
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment
-      has_many :special_comments, Ecto.Query.PlannerTest.Comment.special()
+      has_many :special_comments, Ecto.Query.PlannerTest.Comment, where: Ecto.Query.PlannerTest.Comment.special()
 
-      many_to_many :shared_special_comments, Comment.special(), join_through: CommentPost.inactive()
+      many_to_many :shared_special_comments, Comment, join_through: CommentPost, where: Comment.special(), join_through_where: CommentPost.inactive()
     end
   end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -33,7 +33,7 @@ defmodule Ecto.Query.PlannerTest do
     schema "comment_posts" do
       belongs_to :comment, Comment
       belongs_to :post, Post
-      belongs_to :special_comment, Comment, where: Comment.special()
+      belongs_to :special_comment, Comment, where: {Comment, :special, []}
 
       field :deleted, :boolean
     end
@@ -56,9 +56,9 @@ defmodule Ecto.Query.PlannerTest do
       field :links, {:array, Custom.Permalink}
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment
-      has_many :special_comments, Ecto.Query.PlannerTest.Comment, where: Ecto.Query.PlannerTest.Comment.special()
+      has_many :special_comments, Ecto.Query.PlannerTest.Comment, where: {Ecto.Query.PlannerTest.Comment, :special, []}
 
-      many_to_many :shared_special_comments, Comment, join_through: CommentPost, where: Comment.special(), join_through_where: CommentPost.inactive()
+      many_to_many :shared_special_comments, Comment, join_through: CommentPost, where: {Comment, :special, []}, join_through_where: {CommentPost, :inactive, []}
     end
   end
 

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -569,7 +569,7 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_* expects a queryable" do
-    message = ~r"association :posts queryable must be a schema, a {source, schema}, or a query. got: 123"
+    message = ~r"association :posts queryable must be a schema or a {source, schema}. got: 123"
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
         use Ecto.Schema


### PR DESCRIPTION
Stems from discussion in issue #2480

I encountered some troubles trying to implement this. Even just locking it down to remote function calls, `dynamic`, and keyword lists, I just can't figure out how to build the `dynamic` at run time. They can't be quoted, so it can't be done at runtime, but they can't be built dynamically (can't `apply/3` macros), wasn't able to construct it manually.

Examples
```
  has_many :posts, Post, where: [special: true] # works
  has_many :posts, Post, where: Post.special() # works
  has_many :posts, Post, where: SomeoneElse.special() # works
  belongs_to :post, Post, where: dynamic([p], p.special()) # does not work
```

The ones that work above are both tested at different spots in this PR, but documentation hasn't been changed and comprehensive tests have not been added, just because I'm not sure if this will even work. Feedback much appreciated, thanks!

Edit: I also think I'm doing something wrong by having to `Macro.escape` the mfa and then `Macro.expand` it later. It seems weird to do `Macro.expand(expr, __ENV__)` when that expression should act as if it was evaluated in the caller's context (not use any aliases that are in the current context, that kind of thing)