### PR TITLE
Fix Ecto.Schema.has_one foreign_key docs

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -835,7 +835,7 @@ defmodule Ecto.Schema do
   ## Options
 
     * `:foreign_key` - Sets the foreign key, this should map to a field on the
-      other schema, defaults to the underscored name of the current schema
+      other schema, defaults to the underscored name of the current module
       suffixed by `_id`
 
     * `:references`  - Sets the key on the current schema to be used for the


### PR DESCRIPTION
This line confused me (I'm not sure if I just interpreted it incorrectly) because it suggests the schema name is used, as opposed to what actually happens in that it uses the current module name. Consider the following schema definition:

```
defmodule CommentSchema do
  use Ecto.Schema
  schema "comment" do
    has_one :post, Post.active()
  end
end
```
The foreign key will be `comment_schema_id` rather than `comment_id`, so to fix this you need to set the key explicitly with `foreign_key: :comment_id`

I was going to open an issue but thought it would be easier to see the actual line I'm talking about. Perhaps there's more that can be clarified in addition to changing `schema` to `module`?