### PR TITLE
OVER, PARTITION BY and WINDOW

### DIFF
--- a/integration_test/cases/windows.exs
+++ b/integration_test/cases/windows.exs
@@ -1,0 +1,48 @@
+defmodule Ecto.Integration.WindowsTest do
+  use Ecto.Integration.Case, async: Application.get_env(:ecto, :async_integration_tests, true)
+
+  alias Ecto.Integration.TestRepo
+  import Ecto.Query
+
+  alias Ecto.Integration.Comment
+  alias Ecto.Integration.User
+
+  test "count over partition" do
+    u1 = TestRepo.insert!(%User{name: "Tester"})
+    u2 = TestRepo.insert!(%User{name: "Developer"})
+    c1 = TestRepo.insert!(%Comment{text: "1", author_id: u1.id})
+    c2 = TestRepo.insert!(%Comment{text: "2", author_id: u1.id})
+    c3 = TestRepo.insert!(%Comment{text: "3", author_id: u1.id})
+    c4 = TestRepo.insert!(%Comment{text: "4", author_id: u2.id})
+
+    query = from(c in Comment, select: [c, count(c.id) |> over(partition_by(c.author_id))])
+
+    assert [[^c1, 3], [^c2, 3], [^c3, 3], [^c4, 1]] = TestRepo.all(query)
+  end
+
+  test "last 2 of each author" do
+    u1 = TestRepo.insert!(%User{name: "Tester"})
+    u2 = TestRepo.insert!(%User{name: "Developer"})
+    TestRepo.insert!(%Comment{text: "1", author_id: u1.id})
+    TestRepo.insert!(%Comment{text: "2", author_id: u1.id})
+    TestRepo.insert!(%Comment{text: "3", author_id: u1.id})
+    TestRepo.insert!(%Comment{text: "4", author_id: u2.id})
+
+    subquery = from(c in Comment,
+      windows: [rw: partition_by(c.author_id, order_by: :id)],
+      select: %{
+        comment: c.text,
+        row: row_number() |> over(:rw),
+        total: count(c.id) |> over(partition_by(c.author_id))
+      },
+      where: c.author_id in [^u1.id, ^u2.id]
+    )
+
+    query = from(r in subquery(subquery),
+      select: r.comment,
+      where: (r.total - r.row) < 2
+    )
+
+    assert ["2", "3", "4"] = TestRepo.all(query)
+  end
+end

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -177,6 +177,168 @@ defmodule Ecto.Query.API do
   def coalesce(value, expr), do: doc! [value, expr]
 
   @doc """
+  Invokes specified aggregation function in context of window.
+
+  Accepts any built-in or user-defined aggregate function as well as window functions.
+
+  `window` can be either existing window name or `partition_by/2` expression.
+  """
+  def over(agg_fun, window), do: doc! [agg_fun, window]
+
+  @doc """
+  Defines a partition for `over` or `window` clause.
+
+  `fields` can be either atom or a list of atoms and refers
+  fields in the source which will be used for grouping rows.
+
+  You can also specify an `:order_by` option which syntax and behaviour
+  are similar to `Ecto.Query.order_by/2` except the fact that it affects
+  rows only inside the window.
+
+      from e in Employee,
+           select: {
+             e.depname,
+             e.empno,
+             row_number() |> over(partition_by(e.depname, order_by: e.name))
+           }
+  """
+  def partition_by(fields, opts), do: doc! [fields, opts]
+
+  @doc """
+  Returns number of the current row within its partition, counting from 1.
+
+      from p in Post,
+           select: row_number() |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def row_number(), do: doc! []
+
+  @doc """
+  Returns rank of the current row with gaps; same as `row_number/0` of its first peer.
+
+      from p in Post,
+           select: rank() |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def rank(), do: doc! []
+
+  @doc """
+  Returns rank of the current row without gaps; this function counts peer groups.
+
+      from p in Post,
+           select: dense_rank() |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def dense_rank(), do: doc! []
+
+  @doc """
+  Returns relative rank of the current row: (rank - 1) / (total rows - 1).
+
+      from p in Post,
+           select: percent_rank() |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def percent_rank(), do: doc! []
+
+  @doc """
+  Returns relative rank of the current row:
+  (number of rows preceding or peer with current row) / (total rows).
+
+      from p in Post,
+           select: cume_dist() |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def cume_dist(), do: doc! []
+
+  @doc """
+  Returns integer ranging from 1 to the argument value, dividing the partition as equally as possible.
+
+      from p in Post,
+           select: ntile(10) |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def ntile(num_buckets), do: doc! [num_buckets]
+
+  @doc """
+  Returns value evaluated at the row that is the first row of the window frame.
+
+      from p in Post,
+           select: first_value(p.id) |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def first_value(value), do: doc! [value]
+
+  @doc """
+  Returns value evaluated at the row that is the last row of the window frame.
+
+      from p in Post,
+           select: last_value(p.id) |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def last_value(value), do: doc! [value]
+
+  @doc """
+  Returns value evaluated at the row that is the nth row of the window
+  frame (counting from 1); null if no such row.
+
+      from p in Post,
+           select: nth_value(p.id, 4) |> over(partition_by(p.category_id, order_by: p.date))
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def nth_value(value, nth), do: doc! [value, nth]
+
+  @doc """
+  Returns value evaluated at the row that is offset rows before
+  the current row within the partition; if there is no such row,
+  instead return default (which must be of the same type as value).
+  Both offset and default are evaluated with respect to the current row.
+  If omitted, offset defaults to 1 and default to null.
+
+      from e in Events,
+           windows: [w: partition_by(e.name, order_by: e.tick)],
+           select: {
+             e.tick,
+             e.action,
+             e.name,
+             lag(e.action) |> over(:w), # previous_action
+             lead(e.action) |> over(:w) # next_action
+           }
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def lag(value, offset, default), do: doc! [value, offset, default]
+
+  @doc """
+  Returns value evaluated at the row that is offset rows after
+  the current row within the partition; if there is no such row,
+  instead return default (which must be of the same type as value).
+  Both offset and default are evaluated with respect to the current row.
+  If omitted, offset defaults to 1 and default to null.
+
+      from e in Events,
+           windows: [w: partition_by(e.name, order_by: e.tick)],
+           select: {
+             e.tick,
+             e.action,
+             e.name,
+             lag(e.action) |> over(:w), # previous_action
+             lead(e.action) |> over(:w) # next_action
+           }
+
+  Note that this function must be invoked using window function syntax.
+  """
+  def lead(value, offset, default), do: doc! [value, offset, default]
+
+  @doc """
   Applies the given expression as a FILTER clause against an
   aggregate. This is currently only supported by Postgres.
 

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -1,0 +1,98 @@
+import Kernel, except: [apply: 2]
+
+defmodule Ecto.Query.Builder.Windows do
+  @moduledoc false
+
+  alias Ecto.Query.Builder
+  alias Ecto.Query.Builder.OrderBy
+
+  @doc """
+  Escapes a window params.
+
+  ## Examples
+
+      iex> escape(quote do [x.x, [order_by: [desc: 13]]] end, {%{}, :acc}, [x: 0], __ENV__)
+      {[
+         fields: [
+           {:{}, [],
+            [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :x]]}, [], []]}
+         ],
+         order_by: [desc: 13]
+       ], {%{}, :acc}}
+
+  """
+  @spec escape([Macro.t], {map, term}, Keyword.t, Macro.Env.t | {Macro.Env.t, fun}) :: {Macro.t, {map, term}}
+  def escape(args, params_acc, vars, env) do
+    {fields_exp, opts} = escape_args(args)
+    {fields, params_acc} = Builder.escape(fields_exp, :any, params_acc, vars, env)
+    {opts, params_acc} = Enum.map_reduce(opts, params_acc, &escape_option(&1, &2, vars, env))
+    {[{:fields, fields} | opts], params_acc}
+  end
+
+  defp escape_args([fields, opts]) when is_list(opts), do: {List.wrap(fields), opts}
+  defp escape_args([fields]), do: {List.wrap(fields), []}
+
+  defp escape_option({:order_by, expr}, params_acc, vars, env) do
+    {expr, _} = OrderBy.escape(:order_by, expr, vars, env)
+    {{:order_by, expr}, params_acc}
+  end
+
+  @spec escape_window(Macro.t, {map, term}, Keyword.t, Macro.Env.t | {Macro.Env.t, fun}) :: {Macro.t, {map, term}}
+  def escape_window(expr, params_acc, vars, {env, _}) do
+    escape_window(expr, params_acc, vars, env)
+  end
+
+  def escape_window(expr, params_acc, vars, env) do
+    {expr, params_acc} = escape(expr, params_acc, vars, env)
+    params = Builder.escape_params(elem(params_acc, 0))
+
+    window = quote do: %Ecto.Query.QueryExpr{
+                     expr: unquote(expr),
+                     params: unquote(params),
+                     file: unquote(env.file),
+                     line: unquote(env.line)}
+    {window, params_acc}
+  end
+
+  @doc """
+  Builds a quoted expression.
+
+  The quoted expression should evaluate to a query at runtime.
+  If possible, it does all calculations at compile time to avoid
+  runtime work.
+  """
+  @spec build(Macro.t, [Macro.t], Keyword.t, Macro.Env.t) :: Macro.t
+  def build(query, binding, windows, env) when is_list(windows) do
+    {query, binding} = Builder.escape_binding(query, binding, env)
+    windows = Enum.map(windows, &build_window(binding, &1, env))
+    Builder.apply_query(query, __MODULE__, [windows], env)
+  end
+
+  defp build_window(vars, {name, {:partition_by, _, expr}}, env) do
+    {window, _} = escape_window(expr, {%{}, :acc}, vars, env)
+    {name, window}
+  end
+
+  @spec validate_windows!(Keyword.t, Keyword.t) :: Tuple.t
+  def validate_windows!([], _), do: :ok
+  def validate_windows!([{name, _} | rest], windows) do
+    if Keyword.has_key?(windows, name) do
+      Builder.error! "window with name #{name} is already defined"
+    end
+
+    validate_windows!(rest, windows)
+  end
+
+  @doc """
+  The callback applied by `build/4` to build the query.
+  """
+  @spec apply(Ecto.Queryable.t, Keyword.t) :: Ecto.Query.t
+  def apply(%Ecto.Query{windows: windows} = query, definitions) do
+    validate_windows!(definitions, windows)
+    %{query | windows: windows ++ definitions}
+  end
+
+  def apply(query, definitions) do
+    apply(Ecto.Queryable.to_query(query), definitions)
+  end
+end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -4,7 +4,7 @@ defmodule Ecto.Query.Planner do
 
   alias Ecto.Query.{BooleanExpr, DynamicExpr, JoinExpr, QueryExpr, SelectExpr}
 
-  if map_size(%Ecto.Query{}) != 18 do
+  if map_size(%Ecto.Query{}) != 19 do
     raise "Ecto.Query match out of date in builder"
   end
 
@@ -577,6 +577,20 @@ defmodule Ecto.Query.Planner do
     end
   end
 
+  defp merge_cache(:windows, query, exprs, {cache, params}, adapter) do
+    {expr_cache, {params, cacheable?}} =
+      Enum.map_reduce exprs, {params, true}, fn {_, expr}, {params, cacheable?} ->
+        {params, current_cacheable?} = cast_and_merge_params(:windows, query, expr, params, adapter)
+        {expr_to_cache(expr), {params, cacheable? and current_cacheable?}}
+      end
+
+    case expr_cache do
+      [] -> {cache, params}
+      _  -> {merge_cache({:windows, expr_cache}, cache, cacheable?), params}
+    end
+  end
+
+
   defp expr_to_cache(%BooleanExpr{op: op, expr: expr}), do: {op, expr}
   defp expr_to_cache(%QueryExpr{expr: expr}), do: expr
   defp expr_to_cache(%SelectExpr{expr: expr}), do: expr
@@ -792,6 +806,18 @@ defmodule Ecto.Query.Planner do
       {on, acc} = prewalk(:join, query, join.on, acc, adapter)
       {%{join | on: on, source: source, params: nil}, acc}
     end
+  end
+
+  defp validate_and_increment(:windows, query, exprs, counter, _operation, adapter) do
+    {exprs, counter} =
+      Enum.reduce(exprs, {[], counter}, fn
+        {_, %{expr: []}}, {list, acc} ->
+          {list, acc}
+        {name, expr}, {list, acc} ->
+          {expr, acc} = prewalk(:windows, query, expr, acc, adapter)
+          {[{name, expr}|list], acc}
+      end)
+    {Enum.reverse(exprs), counter}
   end
 
   defp prewalk_source({:fragment, meta, fragments}, kind, query, expr, acc, adapter) do
@@ -1023,6 +1049,29 @@ defmodule Ecto.Query.Planner do
     {type, [expr | fields], from}
   end
 
+  # OVER ()
+  defp collect_fields({:over, _, [call, nil]} = expr, fields, from, query, take) do
+    {type, _, _} = collect_fields(call, fields, from, query, take)
+    {type, [expr | fields], from}
+  end
+
+  # OVER named_window
+  defp collect_fields({:over, _, [call, window_name]} = expr,
+                      fields, from, %Ecto.Query{ windows: windows } = query, take) when is_atom(window_name) do
+    if Keyword.has_key?(windows, window_name) do
+      {type, _, _} = collect_fields(call, fields, from, query, take)
+      {type, [expr | fields], from}
+    else
+      error!(query, "the window :#{window_name} must be defined in `windows`")
+    end
+  end
+
+  # OVER (PARTITION BY ...)
+  defp collect_fields({:over, _, [call, _]} = expr, fields, from, query, take) do
+    {type, _, _} = collect_fields(call, fields, from, query, take)
+    {type, [expr | fields], from}
+  end
+
   defp collect_fields({{:., dot_meta, [{:&, _, [_]}, _]}, _, []} = expr,
                       fields, from, _query, _take) do
     {{:value, Keyword.fetch!(dot_meta, :type)}, [expr | fields], from}
@@ -1213,7 +1262,7 @@ defmodule Ecto.Query.Planner do
   ## Helpers
 
   @exprs [distinct: :distinct, select: :select, from: :from, join: :joins,
-          where: :wheres, group_by: :group_bys, having: :havings,
+          where: :wheres, group_by: :group_bys, having: :havings, windows: :windows,
           order_by: :order_bys, limit: :limit, offset: :offset]
 
   # Traverse all query components with expressions.

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -438,6 +438,112 @@ defmodule Ecto.Adapters.MySQLTest do
     assert delete_all(query) == ~s{DELETE s0.* FROM `first`.`schema` AS s0}
   end
 
+  ## Partitions and windows
+
+  test "one window" do
+    query = Schema
+            |> select([r], r.x)
+            |> windows([r], w: partition_by r.x)
+            |> plan
+
+    assert all(query) == ~s{SELECT s0.`x` FROM `schema` AS s0 WINDOW `w` AS (PARTITION BY s0.`x`)}
+  end
+
+  test "two windows" do
+    query = Schema
+            |> select([r], r.x)
+            |> windows([r], w1: partition_by(r.x), w2: partition_by(r.y))
+            |> plan()
+    assert all(query) == ~s{SELECT s0.`x` FROM `schema` AS s0 WINDOW `w1` AS (PARTITION BY s0.`x`), `w2` AS (PARTITION BY s0.`y`)}
+  end
+
+  test "multifiled partition by" do
+    query = Schema
+            |> windows([r], w: partition_by [r.x, r.z])
+            |> select([r], r.x)
+            |> plan()
+    assert all(query) == ~s{SELECT s0.`x` FROM `schema` AS s0 WINDOW `w` AS (PARTITION BY s0.`x`, s0.`z`)}
+  end
+
+  test "count over all" do
+    query = Schema
+            |> select([r], count(r.x) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT count(s0.`x`) OVER () FROM `schema` AS s0}
+  end
+
+  test "row_number over all" do
+    query = Schema
+            |> select(row_number |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT row_number() OVER () FROM `schema` AS s0}
+  end
+
+  test "nth_value over all" do
+    query = Schema
+            |> select([r], nth_value(r.x, 42) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT nth_value(s0.`x`, 42) OVER () FROM `schema` AS s0}
+  end
+
+  test "lag/2 over all" do
+    query = Schema
+            |> select([r], lag(r.x, 42) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT lag(s0.`x`, 42) OVER () FROM `schema` AS s0}
+  end
+
+  test "custom aggregation over all" do
+    query = Schema
+            |> select([r], fragment("custom_function(?)", r.x) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT custom_function(s0.`x`) OVER () FROM `schema` AS s0}
+  end
+
+  test "count over partition by (inline)" do
+    query = Schema
+            |> select([r], count(r.x) |> over(partition_by [r.x, r.z]))
+
+    query = query |> plan()
+    assert all(query) == ~s{SELECT count(s0.`x`) OVER (PARTITION BY s0.`x`, s0.`z`) FROM `schema` AS s0}
+  end
+
+  test "count over window" do
+    query = Schema
+            |> windows([r], w: partition_by r.x)
+            |> select([r], count(r.x) |> over(:w))
+            |> plan()
+    assert all(query) == ~s{SELECT count(s0.`x`) OVER `w` FROM `schema` AS s0 WINDOW `w` AS (PARTITION BY s0.`x`)}
+  end
+
+  test "count over ordered window (keywords)" do
+    param = :b
+    query = from s in Schema,
+                 windows: [w1: partition_by(s.a)],
+                 windows: [w2: partition_by(s.x, order_by: s.a, order_by: [desc: ^param])],
+                 select: (count(s.x) |> over(:w2))
+
+    query = query |> plan()
+    assert all(query) == ~s{SELECT count(s0.`x`) OVER `w2` FROM `schema` AS s0 WINDOW `w1` AS (PARTITION BY s0.`a`), `w2` AS (PARTITION BY s0.`x` ORDER BY s0.`a`, s0.`b` DESC)}
+  end
+
+  test "count over unknown window" do
+    query = Schema
+            |> windows([r], w: partition_by r.x)
+            |> select([r], count(r.x) |> over(:v))
+    assert_raise Ecto.QueryError, fn ->
+      plan(query)
+    end
+  end
+
+  test "count over ordered partition" do
+    fields = [:y]
+    query = Schema
+            |> select([r], count(r.x) |> over(partition_by(r.x, order_by: ^fields, order_by: r.z)))
+            |> plan()
+    assert all(query) == ~s{SELECT count(s0.`x`) OVER (PARTITION BY s0.`x` ORDER BY s0.`y`, s0.`z`) FROM `schema` AS s0}
+  end
+
   ## Joins
 
   test "join" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -544,6 +544,112 @@ defmodule Ecto.Adapters.PostgresTest do
     assert delete_all(query) == ~s{DELETE FROM "first"."schema" AS s0}
   end
 
+  ## Partitions and windows
+
+  test "one window" do
+    query = Schema
+            |> select([r], r.x)
+            |> windows([r], w: partition_by r.x)
+            |> plan
+
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WINDOW "w" AS (PARTITION BY s0."x")}
+  end
+
+  test "two windows" do
+    query = Schema
+            |> select([r], r.x)
+            |> windows([r], w1: partition_by(r.x), w2: partition_by(r.y))
+            |> plan()
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WINDOW "w1" AS (PARTITION BY s0."x"), "w2" AS (PARTITION BY s0."y")}
+  end
+
+  test "multifiled partition by" do
+    query = Schema
+            |> windows([r], w: partition_by [r.x, r.z])
+            |> select([r], r.x)
+            |> plan()
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WINDOW "w" AS (PARTITION BY s0."x", s0."z")}
+  end
+
+  test "count over all" do
+    query = Schema
+            |> select([r], count(r.x) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT count(s0."x") OVER () FROM "schema" AS s0}
+  end
+
+  test "row_number over all" do
+    query = Schema
+            |> select(row_number |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT row_number() OVER () FROM "schema" AS s0}
+  end
+
+  test "nth_value over all" do
+    query = Schema
+            |> select([r], nth_value(r.x, 42) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT nth_value(s0."x", 42) OVER () FROM "schema" AS s0}
+  end
+
+  test "lag/2 over all" do
+    query = Schema
+            |> select([r], lag(r.x, 42) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT lag(s0."x", 42) OVER () FROM "schema" AS s0}
+  end
+
+  test "custom aggregation over all" do
+    query = Schema
+            |> select([r], fragment("custom_function(?)", r.x) |> over)
+            |> plan()
+    assert all(query) == ~s{SELECT custom_function(s0."x") OVER () FROM "schema" AS s0}
+  end
+
+  test "count over partition by (inline)" do
+    query = Schema
+            |> select([r], count(r.x) |> over(partition_by [r.x, r.z]))
+
+    query = query |> plan()
+    assert all(query) == ~s{SELECT count(s0."x") OVER (PARTITION BY s0."x", s0."z") FROM "schema" AS s0}
+  end
+
+  test "count over window" do
+    query = Schema
+            |> windows([r], w: partition_by r.x)
+            |> select([r], count(r.x) |> over(:w))
+            |> plan()
+    assert all(query) == ~s{SELECT count(s0."x") OVER "w" FROM "schema" AS s0 WINDOW "w" AS (PARTITION BY s0."x")}
+  end
+
+  test "count over ordered window (keywords)" do
+    param = :b
+    query = from s in Schema,
+                 windows: [w1: partition_by(s.a)],
+                 windows: [w2: partition_by(s.x, order_by: s.a, order_by: [desc: ^param])],
+                 select: (count(s.x) |> over(:w2))
+
+    query = query |> plan()
+    assert all(query) == ~s{SELECT count(s0."x") OVER "w2" FROM "schema" AS s0 WINDOW "w1" AS (PARTITION BY s0."a"), "w2" AS (PARTITION BY s0."x" ORDER BY s0."a", s0."b" DESC)}
+  end
+
+  test "count over unknown window" do
+    query = Schema
+            |> windows([r], w: partition_by r.x)
+            |> select([r], count(r.x) |> over(:v))
+    assert_raise Ecto.QueryError, fn ->
+      plan(query)
+    end
+  end
+
+  test "count over ordered partition" do
+    fields = [:y]
+    query = Schema
+            |> select([r], count(r.x) |> over(partition_by(r.x, order_by: ^fields, order_by: r.z)))
+            |> plan()
+    assert all(query) == ~s{SELECT count(s0."x") OVER (PARTITION BY s0."x" ORDER BY s0."y", s0."z") FROM "schema" AS s0}
+  end
+
   ## Joins
 
   test "join" do

--- a/test/ecto/query/builder/windows_test.exs
+++ b/test/ecto/query/builder/windows_test.exs
@@ -1,0 +1,39 @@
+defmodule Ecto.Query.Builder.WindowsTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Query.Builder.Windows
+  doctest Ecto.Query.Builder.Windows
+
+  import Ecto.Query
+
+  defp escape(quoted, vars, env) do
+    {escaped, {params, :acc}} = escape(quoted, {%{}, :acc}, vars, env)
+    {escaped, params}
+  end
+
+  describe "escape" do
+    test "handles expressions and params" do
+      assert {Macro.escape(quote do [fields: [&0.x]] end), %{}} ==
+             escape(quote do [x.x] end, [x: 0], __ENV__)
+
+      assert {Macro.escape(quote do [fields: [&0.x, &0.y]] end), %{}} ==
+             escape(quote do [[x.x, x.y]] end, [x: 0], __ENV__)
+
+      assert {Macro.escape(quote do [fields: [&0.x], order_by: [asc: &0.y]] end), %{}} ==
+             escape(quote do [x.x, [order_by: x.y]] end, [x: 0], __ENV__)
+
+      assert {Macro.escape(quote do [fields: [&0.x, &0.z], order_by: [asc: &0.y]] end), %{}} ==
+             escape(quote do [[x.x, x.z], [order_by: x.y]] end, [x: 0], __ENV__)
+
+      assert {Macro.escape(quote do [fields: [&0.x], order_by: [asc: &0.y], order_by: [asc: &0.z]] end), %{}} ==
+             escape(quote do [x.x, [order_by: x.y, order_by: x.z]] end, [x: 0], __ENV__)
+    end
+
+    test "raises on duplicate window" do
+      query = "q" |> windows([p], w: partition_by p.x)
+      assert_raise Ecto.Query.CompileError, ~r"window with name w is already defined", fn ->
+        query |> windows([p], w: partition_by p.y)
+      end
+    end
+  end
+end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -144,6 +144,34 @@ defmodule Ecto.Query.InspectTest do
            ~s{from p in Inspect.Post, having: p.foo == p.bar, having: true}
   end
 
+  test "window" do
+    assert i(from(x in Post, windows: [a: partition_by x.foo])) ==
+           ~s{from p in Inspect.Post, windows: [a: partition_by([p.foo])]}
+
+    assert i(from(x in Post, windows: [a: partition_by(x.foo), b: partition_by(x.bar)])) ==
+           ~s{from p in Inspect.Post, windows: [a: partition_by([p.foo])], windows: [b: partition_by([p.bar])]}
+
+    assert i(from(x in Post, windows: [a: partition_by(x.foo)], windows: [b: partition_by(x.bar)])) ==
+           ~s{from p in Inspect.Post, windows: [a: partition_by([p.foo])], windows: [b: partition_by([p.bar])]}
+
+    assert i(from(x in Post, windows: [a: partition_by(x.foo, order_by: x.bar)])) ==
+             ~s{from p in Inspect.Post, windows: [a: partition_by([p.foo], order_by: [asc: p.bar])]}
+
+    assert i(from(x in Post, windows: [a: partition_by([x.foo, x.bar], order_by: x.bar)])) ==
+             ~s{from p in Inspect.Post, windows: [a: partition_by([p.foo, p.bar], order_by: [asc: p.bar])]}
+  end
+
+  test "over" do
+    assert i(from(x in Post, select: count(x.x) |> over)) ==
+           ~s{from p in Inspect.Post, select: over(count(p.x))}
+
+    assert i(from(x in Post, select: count(x.x) |> over(partition_by(x.bar)))) ==
+           ~s{from p in Inspect.Post, select: over(count(p.x), partition_by([p.bar]))}
+
+    assert i(from(x in Post, select: count(x.x) |> over(partition_by([x.foo, x.bar], order_by: x.bar)))) ==
+           ~s{from p in Inspect.Post, select: over(count(p.x), partition_by([p.foo, p.bar], order_by: [asc: p.bar]))}
+  end
+
   test "order by" do
     assert i(from(x in Post, order_by: [asc: x.foo, desc: x.bar], order_by: x.foobar)) ==
            ~s{from p in Inspect.Post, order_by: [asc: p.foo, desc: p.bar], order_by: [asc: p.foobar]}


### PR DESCRIPTION
Hi

PR implements window functions for PostgreSQL.
It can be used instead of fragments for the more clear and flexible solution of problems like https://github.com/coderplanets/coderplanets_server/issues/16 or https://github.com/absinthe-graphql/absinthe_relay/issues/100#issuecomment-357557000
```elixir
# SELECT row_number(s0."x") OVER () FROM "schema" AS s0
Schema |> select([r], row_number(r.x) |> over)

# SELECT count(s0."x") OVER w FROM "schema" AS s0 WINDOW w AS (PARTITION BY s0."x" ORDER BY s0."a", s0."b")
from s in Schema,
  window: (w as partition_by s.x, order_by: [s.a, s.b]),
  select: (count(s.x) |> over(w))

# SELECT count(s0."x") OVER (PARTITION BY s0."x" ORDER BY s0."y") FROM "schema" AS s0
partition = partition_by([r], r.x) |> order_by([r], r.y)
Schema |> select([r], count(r.x) |> over(^partition))
```

MySQL also supports window functions since 8.0, but we don't know version at compile time. So I can add the same implementation, but it will throw runtime errors if a user uses MySQL <8, or I can add compile-time errors like "… is not supported by MySQL".

If you are ok with this feature, I will add documentation and some more unit tests.

- [x] traverse of `:windows`
- [x] inspect
- [x] MySQL
- [x] tests
- [x] documentation
