### PR TITLE
Dont wrap json functons in parentheses

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -364,6 +364,14 @@ if Code.ensure_loaded?(Mariaex) do
     defp operator_to_boolean(:and), do: " AND "
     defp operator_to_boolean(:or), do: " OR "
 
+    defp parens_for_select([first_expr | _] = expr) do
+      if is_binary(first_expr) and String.starts_with?(first_expr, ["SELECT", "select"]) do
+        [?(, expr, ?)]
+      else
+        expr
+      end
+    end
+
     defp paren_expr(expr, sources, query) do
       [?(, expr(expr, sources, query), ?)]
     end
@@ -419,7 +427,7 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     defp expr(%Ecto.SubQuery{query: query}, _sources, _query) do
-      all(query)
+      [?(, all(query), ?)]
     end
 
     defp expr({:fragment, _, [kw]}, _sources, query) when is_list(kw) or tuple_size(kw) == 3 do
@@ -431,6 +439,7 @@ if Code.ensure_loaded?(Mariaex) do
         {:raw, part}  -> part
         {:expr, expr} -> expr(expr, sources, query)
       end)
+      |> parens_for_select
     end
 
     defp expr({:datetime_add, _, [datetime, count, interval]}, sources, query) do
@@ -778,7 +787,7 @@ if Code.ensure_loaded?(Mariaex) do
 
     defp get_source(query, sources, ix, source) do
       {expr, name, _schema} = elem(sources, ix)
-      {expr || paren_expr(source, sources, query), name}
+      {expr || expr(source, sources, query), name}
     end
 
     defp quote_name(name)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -415,7 +415,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp operator_to_boolean(:or), do: " OR "
 
     defp parens_for_select([first_expr | _] = expr) do
-      if String.match?(first_expr, ~r/SELECT/i) do
+      if is_binary(first_expr) and String.starts_with?(first_expr, ["SELECT", "select"]) do
         [?(, expr, ?)]
       else
         expr

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -413,6 +413,14 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp operator_to_boolean(:and), do: " AND "
     defp operator_to_boolean(:or), do: " OR "
+    
+    # Don't wrap json functions in parentheses
+    defp paren_expr(expr = {:fragment, _, [{:raw, raw_expr} | _] }, sources, query) do
+      cond do
+        String.match?(raw_expr, ~r/^\s*jsonb?/i) -> [expr(expr, sources, query)]
+        true -> [?(, expr(expr, sources, query), ?)]
+      end
+    end
 
     defp paren_expr(expr, sources, query) do
       [?(, expr(expr, sources, query), ?)]

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -413,12 +413,13 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp operator_to_boolean(:and), do: " AND "
     defp operator_to_boolean(:or), do: " OR "
-    
+
     # Don't wrap json functions in parentheses
-    defp paren_expr(expr = {:fragment, _, [{:raw, raw_expr} | _] }, sources, query) do
-      cond do
-        String.match?(raw_expr, ~r/^\s*jsonb?/i) -> [expr(expr, sources, query)]
-        true -> [?(, expr(expr, sources, query), ?)]
+    defp paren_expr({:fragment, _, [{:raw, raw_expr} | _]} = expr, sources, query) do
+      if String.match?(raw_expr, ~r/^\s*jsonb?/i) do
+        [expr(expr, sources, query)]
+      else
+        [?(, expr(expr, sources, query), ?)]
       end
     end
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -605,6 +605,12 @@ defmodule Ecto.Adapters.PostgresTest do
            "SELECT s0.\"id\", s1.\"id\" FROM \"schema\" AS s0 CROSS JOIN \"schema2\" AS s1"
   end
 
+  test "cross join with fragment" do
+    query = from(p in Schema, cross_join: fragment("jsonb_each(?)", p.j), select: {p.id}) |> normalize()
+    assert all(query) ==
+           ~s{SELECT s0."id" FROM "schema" AS s0 CROSS JOIN jsonb_each(s0."j") AS f1}
+  end
+
   test "join produces correct bindings" do
     query = from(p in Schema, join: c in Schema2, on: true)
     query = from(p in query, join: c in Schema2, on: true, select: {p.id, c.id})
@@ -656,6 +662,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "association join has_many" do
+
     query = Schema |> join(:inner, [p], c in assoc(p, :comments)) |> select([], true) |> normalize
     assert all(query) ==
            "SELECT TRUE FROM \"schema\" AS s0 INNER JOIN \"schema2\" AS s1 ON s1.\"z\" = s0.\"x\""

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -662,7 +662,6 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "association join has_many" do
-
     query = Schema |> join(:inner, [p], c in assoc(p, :comments)) |> select([], true) |> normalize
     assert all(query) ==
            "SELECT TRUE FROM \"schema\" AS s0 INNER JOIN \"schema2\" AS s1 ON s1.\"z\" = s0.\"x\""


### PR DESCRIPTION
Addresses https://github.com/elixir-ecto/ecto/issues/2537 by making sure fragments containing PostgreSQL json functions are not wrapped in parentheses.