### PR TITLE
Implement --strict-version-order for migrations

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -66,6 +66,7 @@ defmodule Ecto.Migrator do
     * `:log` - the level to use for logging. Defaults to `:info`.
       Can be any of `Logger.level/0` values or `false`.
     * `:prefix` - the prefix to run the migrations on
+    * `:strict_version_order` - abort when applying a migration with old timestamp
   """
   @spec up(Ecto.Repo.t, integer, module, Keyword.t) :: :ok | :already_up
   def up(repo, version, module, opts \\ []) do
@@ -82,7 +83,7 @@ defmodule Ecto.Migrator do
         if version != Enum.max([version | versions]) do
           latest = Enum.max(versions)
 
-          Logger.warn """
+          message = """
           You are running migration #{version} but an older \
           migration with version #{latest} has already run.
 
@@ -93,6 +94,12 @@ defmodule Ecto.Migrator do
           If this can be an issue, we recommend to rollback #{version} and change \
           it to a version later than #{latest}.
           """
+
+          if opts[:strict_version_order] do
+            raise Ecto.MigrationError, message
+          else
+            Logger.warn message
+          end
         end
 
         result

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -56,6 +56,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     * `--prefix` - the prefix to run migrations on
     * `--pool-size` - the pool size if the repository is started only for the task (defaults to 1)
     * `--log-sql` - log the raw sql migrations are running
+    * `--strict-version-order` - abort when applying a migration with old timestamp
 
   """
 
@@ -65,7 +66,8 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
     {opts, _, _} = OptionParser.parse args,
       switches: [all: :boolean, step: :integer, to: :integer, quiet: :boolean,
-                 prefix: :string, pool_size: :integer, log_sql: :boolean],
+                 prefix: :string, pool_size: :integer, log_sql: :boolean,
+                 strict_version_order: :boolean],
       aliases: [n: :step]
 
     opts =

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -152,6 +152,12 @@ defmodule Ecto.MigratorTest do
     assert output =~ ~r"== Migrated in \d.\ds"
   end
 
+  test "up raises error in strict mode" do
+    assert_raise Ecto.MigrationError, fn ->
+      up(TestRepo, 0, Migration, log: false, strict_version_order: true)
+    end
+  end
+
   test "up invokes the repository adapter with up commands" do
     assert capture_log(fn ->
       assert up(TestRepo, 0, Migration, log: false) == :ok


### PR DESCRIPTION
I have not actually been able to use the option from the command line to see if it works, since I am using v2.2.10 in my project (which is the latest release, but has drifted quite far away from master).

The tests seem to work fine though. Is this something useful?

https://github.com/elixir-ecto/ecto/issues/2614