### PR TITLE
Bug with returning, conflict target and assoc

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1293,19 +1293,6 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.insert!(%Post{title: "1"}, [log: false])
   end
 
-  @tag :returning
-  test "update/2 and insert/2 on associations with returning" do
-    post = %Post{uuid: Ecto.UUID.generate(), title: "first", comments: [%Comment{}]}
-    {:ok, inserted} = TestRepo.insert(post, returning: [:uuid])
-
-    post =
-      inserted
-      |> Ecto.Changeset.change(%{})
-      |> Ecto.Changeset.put_assoc(:comments, [%Comment{}])
-
-    {:ok, _updated} = TestRepo.update(post, returning: [:uuid])
-  end
-
   describe "upsert via insert" do
     @describetag :upsert
 
@@ -1332,20 +1319,6 @@ defmodule Ecto.Integration.RepoTest do
                    title: "first", comments: [%Comment{}]}
       {:ok, inserted} = TestRepo.insert(post, on_conflict: on_conflict, conflict_target: [:uuid])
       assert inserted.id
-    end
-
-    @tag :returning
-    @tag :with_conflict_target
-    test "on conflict and associations with returning" do
-      on_conflict = [set: [title: "second"]]
-      post = %Post{uuid: Ecto.UUID.generate(),
-                   title: "first", comments: [%Comment{}]}
-      {:ok, _inserted} =
-        TestRepo.insert(post,
-          on_conflict: on_conflict,
-          conflict_target: [:uuid],
-          returning: [:uuid]
-        )
     end
 
     @tag :with_conflict_target

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1299,7 +1299,8 @@ defmodule Ecto.Integration.RepoTest do
     {:ok, inserted} = TestRepo.insert(post, returning: [:uuid])
 
     post =
-      Post.changeset(inserted, %{uuid: Ecto.UUID.generate(), title: "first"})
+      inserted
+      |> Ecto.Changeset.change(%{})
       |> Ecto.Changeset.put_assoc(:comments, [%Comment{}])
 
     {:ok, _updated} = TestRepo.update(post, returning: [:uuid])
@@ -1339,8 +1340,12 @@ defmodule Ecto.Integration.RepoTest do
       on_conflict = [set: [title: "second"]]
       post = %Post{uuid: Ecto.UUID.generate(),
                    title: "first", comments: [%Comment{}]}
-      {:ok, inserted} = TestRepo.insert(post, on_conflict: on_conflict, conflict_target: [:uuid], returning: [:uuid])
-      assert inserted.id
+      {:ok, _inserted} =
+        TestRepo.insert(post,
+          on_conflict: on_conflict,
+          conflict_target: [:uuid],
+          returning: [:uuid]
+        )
     end
 
     @tag :with_conflict_target

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1293,6 +1293,18 @@ defmodule Ecto.Integration.RepoTest do
     TestRepo.insert!(%Post{title: "1"}, [log: false])
   end
 
+  @tag :returning
+  test "update/2 and insert/2 on associations with returning" do
+    post = %Post{uuid: Ecto.UUID.generate(), title: "first", comments: [%Comment{}]}
+    {:ok, inserted} = TestRepo.insert(post, returning: [:uuid])
+
+    post =
+      Post.changeset(inserted, %{uuid: Ecto.UUID.generate(), title: "first"})
+      |> Ecto.Changeset.put_assoc(:comments, [%Comment{}])
+
+    {:ok, _updated} = TestRepo.update(post, returning: [:uuid])
+  end
+
   describe "upsert via insert" do
     @describetag :upsert
 

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1321,6 +1321,16 @@ defmodule Ecto.Integration.RepoTest do
       assert inserted.id
     end
 
+    @tag :returning
+    @tag :with_conflict_target
+    test "on conflict and associations with returning" do
+      on_conflict = [set: [title: "second"]]
+      post = %Post{uuid: Ecto.UUID.generate(),
+                   title: "first", comments: [%Comment{}]}
+      {:ok, inserted} = TestRepo.insert(post, on_conflict: on_conflict, conflict_target: [:uuid], returning: [:uuid])
+      assert inserted.id
+    end
+
     @tag :with_conflict_target
     test "on conflict with inc" do
       uuid = "6fa459ea-ee8a-3ca4-894e-db77e160355e"

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -227,9 +227,11 @@ defmodule Ecto.Repo.Schema do
           {:ok, values} ->
             values = extra ++ values
 
+            children_opts = Keyword.drop(opts, [:returning])
+
             changeset
             |> load_changes(:loaded, return_types, values, embeds, autogen, adapter, schema_meta)
-            |> process_children(children, user_changeset, adapter, opts)
+            |> process_children(children, user_changeset, adapter, children_opts)
 
           {:error, _} = error ->
             error
@@ -310,9 +312,11 @@ defmodule Ecto.Repo.Schema do
 
           case apply(changeset, adapter, action, args) do
             {:ok, values} ->
+              children_opts = Keyword.drop(opts, [:returning])
+
               changeset
               |> load_changes(:loaded, return_types, values, embeds, autogen, adapter, schema_meta)
-              |> process_children(children, user_changeset, adapter, opts)
+              |> process_children(children, user_changeset, adapter, children_opts)
 
             {:error, _} = error ->
               error


### PR DESCRIPTION
Looks like `returning` does not work when `conflict_target` is set and insert had associations. At some point, it tries to read the returned field from the assoc (which is obviously not there).

Here is the raised message:
```elixir
  1) test upsert via insert on conflict and associations with returning (Ecto.Integration.RepoTest)
     integration_test/cases/repo.exs:1314
     ** (KeyError) key :uuid not found in: %{author_id: {:author_id, :id}, id: {:id, :id}, lock_version: {:lock_version, :i
nteger}, post_id: {:post_id, :id}, text: {:text, :string}}
     code: {:ok, inserted} = TestRepo.insert(post, on_conflict: on_conflict, conflict_target: [:uuid], returning: [:uuid])
     stacktrace:
       (stdlib) :maps.get(:uuid, %{author_id: {:author_id, :id}, id: {:id, :id}, lock_version: {:lock_version, :integer}, p
ost_id: {:post_id, :id}, text: {:text, :string}})
       (ecto) lib/ecto/repo/schema.ex:462: anonymous fn/3 in Ecto.Repo.Schema.fields_to_sources/2
       (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto) lib/ecto/repo/schema.ex:190: Ecto.Repo.Schema.do_insert/3
       (ecto) lib/ecto/association.ex:601: Ecto.Association.Has.on_repo_change/5
```

I think returning should be only applied to the parent schema, otherwise we can have conflict in names and we would need a syntax to tell fields from which assoc we would like to read in response.