### PR TITLE
Add statement cache to insert/update/delete

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -347,6 +347,7 @@ defmodule Ecto.Adapters.SQL do
 
   defp cached_query(adapter_meta, name, sql, params, opts) do
     %{cache: cache} = adapter_meta
+    sql = IO.iodata_to_binary(sql)
 
     {op, args} =
       case :ets.lookup(cache, name) do

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -364,6 +364,7 @@ defmodule Ecto.Adapters.SQL do
         ok
 
       {:error, _} = error ->
+        :ets.delete(cache, name)
         error
     end
   end

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -10,7 +10,7 @@ defmodule Ecto.Adapters.SQL.Connection do
   @type statement :: String.t
 
   @typedoc "The cached query which is a DBConnection Query"
-  @type cached :: map
+  @type cached :: %{:statement => iodata, optional(any) => any}
 
   @type connection :: DBConnection.conn()
   @type params :: [term]


### PR DESCRIPTION
This makes introducing the Ecto.Integration.Post schema a thousand times in a row almost twice faster since we avoid a round trip to the database.