### PR TITLE
[WIP] Use module attribute for prefix lookup

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -155,8 +155,20 @@ defmodule Ecto.Association do
 
   """
   def association_key(module, suffix) do
-    prefix = module |> Module.split |> List.last |> Macro.underscore
+    prefix =
+      module
+      |> Module.get_attribute(:find_a_better_name)
+      |> association_prefix(module)
+
     :"#{prefix}_#{suffix}"
+  end
+
+  defp association_prefix(nil, module) do
+    module |> Module.split |> List.last |> Macro.underscore
+  end
+
+  defp association_prefix(prefix, _module) do
+    prefix
   end
 
   @doc """

--- a/test/ecto/association_test.exs
+++ b/test/ecto/association_test.exs
@@ -165,6 +165,19 @@ defmodule Ecto.AssociationTest do
     end
   end
 
+  defmodule AssociationKeyExample do
+    use Ecto.Schema
+
+    @find_a_better_name "should_be_this"
+    schema "association" do
+      field :name
+    end
+  end
+
+  test "association_key/2 should use the module attribute" do
+    assert "should_be_this_id" == Ecto.Association.association_key(AssociationKeyExample, "_id")
+  end
+
   test "has many" do
     assoc = Post.__schema__(:association, :comments)
 


### PR DESCRIPTION
I was about to create an issue about this but I thought it would work with this PR but I got his error

```
(ArgumentError) could not call get_attribute with argument Ecto.AssociationTest.Author because the module is already compiled
```
So I need your help but I think is worth to show you what I am trying to do.


### Why

As did some refactoring in my code I used to have this module name `StrawHat.IAM.PolicyStatement` and then I changed it to `StrawHat.IAM.Policy.Statement`.

I assumed that nothing would go wrong but turns out that the module name matters in the particular case that you create the foreign keys.

Since the ID in the relation is `policy_statement_id` and not `statement_id` I am kind of confused what should I do.

I would prefer to at least have some simple way to configure this. Maybe add some other metadata that it is simple to set up.