### PR TITLE
Prevent noop migrations directory creation on gen.migration task

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
           path = Path.join(source_repo_priv(repo), "migrations")
           base_name = "#{underscore(name)}.exs"
           file = Path.join(path, "#{timestamp()}_#{base_name}")
-          create_directory path
+          unless File.dir?(path), do: create_directory path
 
           fuzzy_path = Path.join(path, "*_#{base_name}")
           if Path.wildcard(fuzzy_path) != [] do


### PR DESCRIPTION
The "migrations" directory is always printed as "just been created" and it can be confusing.
This simple validation before calling the "create_directory" function prevents the logger from printing useless information 😄 

**Before**
```shell
Generated test_ecto_migration app
* creating priv/repo/migrations
* creating priv/repo/migrations/20180511174539_create_foo.exs
```
**After**
```shell
Generated test_ecto_migration app
* creating priv/repo/migrations/20180511174539_create_foo.exs
```