### PR TITLE
mix ecto.load should fail on SQL errors

### DIFF
--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -89,10 +89,10 @@ defmodule Ecto.Integration.StorageTest do
   end
 
   test "structure load will fail on SQL errors" do
+    File.mkdir_p!(tmp_path())
     error_path = Path.join(tmp_path(), "error.sql")
     File.write!(error_path, "DO $$ BEGIN RAISE EXCEPTION 'failing SQL'; END $$;")
-    {:error, message} = Postgres.structure_load(tmp_path(), [dump_path: error_path] ++
-                                                            TestRepo.config())
+    {:error, message} = Postgres.structure_load(tmp_path(), [dump_path: error_path] ++ TestRepo.config())
     assert message =~ ~r/ERROR.*failing SQL/
   end
 

--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -88,6 +88,14 @@ defmodule Ecto.Integration.StorageTest do
     drop_database()
   end
 
+  test "structure load will fail on SQL errors" do
+    error_path = Path.join(tmp_path(), "error.sql")
+    File.write!(error_path, "DO $$ BEGIN RAISE EXCEPTION 'failing SQL'; END $$;")
+    {:error, message} = Postgres.structure_load(tmp_path(), [dump_path: error_path] ++
+                                                            TestRepo.config())
+    assert message =~ ~r/ERROR.*failing SQL/
+  end
+
   test "structure dump and load with migrations table" do
     {:ok, path} = Postgres.structure_dump(tmp_path(), TestRepo.config())
     contents = File.read!(path)

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -215,7 +215,9 @@ defmodule Ecto.Adapters.Postgres do
   @doc false
   def structure_load(default, config) do
     path = config[:dump_path] || Path.join(default, "structure.sql")
-    case run_with_cmd("psql", config, ["--quiet", "--file", path, config[:database]]) do
+    args = ["--quiet", "--file", path, "-vON_ERROR_STOP=1",
+            "--single-transaction", config[:database]]
+    case run_with_cmd("psql", config, args) do
       {_output, 0} -> {:ok, path}
       {output, _}  -> {:error, output}
     end


### PR DESCRIPTION
Submitting as requested in the mailing [list](https://groups.google.com/forum/#!topic/elixir-ecto/yiptot9z8OY). 

This changes arguments to the Postgres & MySQL CLIs such that they fail with a non-zero error when SQL errors are raised. For example, if you run `mix ecto.load` with a database that is already populated with your schema, that operation will fail after applying this change. Today, both providers silently succeed since that is the default in both command programs.

Compatibility risk is low and the change is worth it. I thought I'd mention the one possible issue I know this could cause in case someone comes looking for this later. At work we have this issue:  we have a long history of migrations, and some of it was "compressed" by removing all the migration files and doing a `mix ecto.load` in the first new migration file. e.g. we literally have:

```elixir
  def up do
    Mix.Task.run "ecto.load", ["--force"]
  end
```

In the first migration file. That sort of stuff will need to go away after this change, because `schema_migrations` will be created before loading the script, and so the script will fail trying to create `schema_migrations`. Arguably this should have been done another way to begin with, which for us will probably be simply adding `ecto.load` to our setup alias: e.g.

```elixir 
defp aliases do
    [ "ecto.setup": ["ecto.create", "ecto.load", "ecto.migrate"],
...
```
