### PR TITLE
Remove "timestamps: 0" from .formatter.exs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,7 +6,6 @@ locals_without_parens = [
   field: 1,
   field: 2,
   field: 3,
-  timestamps: 0,
   timestamps: 1,
   belongs_to: 2,
   belongs_to: 3,


### PR DESCRIPTION
As discussed in https://github.com/phoenixframework/phoenix/pull/2866#discussion_r184858272