### PR TITLE
Fix the deprecated_adapter warning

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -66,7 +66,7 @@ defmodule Ecto.Repo.Supervisor do
       Instead pass the adapter configuration when defining the module:
 
           defmodule #{inspect repo} do
-            use #{inspect repo},
+            use Ecto.Repo,
               otp_app: #{inspect otp_app},
               adapter: #{inspect adapter}
       """


### PR DESCRIPTION
The current warning does not have a functioning code snippet; it suggests `use`ing the module currently being defined, e.g.:

```
Generated ecto app
Compiling 10 files (.ex)
warning: retrieving the :adapter from config files for MachineManager.Repo is deprecated.
Instead pass the adapter configuration when defining the module:

    defmodule MachineManager.Repo do
      use MachineManager.Repo,
        otp_app: :machine_manager,
        adapter: Ecto.Adapters.Postgres

  lib/ecto/repo/supervisor.ex:64: Ecto.Repo.Supervisor.deprecated_adapter/3
  lib/ecto/repo/supervisor.ex:47: Ecto.Repo.Supervisor.compile_config/2
  lib/repo.ex:2: (module)
```