### PR TITLE
update LogEntry query_time typespec to include nil

### DIFF
--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -22,7 +22,7 @@ defmodule Ecto.LogEntry do
   alias Ecto.LogEntry
 
   @type t :: %LogEntry{query: String.t | (t -> String.t), source: String.t | Enum.t | nil,
-                       params: [term], query_time: integer, decode_time: integer | nil,
+                       params: [term], query_time: integer | nil, decode_time: integer | nil,
                        queue_time: integer | nil, connection_pid: pid | nil,
                        result: {:ok, term} | {:error, Exception.t},
                        ansi_color: IO.ANSI.ansicode | nil, caller_pid: pid | nil}


### PR DESCRIPTION
I have seen some issues with assuming that a `query_time` is an integer, and it seems as though Ecto  also understands it may be nil. I think the typespec for `query_time` should be expanded to include `nil`, like `queue_time` and `decode_time` do.

https://github.com/elixir-ecto/ecto/blob/64648910450dc1762857fd7b4bca20d358cf1c27/lib/ecto/log_entry.ex#L90-L91 covers the case where a `query_time` may be nil.

https://github.com/elixir-ecto/ecto/blob/64648910450dc1762857fd7b4bca20d358cf1c27/test/ecto/log_entry_test.exs#L8-L9 tests logging an entry with a nil `query_time`.