### PR TITLE
Allows support for '...' in bindings with select_merge macro

### DIFF
--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -200,7 +200,8 @@ defmodule Ecto.Query.Builder.Select do
       Builder.apply_query(query, __MODULE__, [select], env)
     else
       quote do
-        Builder.Select.merge(unquote(query), unquote(select))
+        query = unquote(query)
+        Builder.Select.merge(query, unquote(select))
       end
     end
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -115,6 +115,16 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert query.select.take == %{0 => {:map, [:title]}}
     end
 
+    test "supports '...' in binding list with no prior select" do
+      query =
+        "posts"
+        |> select_merge([..., p], %{title: p.title})
+
+      assert Macro.to_string(query.select.expr) == "merge(&0, %{title: &0.title()})"
+      assert query.select.params == []
+      assert query.select.take == %{}
+    end
+
     test "raises on incompatible pairs" do
       assert_raise Ecto.QueryError, ~r/those select expressions are incompatible/, fn ->
         from p in "posts",


### PR DESCRIPTION
This PR fixes a bug that causes an exception when '...' is used in the bindings for select_merge. This is done by unquoting the query prior to the `Builder.Select.merge/2` call. Currently, '...' only appears to work when a select_merge is already used previously in the query.

This bug is also in Ecto version 2.2 and maybe earlier.

Resolves #2605 