### PR TITLE
Support named and ... bindings when using dynamic in join's :on

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -89,6 +89,27 @@ defmodule Ecto.Integration.JoinsTest do
     assert [{^p2, ^c1}] = TestRepo.all(query)
   end
 
+  test "joins with dynamic in :on" do
+    p = TestRepo.insert!(%Post{title: "1"})
+    c = TestRepo.insert!(%Permalink{url: "1", post_id: p.id})
+
+    join_on = dynamic([p, ..., c], c.id == ^c.id)
+
+    query =
+      from(p in Post, join: c in Permalink, on: ^join_on)
+      |> select([p, c], {p, c})
+
+    assert [{^p, ^c}] = TestRepo.all(query)
+
+    join_on = dynamic([p, permalink: c], c.id == ^c.id)
+
+    query =
+      from(p in Post, join: c in Permalink, as: :permalink, on: ^join_on)
+      |> select([p, c], {p, c})
+
+    assert [{^p, ^c}] = TestRepo.all(query)
+  end
+
   @tag :cross_join
   test "cross joins with missing entries" do
     p1 = TestRepo.insert!(%Post{title: "1"})

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -208,6 +208,15 @@ defmodule Ecto.QueryTest do
               {{:., [], [{:&, [], [1]}, :id]}, [], []}
              ]}
     end
+
+    test "dynamic in :on takes new binding when ... is used" do
+      join_on = dynamic([p, ..., c], c.text == "Test Comment")
+
+      query = from p in "posts", join: c in "comments", on: ^join_on
+
+      assert inspect(query) ==
+        ~s[#Ecto.Query<from p in \"posts\", join: c in \"comments\", on: c.text == \"Test Comment\">]
+    end
   end
 
   describe "named bindings" do
@@ -336,6 +345,15 @@ defmodule Ecto.QueryTest do
         |> where([{:comment, c}, p], c.id == 0)
       )
       end
+    end
+
+    test "dynamic in :on takes new binding when alias is used" do
+      join_on = dynamic([p, comment: c], c.text == "Test Comment")
+
+      query = from p in "posts", join: c in "comments", as: :comment, on: ^join_on
+
+      assert inspect(query) ==
+        ~s[#Ecto.Query<from p in \"posts\", join: c in \"comments\", as: :comment, on: c.text == \"Test Comment\">]
     end
   end
 


### PR DESCRIPTION
Closes #2244 

This PR tries to address the issue of expanding dynamic expression as `:on` expression of join query when either named binding or `...` is used for referring to the joined relation. This approach may seem a bit hackish but I couldn't sort out any better approach to that sort of chicken-and-egg problem (also, I've spent more time trying to wrap my head around the inner workings of dynamic than I'd be willing to admit 🙈 ).