### PR TITLE
Assign alias to source at runtime when `from` can't be expanded

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -930,11 +930,11 @@ defmodule Ecto.Query.Builder do
 
   # Unescapes an `Ecto.Query` struct.
   defp unescape_query({:%, _, [Query, {:%{}, _, list}]}) do
-    struct(Query, unescape_from(unescape_aliases(list)))
+    struct(Query, unescape_aliases(list))
   end
   defp unescape_query({:%{}, _, list} = ast) do
     if List.keyfind(list, :__struct__, 0) == {:__struct__, Query} do
-      Enum.into(unescape_from(unescape_aliases(list)), %{})
+      Enum.into(unescape_aliases(list), %{})
     else
       ast
     end
@@ -950,36 +950,18 @@ defmodule Ecto.Query.Builder do
     end
   end
 
-  defp unescape_from(query) do
-    case List.keytake(query, :from, 0) do
-      {{:from, {:%, _, [_, {:%{}, _, from}]}}, query} ->
-        [from: struct(Query.FromExpr, from)] ++ query
-      _ ->
-        query
-    end
-  end
-
   # Escapes an `Ecto.Query` and associated structs.
-  defp escape_query(%Query{from: from, aliases: aliases} = query) do
-    escaped_from = escape_from(from)
-    escaped_aliases = escape_aliases(aliases)
-
-    query =
-      query
-      |> Map.drop([:from, :aliases])
-      |> Map.to_list()
-
-    {:%{}, [], escaped_from ++ escaped_aliases ++ query}
-  end
+  defp escape_query(%Query{} = query),
+    do: {:%{}, [], escape_aliases(query)}
   defp escape_query(other),
     do: other
 
-  defp escape_aliases(%{} = aliases), do: [aliases: {:%{}, [], Map.to_list(aliases)}]
-  defp escape_aliases(aliases), do: [aliases: aliases]
+  defp escape_aliases(%{aliases: aliases} = query) do
+    query = Map.to_list(Map.delete(query, :aliases))
 
-  defp escape_from(%Query.FromExpr{} = from) do
-    from = from |> Map.from_struct() |> Map.to_list()
-    [from: {:%, [], [Query.FromExpr, {:%{}, [], from}]}]
+    case aliases do
+      %{} -> [aliases: {:%{}, [], Map.to_list(aliases)}] ++ query
+      aliases -> [aliases: aliases] ++ query
+    end
   end
-  defp escape_from(from), do: [from: from]
 end

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -115,8 +115,15 @@ defmodule Ecto.Query.Builder.From do
   end
 
   defp maybe_apply_as(query, nil), do: query
+  defp maybe_apply_as(%{from: %{as: from_as}}, as) when not is_nil(from_as) do
+    Builder.error! "can't apply alias `#{inspect as}` - source binding has `#{inspect from_as}` alias already"
+  end
   defp maybe_apply_as(%{from: from, aliases: aliases} = query, as) do
-    %{query | aliases: Map.put(aliases, as, 0), from: %{from | as: as}}
+    if Map.has_key?(aliases, as) do
+      Builder.error! "alias `#{inspect as}` already exists"
+    else
+      %{query | aliases: Map.put(aliases, as, 0), from: %{from | as: as}}
+    end
   end
 
   defp check_binds(query, count) do

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -118,7 +118,7 @@ defmodule Ecto.Query.Builder.From do
       %{from: from, aliases: aliases} = query
       %{query | aliases: Map.put(aliases, as, 0), from: %{from | as: as}}
     else
-      Builder.error! "can't alias query expression in `from` with `#{inspect as}`"
+      query
     end
   end
 

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -118,7 +118,7 @@ defmodule Ecto.Query.Builder.From do
       %{from: from, aliases: aliases} = query
       %{query | aliases: Map.put(aliases, as, 0), from: %{from | as: as}}
     else
-      query
+      Builder.error! "can't alias query expression in `from` with `#{inspect as}`"
     end
   end
 

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -64,31 +64,33 @@ defmodule Ecto.Query.Builder.From do
           # dependencies between modules are added
           source = quote do: unquote(schema).__schema__(:source)
           prefix = quote do: unquote(schema).__schema__(:prefix)
-          {1, query(prefix, source, schema)}
+          {1, query(prefix, source, schema, as)}
 
         source when is_binary(source) ->
           # When a binary is used, there is no schema
-          {1, query(nil, source, nil)}
+          {1, query(nil, source, nil, as)}
 
         {source, schema} when is_binary(source) and is_atom(schema) ->
           prefix = quote do: unquote(schema).__schema__(:prefix)
-          {1, query(prefix, source, schema)}
+          {1, query(prefix, source, schema, as)}
 
         other ->
           {nil, other}
       end
 
-    quoted = Builder.apply_query(quoted, __MODULE__, [length(binds), as], env)
+    quoted = Builder.apply_query(quoted, __MODULE__, [length(binds)], env)
     {quoted, binds, count_bind}
   end
 
-  defp query(prefix, source, schema) do
+  defp query(prefix, source, schema, as) do
+    aliases = if as, do: [{as, 0}], else: []
+
     {:%, [], [Ecto.Query,
               {:%{}, [],
                [from: {:%, [], [Ecto.Query.FromExpr,
-                                {:%{}, [], [source: {source, schema}]}]},
+                                {:%{}, [], [source: {source, schema}, as: as]}]},
                 prefix: prefix,
-                aliases: {:%{}, [], []}]}]}
+                aliases: {:%{}, [], aliases}]}]}
   end
 
   defp expand_from({left, right}, env) do
@@ -101,33 +103,12 @@ defmodule Ecto.Query.Builder.From do
   @doc """
   The callback applied by `build/2` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, non_neg_integer, atom) :: Ecto.Query.t
-  def apply(query, binds, as) do
-    query =
-      query
-      |> Ecto.Queryable.to_query()
-      |> maybe_apply_as(as)
-
+  @spec apply(Ecto.Queryable.t, non_neg_integer) :: Ecto.Query.t
+  def apply(query, binds) do
+    query = Ecto.Queryable.to_query(query)
     check_binds(query, binds)
     query
   end
-
-  defp maybe_apply_as(query, nil), do: query
-  defp maybe_apply_as(query, as) do
-    if raw_source?(query) do
-      %{from: from, aliases: aliases} = query
-      %{query | aliases: Map.put(aliases, as, 0), from: %{from | as: as}}
-    else
-      query
-    end
-  end
-
-  defp raw_source?(%{from: %{source: source}}), do: raw_source?(source)
-  defp raw_source?({{{:., _, [schema, :__schema__]}, _, [:source]}, schema}), do: true
-  defp raw_source?(schema) when is_atom(schema), do: true
-  defp raw_source?(source) when is_binary(source), do: true
-  defp raw_source?({source, schema}) when is_binary(source) and is_atom(schema), do: true
-  defp raw_source?(_), do: false
 
   defp check_binds(query, count) do
     if count > 1 and count > Builder.count_binds(query) do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -227,6 +227,13 @@ defmodule Ecto.QueryTest do
       assert %{post: 0} == query.aliases
     end
 
+    test "assigns a name to query source in var" do
+      posts_source = "posts"
+      query = from p in posts_source, as: :post
+
+      assert %{post: 0} == query.aliases
+    end
+
     test "assign to source fails when non-atom name passed" do
       message = ~r"`as` must be a compile time atom, got: `\"post\"`"
       assert_raise Ecto.Query.CompileError, message, fn ->

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -234,6 +234,13 @@ defmodule Ecto.QueryTest do
       assert %{post: 0} == query.aliases
     end
 
+    test "assign to source fails when query provided as source" do
+      message = ~r"can't alias query expression in `from` with `:post`"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        from p in subquery("posts"), as: :post
+      end
+    end
+
     test "assign to source fails when non-atom name passed" do
       message = ~r"`as` must be a compile time atom, got: `\"post\"`"
       assert_raise Ecto.Query.CompileError, message, fn ->

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -227,13 +227,6 @@ defmodule Ecto.QueryTest do
       assert %{post: 0} == query.aliases
     end
 
-    test "assigns a name to query source in var" do
-      posts_source = "posts"
-      query = from p in posts_source, as: :post
-
-      assert %{post: 0} == query.aliases
-    end
-
     test "assign to source fails when non-atom name passed" do
       message = ~r"`as` must be a compile time atom, got: `\"post\"`"
       assert_raise Ecto.Query.CompileError, message, fn ->

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -273,6 +273,22 @@ defmodule Ecto.QueryTest do
       end
     end
 
+    test "crashes on assigning the same name twice when aliasing source" do
+      message = ~r"alias `:foo` already exists"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        query = from p in "posts", join: b in "blogs", as: :foo
+        from(p in query, as: :foo)
+      end
+    end
+
+    test "crashes on assigning the name to source when it already has one" do
+      message = ~r"can't apply alias `:foo` - source binding has `:post` alias already"
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        query = from p in "posts", as: :post
+        from(p in query, as: :foo)
+      end
+    end
+
     test "match on binding by name" do
       query =
         "posts"

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -225,6 +225,23 @@ defmodule Ecto.QueryTest do
       query = from p in "posts", as: :post
 
       assert %{post: 0} == query.aliases
+      assert %{as: :post} = query.from
+    end
+
+    test "assigns a name to query source in var" do
+      posts_source = "posts"
+      query = from p in posts_source, as: :post
+
+      assert %{post: 0} == query.aliases
+      assert %{as: :post} = query.from
+    end
+
+    test "assigns a name to a subquery source" do
+      posts_query = from p in "posts"
+      query = from p in subquery(posts_query), as: :post
+
+      assert %{post: 0} == query.aliases
+      assert %{as: :post} = query.from
     end
 
     test "assign to source fails when non-atom name passed" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -234,13 +234,6 @@ defmodule Ecto.QueryTest do
       assert %{post: 0} == query.aliases
     end
 
-    test "assign to source fails when query provided as source" do
-      message = ~r"can't alias query expression in `from` with `:post`"
-      assert_raise Ecto.Query.CompileError, message, fn ->
-        from p in subquery("posts"), as: :post
-      end
-    end
-
     test "assign to source fails when non-atom name passed" do
       message = ~r"`as` must be a compile time atom, got: `\"post\"`"
       assert_raise Ecto.Query.CompileError, message, fn ->


### PR DESCRIPTION
Refs #2502 

~That's another attempt at ensuring that source alias won't get silently ignored when it doesn't apply.~

~I'm not entirely sure whether this is the right way to go - it's possible I overdid it with the escape/unescape dance. Also, https://github.com/elixir-ecto/ecto/compare/master...zoldar:zoldar-crash-on-from-as-query-source-redux?expand=1#diff-2bc73ed242e9a034ae5755e404196341R126 feels a bit fishy to me (it leaks over to `From.apply` even though escape logic is applied) - I don't see a better way to deal with that ATM.~

This PR handles aliasing source in cases where `from` expression can't be expanded at compile time.