### PR TITLE
Update Changeset Documentation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -174,20 +174,54 @@ defmodule Ecto.Changeset do
   ## Schemaless changesets
 
   In the changeset examples so far, we have always used changesets to
-  validate and cast data contained in a struct, such as the `%User{}`
-  struct defined by the `User` module.
-
-  However, changesets can also be used with data in a plain map, by
+  validate and cast data contained in a struct defined by an Ecto Schema, such as the `%User{}`
+  struct defined by the `User` module. 
+  
+  However, changesets can also be used without defining our structs using an Ecto schema:
+  
+      user = %User{}
+      types = %{first_name: :string, last_name: :string, email: :string}
+      changeset =
+        {user, types}
+        |> Ecto.Changeset.cast(params["name"], Map.keys(types))      
+      #   |> Ecto.Changeset.validate_required(...)
+      #   |> Ecto.Changeset.validate_length(...)
+                
+  Where the user struct refers to the definition in the following module. 
+  
+    defmodule User do
+      defstruct [:name, :age]
+    end 
+  
+  Returning the Changeset as a response:
+  
+    #Ecto.Changeset<
+    action: nil,
+    changes: %{name: "Callum"},
+    errors: [],
+    data: #User<>,
+    valid?: true>
+        
+  Elixir structs are just bare maps underneath. Changesets can also be used with data in a plain map, by
   passing a tuple containing both the data and the supported types:
 
-      data  = %{}
-      types = %{first_name: :string, last_name: :string, email: :string}
-
-      changeset =
-        {data, types}
-        |> Ecto.Changeset.cast(params["sign_up"], Map.keys(types))
-        |> Ecto.Changeset.validate_required(...)
-        |> Ecto.Changeset.validate_length(...)
+    data  = %{}
+    types = %{name: :string}
+    params = %{name: "Callum"}
+    changeset =
+      {data, types}
+        |> Ecto.Changeset.cast(params, Map.keys(types))
+    #   |> Ecto.Changeset.validate_required(...)
+    #   |> Ecto.Changeset.validate_length(...)
+        
+  This will produce the following changeset where `params` have been casted to `data` given specified types:
+  
+    Ecto.Changeset<
+    action: nil,
+    changes: %{name: "Callum"},
+    errors: [],
+    data: %{},
+    valid?: true>
 
   Such functionality makes Ecto extremely useful to cast, validate and prune
   data even if it is not meant to be persisted to the database.

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -173,58 +173,40 @@ defmodule Ecto.Changeset do
 
   ## Schemaless changesets
 
-  In the changeset examples so far, we have always used changesets to
-  validate and cast data contained in a struct defined by an Ecto Schema, such as the `%User{}`
-  struct defined by the `User` module. 
+  In the changeset examples so far, we have always used changesets to validate
+  and cast data contained in a struct defined by an Ecto schema, such as the `%User{}`
+  struct defined by the `User` module.
   
-  However, changesets can also be used without defining our structs using an Ecto schema:
+  However, changesets can also be used with "regular" structs too by passing a tuple
+  with the data and its types:
   
       user = %User{}
       types = %{first_name: :string, last_name: :string, email: :string}
       changeset =
         {user, types}
         |> Ecto.Changeset.cast(params["name"], Map.keys(types))      
-      #   |> Ecto.Changeset.validate_required(...)
-      #   |> Ecto.Changeset.validate_length(...)
+        |> Ecto.Changeset.validate_required(...)
+        |> Ecto.Changeset.validate_length(...)
                 
-  Where the user struct refers to the definition in the following module. 
+  where the user struct refers to the definition in the following module:
   
-    defmodule User do
-      defstruct [:name, :age]
-    end 
-  
-  Returning the Changeset as a response:
-  
-    #Ecto.Changeset<
-    action: nil,
-    changes: %{name: "Callum"},
-    errors: [],
-    data: #User<>,
-    valid?: true>
+      defmodule User do
+        defstruct [:name, :age]
+      end 
         
-  Elixir structs are just bare maps underneath. Changesets can also be used with data in a plain map, by
-  passing a tuple containing both the data and the supported types:
+  Changesets can also be used with data in a plain map, by following the same API:
 
-    data  = %{}
-    types = %{name: :string}
-    params = %{name: "Callum"}
-    changeset =
-      {data, types}
+      data  = %{}
+      types = %{name: :string}
+      params = %{name: "Callum"}
+      changeset =
+        {data, types}
         |> Ecto.Changeset.cast(params, Map.keys(types))
-    #   |> Ecto.Changeset.validate_required(...)
-    #   |> Ecto.Changeset.validate_length(...)
+        |> Ecto.Changeset.validate_required(...)
+        |> Ecto.Changeset.validate_length(...)
         
-  This will produce the following changeset where `params` have been casted to `data` given specified types:
-  
-    Ecto.Changeset<
-    action: nil,
-    changes: %{name: "Callum"},
-    errors: [],
-    data: %{},
-    valid?: true>
-
-  Such functionality makes Ecto extremely useful to cast, validate and prune
-  data even if it is not meant to be persisted to the database.
+  Such functionality makes Ecto extremely useful to cast, validate and prune data even
+  if it is not meant to be persisted to the database.
 
   ### Changeset actions
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -176,10 +176,10 @@ defmodule Ecto.Changeset do
   In the changeset examples so far, we have always used changesets to validate
   and cast data contained in a struct defined by an Ecto schema, such as the `%User{}`
   struct defined by the `User` module.
-  
+
   However, changesets can also be used with "regular" structs too by passing a tuple
   with the data and its types:
-  
+
       user = %User{}
       types = %{first_name: :string, last_name: :string, email: :string}
       changeset =
@@ -187,13 +187,13 @@ defmodule Ecto.Changeset do
         |> Ecto.Changeset.cast(params["name"], Map.keys(types))      
         |> Ecto.Changeset.validate_required(...)
         |> Ecto.Changeset.validate_length(...)
-                
+
   where the user struct refers to the definition in the following module:
-  
+
       defmodule User do
         defstruct [:name, :age]
       end 
-        
+
   Changesets can also be used with data in a plain map, by following the same API:
 
       data  = %{}
@@ -204,7 +204,7 @@ defmodule Ecto.Changeset do
         |> Ecto.Changeset.cast(params, Map.keys(types))
         |> Ecto.Changeset.validate_required(...)
         |> Ecto.Changeset.validate_length(...)
-        
+
   Such functionality makes Ecto extremely useful to cast, validate and prune data even
   if it is not meant to be persisted to the database.
 


### PR DESCRIPTION
Clarified changeset documentation with valid code...

Changes include...

+ The documentation conflated 'Elixir structs' and 'structs generated by an Ecto schema'. Whilst in the underlying implementation they are equivalent, I've provided the improvement of making the documentation more beginner friendly by making it more explicit that you really can just feed it a valid struct (you aren't forced to use an Ecto schema, that then generates a struct)! This will be helpful to newcomers who aren't familiar with Ecto schemas and have just read the basic documentation and want to get started with changesets. I assume _if_ the newcomers read the Ecto documentation on Ecto schemas, then they will understand the Ecto schema will generate a regular Elixir struct (with the value of added metadata), just not necessarily the other way around (which is certainly a challenge I faced when I wanted to jump straight into changesets). 

+ Within the previous examples, Ecto.Changeset would not accept the user input as expecting a map (params). I've provided the improvement of providing valid examples (which I tested in iex to make sure 🤓). Now our awesome Ecto athletes can copy and paste from the examples to see what working code looks like and go from there!