### PR TITLE
Fix capitalization typo

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -327,7 +327,7 @@ defmodule Ecto.Query.Builder do
   # Vars are not allowed
   def escape({name, _, context} = var, _type, _params_acc, _vars, _env) when is_atom(name) and is_atom(context) do
     error! "variable `#{Macro.to_string(var)}` is not a valid query expression. " <>
-           "IF you wanted to inject a variable, you have to explicitly interpolate it " <>
+           "If you wanted to inject a variable, you have to explicitly interpolate it " <>
            "with ^. If you wanted to refer to a field, use the source.field syntax"
   end
 


### PR DESCRIPTION
IF -> If in Ecto.Query.CompileError message.

This feels like a typo but there's a long shot it was intentional ¯\\\_(ツ)_/¯