### PR TITLE
CHANGELOG.md: Remove duplicate `Ecto.Multi` entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,6 @@ Running migrations will now lock the migrations table, allowing you to concurren
 ### Deprecations
 
   * [Ecto.Changeset] Passing a list of binaries to `cast/3` is deprecated, please pass a list of atoms instead
-  * [Ecto.Multi] `Ecto.Multi.run/3` now receives the repo in which the transaction is executing as the first argument to functions, and the changes so far as the second argument
   * [Ecto.Query] `join/5` now expects `on: expr` as last argument instead of simply `expr`. This was done in order to properly support `:as` and friends
   * [Ecto.Repo] The `:returning` option for `update_all` and `delete_all` has been deprecated as those statements now support `select` clauses
   * [Ecto.Repo] Passing `:adapter` via config is deprecated in favor of passing it on `use Ecto.Repo`


### PR DESCRIPTION
This entry is also present on L113: https://github.com/elixir-ecto/ecto/compare/master...xtian:patch-1#diff-4ac32a78649ca5bdd8e0ba38b7006a1eL113

Please close if this was intentional.