### PR TITLE
Semantic comparisons in changesets

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -530,13 +530,17 @@ defmodule Ecto.Changeset do
       %{^param_key => value} ->
         value = if value in empty_values, do: Map.get(defaults, key), else: value
         case Ecto.Type.cast(type, value) do
-          {:ok, ^current} ->
-            :missing
           {:ok, value} ->
-            {:ok, value, valid?}
+            if Ecto.Type.equal?(type, current, value) do
+              :missing
+            else
+              {:ok, value, valid?}
+            end
+
           :error ->
             :invalid
         end
+
       _ ->
         :missing
     end
@@ -1104,12 +1108,14 @@ defmodule Ecto.Changeset do
     end
   end
 
-  defp put_change(data, changes, errors, valid?, key, value, _type) do
+  defp put_change(data, changes, errors, valid?, key, value, type) do
     cond do
-      Map.get(data, key) != value ->
+      not Ecto.Type.equal?(type, Map.get(data, key), value) ->
         {Map.put(changes, key, value), errors, valid?}
+
       Map.has_key?(changes, key) ->
         {Map.delete(changes, key), errors, valid?}
+
       true ->
         {changes, errors, valid?}
     end

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -918,9 +918,8 @@ defmodule Ecto.Type do
     do: requires_semantic_comparison?(type)
   defp requires_semantic_comparison?({:map, type}),
     do: requires_semantic_comparison?(type)
-  defp requires_semantic_comparison?(module) when is_atom(module) do
-    function_exported?(module, :equal?, 2)
-  end
+  defp requires_semantic_comparison?(module) when is_atom(module),
+    do: loaded_and_exported?(module, :equal?, 2)
 
   defp do_equal?(:decimal, %Decimal{} = term1, %Decimal{} = term2) do
     Decimal.equal?(term1, term2)
@@ -1023,6 +1022,11 @@ defmodule Ecto.Type do
       {int, ""} -> int
       _ -> nil
     end
+  end
+
+  defp loaded_and_exported?(module, fun, arity) do
+    # TODO: Rely only on Code.ensure_loaded? when targetting Erlang/OTP 21+
+    (:erlang.module_loaded(module) or Code.ensure_loaded?(module)) and function_exported?(module, fun, arity)
   end
 
   defp validate_decimal({:ok, %Decimal{coef: coef}}) when coef in [:inf, :qNaN, :sNaN],

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -94,12 +94,14 @@ defmodule Ecto.Type do
                       :utc_datetime_usec | :naive_datetime_usec | :time_usec
   @typep composite :: {:array, t} | {:map, t} | {:embed, Ecto.Embedded.t} | {:in, t}
 
-  @base ~w(
-    integer float boolean string map
-    binary decimal id binary_id
-    utc_datetime naive_datetime date time any
+  @calendar ~w(
+    utc_datetime naive_datetime date time
     utc_datetime_usec naive_datetime_usec time_usec
   )a
+  @base ~w(
+    integer float boolean string map
+    binary decimal id binary_id any
+  )a ++ @calendar
   @composite ~w(array map in embed)a
 
   @doc """
@@ -144,6 +146,13 @@ defmodule Ecto.Type do
   and it needs to validate them and convert it to an Ecto native type.
   """
   @callback dump(term) :: {:ok, term} | :error
+
+  @doc """
+  Checks if two terms are semantically equal.
+  """
+  @callback equal?(term, term) :: boolean
+
+  @optional_callbacks [equal?: 2]
 
   ## Functions
 
@@ -873,6 +882,94 @@ defmodule Ecto.Type do
       :error ->
         :error
     end
+  end
+
+  @doc """
+  Checks if two terms are equal.
+
+  Depending on the given `type` performs a structural or semantical comparison.
+
+  ## Examples
+
+      iex> equal?(:integer, 1, 1)
+      true
+      iex> equal?(:decimal, Decimal.new("1"), Decimal.new("1.00"))
+      true
+
+  """
+  @spec equal?(t, term, term) :: boolean
+  def equal?(type, term1, term2) do
+    if requires_semantic_comparison?(type) do
+      do_equal?(type, term1, term2)
+    else
+      term1 == term2
+    end
+  end
+
+  defp requires_semantic_comparison?(:decimal),
+    do: true
+  defp requires_semantic_comparison?(:date),
+    do: false
+  defp requires_semantic_comparison?(type) when type in @calendar,
+    do: true
+  defp requires_semantic_comparison?(type) when type in @base,
+    do: false
+  defp requires_semantic_comparison?({:array, type}),
+    do: requires_semantic_comparison?(type)
+  defp requires_semantic_comparison?({:map, type}),
+    do: requires_semantic_comparison?(type)
+  defp requires_semantic_comparison?(module) when is_atom(module) do
+    function_exported?(module, :equal?, 2)
+  end
+
+  defp do_equal?(:decimal, %Decimal{} = term1, %Decimal{} = term2) do
+    Decimal.equal?(term1, term2)
+  end
+  defp do_equal?(type, %Time{} = term1, %Time{} = term2) when type in [:time, :time_usec] do
+    Time.compare(term1, term2) == :eq
+  end
+  defp do_equal?(type, %NaiveDateTime{} = term1, %NaiveDateTime{} = term2)
+       when type in [:naive_datetime, :naive_datetime_usec] do
+    NaiveDateTime.compare(term1, term2) == :eq
+  end
+  defp do_equal?(type, %DateTime{} = term1, %DateTime{} = term2)
+       when type in [:utc_datetime, :utc_datetime_usec] do
+    DateTime.compare(term1, term2) == :eq
+  end
+  defp do_equal?(type, term1, term2) when type in @base do
+    term1 == term2
+  end
+  defp do_equal?(module, term1, term2) when is_atom(module) do
+    module.equal?(term1, term2)
+  end
+  defp do_equal?({:array, type}, xs, ys) do
+    equal_list?(type, xs, ys)
+  end
+  defp do_equal?({:map, _}, map1, map2) when map_size(map1) != map_size(map2) do
+    false
+  end
+  defp do_equal?({:map, type}, map1, map2) do
+    equal_map?(type, Map.to_list(map1), Map.to_list(map2))
+  end
+
+  defp equal_list?(type, [x | xs], [y | ys]) do
+    do_equal?(type, x, y) and equal_list?(type, xs, ys)
+  end
+  defp equal_list?(_type, [], []) do
+    true
+  end
+  defp equal_list?(_type, _, _) do
+    false
+  end
+
+  defp equal_map?(type, [{key, val1} | tail1], [{key, val2} | tail2]) do
+    do_equal?(type, val1, val2) and equal_map?(type, tail1, tail2)
+  end
+  defp equal_map?(_type, [], []) do
+    true
+  end
+  defp equal_map?(_type, _, _) do
+    false
   end
 
   ## Helpers

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -287,6 +287,19 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
+  test "cast/4: semantic comparison" do
+    changeset = cast(%Post{decimal: Decimal.new(1)}, %{decimal: "1.0"}, ~w(decimal)a)
+    assert changeset.changes == %{}
+    changeset = cast(%Post{decimal: Decimal.new(1)}, %{decimal: "1.1"}, ~w(decimal)a)
+    assert changeset.changes == %{decimal: Decimal.new("1.1")}
+
+    {data, types} = {%{x: [Decimal.new(1)]}, %{x: {:array, :decimal}}}
+    changeset = cast({data, types}, %{x: [Decimal.new("1.0")]}, ~w(x)a)
+    assert changeset.changes == %{}
+    changeset = cast({data, types}, %{x: [Decimal.new("1.1")]}, ~w(x)a)
+    assert changeset.changes == %{x: [Decimal.new("1.1")]}
+  end
+
   ## Changeset functions
 
   test "merge/2: merges changes" do
@@ -475,6 +488,12 @@ defmodule Ecto.ChangesetTest do
 
     changeset = change(base_changeset, %{title: "new title", upvotes: 5})
     assert changeset.changes == %{title: "new title"}
+  end
+
+  test "change/2 semantic comparison" do
+    post = %Post{decimal: Decimal.new("1.0")}
+    changeset = change(post, decimal: Decimal.new(1))
+    assert changeset.changes == %{}
   end
 
   test "fetch_field/2" do


### PR DESCRIPTION
Fixes #2473 

* Add `Ecto.Type.equal?/3` callback
* Add `Ecto.Type.equal?/2` function