### PR TITLE
Allow prefix option in from/join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Running migrations will now lock the migrations table, allowing you to concurren
   * [Ecto.Query] Allow virtual field update in subqueries
   * [Ecto.Query] Support `coalesce/2` in queries, such as `select: coalesce(p.title, p.old_title)`
   * [Ecto.Query] Support `filter/2` in queries, such as `select: filter(count(p.id), p.public == true)`
+  * [Ecto.Query] The `:prefix` option is now allowed on both `from` and `join` expressions
   * [Ecto.Repo] Support `:replace_all_except_primary_key` as `:on_conflict` strategy
   * [Ecto.Repo] Support `{:replace, fields}` as `:on_conflict` strategy
   * [Ecto.Repo] Support `select` in queries given to `update_all` and `delete_all`
@@ -102,9 +103,11 @@ Running migrations will now lock the migrations table, allowing you to concurren
   * [Ecto.DataType] `Ecto.DataType` protocol has been removed
   * [Ecto.Multi] `Ecto.Multi.run/5` now receives the repo in which the transaction is executing as the first argument to functions, and the changes so far as the second argument
   * [Ecto.Schema] `:time`, `:naive_datetime` and `:utc_datetime` no longer keep microseconds information. If you want to keep microseconds, use `:time_usec`, `:naive_datetime_usec`, `:utc_datetime_usec`
+  * [Ecto.Schema] The `@schema_prefix` option now only affects the `from`/`join` of where the schema is used and no longer the whole query
 
 ### Adapter changes
 
+  * [Ecto.Adapter] The `:sources` field in `query_meta` now contains three elements tuples with `{source, schema, prefix}` in order to support `from`/`join` prefixes (#2572)
   * [Ecto.Adapter] The database types `time`, `utc_datetime` and `naive_datetime` should translate to types with seconds precision while the database types `time_usec`, `utc_datetime_usec` and `naive_datetime_usec` should have microseconds precision
   * [Ecto.Adapter] The `on_conflict` argument for `insert` and `insert_all` no longer receives a `{:replace_all, list(), atom()}` tuple. Instead, it receives a `{fields :: [atom()], list(), atom()}` where `fields` is a list of atoms of the fields to be replaced
   * [Ecto.Adapter] `exclusion_constraint` will now have type `:exclusion` on the adapter metadata instead of `:exclude` (affects PostgreSQL only)

--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -9,7 +9,7 @@ defmodule Ecto.Adapter do
   @type adapter_meta :: term
 
   @typedoc "Ecto.Query metadata fields (stored in cache)"
-  @type query_meta :: %{prefix: binary | nil, sources: tuple, preloads: term, select: map}
+  @type query_meta :: %{sources: tuple, preloads: term, select: map}
 
   @typedoc "Ecto.Schema metadata fields"
   @type schema_meta :: %{

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -532,26 +532,30 @@ if Code.ensure_loaded?(Mariaex) do
       expr(expr, sources, query)
     end
 
-    defp create_names(%{prefix: prefix, sources: sources}) do
-      create_names(prefix, sources, 0, tuple_size(sources)) |> List.to_tuple()
+    defp create_names(%{sources: sources}) do
+      create_names(sources, 0, tuple_size(sources)) |> List.to_tuple()
     end
 
-    defp create_names(prefix, sources, pos, limit) when pos < limit do
-      current =
-        case elem(sources, pos) do
-          {table, schema} ->
-            name = [create_alias(table) | Integer.to_string(pos)]
-            {quote_table(prefix, table), name, schema}
-          {:fragment, _, _} ->
-            {nil, [?f | Integer.to_string(pos)], nil}
-          %Ecto.SubQuery{} ->
-            {nil, [?s | Integer.to_string(pos)], nil}
-        end
-      [current | create_names(prefix, sources, pos + 1, limit)]
+    defp create_names(sources, pos, limit) when pos < limit do
+      [create_name(sources, pos) | create_names(sources, pos + 1, limit)]
     end
 
-    defp create_names(_prefix, _sources, pos, pos) do
+    defp create_names(_sources, pos, pos) do
       []
+    end
+
+    defp create_name(sources, pos) do
+      case elem(sources, pos) do
+        {:fragment, _, _} ->
+          {nil, [?f | Integer.to_string(pos)], nil}
+
+        {table, schema, prefix} ->
+          name = [create_alias(table) | Integer.to_string(pos)]
+          {quote_table(prefix, table), name, schema}
+
+        %Ecto.SubQuery{} ->
+          {nil, [?s | Integer.to_string(pos)], nil}
+      end
     end
 
     defp create_alias(<<first, _rest::binary>>) when first in ?a..?z when first in ?A..?Z do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -163,8 +163,8 @@ if Code.ensure_loaded?(Postgrex) do
        values, on_conflict(on_conflict, header) | returning(returning)]
     end
 
-    defp insert_as({%{from: from} = query, _, _}) do
-      {_, name} = get_source(%{query | joins: []}, create_names(query), 0, from)
+    defp insert_as({%{sources: sources}, _, _}) do
+      {_expr, name, _schema} = create_name(sources, 0)
       [" AS " | name]
     end
     defp insert_as({_, _, _}) do
@@ -587,26 +587,30 @@ if Code.ensure_loaded?(Postgrex) do
     defp returning(returning),
       do: [" RETURNING " | intersperse_map(returning, ", ", &quote_name/1)]
 
-    defp create_names(%{prefix: prefix, sources: sources}) do
-      create_names(prefix, sources, 0, tuple_size(sources)) |> List.to_tuple()
+    defp create_names(%{sources: sources}) do
+      create_names(sources, 0, tuple_size(sources)) |> List.to_tuple()
     end
 
-    defp create_names(prefix, sources, pos, limit) when pos < limit do
-      current =
-        case elem(sources, pos) do
-          {table, schema} ->
-            name = [create_alias(table) | Integer.to_string(pos)]
-            {quote_table(prefix, table), name, schema}
-          {:fragment, _, _} ->
-            {nil, [?f | Integer.to_string(pos)], nil}
-          %Ecto.SubQuery{} ->
-            {nil, [?s | Integer.to_string(pos)], nil}
-        end
-      [current | create_names(prefix, sources, pos + 1, limit)]
+    defp create_names(sources, pos, limit) when pos < limit do
+      [create_name(sources, pos) | create_names(sources, pos + 1, limit)]
     end
 
-    defp create_names(_prefix, _sources, pos, pos) do
+    defp create_names(_sources, pos, pos) do
       []
+    end
+
+    defp create_name(sources, pos) do
+      case elem(sources, pos) do
+        {:fragment, _, _} ->
+          {nil, [?f | Integer.to_string(pos)], nil}
+
+        {table, schema, prefix} ->
+          name = [create_alias(table) | Integer.to_string(pos)]
+          {quote_table(prefix, table), name, schema}
+
+        %Ecto.SubQuery{} ->
+          {nil, [?s | Integer.to_string(pos)], nil}
+      end
     end
 
     defp create_alias(<<first, _rest::binary>>) when first in ?a..?z when first in ?A..?Z do

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -294,8 +294,8 @@ defmodule Ecto.Adapters.SQL do
     end
   end
 
-  defp put_source(opts, %{sources: sources}) when tuple_size(elem(sources, 0)) == 2 do
-    {source, _} = elem(sources, 0)
+  defp put_source(opts, %{sources: sources}) when is_binary(elem(elem(sources, 0), 0)) do
+    {source, _, _} = elem(sources, 0)
     Keyword.put(opts, :source, source)
   end
 

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -176,10 +176,14 @@ defmodule Ecto.Association do
   end
 
   def assoc_query(refl, t, query, values) do
-    query = query || %Ecto.Query{
-      from: %FromExpr{source: {"join expression", nil}},
-      prefix: refl.queryable.__schema__(:prefix)
-    }
+    query =
+      query ||
+      %Ecto.Query{
+        from: %FromExpr{
+          source: {"join expression", nil},
+          prefix: refl.queryable.__schema__(:prefix)
+        }
+      }
 
     # Find the position for upcoming joins
     position = length(query.joins) + 1
@@ -210,9 +214,15 @@ defmodule Ecto.Association do
     rewrite_ix = assoc.ix
     [assoc | joins] = Enum.map([assoc | joins], &rewrite_join(&1, rewrite_ix))
 
-    %{query | wheres: [assoc_to_where(assoc) | query.wheres], joins: joins,
-              from: merge_from(query.from, assoc.source), sources: nil}
-    |> distinct([x], true)
+    query = %{
+      query
+      | wheres: [assoc_to_where(assoc) | query.wheres],
+        joins: joins,
+        from: merge_from(query.from, assoc.source),
+        sources: nil
+    }
+
+    distinct(query, [x], true)
   end
 
   @doc """
@@ -221,10 +231,12 @@ defmodule Ecto.Association do
   def combine_assoc_query(%{queryable: queryable} = assoc, nil), do: combine_assoc_query(assoc, queryable)
   def combine_assoc_query(%{where: nil}, queryable), do: queryable
   def combine_assoc_query(%{where: []}, queryable), do: queryable
+
   def combine_assoc_query(%{where: {module, function, args}}, queryable) do
     where = apply(module, function, args)
     Ecto.Query.where(queryable, _, ^where)
   end
+
   def combine_assoc_query(%{where: where}, queryable) do
     Ecto.Query.where(queryable, _, ^where)
   end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -196,8 +196,8 @@ defmodule Ecto.Query.Planner do
     {cache, select, prepared}
   end
 
-  defp build_meta(%{prefix: prefix, sources: sources, preloads: preloads}, select) do
-    %{prefix: prefix, select: select, preloads: preloads, sources: sources}
+  defp build_meta(%{sources: sources, preloads: preloads}, select) do
+    %{select: select, preloads: preloads, sources: sources}
   end
 
   @doc """
@@ -236,27 +236,35 @@ defmodule Ecto.Query.Planner do
   end
 
   defp prepare_from(%{from: from} = query, adapter) do
-    source = prepare_source(query, from.source, adapter)
-    {%{from | source: source}, [source]}
+    {from, source} = prepare_source(query, from, adapter)
+    {from, [source]}
   end
 
-  defp prepare_source(query, %Ecto.SubQuery{query: inner_query} = subquery, adapter) do
+  defp prepare_source(query, %{source: %Ecto.SubQuery{} = subquery} = expr, adapter) do
     try do
+      %{query: inner_query} = subquery
       {inner_query, params, key} = prepare(inner_query, :all, adapter, 0)
       assert_no_subquery_assocs!(inner_query)
       {inner_query, select} = inner_query |> ensure_select(true) |> subquery_select(adapter)
-      %{subquery | query: inner_query, params: params, cache: key, select: select}
+      subquery = %{subquery | query: inner_query, params: params, cache: key, select: select}
+      {%{expr | source: subquery}, subquery}
     rescue
       e -> raise Ecto.SubQueryError, query: query, exception: e
     end
   end
 
-  defp prepare_source(_query, {nil, schema}, _adapter) when is_atom(schema) and schema != nil,
-    do: {schema.__schema__(:source), schema}
-  defp prepare_source(_query, {source, schema}, _adapter) when is_binary(source) and is_atom(schema),
-    do: {source, schema}
-  defp prepare_source(_query, {:fragment, _, _} = source, _adapter),
-    do: source
+  defp prepare_source(query, %{source: {nil, schema}, prefix: prefix} = expr, _adapter)
+       when is_atom(schema) and schema != nil do
+    source = schema.__schema__(:source)
+    {%{expr | source: {source, schema}}, {source, schema, prefix || query.prefix}}
+  end
+
+  defp prepare_source(query, %{source: {source, schema}, prefix: prefix} = expr, _adapter)
+       when is_binary(source) and is_atom(schema),
+       do: {expr, {source, schema, prefix || query.prefix}}
+
+  defp prepare_source(_query, %{source: {:fragment, _, _} = source} = expr, _adapter),
+       do: {expr, source}
 
   defp assert_no_subquery_assocs!(%{assocs: assocs, preloads: preloads} = query)
        when assocs != [] or preloads != [] do
@@ -274,6 +282,7 @@ defmodule Ecto.Query.Planner do
         {struct, fields} ->
           {:%, [], [struct, {:%{}, [], fields}]}
       end
+
     query = put_in(query.select.expr, expr)
     {expr, _} = prewalk(expr, :select, query, select, 0, adapter)
     {meta, _fields, _from} = collect_fields(expr, [], :error, query, take)
@@ -325,7 +334,7 @@ defmodule Ecto.Query.Planner do
     error!(query, "subquery must select a source (t), a field (t.field) or a map, got: `#{Macro.to_string(expr)}`")
   end
 
-  defp subquery_struct_and_fields({:source, {_, schema}, types}) do
+  defp subquery_struct_and_fields({:source, {_, schema}, _, types}) do
     {schema, Keyword.keys(types)}
   end
   defp subquery_struct_and_fields({:struct, name, types}) do
@@ -367,7 +376,7 @@ defmodule Ecto.Query.Planner do
     prepare_joins(query.joins, query, [], sources, [], 1, offset, adapter)
   end
 
-  defp prepare_joins([%JoinExpr{assoc: {ix, assoc}, qual: qual, on: on} = join|t],
+  defp prepare_joins([%JoinExpr{assoc: {ix, assoc}, qual: qual, on: on, prefix: prefix} = join|t],
                      query, joins, sources, tail_sources, counter, offset, adapter) do
     schema = schema_for_association_join!(query, join, Enum.fetch!(Enum.reverse(sources), ix))
     refl = schema.__schema__(:association, assoc)
@@ -394,11 +403,15 @@ defmodule Ecto.Query.Planner do
     # All values in the middle should be shifted by offset,
     # all values after join are already correct.
     child = refl.__struct__.joins_query(refl)
+    child = update_in child.joins, &Enum.map(&1, fn join -> rewrite_join_prefix(join, prefix) end)
+
     last_ix = length(child.joins)
     source_ix = counter
 
+    {_, child_from_source} = prepare_source(child, child.from, adapter)
+
     {child_joins, child_sources, child_tail} =
-      prepare_joins(child, [child.from.source], offset + last_ix - 1, adapter)
+      prepare_joins(child, [child_from_source], offset + last_ix - 1, adapter)
 
     # Rewrite joins indexes as mentioned above
     child_joins = Enum.map(child_joins, &rewrite_join(&1, qual, ix, last_ix, source_ix, offset))
@@ -418,18 +431,17 @@ defmodule Ecto.Query.Planner do
     case join_query do
       %{order_bys: [], limit: nil, offset: nil, group_bys: [], joins: [],
         havings: [], preloads: [], assocs: [], distinct: nil, lock: nil} ->
-        source = prepare_source(join_query, join_query.from.source, adapter)
-        [join] = attach_on(query_to_joins(qual, source, join_query, counter), on)
+        {from, source} = prepare_source(join_query, join_query.from, adapter)
+        [join] = attach_on(query_to_joins(qual, from.source, join_query, counter), on)
         prepare_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter)
       _ ->
         error! query, join, "queries in joins can only have `where` conditions"
     end
   end
 
-  defp prepare_joins([%JoinExpr{source: source} = join|t],
+  defp prepare_joins([%JoinExpr{} = join|t],
                       query, joins, sources, tail_sources, counter, offset, adapter) do
-    source = prepare_source(query, source, adapter)
-    join = %{join | source: source, ix: counter}
+    {join, source} = prepare_source(query, %{join | ix: counter}, adapter)
     prepare_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter)
   end
 
@@ -440,6 +452,10 @@ defmodule Ecto.Query.Planner do
   defp attach_on([%{on: on} = h | t], %{expr: expr, params: params}) do
     [%{h | on: merge_expr_and_params(:and, on, expr, params)} | t]
   end
+
+  defp rewrite_join_prefix(%{prefix: prefix} = join, _prefix) when prefix != nil, do: join
+  defp rewrite_join_prefix(%{prefix: nil} = join, nil), do: join
+  defp rewrite_join_prefix(join, prefix), do: %{join | prefix: prefix}
 
   defp rewrite_join(%{on: on, ix: join_ix} = join, qual, ix, last_ix, source_ix, inc_ix) do
     expr = Macro.prewalk on.expr, fn
@@ -477,16 +493,23 @@ defmodule Ecto.Query.Planner do
 
   defp schema_for_association_join!(query, join, source) do
     case source do
-      {source, nil} ->
+      {:fragment, _, _} ->
+        error! query, join, "cannot perform association joins on fragment sources"
+
+      {source, nil, _} ->
           error! query, join, "cannot perform association join on #{inspect source} " <>
                               "because it does not have a schema"
-      {_, schema} ->
+
+      {_, schema, _} ->
         schema
+
       %Ecto.SubQuery{select: {:struct, schema, _}} ->
         schema
+
       %Ecto.SubQuery{} ->
         error! query, join, "can only perform association joins on subqueries " <>
                             "that return a source with schema in select"
+
       _ ->
         error! query, join, "can only perform association joins on sources with a schema"
     end
@@ -498,11 +521,12 @@ defmodule Ecto.Query.Planner do
   def prepare_cache(query, operation, adapter, counter) do
     {query, {cache, params}} =
       traverse_exprs(query, operation, {[], []}, &{&3, merge_cache(&1, &2, &3, &4, adapter)})
+
     {query, Enum.reverse(params), finalize_cache(query, operation, cache, counter)}
   end
 
-  defp merge_cache(:from, _query, %{source: source}, {cache, params}, _adapter) do
-    {key, params} = source_cache(source, params)
+  defp merge_cache(:from, _query, from, {cache, params}, _adapter) do
+    {key, params} = source_cache(from, params)
     {merge_cache(key, cache, key != :nocache), params}
   end
 
@@ -533,8 +557,8 @@ defmodule Ecto.Query.Planner do
   defp merge_cache(:join, query, exprs, {cache, params}, adapter) do
     {expr_cache, {params, cacheable?}} =
       Enum.map_reduce exprs, {params, true}, fn
-        %JoinExpr{on: on, qual: qual, source: source} = join, {params, cacheable?} ->
-          {key, params} = source_cache(source, params)
+        %JoinExpr{on: on, qual: qual} = join, {params, cacheable?} ->
+          {key, params} = source_cache(join, params)
           {params, join_cacheable?} = cast_and_merge_params(:join, query, join, params, adapter)
           {params, on_cacheable?} = cast_and_merge_params(:join, query, on, params, adapter)
           {{qual, key, on.expr},
@@ -592,13 +616,13 @@ defmodule Ecto.Query.Planner do
   defp prepend_if(cache, true, prepend), do: prepend ++ cache
   defp prepend_if(cache, false, _prepend), do: cache
 
-  defp source_cache({_, nil} = source, params),
-    do: {source, params}
-  defp source_cache({bin, schema}, params),
-    do: {{bin, schema, schema.__schema__(:hash)}, params}
-  defp source_cache({:fragment, _, _} = source, params),
-    do: {source, params}
-  defp source_cache(%Ecto.SubQuery{params: inner, cache: key}, params),
+  defp source_cache(%{source: {_, nil} = source, prefix: prefix}, params),
+    do: {{source, prefix}, params}
+  defp source_cache(%{source: {bin, schema}, prefix: prefix}, params),
+    do: {{bin, schema, schema.__schema__(:hash), prefix}, params}
+  defp source_cache(%{source: {:fragment, _, _} = source, prefix: prefix}, params),
+    do: {{source, prefix}, params}
+  defp source_cache(%{source: %Ecto.SubQuery{params: inner, cache: key}}, params),
     do: {key, Enum.reverse(inner, params)}
 
   defp cast_param(_kind, query, expr, %DynamicExpr{}, _type, _value) do
@@ -640,7 +664,7 @@ defmodule Ecto.Query.Planner do
   defp prepare_assocs(_query, _ix, []), do: :ok
   defp prepare_assocs(query, ix, assocs) do
     # We validate the schema exists when preparing joins above
-    {_, parent_schema} = get_source!(:preload, query, ix)
+    {_, parent_schema, _} = get_source!(:preload, query, ix)
 
     Enum.each assocs, fn {assoc, {child_ix, child_assocs}} ->
       refl = parent_schema.__schema__(:association, assoc)
@@ -893,9 +917,11 @@ defmodule Ecto.Query.Planner do
     # In from, if there is a schema and we have a map tag with preloads,
     # it needs to be converted to a map in a later pass.
     {take, from_tag} =
-      case tag do
-        :map when is_tuple(source) and elem(source, 1) != nil and preloads != [] ->
+      case source do
+        {source, schema, _}
+        when tag == :map and preloads != [] and is_binary(source) and schema != nil ->
           {Map.put(take, 0, {:struct, from_take}), :map}
+
         _ ->
           {take, :any}
       end
@@ -910,8 +936,10 @@ defmodule Ecto.Query.Planner do
           fields = from_taken ++ Enum.reverse(assoc_fields, Enum.reverse(fields))
           preprocess = [from_pre | Enum.reverse(assoc_exprs)]
           {fields, preprocess, {from_tag, from_expr}}
+
         :error when preloads != [] or assocs != [] ->
           error! query, "the binding used in `from` must be selected in `select` when using `preload`"
+
         :error ->
           {Enum.reverse(fields), [], :none}
       end
@@ -1084,9 +1112,9 @@ defmodule Ecto.Query.Planner do
 
   defp collect_assocs(exprs, fields, query, tag, take, [{assoc, {ix, children}}|tail]) do
     case get_source!(:preload, query, ix) do
-      {_, schema} = source when schema != nil ->
+      {source, schema, _} = to_take when is_binary(source) and schema != nil ->
         {fetch, take_children} = fetch_assoc(tag, take, assoc)
-        {expr, taken} = take!(source, query, fetch, assoc, ix)
+        {expr, taken} = take!(to_take, query, fetch, assoc, ix)
         exprs = [expr | exprs]
         fields = Enum.reverse(taken, fields)
         {exprs, fields} = collect_assocs(exprs, fields, query, tag, take_children, children)
@@ -1115,35 +1143,35 @@ defmodule Ecto.Query.Planner do
 
   defp take!(source, query, fetched, field, ix) do
     case {fetched, source} do
-      {{:ok, {_, []}}, {_, _}} ->
-        error! query, "at least one field must be selected for binding `#{field}`, got an empty list"
-
-      {{:ok, {:struct, _}}, {_, nil}} ->
-        error! query, "struct/2 in select expects a source with a schema"
-
-      {{:ok, {kind, fields}}, {source, schema}} ->
-        dumper = if schema, do: schema.__schema__(:dump), else: %{}
-        schema = if kind == :map, do: nil, else: schema
-        {types, fields} = select_dump(List.wrap(fields), dumper, ix)
-        {{:source, {source, schema}, types}, fields}
-
       {{:ok, {_, _}}, {:fragment, _, _}} ->
         error! query, "it is not possible to return a map/struct subset of a fragment, " <>
                       "you must explicitly return the desired individual fields"
+
+      {{:ok, {_, []}}, {_, _, _}} ->
+        error! query, "at least one field must be selected for binding `#{field}`, got an empty list"
+
+      {{:ok, {:struct, _}}, {_, nil, _}} ->
+        error! query, "struct/2 in select expects a source with a schema"
+
+      {{:ok, {kind, fields}}, {source, schema, prefix}} ->
+        dumper = if schema, do: schema.__schema__(:dump), else: %{}
+        schema = if kind == :map, do: nil, else: schema
+        {types, fields} = select_dump(List.wrap(fields), dumper, ix)
+        {{:source, {source, schema}, prefix || query.prefix, types}, fields}
 
       {{:ok, {_, _}}, %Ecto.SubQuery{}} ->
         error! query, "it is not possible to return a map/struct subset of a subquery, " <>
                       "you must explicitly select the whole subquery or individual fields only"
 
-      {:error, {_, nil}} ->
-        {{:value, :map}, [{:&, [], [ix]}]}
-
-      {:error, {_, schema}} ->
-        {types, fields} = select_dump(schema.__schema__(:fields), schema.__schema__(:dump), ix)
-        {{:source, source, types}, fields}
-
       {:error, {:fragment, _, _}} ->
         {{:value, :map}, [{:&, [], [ix]}]}
+
+      {:error, {_, nil, _}} ->
+        {{:value, :map}, [{:&, [], [ix]}]}
+
+      {:error, {source, schema, prefix}} ->
+        {types, fields} = select_dump(schema.__schema__(:fields), schema.__schema__(:dump), ix)
+        {{:source, {source, schema}, prefix || query.prefix, types}, fields}
 
       {:error, %Ecto.SubQuery{select: select} = subquery} ->
         fields = for {field, _} <- subquery_types(subquery), do: select_field(field, ix)
@@ -1214,10 +1242,12 @@ defmodule Ecto.Query.Planner do
   defp type!(_kind, _lookup, _query, _expr, nil, _field), do: :any
   defp type!(kind, lookup, query, expr, ix, field) when is_integer(ix) do
     case get_source!(kind, query, ix) do
-      {_, schema} ->
-        type!(kind, lookup, query, expr, schema, field)
       {:fragment, _, _} ->
         :any
+
+      {_, schema, _} ->
+        type!(kind, lookup, query, expr, schema, field)
+
       %Ecto.SubQuery{} = subquery ->
         case Keyword.fetch(subquery_types(subquery), field) do
           {:ok, {:value, type}} ->
@@ -1274,7 +1304,7 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp field_source({_, schema}, field) when schema != nil do
+  defp field_source({source, schema, _}, field) when is_binary(source) and schema != nil do
     # If the field is not found we return the field itself
     # which will be checked and raise later.
     schema.__schema__(:field_source, field) || field

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -453,9 +453,15 @@ defmodule Ecto.Query.Planner do
     [%{h | on: merge_expr_and_params(:and, on, expr, params)} | t]
   end
 
-  defp rewrite_join_prefix(%{prefix: prefix} = join, _prefix) when prefix != nil, do: join
-  defp rewrite_join_prefix(%{prefix: nil} = join, nil), do: join
-  defp rewrite_join_prefix(join, prefix), do: %{join | prefix: prefix}
+  defp rewrite_join_prefix(%{prefix: nil, source: {_, schema}} = join, nil)
+       when schema != nil,
+       do: %{join | prefix: schema.__schema__(:prefix)}
+
+  defp rewrite_join_prefix(%{prefix: nil} = join, prefix)
+       when prefix != nil,
+       do: %{join | prefix: prefix}
+
+  defp rewrite_join_prefix(join, _prefix), do: join
 
   defp rewrite_join(%{on: on, ix: join_ix} = join, qual, ix, last_ix, source_ix, inc_ix) do
     expr = Macro.prewalk on.expr, fn

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -44,10 +44,8 @@ defimpl Ecto.Queryable, for: Atom do
 end
 
 defimpl Ecto.Queryable, for: Tuple do
-  def to_query({source, schema} = from) when is_binary(source) and is_atom(schema) and not is_nil(schema) do
-    %Ecto.Query{
-      from: %Ecto.Query.FromExpr{source: from},
-      prefix: schema.__schema__(:prefix)
-    }
+  def to_query({source, schema} = from)
+      when is_binary(source) and is_atom(schema) and not is_nil(schema) do
+    %Ecto.Query{from: %Ecto.Query.FromExpr{source: from, prefix: schema.__schema__(:prefix)}}
   end
 end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -493,7 +493,7 @@ defmodule Ecto.Repo do
            select: p.title
       MyRepo.all(query)
   """
-  @callback all(queryable :: Ecto.Query.t(), opts :: Keyword.t()) :: [Ecto.Schema.t()] | no_return
+  @callback all(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) :: [Ecto.Schema.t()] | no_return
 
   @doc """
   Returns a lazy enumerable that emits all entries from the data store
@@ -523,7 +523,7 @@ defmodule Ecto.Repo do
         Enum.to_list(stream)
       end)
   """
-  @callback stream(queryable :: Ecto.Query.t(), opts :: Keyword.t()) :: Enum.t()
+  @callback stream(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) :: Enum.t()
 
   @doc """
   Inserts all entries into the repository.

--- a/lib/ecto/repo/assoc.ex
+++ b/lib/ecto/repo/assoc.ex
@@ -89,7 +89,7 @@ defmodule Ecto.Repo.Assoc do
   defp maybe_first(list, _), do: list
 
   defp create_refls(idx, fields, dicts, sources) do
-    {_source, schema} = elem(sources, idx)
+    {_source, schema, _prefix} = elem(sources, idx)
 
     Enum.map(:lists.zip(dicts, fields), fn
       {{_primary_keys, _cache, dict, sub_dicts}, {field, {child_idx, child_fields}}} ->
@@ -103,7 +103,7 @@ defmodule Ecto.Repo.Assoc do
       create_accs(child_idx, child_fields, sources, %{})
     end)
 
-    {_source, schema} = elem(sources, idx)
+    {_source, schema, _prefix} = elem(sources, idx)
     {schema.__schema__(:primary_key), %{}, initial_dict, acc}
   end
 end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -50,11 +50,10 @@ defmodule Ecto.Schema do
 
     * `@schema_prefix` - configures the schema prefix. Defaults to `nil`,
       which generates structs and queries without prefix. When set, the
-      prefix will be used by every built struct and on queries where the
-      current schema is used in `from` (and only `from` exclusively). If
-      a schema is used as a join or part of an assoc, `@schema_prefix` won't
-      be obeyed. In PostgreSQL, the prefix is called "SCHEMA" (typically
-      set via Postgres' `search_path`). In MySQL the prefix points to databases.
+      prefix will be used by every built struct and on queries whenever
+      the schema is used in a `from` or a `join`. In PostgreSQL, the prefix
+      is called "SCHEMA" (typically set via Postgres' `search_path`).
+      In MySQL the prefix points to databases.
 
     * `@foreign_key_type` - configures the default foreign key type
       used by `belongs_to` associations. Defaults to `:id`;
@@ -515,8 +514,10 @@ defmodule Ecto.Schema do
 
         def __schema__(:query) do
           %Ecto.Query{
-            from: %Ecto.Query.FromExpr{source: {unquote(source), __MODULE__}},
-            prefix: unquote(prefix)
+            from: %Ecto.Query.FromExpr{
+              source: {unquote(source), __MODULE__},
+              prefix: unquote(prefix)
+            }
           }
         end
 

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -601,16 +601,6 @@ defmodule Ecto.AssociationTest do
                         where: e.author_id == a.id, distinct: true)
   end
 
-  describe "prefixes" do
-    test "respects the join prefix" do
-      query = from a in Author, join: p in assoc(a, :posts_with_prefix), prefix: "custom"
-      assert hd(query.joins).prefix == "custom"
-
-      query = from a in Author, join: p in assoc(a, :comments_with_prefix), prefix: "custom"
-      assert hd(query.joins).prefix == "custom"
-    end
-  end
-
   ## Integration tests through Ecto
 
   test "build/2" do

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -601,6 +601,16 @@ defmodule Ecto.AssociationTest do
                         where: e.author_id == a.id, distinct: true)
   end
 
+  describe "prefixes" do
+    test "respects the join prefix" do
+      query = from a in Author, join: p in assoc(a, :posts_with_prefix), prefix: "custom"
+      assert hd(query.joins).prefix == "custom"
+
+      query = from a in Author, join: p in assoc(a, :comments_with_prefix), prefix: "custom"
+      assert hd(query.joins).prefix == "custom"
+    end
+  end
+
   ## Integration tests through Ecto
 
   test "build/2" do
@@ -692,8 +702,8 @@ defmodule Ecto.AssociationTest do
 
   test "assoc/2 with prefixes" do
     author = %Author{id: 1}
-    assert Ecto.assoc(author, :posts_with_prefix).prefix == "my_prefix"
-    assert Ecto.assoc(author, :comments_with_prefix).prefix == "my_prefix"
+    assert Ecto.assoc(author, :posts_with_prefix).from.prefix == "my_prefix"
+    assert Ecto.assoc(author, :comments_with_prefix).from.prefix == "my_prefix"
   end
 
   test "assoc/2 filters nil ids" do

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -121,7 +121,7 @@ defmodule Ecto.Query.Builder.JoinTest do
   end
 
   test "raises on mix of valid and invalid options passed to join/5" do
-    assert_raise ArgumentError, ~r/invalid options passed/, fn ->
+    assert_raise ArgumentError, ~r/invalid option `foo` passed/, fn ->
       escape(quote do
         join("posts", :left, [p], c in "comments", on: true, foo: :bar)
       end, [], __ENV__)
@@ -138,6 +138,20 @@ defmodule Ecto.Query.Builder.JoinTest do
     assert_raise Ecto.Query.CompileError, ~r/`as` must be a compile time atom/, fn ->
       escape(quote do
         join("posts", :left, [p], c in "comments", on: true, as: atom)
+      end, [], __ENV__)
+    end
+  end
+
+  test "raises on non-string prefix" do
+    assert_raise Ecto.Query.CompileError, ~r/`prefix` must be a compile time string/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in "comments", on: true, prefix: :atom)
+      end, [], __ENV__)
+    end
+
+    assert_raise Ecto.Query.CompileError, ~r/`prefix` must be a compile time string/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in "comments", on: true, prefix: string)
       end, [], __ENV__)
     end
   end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -97,6 +97,9 @@ defmodule Ecto.Query.InspectTest do
   end
 
   test "as" do
+    assert i(from(x in Post, as: :post)) ==
+      ~s{from p in Inspect.Post, as: :post}
+
     assert i(from(x in Post, join: y in Comment, as: :comment, on: x.id == y.id)) ==
       ~s{from p in Inspect.Post, join: c in Inspect.Comment, as: :comment, on: p.id == c.id}
 
@@ -105,6 +108,20 @@ defmodule Ecto.Query.InspectTest do
 
     assert i(from(x in Post, join: y in subquery(Comment), as: :comment, on: x.id == y.id)) ==
       ~s{from p in Inspect.Post, join: c in subquery(from c in Inspect.Comment), as: :comment, on: p.id == c.id}
+  end
+
+  test "prefix" do
+    assert i(from(x in Post, prefix: "post")) ==
+      ~s{from p in Inspect.Post, prefix: "post"}
+
+    assert i(from(x in Post, join: y in Comment, prefix: "comment", on: x.id == y.id)) ==
+      ~s{from p in Inspect.Post, join: c in Inspect.Comment, prefix: "comment", on: p.id == c.id}
+
+    assert i(from(x in Post, inner_join: y in fragment("foo ? and ?", x.id, ^1), prefix: "foo", on: y.id == x.id)) ==
+      ~s{from p in Inspect.Post, join: f in fragment("foo ? and ?", p.id, ^1), prefix: "foo", on: f.id == p.id}
+
+    assert i(from(x in Post, join: y in subquery(Comment), prefix: "comment", on: x.id == y.id)) ==
+      ~s{from p in Inspect.Post, join: c in subquery(from c in Inspect.Comment), prefix: "comment", on: p.id == c.id}
   end
 
   test "where" do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -297,8 +297,7 @@ defmodule Ecto.Query.InspectTest do
   end
 
   def plan(query) do
-    {query, _params, _key} = Ecto.Query.Planner.prepare(query, :all, Ecto.TestAdapter, 0)
-    {query, _} = Ecto.Query.Planner.normalize(query, :all, Ecto.TestAdapter, 0)
+    {query, _} = Ecto.Adapter.plan_query(:all, Ecto.TestAdapter, query)
     query
   end
 

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -57,7 +57,7 @@ defmodule Ecto.Query.SubqueryTest do
     {query, params, key} = prepare(from(subquery(Post), []))
     assert %{query: %Ecto.Query{}, params: []} = query.from.source
     assert params == []
-    assert key == [:all, 0, [:all, 0, {"posts", Post, 127044068}]]
+    assert key == [:all, 0, [:all, 0, {"posts", Post, 127044068, nil}]]
 
     posts = from(p in Post, where: p.title == ^"hello")
     query = from(c in Comment, join: p in subquery(posts), on: c.post_id == p.id)
@@ -65,7 +65,7 @@ defmodule Ecto.Query.SubqueryTest do
     assert {"comments", Comment} = query.from.source
     assert [%{source: %{query: %Ecto.Query{}, params: ["hello"]}}] = query.joins
     assert params == ["hello"]
-    assert [[], 0, {:join, [{:inner, [:all|_], _}]}, {"comments", _, _}] = key
+    assert [[], 0, {:join, [{:inner, [:all | _], _}]}, {"comments", _, _, _}] = key
   end
 
   test "prepare: subqueries with association joins" do

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -40,10 +40,12 @@ defmodule Ecto.Query.SubqueryTest do
 
   defp normalize_with_params(query, operation \\ :all) do
     {query, params, _key} = prepare(query, operation)
+
     {query, _} =
       query
       |> Planner.ensure_select(operation == :all)
       |> Planner.normalize(operation, Ecto.TestAdapter, 0)
+
     {query, params}
   end
 

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -225,22 +225,32 @@ defmodule Ecto.SchemaTest do
     assert %SchemaWithPrefix{}.__meta__.prefix == "tenant"
   end
 
-  test "schema prefix in queries" do
+  test "schema prefix in queries from" do
     import Ecto.Query
 
     query = from(SchemaWithPrefix, select: 1)
-    assert query.prefix == "tenant"
+    assert query.from.prefix == "tenant"
 
     query = from({"another_company", SchemaWithPrefix}, select: 1)
-    assert query.prefix == "tenant"
+    assert query.from.prefix == "tenant"
 
     from = SchemaWithPrefix
     query = from(from, select: 1)
-    assert query.prefix == "tenant"
+    assert query.from.prefix == "tenant"
 
     from = {"another_company", SchemaWithPrefix}
     query = from(from, select: 1)
-    assert query.prefix == "tenant"
+    assert query.from.prefix == "tenant"
+  end
+
+  test "schema prefix in queries join" do
+    import Ecto.Query
+
+    query = from("query", join: _ in SchemaWithPrefix, select: 1)
+    assert hd(query.joins).prefix == "tenant"
+
+    query = from("query", join: _ in {"another_company", SchemaWithPrefix}, select: 1)
+    assert hd(query.joins).prefix == "tenant"
   end
 
   ## Composite primary keys

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -54,8 +54,8 @@ defmodule Ecto.TestAdapter do
     {1, nil}
   end
 
-  def execute(_, meta, {:nocache, {op, %{from: %{source: {source, _}}}}}, _params, _opts) do
-    send test_process(), {op, {meta.prefix, source}}
+  def execute(_, _meta, {:nocache, {op, %{prefix: prefix, from: %{source: {source, _}}}}}, _params, _opts) do
+    send test_process(), {op, {prefix, source}}
     {1, nil}
   end
 


### PR DESCRIPTION
Currently there are two backwards incompatible changes in this PR:

  1. Adapter backwards incompatible: Each source in the tuple of sources now have three elements instead of two since we now include the prefix. This means adapters will break when building queries but the fix is trivial and performing the fix means this feature will be supported. See the `create_names` change.

  2. User backwards incompatible: The `@schema_prefix` attribute in schemas now behaves differently but we have not decided this is the way to go yet.