### PR TITLE
Raise error with more information in Ecto.Multi

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -580,6 +580,8 @@ defmodule Ecto.Multi do
         {Map.put(acc, name, value), names}
       {:error, value} ->
         return.({name, value, acc})
+      other ->
+        raise "expect multi to return either {:ok, value} or {:error, value}, got #{inspect(other)} in #{inspect(name)}"
     end
   end
 

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -581,7 +581,7 @@ defmodule Ecto.Multi do
       {:error, value} ->
         return.({name, value, acc})
       other ->
-        raise "expect multi to return either {:ok, value} or {:error, value}, got #{inspect(other)} in #{inspect(name)}"
+        raise "expected Ecto.Multi callback named `#{inspect(name)}` to return either {:ok, value} or {:error, value}, got: #{inspect(other)}"
     end
   end
 

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -469,21 +469,19 @@ defmodule Ecto.MultiTest do
       assert changes.run == TestRepo
     end
 
-    test "with functions returning invalidly" do
-      fun = fn _repo, _changes -> :invalid end
-      multi = Multi.new |> Multi.run(:run, fun)
-
-      assert_raise(
-        RuntimeError,
-        "expect multi to return either {:ok, value} or {:error, value}, got :invalid in :run",
-        fn -> TestRepo.transaction(multi) end
-      )
-    end
-
     test "with mfa functions" do
       multi = Multi.new |> Multi.run(:run, __MODULE__, :run_ok, [])
       assert {:ok, changes} = TestRepo.transaction(multi)
       assert changes.run == TestRepo
+    end
+
+    test "raises on invalid return" do
+      fun = fn _repo, _changes -> :invalid end
+      multi = Multi.new |> Multi.run(:run, fun)
+
+      assert_raise RuntimeError, ~r"to return either {:ok, value} or {:error, value}", fn ->
+        TestRepo.transaction(multi)
+      end
     end
   end
 end

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -469,6 +469,17 @@ defmodule Ecto.MultiTest do
       assert changes.run == TestRepo
     end
 
+    test "with functions returning invalidly" do
+      fun = fn _repo, _changes -> :invalid end
+      multi = Multi.new |> Multi.run(:run, fun)
+
+      assert_raise(
+        RuntimeError,
+        "expect multi to return either {:ok, value} or {:error, value}, got :invalid in :run",
+        fn -> TestRepo.transaction(multi) end
+      )
+    end
+
     test "with mfa functions" do
       multi = Multi.new |> Multi.run(:run, __MODULE__, :run_ok, [])
       assert {:ok, changes} = TestRepo.transaction(multi)


### PR DESCRIPTION
I would like to propose raising `Ecto.Multi` error with more information.

Given the following example,

```elixir
Ecto.Multi.new()
|> Ecto.Multi.run(:my_multi, fn _ ->
  :ok
end)
|> MyRepo.transaction()
```

The current behaviour of Multi raises `CaseClauseError`.

```
** (CaseClauseError) no case clause matching: :ok
(ecto) lib/ecto/multi.ex:421: Ecto.Multi.apply_operation/5
(elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
(ecto) lib/ecto/multi.ex:411: anonymous fn/5 in Ecto.Multi.apply_operations/5
(ecto) lib/ecto/adapters/sql.ex:576: anonymous fn/3 in Ecto.Adapters.SQL.do_transaction/3
```

In my opinion this is not very helpful, especially when we pipe multiple multis together, it's very difficult to pinpoint where we make the mistake. Therefore this PR hopes to make the error message more obvious by including the name of the multi causing the problem.

I am fine with all suggestions on the error message or introducing an exception for this. Thank you.