### PR TITLE
Raise a helpful error on invalid SQL default

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -826,7 +826,7 @@ if Code.ensure_loaded?(Postgrex) do
       else
         encoded = "\\x" <> Base.encode16(literal, case: :lower)
         raise(ArgumentError, "default values are interpolated as UTF-8 strings and cannot contain null bytes. " <>
-                             "`#{inspect literal}` is invalid. If you want to write it as a binary, use #{encoded}, " <>
+                             "`#{inspect literal}` is invalid. If you want to write it as a binary, use \"#{encoded}\", " <>
                              "otherwise refer to PostgreSQL documentation for instructions on how to escape this SQL type")
       end
     end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -821,13 +821,13 @@ if Code.ensure_loaded?(Postgrex) do
       ["ARRAY[",  Enum.map(list, &default_type(&1, inner)) |> Enum.intersperse(?,), "]::", ecto_to_db(type)]
     end
     defp default_type(literal, _type) when is_binary(literal) do
-      if :binary.match(literal, <<0>>) == :nomatch && String.valid?(literal) do
+      if :binary.match(literal, <<0>>) == :nomatch and String.valid?(literal) do
         [?', escape_string(literal), ?']
       else
         encoded = "\\x" <> Base.encode16(literal, case: :lower)
-        raise(ArgumentError, "default values are interpolated as UTF-8 strings and cannot contain null bytes. " <>
+        raise ArgumentError, "default values are interpolated as UTF-8 strings and cannot contain null bytes. " <>
                              "`#{inspect literal}` is invalid. If you want to write it as a binary, use \"#{encoded}\", " <>
-                             "otherwise refer to PostgreSQL documentation for instructions on how to escape this SQL type")
+                             "otherwise refer to PostgreSQL documentation for instructions on how to escape this SQL type"
       end
     end
     defp default_type(literal, _type) when is_number(literal),  do: to_string(literal)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -820,7 +820,14 @@ if Code.ensure_loaded?(Postgrex) do
     defp default_type(list, {:array, inner} = type) when is_list(list) do
       ["ARRAY[",  Enum.map(list, &default_type(&1, inner)) |> Enum.intersperse(?,), "]::", ecto_to_db(type)]
     end
-    defp default_type(literal, _type) when is_binary(literal),  do: [?', escape_string(literal), ?']
+    defp default_type(literal, _type) when is_binary(literal) do
+      if :binary.match(literal, <<0>>) == :nomatch && String.valid?(literal) do
+        [?', escape_string(literal), ?']
+      else
+        raise(ArgumentError, "default values are interpolated as UTF-8 strings, and cannot contain null bytes. `#{inspect literal}` is invalid. " <>
+                             "Refer to PostgreSQL documentation for instructions on how to escape this SQL type.")
+      end
+    end
     defp default_type(literal, _type) when is_number(literal),  do: to_string(literal)
     defp default_type(literal, _type) when is_boolean(literal), do: to_string(literal)
     defp default_type(%{} = map, :map) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -824,8 +824,10 @@ if Code.ensure_loaded?(Postgrex) do
       if :binary.match(literal, <<0>>) == :nomatch && String.valid?(literal) do
         [?', escape_string(literal), ?']
       else
-        raise(ArgumentError, "default values are interpolated as UTF-8 strings, and cannot contain null bytes. `#{inspect literal}` is invalid. " <>
-                             "Refer to PostgreSQL documentation for instructions on how to escape this SQL type.")
+        encoded = "\\x" <> Base.encode16(literal, case: :lower)
+        raise(ArgumentError, "default values are interpolated as UTF-8 strings and cannot contain null bytes. " <>
+                             "`#{inspect literal}` is invalid. If you want to write it as a binary, use #{encoded}, " <>
+                             "otherwise refer to PostgreSQL documentation for instructions on how to escape this SQL type")
       end
     end
     defp default_type(literal, _type) when is_number(literal),  do: to_string(literal)

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -887,7 +887,7 @@ defmodule Ecto.Adapters.PostgresTest do
     create = {:create, table(:blobs),
               [{:add, :blob, :binary, [default: <<0>>]}]}
 
-    assert_raise ArgumentError, ~r"UTF-8", fn ->
+    assert_raise ArgumentError, ~r"\\x00\b", fn ->
       execute_ddl(create)
     end
   end
@@ -896,7 +896,7 @@ defmodule Ecto.Adapters.PostgresTest do
     create = {:create, table(:blobs),
               [{:add, :blob, :binary, [default: "foo" <> <<0>>]}]}
 
-    assert_raise ArgumentError, ~r"UTF-8", fn ->
+    assert_raise ArgumentError, ~r"\\x666f6f00\b", fn ->
       execute_ddl(create)
     end
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -887,7 +887,7 @@ defmodule Ecto.Adapters.PostgresTest do
     create = {:create, table(:blobs),
               [{:add, :blob, :binary, [default: <<0>>]}]}
 
-    assert_raise ArgumentError, ~r"\\x00\b", fn ->
+    assert_raise ArgumentError, ~r/"\\x00"/, fn ->
       execute_ddl(create)
     end
   end
@@ -896,7 +896,7 @@ defmodule Ecto.Adapters.PostgresTest do
     create = {:create, table(:blobs),
               [{:add, :blob, :binary, [default: "foo" <> <<0>>]}]}
 
-    assert_raise ArgumentError, ~r"\\x666f6f00\b", fn ->
+    assert_raise ArgumentError, ~r/"\\x666f6f00"/, fn ->
       execute_ddl(create)
     end
   end


### PR DESCRIPTION
This is an alternative approach to #2563 (original issue #2561).

In this one, we don't try to encode default values, we only raise a helpful error when the value is an invalid UTF-8 or contains null bytes.

Here's what the error currently looks like:

> ** (ArgumentError) default values are interpolated as UTF-8 strings, and cannot contain null bytes. `<<102, 111, 111, 0>>` is invalid. Refer to PostgreSQL documentation for instructions on how to escape this SQL type.

@fishcakez and I have been back-and-forth in IRC about the wording of this error (and I still tweaked this version a little), but open to further suggestions.