### PR TITLE
New function `count`

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -735,6 +735,20 @@ defmodule Ecto.Integration.RepoTest do
     assert TestRepo.aggregate(query, :count, :visits) == 3
   end
 
+  test "count" do
+    assert TestRepo.count(Post) == 0
+
+    TestRepo.insert!(%Post{visits: 10})
+    TestRepo.insert!(%Post{visits: 12})
+    TestRepo.insert!(%Post{visits: 14})
+
+    assert TestRepo.count("posts") == 3
+
+    TestRepo.insert!(%Post{visits: 14})
+
+    assert TestRepo.count(Post, :visits) == 4
+  end
+
   @tag :insert_cell_wise_defaults
   test "insert all" do
     assert {2, nil} = TestRepo.insert_all("comments", [[text: "1"], %{text: "2", lock_version: 2}])

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -196,6 +196,10 @@ defmodule Ecto.Repo do
         Ecto.Repo.Queryable.aggregate(__MODULE__, @adapter, queryable, aggregate, field, opts)
       end
 
+      def count(queryable, field \\ :id) do
+        Ecto.Repo.Queryable.aggregate(__MODULE__, @adapter, queryable, :count, field, [])
+      end
+
       def insert_all(schema_or_source, entries, opts \\ []) do
         Ecto.Repo.Schema.insert_all(__MODULE__, @adapter, schema_or_source, entries, opts)
       end
@@ -401,6 +405,20 @@ defmodule Ecto.Repo do
   """
   @callback aggregate(queryable :: Ecto.Queryable.t, aggregate :: :avg | :count | :max | :min | :sum,
                       field :: atom, opts :: Keyword.t) :: term | nil
+
+  @doc """
+  Calculates the records over the given `field`.
+
+  ## Examples
+
+      Repo.count(Post)
+
+      Repo.count("posts")
+
+      # Another primary key
+      Repo.count(Post, :title)
+  """
+  @callback count(queryable :: Ecto.Queryable.t, field :: atom) :: integer
 
   @doc """
   Fetches a single result from the query.


### PR DESCRIPTION
i know there is a aggregate function, but i think it is not explicit. I found a lot of examples like this:

```
Repo.one(from p in "people", select: count(p.id))
```

It will be better if has a count function.

It is just a idea. Thanks