### PR TITLE
Add notes about :decimal and calendar types

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -235,17 +235,21 @@ defmodule Ecto.Schema do
 
   **Notes:**
 
-  - For the `{:array, inner_type}` and `{:map, inner_type}` type,
-    replace `inner_type` with one of the valid types, such as `:string`.
+    * For the `{:array, inner_type}` and `{:map, inner_type}` type,
+      replace `inner_type` with one of the valid types, such as `:string`.
 
-  - For the `:decimal` type, `+Infinity`, `-Infinity`, and `NaN` values are not supported,
-    even though the `Decimal` library handles them. To support them, create a custom type.
+    * For the `:decimal` type, `+Infinity`, `-Infinity`, and `NaN` values
+      are not supported, even though the `Decimal` library handles them.
+      To support them, you can create a custom type.
 
-  - For calendar types with and without microseconds, the correct type is enforced
-    when persisting to the DB. For example, casting `~T[09:00:00]` as `:time_usec`
-    will succeed and result in `~T[09:00:00.000000]`, but persiting to the DB will fail.
-    Similarly, casting `~T[09:00:00.000000]` as `:time` will succeed, but
-    persisting will not.
+    * For calendar types with and without microseconds, the precision is
+      enforced when persisting to the DB. For example, casting `~T[09:00:00]`
+      as `:time_usec` will succeed and result in `~T[09:00:00.000000]`, but
+      persisting a type without microseconds as `:time_usec` will fail.
+      Similarly, casting `~T[09:00:00.000000]` as `:time` will succeed, but
+      persisting will not. This is the same behaviour as seen in other types,
+      where casting has to be done explicitly and is never performed
+      implicitly when loading from or dumping to the database.
 
   ### Custom types
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -233,8 +233,19 @@ defmodule Ecto.Schema do
   `:utc_datetime`         | `DateTime` |
   `:utc_datetime_usec`    | `DateTime` |
 
-  **Note:** For the `{:array, inner_type}` and `{:map, inner_type}` type,
-  replace `inner_type` with one of the valid types, such as `:string`.
+  **Notes:**
+
+  - For the `{:array, inner_type}` and `{:map, inner_type}` type,
+    replace `inner_type` with one of the valid types, such as `:string`.
+
+  - For the `:decimal` type, `+Infinity`, `-Infinity`, and `NaN` values are not supported,
+    even though the `Decimal` library handles them. To support them, create a custom type.
+
+  - For calendar types with and without microseconds, the correct type is enforced
+    when persisting to the DB. For example, casting `~T[09:00:00]` as `:time_usec`
+    will succeed and result in `~T[09:00:00.000000]`, but persiting to the DB will fail.
+    Similarly, casting `~T[09:00:00.000000]` as `:time` will succeed, but
+    persisting will not.
 
   ### Custom types
 


### PR DESCRIPTION
Since we enforce the type, this fails because the default timestamp is `:naive_datetime`, so without microseconds.

```elixir
iex(1)> Friends.Repo.insert(%Friends.Person{inserted_at: NaiveDateTime.utc_now()})
** (Ecto.ChangeError) value `~N[2018-09-18 10:10:51.596624]` for `Friends.Person.inserted_at` in `insert` does not match type :naive_datetime
    (ecto) lib/ecto/repo/schema.ex:831: Ecto.Repo.Schema.dump_field!/6
    (ecto) lib/ecto/repo/schema.ex:840: anonymous fn/6 in Ecto.Repo.Schema.dump_fields!/5
    (stdlib) maps.erl:257: :maps.fold_1/3
    (ecto) lib/ecto/repo/schema.ex:838: Ecto.Repo.Schema.dump_fields!/5
    (ecto) lib/ecto/repo/schema.ex:780: Ecto.Repo.Schema.dump_changes!/6
    (ecto) lib/ecto/repo/schema.ex:219: anonymous fn/15 in Ecto.Repo.Schema.do_insert/3
```

I think ideally the error would provide more information. Should I investigate? 

Mentioned to me by @AndrewDryga. WDYT about these docs update, Andrew?