### PR TITLE
New function `count/0` for `Ecto.Query.API`

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -462,6 +462,8 @@ if Code.ensure_loaded?(Mariaex) do
       [?(, intersperse_map(elems, ?,, &expr(&1, sources, query)), ?)]
     end
 
+    defp expr({:count, _, []}, _sources, _query), do: "count(*)"
+
     defp expr({fun, _, args}, sources, query) when is_atom(fun) and is_list(args) do
       {modifier, args} =
         case args do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -513,6 +513,8 @@ if Code.ensure_loaded?(Postgrex) do
       [?(, intersperse_map(elems, ?,, &expr(&1, sources, query)), ?)]
     end
 
+    defp expr({:count, _, []}, _sources, _query), do: "count(*)"
+
     defp expr({fun, _, args}, sources, query) when is_atom(fun) and is_list(args) do
       {modifier, args} =
         case args do

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -8,7 +8,7 @@ defmodule Ecto.Query.API do
     * Inclusion operator: `in/2`
     * Search functions: `like/2` and `ilike/2`
     * Null check functions: `is_nil/1`
-    * Aggregates: `count/1`, `avg/1`, `sum/1`, `min/1`, `max/1`
+    * Aggregates: `count/0`, `count/1`, `avg/1`, `sum/1`, `min/1`, `max/1`
     * Date/time intervals: `datetime_add/3`, `date_add/3`, `from_now/2`, `ago/2`
     * Inside select: `struct/2`, `map/2`, `merge/2` and literals (map, tuples, lists, etc)
     * General: `fragment/1`, `field/2` and `type/2`
@@ -157,6 +157,13 @@ defmodule Ecto.Query.API do
       from p in Post, select: count(p.id, :distinct)
   """
   def count(value, :distinct), do: doc! [value, :distinct]
+
+  @doc """
+  Counts the entries in the table.
+
+      from p in Post, select: count()
+  """
+  def count, do: doc! []
 
   @doc """
   Takes whichever value is not null, or null if they both are.

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -261,9 +261,15 @@ defmodule Ecto.Query.Builder do
     {expr, params_acc}
   end
 
+  def escape({:count, _, []}, _type, params_acc, _vars, _env) do
+    expr = {:{}, [], [:count, [], []]}
+    {expr, params_acc}
+  end
+
   def escape({:filter, _, [aggregate]}, type, params_acc, vars, env) do
     escape(aggregate, type, params_acc, vars, env)
   end
+
   def escape({:filter, _, [aggregate, filter_expr]}, type, params_acc, vars, env) do
     {aggregate, params_acc} = escape(aggregate, type, params_acc, vars, env)
     {filter_expr, params_acc} = escape(filter_expr, type, params_acc, vars, env)
@@ -820,6 +826,7 @@ defmodule Ecto.Query.Builder do
   # Aggregates
   def quoted_type({:count, _, [_, _]}, _vars), do: :integer
   def quoted_type({:count, _, [_]}, _vars), do: :integer
+  def quoted_type({:count, _, []}, _vars), do: :integer
   def quoted_type({agg, _, [_]}, _vars) when agg in [:avg, :sum], do: :any
   def quoted_type({agg, _, [expr]}, vars) when agg in [:max, :min, :sum] do
     quoted_type(expr, vars)

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -176,6 +176,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert all(query) == ~s{SELECT TRUE FROM `schema` AS s0 LIMIT 3 OFFSET 5}
   end
 
+  test "aggregates" do
+    query = Schema |> select(count()) |> plan()
+    assert all(query) == ~s{SELECT count(*) FROM `schema` AS s0}
+  end
+
   test "aggregate filters" do
     query = Schema |> select([r], count(r.x) |> filter(r.x > 10)) |> plan()
     assert_raise Ecto.QueryError, ~r/MySQL adapter does not support aggregate filters in query/, fn ->

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -119,6 +119,9 @@ defmodule Ecto.Adapters.PostgresTest do
 
     query = Schema |> select([r], count(r.x, :distinct)) |> plan()
     assert all(query) == ~s{SELECT count(DISTINCT s0."x") FROM "schema" AS s0}
+
+    query = Schema |> select([r], count()) |> plan()
+    assert all(query) == ~s{SELECT count(*) FROM "schema" AS s0}
   end
 
   test "aggregate filters" do
@@ -127,6 +130,9 @@ defmodule Ecto.Adapters.PostgresTest do
 
     query = Schema |> select([r], count(r.x) |> filter(r.x > 10 and r.x < 50)) |> plan()
     assert all(query) == ~s{SELECT count(s0."x") FILTER (WHERE (s0."x" > 10) AND (s0."x" < 50)) FROM "schema" AS s0}
+
+    query = Schema |> select([r], count() |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT count(*) FILTER (WHERE s0."x" > 10) FROM "schema" AS s0}
   end
 
   test "distinct" do

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -171,6 +171,7 @@ defmodule Ecto.Query.BuilderTest do
     assert quoted_type({:not, [], [1]}, []) == :boolean
 
     assert quoted_type({:count, [], [1]}, []) == :integer
+    assert quoted_type({:count, [], []}, []) == :integer
     assert quoted_type({:max, [], [1]}, []) == :integer
     assert quoted_type({:avg, [], [1]}, []) == :any
 


### PR DESCRIPTION
### Objective
Create new function `count/0` for `Ecto.Query.API`

```
from(p in Post, select: count()) |> Repo.one

#Ecto.Query<from p in Post, select: count(:*)>                             

00:20:18.358 [debug] QUERY OK source="posts" db=0.4ms                      
SELECT count(*) FROM "posts" AS p0 []                                      
27                                   
iex(27)>   
```

### Information
There is a problem with `count/1` sometimes it can be slower.
See more #2595 

### Acceptance Criteria

- [x] New function in Ecto.Query.API
- [x] New functions Ecto.Query.Builder
- [x] Add new expression in postgres connection
- [x] Update docs
- [x] Add tests