### PR TITLE
Return reasonable error message when has_one with @primary_key false

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -537,7 +537,7 @@ defmodule Ecto.Association.Has do
     }
   end
 
-  defp get_ref(nil, nil, name) do
+  defp get_ref(primary_key, nil, name) when primary_key in [nil, false] do
     raise ArgumentError, "need to set :references option for " <>
       "association #{inspect name} when schema has no primary key"
   end


### PR DESCRIPTION
PR fixes error message on crash when compiling 
```
defmodule MyApp.MySchema do
  use Ecto.Schema

  @primary_key false
  schema "my_schemas" do
    has_one :other_schema, MyApp.MyOtherSchema
  end
end
```

```
== Compilation error in file lib/my_schema.ex ==
** (ArgumentError) argument error
    :erlang.element(1, false)
    lib/ecto/association.ex:498: Ecto.Association.Has.get_ref/3
    lib/ecto/association.ex:448: Ecto.Association.Has.struct/3
    lib/ecto/schema.ex:1400: Ecto.Schema.association/5
    lib/ecto/schema.ex:1570: Ecto.Schema.__has_one__/4
    lib/my_schema.ex:7: (module)
```