### PR TITLE
Use MixProject instead of Mixfile in mix.exs files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Ecto.Mixfile do
+defmodule Ecto.MixProject do
   use Mix.Project
 
   @version "3.0.0-dev"


### PR DESCRIPTION
This change was introduced in Elixir in https://github.com/elixir-lang/elixir/commit/c6a0edcd32359eca284ff0166d19a6dc979ee954.

The new templates in Elixir also include `MixProject` https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/new.ex#L291