### PR TITLE
Parsing "infinity" in Repo url config

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -64,7 +64,7 @@ defmodule Ecto.Repo do
   options `ssl`, `timeout`, `pool_timeout`, `pool_size`:
 
     config :my_app, Repo,
-        url: "ecto://postgres:postgres@localhost/ecto_simple?ssl=true&pool_size=10"
+        url: "ecto://postgres:postgres@localhost/ecto_simple?ssl=true&pool_size=10&timeout=infinity&pool_timeout=infinity"
 
   In case the URL needs to be dynamically configured, for example by
   reading a system environment variable, such can be done via the

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -124,6 +124,12 @@ defmodule Ecto.Repo.Supervisor do
       {"ssl", "false"}, acc ->
         [{:ssl, false}] ++ acc
 
+      {"pool_timeout", "infinity"}, acc ->
+        [{:pool_timeout, :infinity}] ++ acc
+
+      {"timeout", "infinity"}, acc ->
+        [{:timeout, :infinity}] ++ acc
+
       {key, value}, acc when key in @integer_url_query_params ->
         [{String.to_atom(key), parse_integer!(key, value, url)}] ++ acc
 

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -120,4 +120,10 @@ defmodule Ecto.Repo.SupervisorTest do
       end
     end
   end
+
+  test "parse_url accepts infinity in timeouts" do
+    url = parse_url("ecto://host:12345/mydb?pool_timeout=infinity&timeout=infinity")
+    assert {:pool_timeout, :infinity} in url
+    assert {:timeout, :infinity} in url
+  end
 end


### PR DESCRIPTION
With these changes an user can specify `"infinity"` for `pool_timeout` and `timeout` in Repo's URL config.