### PR TITLE
+Accurate Variables in Doc

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -185,7 +185,7 @@ defmodule Ecto.Changeset do
 
       changeset =
         {data, types}
-        |> Ecto.Changeset.cast(params["sign_up"], Map.keys(types))
+        |> Ecto.Changeset.cast(data["sign_up"], Map.keys(types))
         |> Ecto.Changeset.validate_required(...)
         |> Ecto.Changeset.validate_length(...)
 


### PR DESCRIPTION
Hi guys, 

Found a typo in the documentation confusing 'data' and 'params'. Just a small documentation health fix.