### PR TITLE
Clarify behavior of Repo.checkout/2

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -313,6 +313,11 @@ defmodule Ecto.Repo do
   in a row and you want to avoid checking out the connection
   multiple times.
 
+  `checkout/2` and `transaction/2` can be combined and nested 
+  multiple times. If `checkout/2` is called inside the function
+  of another `checkout/2` call, the function is simply executed,
+  without checking out a new connection.
+
   ## Options
 
   See the "Shared options" section at the module documentation.


### PR DESCRIPTION
That's the behavior I interpreted from https://github.com/elixir-ecto/ecto/pull/2708. 

Hope it helps to clarify the behavior for nested `Repo.checkout/2` 🙂

cc @josevalim 
