### PR TITLE
fix getting started link in association guide

### DIFF
--- a/guides/Associations.md
+++ b/guides/Associations.md
@@ -1,6 +1,6 @@
 # Ecto Association Guide
 
-This guide assumes you worked through the [Getting Started guide](Getting%20Started.md) and want to learn more about associations.
+This guide assumes you worked through the [Getting Started guide](getting-started.html) and want to learn more about associations.
 
 If you want to see the code from this guide, you can view it [at
 ecto/examples/ecto_assoc on GitHub](https://github.com/elixir-lang/ecto/tree/master/examples/ecto_assoc).


### PR DESCRIPTION
fixes link on https://hexdocs.pm/ecto/associations.html
breaks link on https://github.com/elixir-ecto/ecto/blob/master/guides/Associations.md