### PR TITLE
Return :error when casting invalid decimals instead of crashing

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -620,7 +620,7 @@ defmodule Ecto.Type do
   def cast(:decimal, term) when is_binary(term) do
     term
     |> Decimal.parse()
-    |> validate_decimal(term)
+    |> validate_decimal()
   end
   def cast(:decimal, term) when is_integer(term) do
     {:ok, Decimal.new(term)}
@@ -629,7 +629,7 @@ defmodule Ecto.Type do
     {:ok, Decimal.from_float(term)}
   end
   def cast(:decimal, %Decimal{} = term) do
-    validate_decimal({:ok, term}, term)
+    validate_decimal({:ok, term})
   end
 
   def cast(:date, term) do
@@ -928,10 +928,8 @@ defmodule Ecto.Type do
     end
   end
 
-  defp validate_decimal({:ok, %Decimal{coef: coef}}, value) when coef in [:inf, :qNaN, :sNaN] do
-    message = "cannot cast #{inspect value} to :decimal. Define custom type to handle NaN or infinite decimals"
-    raise Ecto.CastError, type: :decimal, value: value, message: message
-  end
-
-  defp validate_decimal(other, _), do: other
+  defp validate_decimal({:ok, %Decimal{coef: coef}}) when coef in [:inf, :qNaN, :sNaN],
+    do: :error
+  defp validate_decimal(other),
+    do: other
 end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -105,18 +105,9 @@ defmodule Ecto.TypeTest do
     assert cast(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
     assert cast(:decimal, 1) == {:ok, Decimal.new("1")}
     assert cast(:decimal, Decimal.new("1")) == {:ok, Decimal.new("1")}
-
-    assert_raise Ecto.CastError, ~r{cannot cast "nan" to :decimal}, fn ->
-      cast(:decimal, "nan")
-    end
-
-    assert_raise Ecto.CastError, ~r{cannot cast #Decimal<NaN> to :decimal}, fn ->
-      cast(:decimal, Decimal.new("NaN"))
-    end
-
-    assert_raise Ecto.CastError, ~r{cannot cast #Decimal<Infinity> to :decimal}, fn ->
-      cast(:decimal, Decimal.new("Infinity"))
-    end
+    assert cast(:decimal, "nan") == :error
+    assert cast(:decimal, Decimal.new("NaN")) == :error
+    assert cast(:decimal, Decimal.new("Infinity")) == :error
 
     assert dump(:decimal, "1.0") == :error
     assert dump(:decimal, 1.0) == {:ok, Decimal.new("1.0")}


### PR DESCRIPTION
Ref #2547 

```elixir
Ecto.Changeset.cast({%{}, %{x: :decimal, y: :decimal}}, %{x: "1", y: "nan"}, ~w(x y)a)
#Ecto.Changeset<
  action: nil,
  changes: %{x: #Decimal<1>},
  errors: [y: {"is invalid", [type: :decimal, validation: :cast]}],
  data: %{},
  valid?: false

```