### PR TITLE
Loading PG timestamp with time zone into utc_datetime

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -3,16 +3,18 @@ Code.require_file "../support/types.exs", __DIR__
 defmodule Ecto.Integration.TypeTest do
   use Ecto.Integration.Case, async: Application.get_env(:ecto, :async_integration_tests, true)
 
-  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag}
+  alias Ecto.Integration.{Custom, ExternalEntity, Item, Order, Post, User, Tag}
   alias Ecto.Integration.TestRepo
   import Ecto.Query
 
   test "primitive types" do
-    integer  = 1
-    float    = 0.1
-    text     = <<0, 1>>
-    uuid     = "00010203-0405-4607-8809-0a0b0c0d0e0f"
-    datetime = ~N[2014-01-16 20:26:51]
+    integer           = 1
+    float             = 0.1
+    text              = <<0, 1>>
+    uuid              = "00010203-0405-4607-8809-0a0b0c0d0e0f"
+    datetime          = ~N[2014-01-16 20:26:51]
+    utc_datetime      = DateTime.from_naive!(datetime, "Etc/UTC")
+    utc_datetime_usec = %{utc_datetime | microsecond: {322937, 6}}
 
     TestRepo.insert!(%Post{text: text, public: true, visits: integer, uuid: uuid,
                            counter: integer, inserted_at: datetime, intensity: float})
@@ -52,6 +54,12 @@ defmodule Ecto.Integration.TypeTest do
     datetime = DateTime.from_unix!(System.system_time(:seconds), :seconds)
     TestRepo.insert!(%User{inserted_at: datetime})
     assert [^datetime] = TestRepo.all(from u in User, where: u.inserted_at == ^datetime, select: u.inserted_at)
+
+    if Mix.env == :pg do
+      # Datetime from timestamp with time zone
+      assert [[^utc_datetime, ^utc_datetime_usec]] =
+        TestRepo.all(from e in ExternalEntity, select: [e.timestamp_tz, e.timestamp_tz_usec])
+    end
   end
 
   test "aggregate types" do

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -115,5 +115,25 @@ defmodule Ecto.Integration.Migration do
       add :published_at, :naive_datetime_usec
       add :submitted_at, :utc_datetime_usec
     end
+
+    if Mix.env == :pg do
+      # Simulating a table created externally (not using ecto regular migrations)
+      execute("CREATE SEQUENCE external_entities_id_seq")
+      execute("""
+      CREATE TABLE external_entities(
+        id bigint NOT NULL DEFAULT nextval('external_entities_id_seq'::regclass),
+        timestamp_tz timestamp with time zone,
+        timestamp_tz_usec timestamp with time zone
+      )
+      """)
+      execute("""
+      ALTER TABLE external_entities ADD CONSTRAINT external_entities_pkey PRIMARY KEY (id)
+      """)
+      execute("""
+      INSERT INTO external_entities(timestamp_tz, timestamp_tz_usec) VALUES(
+        '2014-01-16 20:26:51Z', '2014-01-16 20:26:51.322937Z'
+      )
+      """)
+    end
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -297,3 +297,22 @@ defmodule Ecto.Integration.Article do
     field :submitted_at, :utc_datetime_usec
   end
 end
+
+defmodule Ecto.Integration.ExternalEntity do
+  @moduledoc """
+  This module is used to test:
+
+    * Loading of entities created outside of Ecto into Ecto Schema
+
+  """
+  use Ecto.Integration.Schema
+
+  schema "external_entities" do
+    field :timestamp_tz, :utc_datetime
+    field :timestamp_tz_usec, :utc_datetime_usec
+  end
+
+  def changeset(schema, params) do
+    Ecto.Changeset.cast(schema, params, [:timestamp_tz, :timestamp_tz_usec])
+  end
+end

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -468,8 +468,16 @@ defmodule Ecto.Type do
     naive_datetime |> zerofy_microsecond |> DateTime.from_naive("Etc/UTC")
   end
 
+  def load(:utc_datetime, %DateTime{} = datetime, _loader) do
+    {:ok, zerofy_microsecond(datetime)}
+  end
+
   def load(:utc_datetime_usec, %NaiveDateTime{} = naive_datetime, _loader) do
-     DateTime.from_naive(naive_datetime, "Etc/UTC")
+    DateTime.from_naive(naive_datetime, "Etc/UTC")
+  end
+
+  def load(:utc_datetime_usec, %DateTime{} = datetime, _loader) do
+    {:ok, datetime}
   end
 
   def load(type, value, _loader) do

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -572,6 +572,10 @@ defmodule Ecto.TypeTest do
     assert Ecto.Type.load(:utc_datetime, ~N[2015-01-23 23:50:00]) == {:ok, @datetime_zero}
     assert Ecto.Type.load(:utc_datetime, ~N[2015-01-23 23:50:07.008000]) == {:ok, @datetime}
     assert Ecto.Type.load(:utc_datetime, ~N[2000-02-29 23:50:07]) == {:ok, @datetime_leapyear}
+    assert Ecto.Type.load(:utc_datetime, @datetime) == {:ok, @datetime}
+    assert Ecto.Type.load(:utc_datetime, @datetime_zero) == {:ok, @datetime_zero}
+    assert Ecto.Type.load(:utc_datetime, @datetime_usec) == {:ok, @datetime}
+    assert Ecto.Type.load(:utc_datetime, @datetime_leapyear) == {:ok, @datetime_leapyear}
   end
 
   describe "utc_datetime_usec type" do
@@ -660,6 +664,10 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:00]) == {:ok, @datetime_zero}
       assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:07.008000]) == {:ok, @datetime_usec}
       assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07]) == {:ok, @datetime_leapyear}
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime) == {:ok, @datetime}
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_zero) == {:ok, @datetime_zero}
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear}
     end
   end
 end


### PR DESCRIPTION
This is my take on #2648 

It allows loading 'timestamp with time zone' fields (for example if a table was created manually) with Ecto.

The problem is that when we have 'timestamp with time zone' field, the adapter returns it as DateTime, not as NaiveDateTime and `lib/ecto/type.ex` has no matching function to load DateTime.

From my observation, when we put a non-UTC value into timestamp with time zone, it gets read as UTC by the adapter. However, maybe we should add an additional check that it is UTC and convert to UTC if not? Just how it is done here: https://github.com/elixir-ecto/ecto/blob/022f244aa4839d61dc4cf413813e5d02fd4fbd64/lib/ecto/type.ex#L860-L866


This PR does not fully return the ability to work with 'timestamp with time zone' we had in 2.2 because such fields cannot be used in where conditions and inserted/updated.

I.e. If we try to insert into the field, we got:
```
iex(2)> MyApp.Repo.insert!(MyApp.NotOk.changeset(%MyApp.NotOk{}, %{created_at: DateTime.utc_now}))

10:32:12.492 [debug] QUERY ERROR db=1.8ms
INSERT INTO "not_oks" ("created_at") VALUES ($1) RETURNING "id" [~N[2018-08-13 04:32:12]]
** (ArgumentError) Postgrex expected %DateTime{}, got ~N[2018-08-13 04:32:12]. Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly.
    (postgrex) lib/postgrex/type_module.ex:714: Postgrex.DefaultTypes.encode_params/3
    (postgrex) lib/postgrex/query.ex:45: DBConnection.Query.Postgrex.Query.encode/3
    (db_connection) lib/db_connection.ex:1658: DBConnection.encode/5
    (db_connection) lib/db_connection.ex:1719: DBConnection.run_prepare_execute/6
    (db_connection) lib/db_connection.ex:1834: DBConnection.run/6
    (db_connection) lib/db_connection.ex:673: DBConnection.prepare_execute/4
    (ecto) lib/ecto/adapters/postgres/connection.ex:81: Ecto.Adapters.Postgres.Connection.execute/4
    (ecto) lib/ecto/adapters/sql.ex:288: Ecto.Adapters.SQL.sql_call/5
```

Looks like again the adapter expects a DateTime for timestamp with timezone field, but Ecto gives NaiveDateTime for all utc_datetime fields. I have no idea how to fix it yet; haven't dig into that.