### PR TITLE
Document non-atom Multi name example

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -94,9 +94,9 @@ defmodule Ecto.Multi do
         assert inspect(query) == "#Ecto.Query<from a in Session>"
       end
 
-  It is worth noting that the name of each operation does not have to be an
-  atom. This can be particularly useful when you wish to update a collection of
-  changesets at once, and track their errors individually:
+  The name of each operation does not have to be an atom. This can be particularly
+  useful when you wish to update a collection of changesets at once, and track their
+  errors individually:
 
       accounts = [%Account{id: 1}, %Account{id: 2}]
 

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -93,6 +93,20 @@ defmodule Ecto.Multi do
         assert log_changeset.valid?
         assert inspect(query) == "#Ecto.Query<from a in Session>"
       end
+
+  It is worth noting that the name of each operation does not have to be an
+  atom. This can be particularly useful when you wish to update a collection of
+  changesets at once, and track their errors individually:
+
+      accounts = [%Account{id: 1}, %Account{id: 2}]
+
+      Enum.reduce(accounts, Multi.new(), fn account, multi ->
+        Multi.update(
+          multi,
+          {:account, account.id},
+          Account.password_reset_changeset(account, params)
+        )
+      end)
   """
 
   alias __MODULE__


### PR DESCRIPTION
The current example usages of `Ecto.Multi` do not make it obvious that the `name` you use in each operation can actually be anything. The purpose of this pull request is to add an example which illustrates how you might reduce over a collection, using a non-atom as the name of each operation.