### PR TITLE
Allow integration tests to run on PostgreSQL 10.4

### DIFF
--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -67,7 +67,7 @@ _   = Ecto.Adapters.Postgres.storage_down(TestRepo.config)
 %{rows: [[version]]} = TestRepo.query!("SHOW server_version", [])
 
 version =
-  case Regex.named_captures(~r/(?<major>[0-9]*)\.(?<minor>[0-9]*)?.*/, version) do
+  case Regex.named_captures(~r/(?<major>[0-9]*)(\.(?<minor>[0-9]*))?.*/, version) do
     %{"major" => major, "minor" => minor} -> "#{major}.#{minor}.0"
     %{"major" => major} -> "#{major}.0.0"
     _other -> version

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -67,8 +67,9 @@ _   = Ecto.Adapters.Postgres.storage_down(TestRepo.config)
 %{rows: [[version]]} = TestRepo.query!("SHOW server_version", [])
 
 version =
-  case String.split(version, ".") do
-    [x, y] -> "#{x}.#{y}.0"
+  case Regex.named_captures(~r/(?<major>[0-9]*)\.(?<minor>[0-9]*)?.*/, version) do
+    %{"major" => major, "minor" => minor} -> "#{major}.#{minor}.0"
+    %{"major" => major} -> "#{major}.0.0"
     _other -> version
   end
 

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -73,7 +73,7 @@ version =
     _other -> version
   end
 
-if Version.match?(version, "~> 9.5") do
+if Version.match?(version, ">= 9.5.0") do
   ExUnit.configure(exclude: [:without_conflict_target])
 else
   Application.put_env(:ecto, :postgres_map_type, "json")


### PR DESCRIPTION
I just tried to run integration tests locally with official PostgreSQL 10.4 container, got the following error:

```
MIX_ENV=pg mix test
** (Version.InvalidVersionError) invalid version: "10.4 (Debian 10.4-2.pgdg90+1)"
    (elixir) lib/version.ex:337: Version.to_matchable/2
    (elixir) lib/version.ex:179: Version.match?/3
    integration_test/pg/test_helper.exs:75: (file)
    (elixir) lib/code.ex:767: Code.require_file/2
```

I think using new regex would help us to not get back to PG version match issue over and over again.