### PR TITLE
Add fragment support for conflict targets

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -187,7 +187,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp conflict_target({:constraint, constraint}),
       do: ["ON CONSTRAINT ", quote_name(constraint), ?\s]
-    defp conflict_target({:fragment, fragment}), 
+    defp conflict_target({:unsafe_fragment, fragment}), 
       do: [fragment, ?\s]
     defp conflict_target([]),
       do: []

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -187,7 +187,8 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp conflict_target({:constraint, constraint}),
       do: ["ON CONSTRAINT ", quote_name(constraint), ?\s]
-    defp conflict_target({:fragment, fragment}), do: [fragment, ?\s]
+    defp conflict_target({:fragment, fragment}), 
+      do: [fragment, ?\s]
     defp conflict_target([]),
       do: []
     defp conflict_target(targets),

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -187,6 +187,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp conflict_target({:constraint, constraint}),
       do: ["ON CONSTRAINT ", quote_name(constraint), ?\s]
+    defp conflict_target({:fragment, fragment}), do: [fragment, ?\s]
     defp conflict_target([]),
       do: []
     defp conflict_target(targets),

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -566,10 +566,10 @@ defmodule Ecto.Repo do
     * `:conflict_target` - Which columns to verify for conflicts. If
       none is specified, the conflict target is left up to the database
       and is usually made of primary keys and/or unique/exclusion constraints.
-      May also be `{:constraint, constraint_name_as_atom}` in databases
-      that support the "ON CONSTRAINT" expression or `{:unsafe_fragment, binary_fragment}`
-      for targets that require expressions on columns rather than raw column names,
-      e.g. `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
+      It may also be `{:constraint, constraint_name_as_atom}` in databases
+      that support the "ON CONSTRAINT" expression, or `{:unsafe_fragment, binary_fragment}`
+      to pass any expression to the database without any sanitization, such as
+      `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
 
   See the "Shared options" section at the module documentation for
   remaining options.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -567,7 +567,9 @@ defmodule Ecto.Repo do
       none is specified, the conflict target is left up to the database
       and is usually made of primary keys and/or unique/exclusion constraints.
       May also be `{:constraint, constraint_name_as_atom}` in databases
-      that support the "ON CONSTRAINT" expression.
+      that support the "ON CONSTRAINT" expression or `{:fragment, binary_fragment}`
+      for targets that require expressions on columns rather than raw column names,
+      e.g. ON CONFLICT (coalesce(u.firstname, ""), coalesce(u.lastname, ""))
 
   See the "Shared options" section at the module documentation for
   remaining options.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -569,7 +569,7 @@ defmodule Ecto.Repo do
       May also be `{:constraint, constraint_name_as_atom}` in databases
       that support the "ON CONSTRAINT" expression or `{:fragment, binary_fragment}`
       for targets that require expressions on columns rather than raw column names,
-      e.g. ON CONFLICT (coalesce(u.firstname, ""), coalesce(u.lastname, ""))
+      e.g. `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
 
   See the "Shared options" section at the module documentation for
   remaining options.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -567,7 +567,7 @@ defmodule Ecto.Repo do
       none is specified, the conflict target is left up to the database
       and is usually made of primary keys and/or unique/exclusion constraints.
       May also be `{:constraint, constraint_name_as_atom}` in databases
-      that support the "ON CONSTRAINT" expression or `{:fragment, binary_fragment}`
+      that support the "ON CONSTRAINT" expression or `{:unsafe_fragment, binary_fragment}`
       for targets that require expressions on columns rather than raw column names,
       e.g. `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -482,8 +482,8 @@ defmodule Ecto.Repo.Schema do
   defp conflict_target({:constraint, constraint}, _dumper) when is_atom(constraint) do
     {:constraint, constraint}
   end
-  defp conflict_target({:fragment, fragment}, _dumper) when is_binary(fragment) do
-    {:fragment, fragment}
+  defp conflict_target({:unsafe_fragment, fragment}, _dumper) when is_binary(fragment) do
+    {:unsafe_fragment, fragment}
   end
   defp conflict_target(conflict_target, dumper) do
     for target <- List.wrap(conflict_target) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -482,6 +482,9 @@ defmodule Ecto.Repo.Schema do
   defp conflict_target({:constraint, constraint}, _dumper) when is_atom(constraint) do
     {:constraint, constraint}
   end
+  defp conflict_target({:fragment, fragment}, _dumper) when is_binary(fragment) do
+    {:fragment, fragment}
+  end
   defp conflict_target(conflict_target, dumper) do
     for target <- List.wrap(conflict_target) do
       case dumper do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -689,7 +689,7 @@ defmodule Ecto.Adapters.PostgresTest do
     query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], {:constraint, :foo}}, [])
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT ON CONSTRAINT \"foo\" DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
 
-    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], {:fragment, "(\"id\")"}}, [])
+    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], {:unsafe_fragment, "(\"id\")"}}, [])
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT (\"id\") DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
   end
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -688,6 +688,9 @@ defmodule Ecto.Adapters.PostgresTest do
 
     query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], {:constraint, :foo}}, [])
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT ON CONSTRAINT \"foo\" DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
+
+    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:replace_all, [], {:fragment, "(\"id\")"}}, [])
+    assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT (\"id\") DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
   end
 
   test "update" do


### PR DESCRIPTION
This is to clean up a remaining bug from https://github.com/elixir-ecto/ecto/issues/2081.

Basically, Postgres unique indexes support expressions and partial indexing, both of which make it
impossible to define an explicit constraint for them.  Ecto conflict targets on upserts
automagically columnize each clause, and the constraint alternative also is no help, because no constraint can be made for such a unique index, so this is a simple stopgap to handle these corner cases.