### PR TITLE
Raise better error message when dumping certain types

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -181,7 +181,49 @@ defmodule Ecto.NoPrimaryKeyValueError do
 end
 
 defmodule Ecto.ChangeError do
-  defexception [:message]
+  defexception [:action, :schema, :field, :type, :value]
+
+  def exception(opts) do
+    struct!(__MODULE__, opts)
+  end
+
+  def message(%__MODULE__{type: :decimal, value: %Decimal{coef: coef}} = exception) when coef in [:inf, :qNaN, :sNaN] do
+    common_message(exception) <>
+      """
+
+
+      `+Infinity`, `-Infinity`, and `NaN` values are not supported, even though the `Decimal` library handles them.
+      To support them, you can create a custom type.
+      """
+  end
+
+  def message(%__MODULE__{type: type, value: %schema{microsecond: microsecond}} = exception)
+      when type in [:time, :naive_datetime, :utc_datetime] and microsecond != {0, 0} do
+
+    common_message(exception) <>
+      "\n\nMicroseconds must be empty." <>
+      if truncate_available?(), do: " Use `#{inspect schema}.truncate/2` to remove microseconds.", else: ""
+  end
+
+  def message(%__MODULE__{type: type, value: %{microsecond: {_, precision}}} = exception)
+      when type in [:time_usec, :naive_datetime_usec, :utc_datetime_usec] and precision != 6 do
+
+    common_message(exception) <> "\n\nMicrosecond precision is required."
+  end
+
+  def message(exception) do
+    common_message(exception)
+  end
+
+  defp common_message(%__MODULE__{action: action, schema: schema, field: field, type: type, value: value}) do
+    "value `#{inspect value}` for `#{inspect schema}.#{field}` " <>
+      "in `#{action}` does not match type #{inspect type}"
+  end
+
+  # TODO: remove when requiring Elixir v1.6
+  defp truncate_available?() do
+    function_exported?(Time, :truncate, 2)
+  end
 end
 
 defmodule Ecto.NoResultsError do

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -183,29 +183,22 @@ end
 defmodule Ecto.ChangeError do
   defexception [:action, :schema, :field, :type, :value]
 
-  def exception(opts) do
-    struct!(__MODULE__, opts)
-  end
-
-  def message(%__MODULE__{type: :decimal, value: %Decimal{coef: coef}} = exception) when coef in [:inf, :qNaN, :sNaN] do
+  def message(%{type: :decimal, value: %Decimal{coef: coef}} = exception) when coef in [:inf, :qNaN, :sNaN] do
     common_message(exception) <>
       """
-
-
-      `+Infinity`, `-Infinity`, and `NaN` values are not supported, even though the `Decimal` library handles them.
+      \n\n`+Infinity`, `-Infinity`, and `NaN` values are not supported, even though the `Decimal` library handles them. \
       To support them, you can create a custom type.
       """
   end
 
-  def message(%__MODULE__{type: type, value: %schema{microsecond: microsecond}} = exception)
+  def message(%{type: type, value: %schema{microsecond: microsecond}} = exception)
       when type in [:time, :naive_datetime, :utc_datetime] and microsecond != {0, 0} do
 
     common_message(exception) <>
-      "\n\nMicroseconds must be empty." <>
-      if truncate_available?(), do: " Use `#{inspect schema}.truncate/2` to remove microseconds.", else: ""
+      "\n\nMicroseconds must be empty. Use `#{inspect schema}.truncate/2` (available in Elixir v1.6+) to remove microseconds."
   end
 
-  def message(%__MODULE__{type: type, value: %{microsecond: {_, precision}}} = exception)
+  def message(%{type: type, value: %{microsecond: {_, precision}}} = exception)
       when type in [:time_usec, :naive_datetime_usec, :utc_datetime_usec] and precision != 6 do
 
     common_message(exception) <> "\n\nMicrosecond precision is required."
@@ -215,14 +208,9 @@ defmodule Ecto.ChangeError do
     common_message(exception)
   end
 
-  defp common_message(%__MODULE__{action: action, schema: schema, field: field, type: type, value: value}) do
+  defp common_message(%{action: action, schema: schema, field: field, type: type, value: value}) do
     "value `#{inspect value}` for `#{inspect schema}.#{field}` " <>
       "in `#{action}` does not match type #{inspect type}"
-  end
-
-  # TODO: remove when requiring Elixir v1.6
-  defp truncate_available?() do
-    function_exported?(Time, :truncate, 2)
   end
 end
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -844,9 +844,7 @@ defmodule Ecto.Repo.Schema do
       {:ok, value} ->
         value
       :error ->
-        raise Ecto.ChangeError,
-              "value `#{inspect value}` for `#{inspect schema}.#{field}` " <>
-              "in `#{action}` does not match type #{inspect type}"
+        raise Ecto.ChangeError, action: action, schema: schema, field: field, type: type, value: value
     end
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -24,6 +24,9 @@ defmodule Ecto.RepoTest do
     use Ecto.Schema
 
     schema "my_schema" do
+      field :d, :decimal
+      field :t, :time
+      field :t_usec, :time_usec
       field :x, :string
       field :y, :binary, source: :yyy
       field :z, :string, default: "z"
@@ -344,7 +347,31 @@ defmodule Ecto.RepoTest do
     test "validates schema types" do
       schema = %MySchema{x: 123}
 
-      assert_raise Ecto.ChangeError, fn ->
+      assert_raise Ecto.ChangeError, ~r"does not match type :string$", fn ->
+        TestRepo.insert!(schema)
+      end
+
+      schema = %MySchema{d: Decimal.new("NaN")}
+
+      assert_raise Ecto.ChangeError, ~r"and `NaN` values are not supported", fn ->
+        TestRepo.insert!(schema)
+      end
+
+      schema = %MySchema{d: Decimal.new("NaN")}
+
+      assert_raise Ecto.ChangeError, ~r"and `NaN` values are not supported", fn ->
+        TestRepo.insert!(schema)
+      end
+
+      schema = %MySchema{t: ~T[09:00:00.000000]}
+
+      assert_raise Ecto.ChangeError, ~r"Microseconds must be empty.", fn ->
+        TestRepo.insert!(schema)
+      end
+
+      schema = %MySchema{t_usec: ~T[09:00:00]}
+
+      assert_raise Ecto.ChangeError, ~r"Microsecond precision is required.", fn ->
         TestRepo.insert!(schema)
       end
     end


### PR DESCRIPTION
Closes #2692 

No need to handle loading, adapters will already throw a good error message when they cannot load.

```
iex> Repo.insert(%Post{d: Decimal.new("Inf")})
** (Ecto.ChangeError) value `#Decimal<Infinity>` for `Post.d` in `insert` does not match type :decimal

`+Infinity`, `-Infinity`, and `NaN` values are not supported, even though the `Decimal` library handles them.
To support them, you can create a custom type.

    (ecto) lib/ecto/repo/schema.ex:847: Ecto.Repo.Schema.dump_field!/6
    (ecto) lib/ecto/repo/schema.ex:854: anonymous fn/6 in Ecto.Repo.Schema.dump_fields!/5
    (stdlib) maps.erl:257: :maps.fold_1/3
    (ecto) lib/ecto/repo/schema.ex:852: Ecto.Repo.Schema.dump_fields!/5
    (ecto) lib/ecto/repo/schema.ex:796: Ecto.Repo.Schema.dump_changes!/6
    (ecto) lib/ecto/repo/schema.ex:219: anonymous fn/15 in Ecto.Repo.Schema.do_insert/3
```

```
iex> Repo.insert(%Post{t: ~T"09:00:00.123456"})
** (Ecto.ChangeError) value `~T[09:00:00.123456]` for `Post.t` in `insert` does not match type :time

Microseconds must be empty. Use `Time.truncate/2` to remove microseconds.
    (ecto) lib/ecto/repo/schema.ex:847: Ecto.Repo.Schema.dump_field!/6
    (ecto) lib/ecto/repo/schema.ex:854: anonymous fn/6 in Ecto.Repo.Schema.dump_fields!/5
    (stdlib) maps.erl:257: :maps.fold_1/3
    (ecto) lib/ecto/repo/schema.ex:852: Ecto.Repo.Schema.dump_fields!/5
    (ecto) lib/ecto/repo/schema.ex:796: Ecto.Repo.Schema.dump_changes!/6
    (ecto) lib/ecto/repo/schema.ex:219: anonymous fn/15 in Ecto.Repo.Schema.do_insert/3
```

```
iex> Repo.insert(%Post{t_usec: ~T"09:00:00"})
** (Ecto.ChangeError) value `~T[09:00:00]` for `Post.t_usec` in `insert` does not match type :time_usec

Microsecond precision is required.
    (ecto) lib/ecto/repo/schema.ex:847: Ecto.Repo.Schema.dump_field!/6
    (ecto) lib/ecto/repo/schema.ex:854: anonymous fn/6 in Ecto.Repo.Schema.dump_fields!/5
    (stdlib) maps.erl:257: :maps.fold_1/3
    (ecto) lib/ecto/repo/schema.ex:852: Ecto.Repo.Schema.dump_fields!/5
    (ecto) lib/ecto/repo/schema.ex:796: Ecto.Repo.Schema.dump_changes!/6
    (ecto) lib/ecto/repo/schema.ex:219: anonymous fn/15 in Ecto.Repo.Schema.do_insert/3
```