### PR TITLE
Rework Ecto.Type

### DIFF
--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -214,6 +214,23 @@ defmodule Ecto.Integration.Item do
   embedded_schema do
     field :price, :integer
     field :valid_at, :date
+
+    embeds_one :primary_color, Ecto.Integration.ItemColor
+    embeds_many :secondary_colors, Ecto.Integration.ItemColor
+  end
+end
+
+defmodule Ecto.Integration.ItemColor do
+  @moduledoc """
+  This module is used to test:
+
+    * Nested embeds
+
+  """
+  use Ecto.Schema
+
+  embedded_schema do
+    field :name, :string
   end
 end
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -296,7 +296,6 @@ defmodule Ecto.Type do
       iex> dump({:array, :binary}, ["1", "2", "3"])
       {:ok, ["1", "2", "3"]}
 
-  A `dumper` function may be given for handling recursive types, see: `dump/3`.
   """
   @spec dump(t, term) :: {:ok, term} | :error
   def dump(_type, nil) do
@@ -308,9 +307,10 @@ defmodule Ecto.Type do
   end
 
   @doc """
-  Dumps a value to the given type using a custom function.
+  Dumps a value to the given type.
 
-  See `dump/2` for more information.
+  This function behaves the same as `dump/2`, except for composite types
+  the given `dumper` function is used.
   """
   @spec dump(t, term, (t, term -> {:ok, term} | :error)) :: {:ok, term} | :error
   def dump(_type, nil, _dumper) do
@@ -461,7 +461,6 @@ defmodule Ecto.Type do
       iex> load(:integer, "10")
       :error
 
-  A `loader` function may be given for handling recursive types, see: `load/3`.
   """
   @spec load(t, term) :: {:ok, term} | :error
   def load({:embed, embed}, value) do
@@ -477,9 +476,10 @@ defmodule Ecto.Type do
   end
 
   @doc """
-  Dumps a value to the given type using a custom function.
+  Loads a value with the given type.
 
-  See `dump/2` for more information.
+  This function behaves the same as `load/2`, except for composite types
+  the given `loader` function is used.
   """
   @spec load(t, term, (t, term -> {:ok, term} | :error)) :: {:ok, term} | :error
   def load({:embed, embed}, value, loader) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -899,6 +899,7 @@ defmodule Ecto.Type do
     end
   end
 
+  defp equal_fun(nil), do: nil
   defp equal_fun(:decimal), do: &equal_decimal?/2
   defp equal_fun(t) when t in [:time, :time_usec], do: &equal_time?/2
   defp equal_fun(t) when t in [:utc_datetime, :utc_datetime_usec], do: &equal_utc_datetime?/2

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -679,8 +679,10 @@ defmodule Ecto.Type do
   def cast_decimal(term) when is_float(term) do
     {:ok, Decimal.from_float(term)}
   end
-  def cast_decimal(%Decimal{coef: coef} = decimal)
-      when coef not in [:inf, :qNaN, :sNaN] do
+  def cast_decimal(%Decimal{coef: coef}) when coef in [:inf, :qNaN, :sNaN] do
+    :error
+  end
+  def cast_decimal(%Decimal{} = decimal) do
     {:ok, decimal}
   end
   def cast_decimal(_) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -299,10 +299,23 @@ defmodule Ecto.Type do
       iex> dump({:array, :binary}, ["1", "2", "3"])
       {:ok, ["1", "2", "3"]}
 
-  A `dumper` function may be given for handling recursive types.
+  A `dumper` function may be given for handling recursive types, see: `dump/3`.
   """
-  # @spec dump(t, term, (t, term -> {:ok, term} | :error)) :: {:ok, term} | :error
+  @spec dump(t, term) :: {:ok, term} | :error
+  def dump(_type, nil) do
+    {:ok, nil}
+  end
 
+  def dump(type, value) do
+    dump_fun(type).(value)
+  end
+
+  @doc """
+  Dumps a value to the given type using a custom function.
+
+  See `dump/2` for more information.
+  """
+  @spec dump(t, term, (t, term -> {:ok, term} | :error)) :: {:ok, term} | :error
   def dump(_type, nil, _dumper) do
     {:ok, nil}
   end
@@ -322,22 +335,11 @@ defmodule Ecto.Type do
     map(Map.to_list(value), type, dumper, %{})
   end
 
-  # TODO: this head is required to pass `dumper`, see
-  # the head below ignroes dumper. Maybe return 2-arity
-  # function from `dump_fun` and always pass dumper instead?
   def dump({:array, type}, value, dumper) do
     array(value, type, dumper, [])
   end
 
   def dump(type, value, _) do
-    dump_fun(type).(value)
-  end
-
-  def dump(_type, nil) do
-    {:ok, nil}
-  end
-
-  def dump(type, value) do
     dump_fun(type).(value)
   end
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1062,8 +1062,11 @@ defmodule Ecto.Type do
 
   defp loaded_and_exported?(module, fun, arity) do
     # TODO: Rely only on Code.ensure_loaded? when targetting Erlang/OTP 21+
-    (:erlang.module_loaded(module) or Code.ensure_loaded?(module)) and
+    if :erlang.module_loaded(module) or Code.ensure_loaded?(module) do
       function_exported?(module, fun, arity)
+    else
+      raise ArgumentError, "module #{inspect(module)} is not available"
+    end
   end
 
   defp maybe_truncate_usec({:ok, struct}), do: {:ok, truncate_usec(struct)}

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -95,8 +95,7 @@ defmodule Ecto.Type do
   @typep composite :: {:array, t} | {:map, t} | {:embed, Ecto.Embedded.t} | {:in, t}
 
   @base ~w(
-    integer float boolean string map binary id binary_id any
-    decimal
+    integer float decimal boolean string map binary id binary_id any
     utc_datetime naive_datetime date time
     utc_datetime_usec naive_datetime_usec time_usec
   )a

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -603,40 +603,40 @@ defmodule Ecto.Type do
   def cast(_type, nil), do: {:ok, nil}
 
   def cast(type, value) do
-    caster(type).(value)
+    cast_fun(type).(value)
   end
 
-  defp caster(:integer), do: &cast_integer/1
-  defp caster(:float), do: &cast_float/1
-  defp caster(:boolean), do: &cast_boolean/1
-  defp caster(:map), do: &cast_map/1
-  defp caster(:string), do: &cast_binary/1
-  defp caster(:binary), do: &cast_binary/1
-  defp caster(:id), do: &cast_integer/1
-  defp caster(:binary_id), do: &cast_binary/1
-  defp caster(:any), do: &{:ok, &1}
-  defp caster(:decimal), do: &cast_decimal/1
-  defp caster(:date), do: &cast_date/1
-  defp caster(:time), do: &maybe_truncate_usec(cast_time(&1))
-  defp caster(:time_usec), do: &maybe_pad_usec(cast_time(&1))
-  defp caster(:naive_datetime), do: &maybe_truncate_usec(cast_naive_datetime(&1))
-  defp caster(:naive_datetime_usec), do: &maybe_pad_usec(cast_naive_datetime(&1))
-  defp caster(:utc_datetime), do: &maybe_truncate_usec(cast_utc_datetime(&1))
-  defp caster(:utc_datetime_usec), do: &maybe_pad_usec(cast_utc_datetime(&1))
+  defp cast_fun(:integer), do: &cast_integer/1
+  defp cast_fun(:float), do: &cast_float/1
+  defp cast_fun(:boolean), do: &cast_boolean/1
+  defp cast_fun(:map), do: &cast_map/1
+  defp cast_fun(:string), do: &cast_binary/1
+  defp cast_fun(:binary), do: &cast_binary/1
+  defp cast_fun(:id), do: &cast_integer/1
+  defp cast_fun(:binary_id), do: &cast_binary/1
+  defp cast_fun(:any), do: &{:ok, &1}
+  defp cast_fun(:decimal), do: &cast_decimal/1
+  defp cast_fun(:date), do: &cast_date/1
+  defp cast_fun(:time), do: &maybe_truncate_usec(cast_time(&1))
+  defp cast_fun(:time_usec), do: &maybe_pad_usec(cast_time(&1))
+  defp cast_fun(:naive_datetime), do: &maybe_truncate_usec(cast_naive_datetime(&1))
+  defp cast_fun(:naive_datetime_usec), do: &maybe_pad_usec(cast_naive_datetime(&1))
+  defp cast_fun(:utc_datetime), do: &maybe_truncate_usec(cast_utc_datetime(&1))
+  defp cast_fun(:utc_datetime_usec), do: &maybe_pad_usec(cast_utc_datetime(&1))
 
-  defp caster({:in, type}) do
-    &cast_array(&1, caster(type), [])
+  defp cast_fun({:in, type}) do
+    &cast_array(&1, cast_fun(type), [])
   end
 
-  defp caster({:array, type}) do
-    &cast_array(&1, caster(type), [])
+  defp cast_fun({:array, type}) do
+    &cast_array(&1, cast_fun(type), [])
   end
 
-  defp caster({:map, type}) do
-    &cast_map(&1, caster(type), %{})
+  defp cast_fun({:map, type}) do
+    &cast_map(&1, cast_fun(type), %{})
   end
 
-  defp caster(mod) when is_atom(mod) do
+  defp cast_fun(mod) when is_atom(mod) do
     &mod.cast(&1)
   end
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -217,9 +217,7 @@ defmodule Ecto.Type do
   """
   @spec type(t) :: t
   def type(type)
-
   def type({:array, type}), do: {:array, type(type)}
-
   def type({:map, type}), do: {:map, type(type)}
 
   def type(type) do
@@ -359,18 +357,9 @@ defmodule Ecto.Type do
   defp dump_fun(:naive_datetime_usec), do: &dump_naive_datetime_usec/1
   defp dump_fun(:utc_datetime), do: &dump_utc_datetime/1
   defp dump_fun(:utc_datetime_usec), do: &dump_utc_datetime_usec/1
-
-  defp dump_fun({:array, type}) do
-    &array(&1, dump_fun(type), [])
-  end
-
-  defp dump_fun({:map, type}) do
-    &map(&1, dump_fun(type), %{})
-  end
-
-  defp dump_fun(mod) when is_atom(mod) do
-    &mod.dump(&1)
-  end
+  defp dump_fun({:array, type}), do: &array(&1, dump_fun(type), [])
+  defp dump_fun({:map, type}), do: &map(&1, dump_fun(type), %{})
+  defp dump_fun(mod) when is_atom(mod), do: &mod.dump(&1)
 
   defp dump_integer(term) when is_integer(term), do: {:ok, term}
   defp dump_integer(_), do: :error
@@ -522,18 +511,9 @@ defmodule Ecto.Type do
   defp load_fun(:naive_datetime_usec), do: &load_naive_datetime_usec/1
   defp load_fun(:utc_datetime), do: &load_utc_datetime/1
   defp load_fun(:utc_datetime_usec), do: &load_utc_datetime_usec/1
-
-  defp load_fun({:array, type}) do
-    &array(&1, load_fun(type), [])
-  end
-
-  defp load_fun({:map, type}) do
-    &map(&1, load_fun(type), %{})
-  end
-
-  defp load_fun(mod) when is_atom(mod) do
-    &mod.load(&1)
-  end
+  defp load_fun({:array, type}), do: &array(&1, load_fun(type), [])
+  defp load_fun({:map, type}), do: &map(&1, load_fun(type), %{})
+  defp load_fun(mod) when is_atom(mod), do: &mod.load(&1)
 
   defp load_float(term) when is_float(term), do: {:ok, term}
   defp load_float(term) when is_integer(term), do: {:ok, :erlang.float(term)}
@@ -690,22 +670,10 @@ defmodule Ecto.Type do
   defp cast_fun(:naive_datetime_usec), do: &maybe_pad_usec(cast_naive_datetime(&1))
   defp cast_fun(:utc_datetime), do: &maybe_truncate_usec(cast_utc_datetime(&1))
   defp cast_fun(:utc_datetime_usec), do: &maybe_pad_usec(cast_utc_datetime(&1))
-
-  defp cast_fun({:in, type}) do
-    &array(&1, cast_fun(type), [])
-  end
-
-  defp cast_fun({:array, type}) do
-    &array(&1, cast_fun(type), [])
-  end
-
-  defp cast_fun({:map, type}) do
-    &map(&1, cast_fun(type), %{})
-  end
-
-  defp cast_fun(mod) when is_atom(mod) do
-    &mod.cast(&1)
-  end
+  defp cast_fun({:in, type}), do: &array(&1, cast_fun(type), [])
+  defp cast_fun({:array, type}), do: &array(&1, cast_fun(type), [])
+  defp cast_fun({:map, type}), do: &map(&1, cast_fun(type), %{})
+  defp cast_fun(mod) when is_atom(mod), do: &mod.cast(&1)
 
   defp cast_integer(term) when is_binary(term) do
     case Integer.parse(term) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1068,7 +1068,7 @@ defmodule Ecto.Type do
     if :erlang.module_loaded(module) or Code.ensure_loaded?(module) do
       function_exported?(module, fun, arity)
     else
-      raise ArgumentError, "module #{inspect(module)} is not available"
+      raise ArgumentError, "cannot use #{inspect(module)} as Ecto.Type, module is not available"
     end
   end
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -150,7 +150,7 @@ defmodule Ecto.Type do
   """
   @callback equal?(term, term) :: boolean
 
-  @optional_callbacks [cast: 1, dump: 1, load: 1, equal?: 2]
+  @optional_callbacks [equal?: 2]
 
   ## Functions
 
@@ -629,11 +629,7 @@ defmodule Ecto.Type do
   end
 
   defp caster(mod) when is_atom(mod) do
-    if loaded_and_exported?(mod, :cast, 1) do
-      &mod.cast(&1)
-    else
-      &{:ok, &1}
-    end
+    &mod.cast(&1)
   end
 
   defp cast_basic(:float, term) when is_binary(term) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1023,8 +1023,6 @@ defmodule Ecto.Type do
   defp of_base_type?(:date, value), do: Kernel.match?(%Date{}, value)
   defp of_base_type?(_, _), do: false
 
-  # TODO: pasted from array/4, remove after changing dump/1 and load/1
-
   # nil always passes through
   defp array([nil | t], fun, acc) do
     array(t, fun, [nil | acc])
@@ -1068,10 +1066,10 @@ defmodule Ecto.Type do
     :error
   end
 
-  defp array([h|t], type, fun, acc) do
+  defp array([h | t], type, fun, acc) do
     case fun.(type, h) do
-      {:ok, h} -> array(t, type, fun, [h|acc])
-      :error   -> :error
+      {:ok, h} -> array(t, type, fun, [h | acc])
+      :error -> :error
     end
   end
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -97,6 +97,24 @@ defmodule Ecto.TypeTest do
     assert cast({:array, Custom}, 1) == :error
   end
 
+  test "custom types with map" do
+    assert load({:map, Custom}, %{"x" => "foo"}) == {:ok, %{"x" => :load}}
+    assert dump({:map, Custom}, %{"x" => "foo"}) == {:ok, %{"x" => :dump}}
+    assert cast({:map, Custom}, %{"x" => "foo"}) == {:ok, %{"x" => :cast}}
+
+    assert load({:map, Custom}, %{"x" => nil}) == {:ok, %{"x" => nil}}
+    assert dump({:map, Custom}, %{"x" => nil}) == {:ok, %{"x" => nil}}
+    assert cast({:map, Custom}, %{"x" => nil}) == {:ok, %{"x" => nil}}
+
+    assert load({:map, Custom}, nil) == {:ok, nil}
+    assert dump({:map, Custom}, nil) == {:ok, nil}
+    assert cast({:map, Custom}, nil) == {:ok, nil}
+
+    assert load({:map, Custom}, 1) == :error
+    assert dump({:map, Custom}, 1) == :error
+    assert cast({:map, Custom}, 1) == :error
+  end
+
   test "in" do
     assert cast({:in, :integer}, ["1", "2", "3"]) == {:ok, [1, 2, 3]}
     assert cast({:in, :integer}, nil) == :error

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -115,6 +115,12 @@ defmodule Ecto.TypeTest do
     assert cast({:map, Custom}, 1) == :error
   end
 
+  test "dump with custom function" do
+    dumper = fn :integer, term -> {:ok, term * 2} end
+    assert dump({:array, :integer}, [1, 2], dumper) == {:ok, [2, 4]}
+    assert dump({:map, :integer}, %{x: 1, y: 2}, dumper) == {:ok, %{x: 2, y: 4}}
+  end
+
   test "in" do
     assert cast({:in, :integer}, ["1", "2", "3"]) == {:ok, [1, 2, 3]}
     assert cast({:in, :integer}, nil) == :error

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -54,6 +54,10 @@ defmodule Ecto.TypeTest do
 
     assert cast(CustomDefault, "foo") == {:ok, "foo"}
 
+    assert_raise ArgumentError, "module :foo is not available", fn ->
+      cast(:foo, "foo")
+    end
+
     assert match?(Custom, :any)
     assert match?(:any, Custom)
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -679,6 +679,8 @@ defmodule Ecto.TypeTest do
     test "primitive" do
       assert Ecto.Type.equal?(:integer, 1, 1)
       refute Ecto.Type.equal?(:integer, 1, 2)
+      refute Ecto.Type.equal?(:integer, 1, "1")
+      refute Ecto.Type.equal?(:integer, 1, nil)
     end
 
     test "composite primitive" do
@@ -690,7 +692,9 @@ defmodule Ecto.TypeTest do
 
     test "semantical comparison" do
       assert Ecto.Type.equal?(:decimal, d(1), d("1.0"))
+      refute Ecto.Type.equal?(:decimal, d(1), 1)
       refute Ecto.Type.equal?(:decimal, d(1), d("1.1"))
+      refute Ecto.Type.equal?(:decimal, d(1), nil)
 
       assert Ecto.Type.equal?(:time, ~T[09:00:00], ~T[09:00:00.000000])
       refute Ecto.Type.equal?(:time, ~T[09:00:00], ~T[09:00:00.999999])

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -19,11 +19,6 @@ defmodule Ecto.TypeTest do
     def cast(_),   do: {:ok, :cast}
   end
 
-  defmodule CustomDefault do
-    @behaviour Ecto.Type
-    def type, do: :any
-  end
-
   defmodule Schema do
     use Ecto.Schema
 
@@ -51,12 +46,6 @@ defmodule Ecto.TypeTest do
     assert load(Custom, nil) == {:ok, nil}
     assert dump(Custom, nil) == {:ok, nil}
     assert cast(Custom, nil) == {:ok, nil}
-
-    assert cast(CustomDefault, "foo") == {:ok, "foo"}
-
-    assert_raise ArgumentError, ~r"module is not available", fn ->
-      cast(:foo, "foo")
-    end
 
     assert match?(Custom, :any)
     assert match?(:any, Custom)

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -151,11 +151,13 @@ defmodule Ecto.TypeTest do
 
     assert {:ok, %Schema{id: @uuid_string, a: 1, c: 0}} =
            adapter_load(Ecto.TestAdapter, type, %{"id" => @uuid_binary, "abc" => 1})
-    assert {:ok, nil} == adapter_load(Ecto.TestAdapter,type, nil)
+    assert {:ok, nil} == adapter_load(Ecto.TestAdapter, type, nil)
     assert :error == adapter_load(Ecto.TestAdapter, type, 1)
 
     assert {:ok, %{abc: 1, c: 0, id: @uuid_binary}} ==
            adapter_dump(Ecto.TestAdapter, type, %Schema{id: @uuid_string, a: 1})
+    assert {:ok, nil} = adapter_dump(Ecto.TestAdapter, type, nil)
+    assert :error = adapter_dump(Ecto.TestAdapter, type, 1)
 
     assert :error == cast(type, %{"a" => 1})
     assert cast(type, %Schema{}) == {:ok, %Schema{}}
@@ -175,6 +177,8 @@ defmodule Ecto.TypeTest do
 
     assert {:ok, [%{id: @uuid_binary, abc: 1, c: 0}]} ==
            adapter_dump(Ecto.TestAdapter, type, [%Schema{id: @uuid_string, a: 1}])
+    assert {:ok, nil} = adapter_dump(Ecto.TestAdapter, type, nil)
+    assert :error = adapter_dump(Ecto.TestAdapter, type, 1)
 
     assert cast(type, [%{"abc" => 1}]) == :error
     assert cast(type, [%Schema{}]) == {:ok, [%Schema{}]}

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -19,6 +19,11 @@ defmodule Ecto.TypeTest do
     def cast(_),   do: {:ok, :cast}
   end
 
+  defmodule CustomDefault do
+    @behaviour Ecto.Type
+    def type, do: :any
+  end
+
   defmodule Schema do
     use Ecto.Schema
 
@@ -46,6 +51,8 @@ defmodule Ecto.TypeTest do
     assert load(Custom, nil) == {:ok, nil}
     assert dump(Custom, nil) == {:ok, nil}
     assert cast(Custom, nil) == {:ok, nil}
+
+    assert cast(CustomDefault, "foo") == {:ok, "foo"}
 
     assert match?(Custom, :any)
     assert match?(:any, Custom)

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -763,6 +763,11 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.equal?(Custom, true, false)
       refute Ecto.Type.equal?(Custom, false, false)
     end
+
+    test "unknown type" do
+      assert Ecto.Type.equal?(nil, 1, 1.0)
+      refute Ecto.Type.equal?(nil, 1, 2)
+    end
   end
 
   defp d(decimal), do: Decimal.new(decimal)

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -54,7 +54,7 @@ defmodule Ecto.TypeTest do
 
     assert cast(CustomDefault, "foo") == {:ok, "foo"}
 
-    assert_raise ArgumentError, "module :foo is not available", fn ->
+    assert_raise ArgumentError, ~r"module is not available", fn ->
       cast(:foo, "foo")
     end
 
@@ -764,9 +764,15 @@ defmodule Ecto.TypeTest do
       refute Ecto.Type.equal?(Custom, false, false)
     end
 
-    test "unknown type" do
+    test "nil type" do
       assert Ecto.Type.equal?(nil, 1, 1.0)
       refute Ecto.Type.equal?(nil, 1, 2)
+    end
+
+    test "bad type" do
+      assert_raise ArgumentError, ~r"cannot use :foo as Ecto.Type", fn ->
+        Ecto.Type.equal?(:foo, 1, 1.0)
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Optimize `Ecto.Type.equal?/3`
- [x] Make `Ecto.Type.cast/1` callback optional
- [x] Make `Ecto.Type.dump/1` callback optional
- [x] Make `Ecto.Type.load/1` callback optional

---

Before, for `{:array, Custom}` we were hitting `function_exported?(Custom, :equal, 2)` for each element in the list.
Now, we compute `equal_fun` once and then just call it for each element.

cc @michalmuskala 