### PR TITLE
Repo.delete exception not documented

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -928,7 +928,8 @@ defmodule Ecto.Repo do
   Deletes a struct using its primary key.
 
   If the struct has no primary key, `Ecto.NoPrimaryKeyFieldError`
-  will be raised.
+  will be raised. If the struct has been removed from db prior to
+  call, `Ecto.StaleEntryError` will be raised.
 
   It returns `{:ok, struct}` if the struct has been successfully
   deleted or `{:error, changeset}` if there was a validation


### PR DESCRIPTION
If a row is already deleted from db Repo.delete raises Ecto.StaleEntryError.
This change docs this for the API.