### PR TITLE
Correct typo in upsert example

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -886,7 +886,7 @@ defmodule Ecto.Repo do
 
       # In Postgres (it requires the conflict target for updates):
       on_conflict = [set: [body: "updated"]]
-      {:ok, updated} = MyRepo.insert(%Post{title: "this is unique"},
+      {:ok, inserted} = MyRepo.insert(%Post{title: "this is unique"},
                                      on_conflict: on_conflict, conflict_target: :title)
 
       # In MySQL (conflict target is not supported):


### PR DESCRIPTION
It looks like in this example the result of the initial insert is bound to `updated` and then referenced on the next line of code as `inserted`. I think the intention was probably that the initial result be bound to `inserted`.