### PR TITLE
Stricter handling of usec and non-usec calendar types

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -3,7 +3,7 @@ Code.require_file "../support/types.exs", __DIR__
 defmodule Ecto.Integration.TypeTest do
   use Ecto.Integration.Case, async: Application.get_env(:ecto, :async_integration_tests, true)
 
-  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag}
+  alias Ecto.Integration.{Custom, Item, Order, Post, User, Tag, Article}
   alias Ecto.Integration.TestRepo
   import Ecto.Query
 
@@ -52,6 +52,19 @@ defmodule Ecto.Integration.TypeTest do
     datetime = DateTime.from_unix!(System.system_time(:seconds), :seconds)
     TestRepo.insert!(%User{inserted_at: datetime})
     assert [^datetime] = TestRepo.all(from u in User, where: u.inserted_at == ^datetime, select: u.inserted_at)
+
+    # usec
+    naive_datetime = ~N[2014-01-16 20:26:51.000000]
+    datetime = DateTime.from_naive!(~N[2014-01-16 20:26:51.000000], "Etc/UTC")
+    TestRepo.insert!(%Article{published_at: naive_datetime, submitted_at: datetime})
+    assert [^naive_datetime] = TestRepo.all(from u in Article, where: u.published_at == ^naive_datetime, select: u.published_at)
+    assert [^datetime] = TestRepo.all(from u in Article, where: u.submitted_at == ^datetime, select: u.submitted_at)
+
+    naive_datetime = ~N[2014-01-16 20:26:51.123000]
+    datetime = DateTime.from_naive!(~N[2014-01-16 20:26:51.123000], "Etc/UTC")
+    TestRepo.insert!(%Article{published_at: naive_datetime, submitted_at: datetime})
+    assert [^naive_datetime] = TestRepo.all(from u in Article, where: u.published_at == ^naive_datetime, select: u.published_at)
+    assert [^datetime] = TestRepo.all(from u in Article, where: u.submitted_at == ^datetime, select: u.submitted_at)
   end
 
   test "aggregate types" do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -469,9 +469,7 @@ defmodule Ecto.Type do
   end
 
   def load(:utc_datetime_usec, %NaiveDateTime{} = naive_datetime, _loader) do
-    with {:ok, %DateTime{} = datetime} <- DateTime.from_naive(naive_datetime, "Etc/UTC") do
-      {:ok, pad_usec(datetime)}
-    end
+    naive_datetime |> pad_usec() |> DateTime.from_naive("Etc/UTC")
   end
 
   def load(type, value, _loader) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1049,8 +1049,10 @@ defmodule Ecto.Type do
     do: other
 
   defp truncate_usec(nil), do: nil
+  defp truncate_usec(%{microsecond: {0, 0}} = struct), do: struct
   defp truncate_usec(struct), do: %{struct | microsecond: {0, 0}}
 
   defp pad_usec(nil), do: nil
+  defp pad_usec(%{microsecond: {_, 6}} = struct), do: struct
   defp pad_usec(%{microsecond: {microsecond, _}} = struct), do: %{struct | microsecond: {microsecond, 6}}
 end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -666,13 +666,12 @@ defmodule Ecto.TypeTest do
     end
 
     test "load :utc_datetime_usec" do
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
       assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:07.008000]) == {:ok, @datetime_usec}
       assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07.008000]) == {:ok, @datetime_leapyear_usec}
-      assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07]) == {:ok, @datetime_leapyear}
-      assert Ecto.Type.load(:utc_datetime_usec, @datetime) == {:ok, @datetime}
-      assert Ecto.Type.load(:utc_datetime_usec, @datetime_zero) == {:ok, @datetime_zero}
-      assert Ecto.Type.load(:utc_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.load(:utc_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear}
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_leapyear_usec) == {:ok, @datetime_leapyear_usec}
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_zero) == {:ok, @datetime_zero_usec}
+      assert Ecto.Type.load(:utc_datetime_usec, ~D[2018-01-01]) == :error
     end
   end
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -218,6 +218,7 @@ defmodule Ecto.TypeTest do
 
   @time ~T[23:50:07]
   @time_zero ~T[23:50:00]
+  @time_zero_usec ~T[23:50:00.000000]
   @time_usec ~T[23:50:07.030000]
 
   test "time casting" do
@@ -268,8 +269,8 @@ defmodule Ecto.TypeTest do
 
   test "dump :time" do
     assert Ecto.Type.dump(:time, @time) == {:ok, @time}
-    assert Ecto.Type.dump(:time, @time_usec) == {:ok, @time}
     assert Ecto.Type.dump(:time, @time_zero) ==  {:ok, @time_zero}
+    assert Ecto.Type.dump(:time, @time_usec) == :error
   end
 
   test "load :time" do
@@ -280,14 +281,15 @@ defmodule Ecto.TypeTest do
 
   describe "time_usec type" do
     test "cast :time_usec from Time" do
-      assert Ecto.Type.cast(:time_usec, @time) == {:ok, @time}
       assert Ecto.Type.cast(:time_usec, @time_usec) == {:ok, @time_usec}
-      assert Ecto.Type.cast(:time_usec, @time_zero) ==  {:ok, @time_zero}
+      assert Ecto.Type.cast(:time_usec, @time_zero) ==  {:ok, @time_zero_usec}
     end
 
     test "cast :time_usec from binary" do
-      assert Ecto.Type.cast(:time_usec, "23:50:07") == {:ok, @time}
-      assert Ecto.Type.cast(:time_usec, "23:50:07Z") == {:ok, @time}
+      assert Ecto.Type.cast(:time_usec, "23:50:00") == {:ok, @time_zero_usec}
+      assert Ecto.Type.cast(:time_usec, "23:50:00Z") == {:ok, @time_zero_usec}
+      assert Ecto.Type.cast(:time_usec, "23:50:07.03") == {:ok, @time_usec}
+      assert Ecto.Type.cast(:time_usec, "23:50:07.03Z") == {:ok, @time_usec}
       assert Ecto.Type.cast(:time_usec, "23:50:07.030000") == {:ok, @time_usec}
       assert Ecto.Type.cast(:time_usec, "23:50:07.030000Z") == {:ok, @time_usec}
 
@@ -299,12 +301,12 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast :time_usec from map" do
-      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50", "second" => "07"}) == {:ok, @time}
-      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 07}) == {:ok, @time}
+      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50", "second" => "00"}) == {:ok, @time_zero_usec}
+      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 0}) == {:ok, @time_zero_usec}
       assert Ecto.Type.cast(:time_usec, %{"hour" => "", "minute" => ""}) == {:ok, nil}
       assert Ecto.Type.cast(:time_usec, %{hour: nil, minute: nil}) == {:ok, nil}
-      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50"}) == {:ok, @time_zero}
-      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50}) == {:ok, @time_zero}
+      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50"}) == {:ok, @time_zero_usec}
+      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50}) == {:ok, @time_zero_usec}
       assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 07, microsecond: 30_000}) == {:ok, @time_usec}
       assert Ecto.Type.cast(:time_usec, %{"hour" => 23, "minute" => 50, "second" => 07, "microsecond" => 30_000}) == {:ok, @time_usec}
       assert Ecto.Type.cast(:time_usec, %{"hour" => "", "minute" => "50"}) == :error
@@ -312,7 +314,7 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast :time_usec from NaiveDateTime" do
-      assert Ecto.Type.cast(:time_usec, ~N[2016-11-11 23:30:10]) == {:ok, ~T[23:30:10]}
+      assert Ecto.Type.cast(:time_usec, ~N[2016-11-11 23:30:10]) == {:ok, ~T[23:30:10.000000]}
     end
 
     test "cast :time_usec from Date" do
@@ -320,22 +322,22 @@ defmodule Ecto.TypeTest do
     end
 
     test "dump :time_usec" do
-      assert Ecto.Type.dump(:time_usec, @time) == {:ok, @time}
       assert Ecto.Type.dump(:time_usec, @time_usec) == {:ok, @time_usec}
-      assert Ecto.Type.dump(:time_usec, @time_zero) ==  {:ok, @time_zero}
+      assert Ecto.Type.dump(:time_usec, @time) == :error
     end
 
     test "load :time_usec" do
-      assert Ecto.Type.load(:time_usec, @time) == {:ok, @time}
       assert Ecto.Type.load(:time_usec, @time_usec) == {:ok, @time_usec}
-      assert Ecto.Type.load(:time_usec, @time_zero) ==  {:ok, @time_zero}
+      assert Ecto.Type.load(:time_usec, @time_zero) ==  {:ok, @time_zero_usec}
     end
   end
 
   @datetime ~N[2015-01-23 23:50:07]
   @datetime_zero ~N[2015-01-23 23:50:00]
+  @datetime_zero_usec ~N[2015-01-23 23:50:00.000000]
   @datetime_usec ~N[2015-01-23 23:50:07.008000]
   @datetime_leapyear ~N[2000-02-29 23:50:07]
+  @datetime_leapyear_usec ~N[2000-02-29 23:50:07.000000]
 
   test "casting naive datetime" do
     assert Ecto.Type.cast(:naive_datetime, @datetime) == {:ok, @datetime}
@@ -398,8 +400,8 @@ defmodule Ecto.TypeTest do
   test "dump :naive_datetime" do
     assert Ecto.Type.dump(:naive_datetime, @datetime) == {:ok, @datetime}
     assert Ecto.Type.dump(:naive_datetime, @datetime_zero) == {:ok, @datetime_zero}
-    assert Ecto.Type.dump(:naive_datetime, @datetime_usec) == {:ok, @datetime}
     assert Ecto.Type.dump(:naive_datetime, @datetime_leapyear) == {:ok, @datetime_leapyear}
+    assert Ecto.Type.dump(:naive_datetime, @datetime_usec) == :error
   end
 
   test "load :naive_datetime" do
@@ -411,16 +413,16 @@ defmodule Ecto.TypeTest do
 
   describe "naive_datetime_usec type" do
     test "cast :naive_datetime_usec from NaiveDateTime" do
-      assert Ecto.Type.cast(:naive_datetime_usec, @datetime) == {:ok, @datetime}
+      assert Ecto.Type.cast(:naive_datetime_usec, @datetime_zero) == {:ok, @datetime_zero_usec}
       assert Ecto.Type.cast(:naive_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear}
+      assert Ecto.Type.cast(:naive_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear_usec}
     end
 
     test "cast :naive_datetime_usec from binary" do
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23 23:50:07") == {:ok, @datetime}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07") == {:ok, @datetime}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07Z") == {:ok, @datetime}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2000-02-29T23:50:07") == {:ok, @datetime_leapyear}
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23 23:50:00") == {:ok, @datetime_zero_usec}
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:00") == {:ok, @datetime_zero_usec}
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:00Z") == {:ok, @datetime_zero_usec}
+      assert Ecto.Type.cast(:naive_datetime_usec, "2000-02-29T23:50:07") == {:ok, @datetime_leapyear_usec}
       assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07.008000") == {:ok, @datetime_usec}
       assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07.008000Z") == {:ok, @datetime_usec}
 
@@ -428,11 +430,11 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast :naive_datetime_usec from map" do
-      term = %{"year" => "2015", "month" => "1", "day" => "23", "hour" => "23", "minute" => "50", "second" => "07"}
-      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime}
+      term = %{"year" => "2015", "month" => "1", "day" => "23", "hour" => "23", "minute" => "50", "second" => "00"}
+      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
-      term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07}
-      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime}
+      term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 0}
+      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %{"year" => "", "month" => "", "day" => "", "hour" => "", "minute" => ""}
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, nil}
@@ -441,10 +443,10 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, nil}
 
       term = %{"year" => "2015", "month" => "1", "day" => "23", "hour" => "23", "minute" => "50"}
-      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero}
+      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50}
-      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero}
+      assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07, microsecond: 8_000}
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_usec}
@@ -466,7 +468,7 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast :naive_datetime_usec from DateTime" do
-      assert Ecto.Type.cast(:naive_datetime_usec, DateTime.from_unix!(10, :second)) == {:ok, ~N[1970-01-01 00:00:10]}
+      assert Ecto.Type.cast(:naive_datetime_usec, DateTime.from_unix!(10, :second)) == {:ok, ~N[1970-01-01 00:00:10.000000]}
     end
 
     test "cast :naive_datetime_usec from Time" do
@@ -478,17 +480,15 @@ defmodule Ecto.TypeTest do
     end
 
     test "dump :naive_datetime_usec" do
-      assert Ecto.Type.dump(:naive_datetime_usec, @datetime) == {:ok, @datetime}
-      assert Ecto.Type.dump(:naive_datetime_usec, @datetime_zero) == {:ok, @datetime_zero}
+      assert Ecto.Type.dump(:naive_datetime_usec, @datetime) == :error
+      assert Ecto.Type.dump(:naive_datetime_usec, @datetime_zero) == :error
       assert Ecto.Type.dump(:naive_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.dump(:naive_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear}
+      assert Ecto.Type.dump(:naive_datetime_usec, @datetime_leapyear_usec) == {:ok, @datetime_leapyear_usec}
     end
 
     test "load :naive_datetime_usec" do
-      assert Ecto.Type.load(:naive_datetime_usec, @datetime) == {:ok, @datetime}
-      assert Ecto.Type.load(:naive_datetime_usec, @datetime_zero) == {:ok, @datetime_zero}
       assert Ecto.Type.load(:naive_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.load(:naive_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear}
+      assert Ecto.Type.load(:naive_datetime_usec, @datetime_leapyear_usec) == {:ok, @datetime_leapyear_usec}
     end
   end
 
@@ -496,6 +496,7 @@ defmodule Ecto.TypeTest do
   @datetime_zero DateTime.from_unix!(1422057000, :second)
   @datetime_usec DateTime.from_unix!(1422057007008000, :microsecond)
   @datetime_leapyear DateTime.from_unix!(951868207, :second)
+  @datetime_leapyear_usec DateTime.from_unix!(951868207008000, :microsecond)
 
   test "casting utc datetime" do
     assert Ecto.Type.cast(:utc_datetime, @datetime) == {:ok, @datetime}
@@ -563,8 +564,8 @@ defmodule Ecto.TypeTest do
   test "dump :utc_datetime" do
     assert Ecto.Type.dump(:utc_datetime, @datetime) == {:ok, ~N[2015-01-23 23:50:07]}
     assert Ecto.Type.dump(:utc_datetime, @datetime_zero) == {:ok, ~N[2015-01-23 23:50:00]}
-    assert Ecto.Type.dump(:utc_datetime, @datetime_usec) == {:ok, ~N[2015-01-23 23:50:07]}
     assert Ecto.Type.dump(:utc_datetime, @datetime_leapyear) == {:ok, ~N[2000-02-29 23:50:07]}
+    assert Ecto.Type.dump(:utc_datetime, @datetime_usec) == :error
   end
 
   test "load :utc_datetime" do
@@ -649,17 +650,13 @@ defmodule Ecto.TypeTest do
     end
 
     test "dump :utc_datetime_usec" do
-      assert Ecto.Type.dump(:utc_datetime_usec, @datetime) == {:ok, ~N[2015-01-23 23:50:07]}
-      assert Ecto.Type.dump(:utc_datetime_usec, @datetime_zero) == {:ok, ~N[2015-01-23 23:50:00]}
+      assert Ecto.Type.dump(:utc_datetime_usec, @datetime) == :error
       assert Ecto.Type.dump(:utc_datetime_usec, @datetime_usec) == {:ok, ~N[2015-01-23 23:50:07.008000]}
-      assert Ecto.Type.dump(:utc_datetime_usec, @datetime_leapyear) == {:ok, ~N[2000-02-29 23:50:07]}
     end
 
     test "load :utc_datetime_usec" do
-      assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:07]) == {:ok, @datetime}
-      assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:00]) == {:ok, @datetime_zero}
       assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:07.008000]) == {:ok, @datetime_usec}
-      assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07]) == {:ok, @datetime_leapyear}
+      assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07.008000]) == {:ok, @datetime_leapyear_usec}
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/elixir-ecto/ecto/issues/2018#issuecomment-411356454

* `cast` was already truncating microseconds for non-usec, it's now padding them for usec types too:

      iex> Ecto.Type.cast(:time, ~T[09:00:00.123])
      {:ok, ~T[09:00:00]}

      iex> Ecto.Type.cast(:time_usec, ~T[09:00:00])
      {:ok, ~T[09:00:00.000000]}

* similarly, `dump` enforces precision:

      iex> Ecto.Type.dump(:time_usec, ~T[09:00:00.123456])
      {:ok, ~T[09:00:00.123456]}
      iex> Ecto.Type.dump(:time, ~T[09:00:00])
      {:ok, ~T[09:00:00]}

      iex> Ecto.Type.dump(:time_usec, ~T[09:00:00.123])
      :error
      iex> Ecto.Type.dump(:time, ~T[09:00:00.123456])
      :error

* `load` was already truncating, it's now padding too.
  Note, it's less strict than dump as e.g. Postgrex always has microsecond precision
  and Mariaex has second precision if microseconds are 0.

      iex> Ecto.Type.load(:time, ~T[09:00:00.123])
      {:ok, ~T[09:00:00]}
      iex> Ecto.Type.load(:time_usec, ~T[09:00:00])
      {:ok, ~T[09:00:00.000000]}
      iex> Ecto.Type.load(:time_usec, ~T[09:00:00.123])
      {:ok, ~T[09:00:00.123000]}

**Note**: this effectively prohibits `~T[09:00:00.123]` as _internal_ data,
the millisecond precision might be in user input and in "external" DB
but this would be handled by Ecto internally as either second or microsecond precision.