### PR TITLE
reverse modify in migration

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -79,27 +79,21 @@ defmodule Ecto.Integration.MigrationTest do
         add :id, :integer, primary_key: true
       end
       create table(:modify_from_posts) do
-        add :author, references(:modify_from_authors, type: :integer)
+        add :author_id, references(:modify_from_authors, type: :integer)
       end
 
       if direction() == :up do
-        execute "INSERT INTO modify_from_authors (id) VALUES (1)"
-        execute "INSERT INTO modify_from_posts (author) VALUES (1)"
+        flush()
+        PoolRepo.insert_all "modify_from_authors", [[id: 1]]
+        PoolRepo.insert_all "modify_from_posts", [[author_id: 1]]
       end
 
       alter table(:modify_from_posts) do
-        # remove the constraints modify_from_posts_author_fkey
-        modify :author, :integer, from: references(:modify_from_authors, type: :integer)
+        # remove the constraints modify_from_posts_author_id_fkey
+        modify :author_id, :integer, from: references(:modify_from_authors, type: :integer)
       end
       alter table(:modify_from_authors) do
         modify :id, :bigint, from: :integer
-      end
-      case PoolRepo.__adapter__ do
-        Ecto.Adapters.MySQL ->
-          execute ~s{ALTER TABLE modify_from_posts CHANGE author author_id BIGINT UNSIGNED},
-                  ~s{ALTER TABLE modify_from_posts CHANGE author_id author BIGINT UNSIGNED}
-        _ ->
-          rename table(:modify_from_posts), :author, to: :author_id
       end
       alter table(:modify_from_posts) do
         # add the constraints modify_from_posts_author_id_fkey

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -94,7 +94,13 @@ defmodule Ecto.Integration.MigrationTest do
       alter table(:modify_from_authors) do
         modify :id, :bigint, from: :integer
       end
-      rename table(:modify_from_posts), :author, to: :author_id
+      case PoolRepo.__adapter__ do
+        Ecto.Adapters.MySQL ->
+          execute ~s{ALTER TABLE modify_from_posts CHANGE author author_id BIGINT UNSIGNED},
+                  ~s{ALTER TABLE modify_from_posts CHANGE author_id author BIGINT UNSIGNED}
+        _ ->
+          rename table(:modify_from_posts), :author, to: :author_id
+      end
       alter table(:modify_from_posts) do
         # add the constraints modify_from_posts_author_id_fkey
         modify :author_id, references(:modify_from_authors, type: :bigint), from: :integer

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -71,6 +71,37 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule AlterColumnFromMigration do
+    use Ecto.Migration
+
+    def change do
+      create table(:modify_from_authors, primary_key: false) do
+        add :id, :integer, primary_key: true
+      end
+      create table(:modify_from_posts) do
+        add :author, references(:modify_from_authors, type: :integer)
+      end
+
+      if direction() == :up do
+        execute "INSERT INTO modify_from_authors (id) VALUES (1)"
+        execute "INSERT INTO modify_from_posts (author) VALUES (1)"
+      end
+
+      alter table(:modify_from_posts) do
+        # remove the constraints modify_from_posts_author_fkey
+        modify :author, :integer, from: references(:modify_from_authors, type: :integer)
+      end
+      alter table(:modify_from_authors) do
+        modify :id, :bigint, from: :integer
+      end
+      rename table(:modify_from_posts), :author, to: :author_id
+      alter table(:modify_from_posts) do
+        # add the constraints modify_from_posts_author_id_fkey
+        modify :author_id, references(:modify_from_authors, type: :bigint), from: :integer
+      end
+    end
+  end
+
   defmodule AlterForeignKeyOnDeleteMigration do
     use Ecto.Migration
 
@@ -383,6 +414,16 @@ defmodule Ecto.Integration.MigrationTest do
     assert catch_error(PoolRepo.query!(query))
 
     :ok = down(PoolRepo, 20080906120000, AlterColumnMigration, log: false)
+  end
+
+  @tag :modify_column_with_from
+  test "modify column with from" do
+    assert :ok == up(PoolRepo, 20180918120000, AlterColumnFromMigration, log: false)
+
+    assert [1] ==
+           PoolRepo.all from p in "modify_from_posts", select: p.author_id
+
+    :ok = down(PoolRepo, 20180918120000, AlterColumnFromMigration, log: false)
   end
 
   @tag :modify_foreign_key_on_delete

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -914,7 +914,7 @@ if Code.ensure_loaded?(Postgrex) do
            reference_on_delete(ref.on_delete), reference_on_update(ref.on_update)]
 
     defp drop_constraint_expr(%Reference{} = ref, table, name),
-      do: ["DROP CONSTRAINT IF EXISTS ", reference_name(ref, table, name), ", "]
+      do: ["DROP CONSTRAINT ", reference_name(ref, table, name), ", "]
     defp drop_constraint_expr(_, _, _),
       do: []
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -786,12 +786,12 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp column_change(table, {:modify, name, %Reference{} = ref, opts}) do
-      ["ALTER COLUMN ", quote_name(name), " TYPE ", reference_column_type(ref.type, opts),
+      [drop_constraint_expr(opts[:from], table, name), "ALTER COLUMN ", quote_name(name), " TYPE ", reference_column_type(ref.type, opts),
        constraint_expr(ref, table, name), modify_null(name, opts), modify_default(name, ref.type, opts)]
     end
 
-    defp column_change(_table, {:modify, name, type, opts}) do
-      ["ALTER COLUMN ", quote_name(name), " TYPE ",
+    defp column_change(table, {:modify, name, type, opts}) do
+      [drop_constraint_expr(opts[:from], table, name), "ALTER COLUMN ", quote_name(name), " TYPE ",
        column_type(type, opts), modify_null(name, opts), modify_default(name, type, opts)]
     end
 
@@ -912,6 +912,11 @@ if Code.ensure_loaded?(Postgrex) do
            "FOREIGN KEY (", quote_name(name),
            ") REFERENCES ", quote_table(table.prefix, ref.table), ?(, quote_name(ref.column), ?),
            reference_on_delete(ref.on_delete), reference_on_update(ref.on_update)]
+
+    defp drop_constraint_expr(%Reference{} = ref, table, name),
+      do: ["DROP CONSTRAINT IF EXISTS ", reference_name(ref, table, name), ", "]
+    defp drop_constraint_expr(_, _, _),
+      do: []
 
     defp reference_name(%Reference{name: nil}, table, column),
       do: quote_name("#{table.name}_#{column}_fkey")

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -781,8 +781,9 @@ defmodule Ecto.Migration do
   @doc """
   Modifies the type of column when altering a table.
 
-  This command is not reversible as Ecto does not know what
-  is the current type to revert it back to.
+  This command is not reversible unless option `:from` is provided.
+  If the given `:from` is a %Reference{}, the adapter would try to drop
+  the corresponding foreign key constraints before modifies the type.
 
   See `add/3` for more information on supported types.
 
@@ -796,6 +797,7 @@ defmodule Ecto.Migration do
 
     * `:null` - sets to null or not null
     * `:default` - changes the default
+    * `:from` - provide the current type
     * `:size` - the size of the type (for example the numbers of characters). Default is no size.
     * `:precision` - the precision for a numeric type. Required when `scale` is specified.
     * `:scale` - the scale of a numeric type. Default is 0 scale.

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -229,7 +229,12 @@ defmodule Ecto.Migration.Runner do
   defp table_reverse([{:remove, name, type, opts}| t], acc) do
     table_reverse(t, [{:add, name, type, opts} | acc])
   end
-
+  defp table_reverse([{:modify, name, type, opts} | t], acc) do
+    case opts[:from] do
+      nil -> false
+      from -> table_reverse(t, [{:modify, name, from, Keyword.put(opts, :from, type)} | acc])
+    end
+  end
   defp table_reverse([{:add, name, _type, _opts} | t], acc) do
     table_reverse(t, [{:remove, name} | acc])
   end

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -845,6 +845,9 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
                 {:modify, :cost, :integer, [null: false, default: nil]},
                 {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
+                {:modify, :status, :string, from: :integer},
+                {:modify, :user_id, :integer, from: %Reference{table: :users}},
+                {:modify, :group_id, %Reference{table: :groups, column: :gid}, from: %Reference{table: :groups}},
                 {:remove, :summary}]}
 
     assert execute_ddl(alter) == ["""
@@ -854,6 +857,12 @@ defmodule Ecto.Adapters.MySQLTest do
     MODIFY `price` numeric(8,2) NULL, MODIFY `cost` integer DEFAULT NULL NOT NULL,
     MODIFY `permalink_id` BIGINT UNSIGNED NOT NULL,
     ADD CONSTRAINT `posts_permalink_id_fkey` FOREIGN KEY (`permalink_id`) REFERENCES `permalinks`(`id`),
+    MODIFY `status` varchar(255),
+    DROP FOREIGN KEY `posts_user_id_fkey`,
+    MODIFY `user_id` integer,
+    DROP FOREIGN KEY `posts_group_id_fkey`,
+    MODIFY `group_id` BIGINT UNSIGNED,
+    ADD CONSTRAINT `posts_group_id_fkey` FOREIGN KEY (`group_id`) REFERENCES `groups`(`gid`),
     DROP `summary`
     """ |> remove_newlines]
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1065,6 +1065,9 @@ defmodule Ecto.Adapters.PostgresTest do
               {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
               {:modify, :cost, :integer, [null: false, default: nil]},
               {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
+              {:modify, :status, :string, from: :integer},
+              {:modify, :user_id, :integer, from: %Reference{table: :users}},
+              {:modify, :group_id, %Reference{table: :groups, column: :gid}, from: %Reference{table: :groups}},
               {:remove, :summary}]}
 
     assert execute_ddl(alter) == ["""
@@ -1079,6 +1082,12 @@ defmodule Ecto.Adapters.PostgresTest do
     ALTER COLUMN "permalink_id" TYPE bigint,
     ADD CONSTRAINT "posts_permalink_id_fkey" FOREIGN KEY ("permalink_id") REFERENCES "permalinks"("id"),
     ALTER COLUMN "permalink_id" SET NOT NULL,
+    ALTER COLUMN "status" TYPE varchar(255),
+    DROP CONSTRAINT IF EXISTS "posts_user_id_fkey",
+    ALTER COLUMN "user_id" TYPE integer,
+    DROP CONSTRAINT IF EXISTS "posts_group_id_fkey",
+    ALTER COLUMN "group_id" TYPE bigint,
+    ADD CONSTRAINT "posts_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups"("gid"),
     DROP COLUMN "summary"
     """ |> remove_newlines]
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1083,9 +1083,9 @@ defmodule Ecto.Adapters.PostgresTest do
     ADD CONSTRAINT "posts_permalink_id_fkey" FOREIGN KEY ("permalink_id") REFERENCES "permalinks"("id"),
     ALTER COLUMN "permalink_id" SET NOT NULL,
     ALTER COLUMN "status" TYPE varchar(255),
-    DROP CONSTRAINT IF EXISTS "posts_user_id_fkey",
+    DROP CONSTRAINT "posts_user_id_fkey",
     ALTER COLUMN "user_id" TYPE integer,
-    DROP CONSTRAINT IF EXISTS "posts_group_id_fkey",
+    DROP CONSTRAINT "posts_group_id_fkey",
     ALTER COLUMN "group_id" TYPE bigint,
     ADD CONSTRAINT "posts_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups"("gid"),
     DROP COLUMN "summary"

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -548,13 +548,21 @@ defmodule Ecto.MigrationTest do
   test "backward: alters a table" do
     alter table(:posts) do
       add :summary, :text
-      add :extension, :text
+      modify :extension, :text, from: :string
     end
     flush()
 
     assert last_command() ==
            {:alter, %Table{name: "posts"},
-              [{:remove, :extension}, {:remove, :summary}]}
+              [{:modify, :extension, :string, from: :text}, {:remove, :summary}]}
+
+    assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
+      alter table(:posts) do
+        add :summary, :text
+        modify :summary, :string
+      end
+      flush()
+    end
 
     assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
       alter table(:posts) do


### PR DESCRIPTION
This pull request fixes #2682 via adding ability for `modify` to revert.

If use `modify` with `:from` option, e.g.
```elixir
alter table(:some_table) do
  # the option :from is optional, if not supplied, it works just as before (could not revert at all)
  modify :some_field, new_type, from: old_type
end
```
it could revert the change when `ecto.rollback`.

Note that since we get more information in of the `old` type, it is possible to do more thing when modify the type, such as to remove the foreign key constraint for the modified column if exists when the `old_type` is some reference.
(This feature only available for adapters of postgresql now, I think it could be port to mysql as well.)
Be careful when use with rename, you'd like to rename/remove the constraint as well.
```elixir
alter table(:some_table) do
  # remove the constraints some_table_old_name_fkey
  modify :old_name, :old_type, from: reference(:table1, type: :old_type)
end
alter table(:table1) do
  modify :old_name, :new_type, from: :old_type
end
rename table(:some_table), :old_name, to: :new_name
alter table(:some_table) do
  # add the constraints some_table_new_name_fkey
  modify :new_name, reference(:table1, type: :new_type), from: old_type
end
```

All the change would remain compatibility with old code (that is if no `:from` supplied, no constraints would be removed and no `ecto.rollback` could be performed.