### PR TITLE
Use String.pad_trailing to format ecto.migrations

### DIFF
--- a/lib/mix/tasks/ecto.migrations.ex
+++ b/lib/mix/tasks/ecto.migrations.ex
@@ -34,33 +34,30 @@ defmodule Mix.Tasks.Ecto.Migrations do
   def run(args, migrations \\ &Ecto.Migrator.migrations/1, puts \\ &IO.puts/1) do
     repos = parse_repo(args)
 
-    result = Enum.map(repos, fn repo ->
-      ensure_repo(repo, args)
-      ensure_migrations_path(repo)
-      {:ok, pid, _} = ensure_started(repo, all: true)
+    format = fn x, n -> x |> to_string() |> String.pad_trailing(n) end
 
-      repo_status = migrations.(repo)
+    result =
+      Enum.map(repos, fn repo ->
+        ensure_repo(repo, args)
+        ensure_migrations_path(repo)
+        {:ok, pid, _} = ensure_started(repo, all: true)
 
-      pid && repo.stop(pid)
+        repo_status = migrations.(repo)
 
-      """
+        pid && repo.stop(pid)
 
-      Repo: #{inspect repo}
+        """
 
-        Status    Migration ID    Migration Name
-      --------------------------------------------------
-      """ <>
-      Enum.map_join(repo_status, "\n", fn({status, number, description}) ->
-        status =
-          case status do
-            :up   -> "up  "
-            :down -> "down"
-          end
+        Repo: #{inspect(repo)}
 
-        "  #{status}      #{number}  #{description}"
-      end) <> "\n"
-    end)
+          Status    Migration ID    Migration Name
+        --------------------------------------------------
+        """ <>
+          Enum.map_join(repo_status, "\n", fn {status, number, description} ->
+            "  #{format.(status, 4)}      #{format.(number, 14)}  #{description}"
+          end) <> "\n"
+      end)
 
-     puts.(Enum.join(result, "\n"))
+    puts.(Enum.join(result, "\n"))
   end
 end

--- a/lib/mix/tasks/ecto.migrations.ex
+++ b/lib/mix/tasks/ecto.migrations.ex
@@ -34,8 +34,6 @@ defmodule Mix.Tasks.Ecto.Migrations do
   def run(args, migrations \\ &Ecto.Migrator.migrations/1, puts \\ &IO.puts/1) do
     repos = parse_repo(args)
 
-    format = fn x, n -> x |> to_string() |> String.pad_trailing(n) end
-
     result =
       Enum.map(repos, fn repo ->
         ensure_repo(repo, args)
@@ -54,10 +52,16 @@ defmodule Mix.Tasks.Ecto.Migrations do
         --------------------------------------------------
         """ <>
           Enum.map_join(repo_status, "\n", fn {status, number, description} ->
-            "  #{format.(status, 4)}      #{format.(number, 14)}  #{description}"
+            "  #{format(status, 10)}#{format(number, 16)}#{description}"
           end) <> "\n"
       end)
 
     puts.(Enum.join(result, "\n"))
+  end
+
+  defp format(content, pad) do
+    content
+    |> to_string
+    |> String.pad_trailing(pad)
   end
 end

--- a/test/mix/tasks/ecto.migrations_test.exs
+++ b/test/mix/tasks/ecto.migrations_test.exs
@@ -41,6 +41,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
 
     migrations = fn _ ->
       [
+        {:up,   0,              "up_migration_0"},
         {:up,   20160000000001, "up_migration_1"},
         {:up,   20160000000002, "up_migration_2"},
         {:up,   20160000000003, "up_migration_3"},
@@ -55,6 +56,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
 
         Status    Migration ID    Migration Name
       --------------------------------------------------
+        up        0               up_migration_0
         up        20160000000001  up_migration_1
         up        20160000000002  up_migration_2
         up        20160000000003  up_migration_3


### PR DESCRIPTION
Decided to play around with the id a bit in a recent project, and I got this output via `mix ecto.migrations`:

```
  Status    Migration ID    Migration Name
--------------------------------------------------
  up        0  base_db
```

So made some changes to this task to better format both the "Status" and "Migration ID". 

Also applied `mix format` to this file