### PR TITLE
Allows `--protocol` to be configurable for the `mysql` cmd

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -30,6 +30,7 @@ defmodule Ecto.Adapters.MySQL do
     * `:port` - Server port (default: 3306)
     * `:username` - Username
     * `:password` - User password
+    * `:protocol` - Protocol used for the mysql client connection (default: tcp)
     * `:ssl` - Set to true if ssl should be used (default: false)
     * `:ssl_opts` - A list of ssl options, see Erlang's `ssl` docs
     * `:parameters` - Keyword list of connection parameters
@@ -333,9 +334,18 @@ defmodule Ecto.Adapters.MySQL do
         []
       end
 
-    host = opts[:hostname] || System.get_env("MYSQL_HOST") || "localhost"
-    port = opts[:port] || System.get_env("MYSQL_TCP_PORT") || "3306"
-    args = ["--user", opts[:username], "--host", host, "--port", to_string(port), "--protocol=tcp"] ++ opt_args
+    host     = opts[:hostname] || System.get_env("MYSQL_HOST") || "localhost"
+    port     = opts[:port] || System.get_env("MYSQL_TCP_PORT") || "3306"
+    protocol = opts[:protocol] || System.get_env("MYSQL_PROTOCOL") || "tcp"
+
+    args =
+      [
+        "--user", opts[:username],
+        "--host", host,
+        "--port", to_string(port),
+        "--protocol", protocol
+      ] ++ opt_args
+
     System.cmd(cmd, args, env: env, stderr_to_stdout: true)
   end
 end

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -30,16 +30,15 @@ defmodule Ecto.Adapters.MySQL do
     * `:port` - Server port (default: 3306)
     * `:username` - Username
     * `:password` - User password
-    * `:protocol` - Protocol used for the mysql client connection (default: tcp)
     * `:ssl` - Set to true if ssl should be used (default: false)
     * `:ssl_opts` - A list of ssl options, see Erlang's `ssl` docs
     * `:parameters` - Keyword list of connection parameters
     * `:connect_timeout` - The timeout for establishing new connections (default: 5000)
     * `:socket_options` - Specifies socket configuration
-
-  The `:protocol` option is only used for `ecto.load` and `ecto.dump`, via
-  the `mysql` command. For more information please check out the [MySQL
-  documentation](https://dev.mysql.com/doc/en/connecting.html).
+    * `:protocol` - The protocol used for the mysql client connection (default: tcp).
+      This option is only used for `mix ecto.load` and `mix ecto.dump`,
+      via the `mysql` command. For more information, please check
+      [MySQL docs](https://dev.mysql.com/doc/en/connecting.html)
 
   The `:socket_options` are particularly useful when configuring the size
   of both send and receive buffers. For example, when Ecto starts with a

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -37,6 +37,10 @@ defmodule Ecto.Adapters.MySQL do
     * `:connect_timeout` - The timeout for establishing new connections (default: 5000)
     * `:socket_options` - Specifies socket configuration
 
+  The `:protocol` option is only used for `ecto.load` and `ecto.dump`, via
+  the `mysql` command. For more information please check out the [MySQL
+  documentation](https://dev.mysql.com/doc/en/connecting.html).
+
   The `:socket_options` are particularly useful when configuring the size
   of both send and receive buffers. For example, when Ecto starts with a
   pool of 20 connections, the memory usage may quickly grow from 20MB to

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -35,7 +35,7 @@ defmodule Ecto.Adapters.MySQL do
     * `:parameters` - Keyword list of connection parameters
     * `:connect_timeout` - The timeout for establishing new connections (default: 5000)
     * `:socket_options` - Specifies socket configuration
-    * `:protocol` - The protocol used for the mysql client connection (default: tcp).
+    * `:cli_protocol` - The protocol used for the mysql client connection (default: tcp).
       This option is only used for `mix ecto.load` and `mix ecto.dump`,
       via the `mysql` command. For more information, please check
       [MySQL docs](https://dev.mysql.com/doc/en/connecting.html)
@@ -339,7 +339,7 @@ defmodule Ecto.Adapters.MySQL do
 
     host     = opts[:hostname] || System.get_env("MYSQL_HOST") || "localhost"
     port     = opts[:port] || System.get_env("MYSQL_TCP_PORT") || "3306"
-    protocol = opts[:protocol] || System.get_env("MYSQL_PROTOCOL") || "tcp"
+    protocol = opts[:cli_protocol] || System.get_env("MYSQL_CLI_PROTOCOL") || "tcp"
 
     args =
       [


### PR DESCRIPTION
Hi,

Today I ran into an issue that took me hours to figure out. I was trying to use `mix ecto.load` to load a schema file, after seeing the file's successfully loaded message, I checked the database and saw nothing was imported.

I dug into the code to see what goes behind the scenes of `ecto.load`, and noticed that it uses the `mysql` command. So I ran the `mysql` command manually and it imported correctly.

Then I started debugging what exactly was the command generated by the ecto's mysql adapter. It turns out, the `--protocol=tcp` part was the culprit. As for my local mysql installation, it uses socket to connect.

I'm not sure why `--protocol=tcp` was hard-coded, so I'm going to go out on a limb and guess that it was an oversight?

This PR retains the `--protocol=tcp` behaviour, but allows users to configure it to other values (`tcp`, `memory`, `pipe`, etc).

I couldn't figure out a way to add tests (there are no tests for testing adapter's load/dump behaviour, other than a few for a mocked version) so I'm going to simply make these straightforward changes. Please let me know if you have any suggestions and I'm more than happy to look into it.

Thanks!

