### PR TITLE
Ecto type for postgres daterange

### DIFF
--- a/lib/ecto/discrete_range.ex
+++ b/lib/ecto/discrete_range.ex
@@ -1,0 +1,311 @@
+defmodule Ecto.DiscreteRange do
+  @moduledoc """
+  Define useful functions to create an ecto.type for the postgres
+  range type for discrete types. It represents the interval as a
+  `closed-open` interval.
+
+  To use this module your type must have a well define successor
+  function and a comparison function.
+  """
+
+  @typedoc """
+  The type of a point in the range.
+  """
+  @type t :: :infinity | :_infinity | term
+
+  @typedoc """
+  The successor function. For example, for integer type, returns,
+  `succ_fn(n)` must return `n+1`.
+  """
+  @type succ_fn :: (t -> t)
+
+  @typedoc """
+  The comparison function.
+  """
+  @type comp_fn :: (t, t -> :lt | :eq | :gt)
+
+  @typedoc """
+  Allen's relantionships between intervals. Refer to
+  https://en.wikipedia.org/w/index.php?title=Allen%27s_interval_algebra&oldid=846947944 for more information.
+  """
+  @type allens_relation ::
+          :equals | :finishes | :starts | :meets | :before | :after | :during | :overlaps
+
+  @doc """
+  Creates a new interval.
+
+    * `:succ_fn` computes the next value;
+    * `:comp_fn` comparator for the given type;
+    * `:lower` the lower term of the interval;
+    * `:upper` the upper term of the interval;
+    * `:mode` defines how to interpret interval boundaries;
+  """
+  @spec new(succ_fn, comp_fn, Ecto.Type, t, t, {:open | :closed, :open | :closed}) ::
+          {:ok, {t, t}} | :error
+  def new(succ_fn, comp_fn, ecto_ty, lower, upper, mode) do
+    interval_fn =
+      case mode do
+        {:closed, :open} ->
+          fn a, b -> {:ok, {a, b}} end
+
+        {:closed, :closed} ->
+          fn a, b -> {:ok, {a, succ_term(succ_fn, b)}} end
+
+        {:open, :open} ->
+          fn a, b -> {:ok, {succ_term(succ_fn, a), b}} end
+
+        {:open, :closed} ->
+          fn a, b -> {:ok, {succ_term(succ_fn, a), succ_term(succ_fn, b)}} end
+
+        _ ->
+          fn _a, _b -> :error end
+      end
+
+    with {:ok, lower} <- cast_term(:l, ecto_ty, lower),
+         {:ok, upper} <- cast_term(:r, ecto_ty, upper),
+         {:ok, {lower, upper}} <- interval_fn.(lower, upper),
+         true <- :gt != comp_term(comp_fn, lower, upper) do
+      {:ok, {lower, upper}}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec load(succ_fn, Ecto.Type.t(), %Postgrex.Range{}) :: {:ok, {t, t}} | :error
+  def load(succ_fn, ecto_ty, value = %Postgrex.Range{}) do
+    with {:ok, lower} <- load_term(:l, ecto_ty, value.lower),
+         {:ok, upper} <- load_term(:u, ecto_ty, value.upper) do
+      lower =
+        if value.lower_inclusive do
+          lower
+        else
+          succ_term(succ_fn, lower)
+        end
+
+      upper =
+        if value.upper_inclusive do
+          succ_term(succ_fn, upper)
+        else
+          upper
+        end
+
+      {:ok, {lower, upper}}
+    end
+  end
+
+  @spec cast(succ_fn, comp_fn, Ecto.Type.t(), String.t()) :: {:ok, {t, t}} | :error
+  def cast(succ_fn, comp_fn, ecto_ty, value) when is_binary(value) do
+    with [lower, upper] <- String.split(value, ",", parts: 2),
+         {:ok, lmode} <- cast_mode(:l, String.at(lower, 0)),
+         {:ok, rmode} <- cast_mode(:u, String.at(upper, -1)),
+         {:ok, lower} <- cast_term(:l, ecto_ty, String.slice(lower, 1..-1)),
+         {:ok, upper} <- cast_term(:u, ecto_ty, String.slice(upper, 0..-2)) do
+      new(succ_fn, comp_fn, ecto_ty, lower, upper, {lmode, rmode})
+    else
+      _ -> :error
+    end
+  end
+
+  @spec dump(Ecto.Type.t(), t, t) :: {:ok, Postgrex.Range.t()} | :error
+  def dump(ecto_ty, lower, upper) do
+    with {:ok, lower} <- dump_term(ecto_ty, lower),
+         {:ok, upper} <- dump_term(ecto_ty, upper) do
+      {:ok,
+       %Postgrex.Range{
+         lower: lower,
+         upper: upper,
+         lower_inclusive: lower != nil,
+         upper_inclusive: false
+       }}
+    end
+  end
+
+  @doc """
+  Compute the allen relationship between two proper intervals:
+
+  * before/after:
+  ```
+    _xxx_____
+    _____yyy_
+  ```
+
+  * equals:
+  ```
+    ___xxx___
+    ___yyy___
+  ```
+
+  * finishes:
+  ```
+    _____xxx
+    ___yyyyy
+  ```
+
+  * starts
+  ```
+    xxx_____
+    yyyyy___
+  ```
+
+  * meets:
+  ```
+    xxx_____
+    ___yyy__
+  ```
+
+  * overlaps:
+  ```
+    _xxx____
+    __yyy___
+  ```
+
+  * during:
+  ```
+    __xxxx__
+    _yyyyyy_
+  ```
+  """
+  @spec relation(comp_fn, t, t, t, t) :: allens_relation
+  def relation(comp_fn, a_lower, a_upper, b_lower, b_upper) do
+    cmp_u_l = comp_term(comp_fn, a_upper, b_lower)
+    cmp_u_u = comp_term(comp_fn, a_upper, b_upper)
+    cmp_l_l = comp_term(comp_fn, a_lower, b_lower)
+    cmp_l_u = comp_term(comp_fn, a_lower, b_upper)
+
+    cond do
+      cmp_l_l == :eq and cmp_u_u == :eq ->
+        :equals
+
+      cmp_u_u == :eq ->
+        :finishes
+
+      cmp_l_l == :eq ->
+        :starts
+
+      cmp_u_l == :eq or cmp_l_u == :eq ->
+        :meets
+
+      cmp_u_l == :lt ->
+        :before
+
+      cmp_l_u == :gt ->
+        :after
+
+      cmp_l_l == :lt and cmp_u_u == :gt ->
+        :during
+
+      cmp_l_l == :gt and cmp_u_u == :lt ->
+        :during
+
+      cmp_l_l == :lt and cmp_u_u != :gt ->
+        :overlaps
+
+      cmp_l_l == :gt and cmp_u_u != :lt ->
+        :overlaps
+    end
+  end
+
+  @doc """
+  test if the interval contains a point.
+  """
+  @spec contains?(comp_fn, t, t, t) :: boolean
+  def contains?(comp_fn, a, b, c) do
+    :gt != comp_term(comp_fn, a, c) and :lt == comp_term(comp_fn, c, b) and :infinity != c and
+      :_infinity != c
+  end
+
+  @spec succ_term(succ_fn, t) :: t
+  defp succ_term(succ_fn, value) do
+    case value do
+      :infinity -> :infinity
+      :_infinity -> :_infinity
+      _value -> succ_fn.(value)
+    end
+  end
+
+  @spec dump_term(Ecto.Type.t(), t) :: {:ok, term} | :error
+  defp dump_term(ecto_ty, term) do
+    case term do
+      :_infinity -> {:ok, nil}
+      :infinity -> {:ok, nil}
+      _term -> Ecto.Type.dump(ecto_ty, term)
+    end
+  end
+
+  @spec load_term(:u | :l, Ecto.Type.t(), term) :: {:ok, t} | :error
+  defp load_term(mode, ecto_ty, value) do
+    case value do
+      nil ->
+        case mode do
+          :u -> {:ok, :infinity}
+          :l -> {:ok, :_infinity}
+        end
+
+      _value ->
+        Ecto.Type.load(ecto_ty, value)
+    end
+  end
+
+  @spec cast_term(:r | :u, Ecto.Type.t(), term) :: {:ok, t} | :error
+  defp cast_term(mode, ecto_ty, term) do
+    case term do
+      "" ->
+        case mode do
+          :u -> :infinity
+          :l -> :_infinity
+        end
+
+      "-infinity" ->
+        {:ok, :_infinity}
+
+      "infinity" ->
+        {:ok, :infinity}
+
+      :_infinity ->
+        {:ok, :_infinity}
+
+      :infinity ->
+        {:ok, :infinity}
+
+      _term ->
+        Ecto.Type.cast(ecto_ty, term)
+    end
+  end
+
+  @spec cast_mode(:u | :l, String.t()) :: {:ok, :open} | {:ok, :closed} | :error
+  defp cast_mode(dir, c) do
+    case {dir, c} do
+      {:l, "("} -> {:ok, :open}
+      {:l, "["} -> {:ok, :closed}
+      {:u, ")"} -> {:ok, :open}
+      {:u, "]"} -> {:ok, :closed}
+      _ -> :error
+    end
+  end
+
+  @spec comp_term(comp_fn, t, t) :: :lt | :eq | :gt
+  defp comp_term(comp_fn, a, b) do
+    case {a, b} do
+      {:_infinity, :_infinity} ->
+        :eq
+
+      {:infinity, :infinity} ->
+        :eq
+
+      {:_infinity, _} ->
+        :lt
+
+      {:infinity, _} ->
+        :gt
+
+      {_, :infinity} ->
+        :lt
+
+      {_, :_infinity} ->
+        :gt
+
+      _otherwise ->
+        comp_fn.(a, b)
+    end
+  end
+end

--- a/lib/ecto/postgres_date_range.ex
+++ b/lib/ecto/postgres_date_range.ex
@@ -1,0 +1,106 @@
+defmodule Ecto.PostgresDateRange do
+  @moduledoc """
+  An ecto type for postgrex daterange.
+  """
+  @behaviour Ecto.Type
+
+  alias Ecto.DiscreteRange
+
+  defstruct [:lower, :upper]
+
+  @impl true
+  def type, do: :daterange
+
+  @type t :: %__MODULE__{}
+
+  @doc """
+  Creates a new date range. The `lower` value must the less or equal
+  than the `upper` value. The default is to create an `closed-open`
+  interval but you can use any variant as long as don't break the
+  less-or-equal than invariant.
+  """
+  @spec new(Date.t() | String.t(), Date.t() | String.t(), {:open | :closed, :open | :closed}) ::
+          {:ok, t} | :error
+  def new(lower, upper, mode \\ {:closed, :open}) do
+    with {:ok, {lower, upper}} <-
+           DiscreteRange.new(succ_fn(), comp_fn(), :date, lower, upper, mode) do
+      {:ok, %__MODULE__{lower: lower, upper: upper}}
+    end
+  end
+
+  @doc """
+  Bang version of the `new/3` and `new/4` functions.
+  """
+  @spec new(Date.t() | String.t(), Date.t() | String.t(), {:open | :closed, :open | :closed}) :: t
+  def new!(lower, upper, mode \\ {:closed, :open}) do
+    {:ok, range} = new(lower, upper, mode)
+    range
+  end
+
+  @impl true
+  def cast(value) do
+    case value do
+      %__MODULE__{} ->
+        {:ok, value}
+
+      _ when is_binary(value) ->
+        with {:ok, {lower, upper}} <- DiscreteRange.cast(succ_fn(), comp_fn(), :date, value) do
+          {:ok, %__MODULE__{lower: lower, upper: upper}}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  @impl true
+  def dump(value) do
+    case value do
+      %__MODULE__{} ->
+        DiscreteRange.dump(:date, value.lower, value.upper)
+
+      _ ->
+        :error
+    end
+  end
+
+  @impl true
+  def load(value) do
+    with {:ok, {lower, upper}} <- DiscreteRange.load(succ_fn(), :date, value) do
+      {:ok, %__MODULE__{lower: lower, upper: upper}}
+    end
+  end
+
+  @doc """
+  Compute the allen relationship between two date intervals. Refer to
+  `Ecto.DiscreteRange.relation` for more information.
+
+  Examples:
+
+      iex> relation(new!(~D[1900-01-01], ~D[1900-02-01]), new!(~D[1900-01-20], ~D[1900-02-10]))
+      :overlaps
+  """
+  @spec relation(t, t) :: DiscreteRange.allens_relation()
+  def relation(a = %__MODULE__{}, b = %__MODULE__{}) do
+    DiscreteRange.relation(comp_fn(), a.lower, a.upper, b.lower, b.upper)
+  end
+
+  @doc """
+  Membership check. Checks if the interval contains a date.
+
+  Examples:
+
+      iex> contains?(new!(~D[1900-01-01], ~D[1900-01-02]), ~D[1900-01-01])
+      true
+      iex> contains?(new!(~D[1900-01-01], ~D[1900-01-02]), ~D[1900-01-02])
+      false
+  """
+  @spec contains?(t, Date.t()) :: boolean
+  def contains?(a = %__MODULE__{}, x = %Date{}) do
+    DiscreteRange.contains?(comp_fn(), a.lower, a.upper, x)
+  end
+
+  defp comp_fn, do: &Date.compare/2
+
+  defp succ_fn, do: fn date -> Date.add(date, 1) end
+end

--- a/test/ecto/discrete_range_test.exs
+++ b/test/ecto/discrete_range_test.exs
@@ -1,0 +1,182 @@
+defmodule Ecto.DiscreteRangeTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.DiscreteRange
+
+  describe "allen relationships" do
+    test "equals" do
+      assert :equals == DiscreteRange.relation(&comp_fn/2, 0, 1, 0, 1)
+
+      assert :equals == DiscreteRange.relation(&comp_fn/2, :_infinity, 1, :_infinity, 1)
+      assert :equals == DiscreteRange.relation(&comp_fn/2, 0, :infinity, 0, :infinity)
+
+      assert :equals ==
+               DiscreteRange.relation(&comp_fn/2, :_infinity, :infinity, :_infinity, :infinity)
+    end
+
+    test "during" do
+      assert :during == DiscreteRange.relation(&comp_fn/2, 0, 3, 1, 2)
+      assert :during == DiscreteRange.relation(&comp_fn/2, 1, 2, 0, 3)
+
+      assert :during == DiscreteRange.relation(&comp_fn/2, :_infinity, 3, 1, 2)
+      assert :during == DiscreteRange.relation(&comp_fn/2, 1, 2, :_infinity, 3)
+
+      assert :during == DiscreteRange.relation(&comp_fn/2, 0, :infinity, 1, 2)
+      assert :during == DiscreteRange.relation(&comp_fn/2, 1, 2, 0, :infinity)
+    end
+
+    test "overlaps" do
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 0, 2, 1, 3)
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 1, 3, 0, 2)
+
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, :_infinity, 2, 1, 3)
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 1, 3, :_infinity, 2)
+
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 0, 2, 1, :infinity)
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 1, :infinity, 0, 2)
+    end
+
+    test "meets" do
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 0, 1, 1, 2)
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 1, 2, 0, 1)
+
+      assert :meets == DiscreteRange.relation(&comp_fn/2, :_infinity, 1, 1, 2)
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 1, 2, :_infinity, 1)
+
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 0, 1, 1, :infinity)
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 1, :infinity, 0, 1)
+    end
+
+    test "before" do
+      assert :before = DiscreteRange.relation(&comp_fn/2, 0, 1, 2, 3)
+      assert :before = DiscreteRange.relation(&comp_fn/2, :_infinity, 1, 2, 3)
+      assert :before = DiscreteRange.relation(&comp_fn/2, 0, 1, 2, :infinity)
+    end
+
+    test "after" do
+      assert :after = DiscreteRange.relation(&comp_fn/2, 2, 3, 0, 1)
+      assert :after = DiscreteRange.relation(&comp_fn/2, 2, 3, :_infinity, 1)
+      assert :after = DiscreteRange.relation(&comp_fn/2, 2, :infinity, 0, 1)
+    end
+
+    test "finishes" do
+      assert :finishes == DiscreteRange.relation(&comp_fn/2, 0, 2, 1, 2)
+      assert :finishes == DiscreteRange.relation(&comp_fn/2, 1, 2, 0, 2)
+
+      assert :finishes == DiscreteRange.relation(&comp_fn/2, :_infinity, 2, 1, 2)
+      assert :finishes == DiscreteRange.relation(&comp_fn/2, 1, 2, :_infinity, 2)
+
+      assert :finishes == DiscreteRange.relation(&comp_fn/2, 0, :infinity, 1, :infinity)
+      assert :finishes == DiscreteRange.relation(&comp_fn/2, 1, :infinity, 0, :infinity)
+    end
+
+    test "starts" do
+      assert :starts == DiscreteRange.relation(&comp_fn/2, 0, 2, 0, 1)
+      assert :starts == DiscreteRange.relation(&comp_fn/2, 0, 1, 0, 2)
+
+      assert :starts == DiscreteRange.relation(&comp_fn/2, :_infinity, 2, :_infinity, 1)
+      assert :starts == DiscreteRange.relation(&comp_fn/2, :_infinity, 1, :_infinity, 2)
+
+      assert :starts == DiscreteRange.relation(&comp_fn/2, 0, :infinity, 0, 1)
+      assert :starts == DiscreteRange.relation(&comp_fn/2, 0, 1, 0, :infinity)
+    end
+
+    test "moving a interval on a timeline" do
+      assert :before == DiscreteRange.relation(&comp_fn/2, 0, 2, 3, 5)
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 1, 3, 3, 5)
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 2, 4, 3, 5)
+      assert :equals == DiscreteRange.relation(&comp_fn/2, 3, 5, 3, 5)
+      assert :overlaps == DiscreteRange.relation(&comp_fn/2, 4, 6, 3, 5)
+      assert :meets == DiscreteRange.relation(&comp_fn/2, 5, 7, 3, 5)
+      assert :after == DiscreteRange.relation(&comp_fn/2, 6, 8, 3, 5)
+    end
+  end
+
+  describe "contains?" do
+    test "a point outside the interval" do
+      refute DiscreteRange.contains?(&comp_fn/2, 2, 3, 1)
+      refute DiscreteRange.contains?(&comp_fn/2, 2, 3, 3)
+      refute DiscreteRange.contains?(&comp_fn/2, 2, 3, 4)
+
+      refute DiscreteRange.contains?(&comp_fn/2, 2, :infinity, 1)
+      refute DiscreteRange.contains?(&comp_fn/2, :_infinity, 3, 4)
+    end
+
+    test "a point in the interval" do
+      assert DiscreteRange.contains?(&comp_fn/2, 2, 4, 2)
+      assert DiscreteRange.contains?(&comp_fn/2, 2, 4, 3)
+    end
+
+    test "an empty interval" do
+      refute DiscreteRange.contains?(&comp_fn/2, 2, 2, 2)
+    end
+
+    test "infinity is never in the interval" do
+      refute DiscreteRange.contains?(&comp_fn/2, :_infinity, :infinity, :infinity)
+      refute DiscreteRange.contains?(&comp_fn/2, :_infinity, :infinity, :_infinity)
+    end
+  end
+
+  describe "new" do
+    test "closed, open is the default" do
+      assert {:ok, {0, 1}} ==
+               DiscreteRange.new(&succ_fn/1, &comp_fn/2, :integer, 0, 1, {:closed, :open})
+    end
+
+    test "normalizes the interval in other modes" do
+      assert {:ok, {1, 1}} ==
+               DiscreteRange.new(&succ_fn/1, &comp_fn/2, :integer, 0, 1, {:open, :open})
+
+      assert {:ok, {1, 2}} ==
+               DiscreteRange.new(&succ_fn/1, &comp_fn/2, :integer, 0, 1, {:open, :closed})
+
+      assert {:ok, {0, 2}} ==
+               DiscreteRange.new(&succ_fn/1, &comp_fn/2, :integer, 0, 1, {:closed, :closed})
+    end
+
+    test "intervals with infinity" do
+      for lmode <- [:open, :closed], rmode <- [:open, :closed] do
+        assert {:ok, {:_infinity, :infinity}} ==
+                 DiscreteRange.new(
+                   &succ_fn/1,
+                   &comp_fn/2,
+                   :integer,
+                   :_infinity,
+                   :infinity,
+                   {lmode, rmode}
+                 )
+      end
+    end
+
+    test "minus infinity" do
+      assert {:ok, {:_infinity, 1}} ==
+               DiscreteRange.new(
+                 &succ_fn/1,
+                 &comp_fn/2,
+                 :integer,
+                 :_infinity,
+                 1,
+                 {:closed, :open}
+               )
+    end
+
+    test "infinity" do
+      assert {:ok, {0, :infinity}} ==
+               DiscreteRange.new(&succ_fn/1, &comp_fn/2, :integer, 0, :infinity, {:closed, :open})
+    end
+
+    test "invalid ranges: a > b" do
+      assert :error == DiscreteRange.new(&succ_fn/1, &comp_fn/2, :integer, 1, 0, {:closed, :open})
+    end
+  end
+
+  defp succ_fn(x), do: x + 1
+
+  defp comp_fn(x, y) when is_integer(x) and is_integer(y) do
+    cond do
+      x < y -> :lt
+      x > y -> :gt
+      x == y -> :eq
+    end
+  end
+end

--- a/test/ecto/postgres_date_range_test.exs
+++ b/test/ecto/postgres_date_range_test.exs
@@ -1,0 +1,70 @@
+defmodule Ecto.PostgresDateRangeTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.PostgresDateRange
+
+  doctest Ecto.PostgresDateRange, import: true
+
+  describe "cast" do
+    test "using postgres range format" do
+      assert PostgresDateRange.new(~D[1900-01-01], ~D[1900-02-01], {:closed, :open}) ==
+               PostgresDateRange.cast("[1900-01-01,1900-02-01)")
+
+      assert PostgresDateRange.new(~D[1900-01-01], ~D[1900-02-01], {:open, :open}) ==
+               PostgresDateRange.cast("(1900-01-01,1900-02-01)")
+
+      assert PostgresDateRange.new(~D[1900-01-01], ~D[1900-02-01], {:closed, :closed}) ==
+               PostgresDateRange.cast("[1900-01-01,1900-02-01]")
+
+      assert PostgresDateRange.new(~D[1900-01-01], ~D[1900-02-01], {:open, :closed}) ==
+               PostgresDateRange.cast("(1900-01-01,1900-02-01]")
+    end
+
+    test "using" do
+      assert PostgresDateRange.new(~D[1900-01-01], ~D[1900-02-01]) ==
+               PostgresDateRange.cast(PostgresDateRange.new!(~D[1900-01-01], ~D[1900-02-01]))
+    end
+  end
+
+  describe "load" do
+    test "load postgrex range type" do
+      for lmode <- [:open, :closed], rmode <- [:open, :closed] do
+        assert PostgresDateRange.new(~D[1900-01-01], ~D[1900-02-01], {lmode, rmode}) ==
+                 PostgresDateRange.load(%Postgrex.Range{
+                   lower: ~D[1900-01-01],
+                   upper: ~D[1900-02-01],
+                   lower_inclusive: lmode == :closed,
+                   upper_inclusive: rmode == :closed
+                 })
+      end
+    end
+  end
+
+  describe "dump" do
+    test "creates a postgrex range format" do
+      assert {:ok,
+              %Postgrex.Range{
+                lower: ~D[1900-01-01],
+                upper: ~D[1900-02-01],
+                lower_inclusive: true,
+                upper_inclusive: false
+              }} == PostgresDateRange.dump(PostgresDateRange.new!(~D[1900-01-01], ~D[1900-02-01]))
+
+      assert {:ok,
+              %Postgrex.Range{
+                lower: nil,
+                upper: ~D[1900-02-01],
+                lower_inclusive: false,
+                upper_inclusive: false
+              }} == PostgresDateRange.dump(PostgresDateRange.new!(:_infinity, ~D[1900-02-01]))
+
+      assert {:ok,
+              %Postgrex.Range{
+                lower: ~D[1900-01-01],
+                upper: nil,
+                lower_inclusive: true,
+                upper_inclusive: false
+              }} == PostgresDateRange.dump(PostgresDateRange.new!(~D[1900-01-01], :infinity))
+    end
+  end
+end


### PR DESCRIPTION
## summary

This patch creates an ecto type for `daterange` using `postgrex` range
type. It also contains a module with primitives to create another
discrete range types, like `intrange`.

The idea is to define types for all other discrete range types as well
but I'd like to test the reception of a patch of this nature and
collect feedback before doing more deep work as currently we only use
`daterange`.

As far as I know this type is Postgres only the code probably makes
this hypothesis very evident as it is completely dependent of
`postgrex`.

## code

there are two modules. `discrete_range.ex` contains functions to create range types. In short it requires a `successor` function and a `comparison` function to work. The other module is defined in `postgres_date_range.ex` and contains the actual ecto type.