### PR TITLE
Introduce stale_error_field option

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -797,6 +797,9 @@ defmodule Ecto.Repo do
       If none is specified, the conflict target is left up to the database.
       May also be `{:constraint, constraint_name_as_atom}` in databases
       that support the "ON CONSTRAINT" expression, such as PostgreSQL.
+    * `:stale_error_field` - The field where stale errors will be added in
+      the returning changeset. This option can be used to avoid raising
+      `Ecto.StaleEntryError`.
 
   See the "Shared options" section at the module documentation.
 
@@ -934,6 +937,9 @@ defmodule Ecto.Repo do
     * `:prefix` - The prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). This overrides the prefix set
       in the struct.
+    * `:stale_error_field` - The field where stale errors will be added in
+      the returning changeset. This option can be used to avoid raising
+      `Ecto.StaleEntryError`.
 
   ## Example
 
@@ -1004,6 +1010,9 @@ defmodule Ecto.Repo do
     * `:prefix` - The prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). This overrides the prefix set
       in the struct.
+    * `:stale_error_field` - The field where stale errors will be added in
+      the returning changeset. This option can be used to avoid raising
+      `Ecto.StaleEntryError`.
 
   See the "Shared options" section at the module documentation.
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -591,7 +591,16 @@ defmodule Ecto.Repo.Schema do
       {:invalid, _} = constraints ->
         constraints
       {:error, :stale} ->
-        raise Ecto.StaleEntryError, struct: changeset.data, action: action
+        opts = List.last(args)
+
+        case Keyword.fetch(opts, :stale_error_field) do
+          {:ok, stale_error_field} ->
+            changeset = Ecto.Changeset.add_error(changeset, stale_error_field, "stale")
+            {:error, changeset}
+
+          :error ->
+            raise Ecto.StaleEntryError, struct: changeset.data, action: action
+        end
     end
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -368,6 +368,21 @@ defmodule Ecto.RepoTest do
       assert_raise Ecto.StaleEntryError, fn -> TestRepo.delete(stale) end
     end
 
+    test "insert, update, and delete adds error to stale error field" do
+      my_schema = %MySchema{id: 1}
+      my_schema = put_in(my_schema.__meta__.context, {:error, :stale})
+      stale = Ecto.Changeset.cast(my_schema, %{x: "foo"}, [:x])
+
+      assert {:error, changeset} = TestRepo.insert(stale, [stale_error_field: :id])
+      assert changeset.errors == [id: {"stale", []}]
+
+      assert {:error, changeset} = TestRepo.update(stale, [stale_error_field: :id])
+      assert changeset.errors == [id: {"stale", []}]
+
+      assert {:error, changeset} = TestRepo.delete(stale, [stale_error_field: :id])
+      assert changeset.errors == [id: {"stale", []}]
+    end
+
     test "insert, update, insert_or_update and delete sets schema prefix" do
       valid = Ecto.Changeset.cast(%MySchema{id: 1}, %{x: "foo"}, [:x])
 


### PR DESCRIPTION
I would like to propose a small behavior change to `Ecto.Repo` upserting with an `on_conflict` query.

Given the following code trying to upsert an entry with a condition in `on_conflict` query.

```elixir
post = %Post{title: "first", uuid: Ecto.UUID.generate()}
MyRepo.insert!(post)

on_conflict = from Post, where: [deleted: false], update: [set: [title: "first"]]
MyRepo.insert(post, on_conflict: on_conflict, conflict_target: [:uuid])
```

The current behavior for this case raises `Ecto.StaleEntryError`, which is a bit confusing IMO, because there isn't any optimistic lock set. I think the ideal behavior in this case could be exactly as `on_conflict: :nothing`.

Suggestions are very appreciated. I could update the needed documentation if this PR is accepted. Thank you.