### PR TITLE
Fix Mix.Ecto.ensure_started/2 specs

### DIFF
--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -79,7 +79,7 @@ defmodule Mix.Ecto do
   @doc """
   Ensures the given repository is started and running.
   """
-  @spec ensure_started(Ecto.Repo.t, Keyword.t) :: {:ok, pid, [atom]}
+  @spec ensure_started(Ecto.Repo.t, Keyword.t) :: {:ok, pid | nil, [atom]}
   def ensure_started(repo, opts) do
     {:ok, started} = Application.ensure_all_started(:ecto)
 


### PR DESCRIPTION
Function can return pid or nil as the second item in the 3-elements tuple.

I have used this function in my project and copied `pid && repo.stop(pid)` pattern from migration task. Dialyzer was complaining that `pid` cannot be false.