### PR TITLE
 index/3 raises if given multiple `where:` clauses

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -582,6 +582,7 @@ defmodule Ecto.Migration do
   end
 
   def index(table, columns, opts) when is_binary(table) and is_list(columns) and is_list(opts) do
+    validate_index_opts!(opts)
     index = struct(%Index{table: table, columns: columns}, opts)
     %{index | name: index.name || default_index_name(index)}
   end
@@ -955,6 +956,17 @@ defmodule Ecto.Migration do
   defp validate_type!(%Reference{} = reference) do
     reference
   end
+
+  defp validate_index_opts!(opts) when is_list(opts) do
+    case Keyword.get_values(opts, :where) do
+      [_, _ | _] ->
+        raise ArgumentError, message:
+       "only one 'where' keyword is supported when declaring a partial index. To specify multiple conditions, write a single WHERE clause using AND between them."
+      _ -> :ok
+    end
+  end
+
+  defp validate_index_opts!(opts), do: opts
 
   @doc false
   def __prefix__(%{prefix: prefix} = index_or_table) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -963,7 +963,9 @@ defmodule Ecto.Migration do
         raise ArgumentError,
               "only one `where` keyword is supported when declaring a partial index. " <>
                 "To specify multiple conditions, write a single WHERE clause using AND between them"
-      _ -> :ok
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -960,8 +960,9 @@ defmodule Ecto.Migration do
   defp validate_index_opts!(opts) when is_list(opts) do
     case Keyword.get_values(opts, :where) do
       [_, _ | _] ->
-        raise ArgumentError, message:
-       "only one 'where' keyword is supported when declaring a partial index. To specify multiple conditions, write a single WHERE clause using AND between them."
+        raise ArgumentError,
+              "only one `where` keyword is supported when declaring a partial index. " <>
+                "To specify multiple conditions, write a single WHERE clause using AND between them"
       _ -> :ok
     end
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -54,6 +54,8 @@ defmodule Ecto.MigrationTest do
            %Index{table: "posts", unique: false, name: :posts_lower_title_index, columns: ["lower(title)"]}
     assert index(:posts, [:title], name: :foo, unique: true) ==
            %Index{table: "posts", unique: true, name: :foo, columns: [:title]}
+    assert index(:posts, [:title], where: "status = 'published'", name: :published_posts_title_index, unique: true) ==
+           %Index{table: "posts", unique: true, where: "status = 'published'", name: :published_posts_title_index, columns: [:title]}
     assert unique_index(:posts, [:title], name: :foo) ==
            %Index{table: "posts", unique: true, name: :foo, columns: [:title]}
     assert unique_index(:posts, :title, name: :foo) ==

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -64,6 +64,12 @@ defmodule Ecto.MigrationTest do
            %Index{table: "table_one__table_two", unique: true, name: :table_one__table_two_title_index, columns: [:title]}
   end
 
+  test "raises if given multiple 'where' clauses for an index" do
+    assert_raise(ArgumentError, fn ->
+      index(:posts, [:title], where: "status = 'published'", where: "deleted = 'false'")
+    end)
+  end
+
   test "creates a reference" do
     assert references(:posts) ==
            %Reference{table: "posts", column: :id, type: :bigserial}


### PR DESCRIPTION
Because multiple `where:` keywords are supported by Ecto.Query, users
may provide multiple `where:` keywords when declaring a partial index.
However, this is not supported.

Previously, this would fail in a surprising way: the final `where:`
would be used and the other discarded. Now we raise an error, explaining
that these clauses should be combined into a single string.

Fixes #2690