### PR TITLE
Improve stale error handling

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1461,7 +1461,7 @@ defmodule Ecto.Integration.RepoTest do
       ]
 
       assert {:error, changeset} = TestRepo.insert(post, insert_options)
-      assert changeset.errors == [counter: {"stale", []}]
+      assert changeset.errors == [counter: {"is stale", [stale: true]}]
 
       assert TestRepo.get!(Post, inserted.id).title == "first"
     end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -800,6 +800,8 @@ defmodule Ecto.Repo do
     * `:stale_error_field` - The field where stale errors will be added in
       the returning changeset. This option can be used to avoid raising
       `Ecto.StaleEntryError`.
+    * `:stale_error_message` - The message to add to the configured
+      `:stale_error_field` when stale errors happen, defaults to "is stale".
 
   See the "Shared options" section at the module documentation.
 
@@ -940,6 +942,8 @@ defmodule Ecto.Repo do
     * `:stale_error_field` - The field where stale errors will be added in
       the returning changeset. This option can be used to avoid raising
       `Ecto.StaleEntryError`.
+    * `:stale_error_message` - The message to add to the configured
+      `:stale_error_field` when stale errors happen, defaults to "is stale".
 
   ## Example
 
@@ -1013,6 +1017,8 @@ defmodule Ecto.Repo do
     * `:stale_error_field` - The field where stale errors will be added in
       the returning changeset. This option can be used to avoid raising
       `Ecto.StaleEntryError`.
+    * `:stale_error_message` - The message to add to the configured
+      `:stale_error_field` when stale errors happen, defaults to "is stale".
 
   See the "Shared options" section at the module documentation.
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -594,13 +594,13 @@ defmodule Ecto.Repo.Schema do
         opts = List.last(args)
 
         case Keyword.fetch(opts, :stale_error_field) do
-          {:ok, stale_error_field} ->
+          {:ok, stale_error_field} when is_atom(stale_error_field) ->
             stale_message = Keyword.get(opts, :stale_error_message, "is stale")
             changeset = Changeset.add_error(changeset, stale_error_field, stale_message, [stale: true])
 
             {:error, changeset}
 
-          :error ->
+          _other ->
             raise Ecto.StaleEntryError, struct: changeset.data, action: action
         end
     end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -595,7 +595,9 @@ defmodule Ecto.Repo.Schema do
 
         case Keyword.fetch(opts, :stale_error_field) do
           {:ok, stale_error_field} ->
-            changeset = Ecto.Changeset.add_error(changeset, stale_error_field, "stale")
+            stale_message = Keyword.get(opts, :stale_error_message, "is stale")
+            changeset = Changeset.add_error(changeset, stale_error_field, stale_message, [stale: true])
+
             {:error, changeset}
 
           :error ->

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -381,6 +381,8 @@ defmodule Ecto.RepoTest do
 
       assert {:error, changeset} = TestRepo.delete(stale, [stale_error_field: :id])
       assert changeset.errors == [id: {"is stale", [stale: true]}]
+
+      assert_raise Ecto.StaleEntryError, fn -> TestRepo.insert(stale, [stale_error_field: "id"]) end
     end
 
     test "insert, update, and delete adds custom stale error message" do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -374,13 +374,33 @@ defmodule Ecto.RepoTest do
       stale = Ecto.Changeset.cast(my_schema, %{x: "foo"}, [:x])
 
       assert {:error, changeset} = TestRepo.insert(stale, [stale_error_field: :id])
-      assert changeset.errors == [id: {"stale", []}]
+      assert changeset.errors == [id: {"is stale", [stale: true]}]
 
       assert {:error, changeset} = TestRepo.update(stale, [stale_error_field: :id])
-      assert changeset.errors == [id: {"stale", []}]
+      assert changeset.errors == [id: {"is stale", [stale: true]}]
 
       assert {:error, changeset} = TestRepo.delete(stale, [stale_error_field: :id])
-      assert changeset.errors == [id: {"stale", []}]
+      assert changeset.errors == [id: {"is stale", [stale: true]}]
+    end
+
+    test "insert, update, and delete adds custom stale error message" do
+      my_schema = %MySchema{id: 1}
+      my_schema = put_in(my_schema.__meta__.context, {:error, :stale})
+      stale = Ecto.Changeset.cast(my_schema, %{x: "foo"}, [:x])
+
+      options = [
+        stale_error_field: :id,
+        stale_error_message: "is old"
+      ]
+
+      assert {:error, changeset} = TestRepo.insert(stale, options)
+      assert changeset.errors == [id: {"is old", [stale: true]}]
+
+      assert {:error, changeset} = TestRepo.update(stale, options)
+      assert changeset.errors == [id: {"is old", [stale: true]}]
+
+      assert {:error, changeset} = TestRepo.delete(stale, options)
+      assert changeset.errors == [id: {"is old", [stale: true]}]
     end
 
     test "insert, update, insert_or_update and delete sets schema prefix" do


### PR DESCRIPTION
Spawned from https://github.com/elixir-ecto/ecto/pull/2687#discussion_r218570358.

Summary of what this PR does:

* Make the stale error message configurable by introducing `:stale_error_message` option.
* Stricter with `:stale_error_field`, only accept atoms.