### PR TITLE
Handle relation changeset error in one place

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -750,9 +750,9 @@ defmodule Ecto.Changeset do
               changeset = %{force_update(changeset, opts) | changes: changes, valid?: valid?}
               missing_relation(changeset, key, current, required?, relation, opts)
 
-            :error ->
-              meta = [validation: type, type: expected_relation_type(relation)]
-              error = {key, {message(opts, :invalid_message, "is invalid"), meta}}
+            {:error, {message, meta}} ->
+              meta = [validation: type] ++ meta
+              error = {key, {message(opts, :invalid_message, message), meta}}
               %{changeset | errors: [error | changeset.errors], valid?: false}
 
             # ignore or ok with change == original
@@ -793,9 +793,6 @@ defmodule Ecto.Changeset do
       end
     end
   end
-
-  defp expected_relation_type(%{cardinality: :one}), do: :map
-  defp expected_relation_type(%{cardinality: :many}), do: {:array, :map}
 
   defp missing_relation(%{changes: changes, errors: errors} = changeset,
                         name, current, required?, relation, opts) do
@@ -1105,8 +1102,8 @@ defmodule Ecto.Changeset do
         {Map.put(changes, key, change), errors, valid? and relation_valid?}
       :ignore ->
         {changes, errors, valid?}
-      :error ->
-        error = {key, {"is invalid", [type: expected_relation_type(relation)]}}
+      {:error, reason} ->
+        error = {key, reason}
         {changes, [error | errors], false}
     end
   end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1102,9 +1102,8 @@ defmodule Ecto.Changeset do
         {Map.put(changes, key, change), errors, valid? and relation_valid?}
       :ignore ->
         {changes, errors, valid?}
-      {:error, reason} ->
-        error = {key, reason}
-        {changes, [error | errors], false}
+      {:error, error} ->
+        {changes, [{key, error} | errors], false}
     end
   end
 

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -97,9 +97,7 @@ defmodule Ecto.Changeset.Relation do
       |> Enum.map(&key_as_int/1)
       |> Enum.sort
       |> Enum.map(&elem(&1, 1))
-
-    with :error <- cast(relation, params, current, on_cast),
-         do: {:error, {"is invalid", [type: expected_type(relation)]}}
+    cast(relation, params, current, on_cast)
   end
 
   def cast(%{related: mod} = relation, params, current, on_cast) do

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -86,7 +86,7 @@ defmodule Ecto.Changeset.Relation do
   """
   def cast(%{cardinality: :one} = relation, nil, current, _on_cast) do
     case current && on_replace(relation, current) do
-      :error -> :error
+      :error -> {:error, {"is invalid", [type: expected_type(relation)]}}
       _ -> {:ok, nil, true}
     end
   end
@@ -97,13 +97,17 @@ defmodule Ecto.Changeset.Relation do
       |> Enum.map(&key_as_int/1)
       |> Enum.sort
       |> Enum.map(&elem(&1, 1))
-    cast(relation, params, current, on_cast)
+
+    with :error <- cast(relation, params, current, on_cast),
+         do: {:error, {"is invalid", [type: expected_type(relation)]}}
   end
 
   def cast(%{related: mod} = relation, params, current, on_cast) do
     pks = mod.__schema__(:primary_key)
-    cast_or_change(relation, params, current, data_pk(pks),
-                   param_pk(mod, pks), &do_cast(relation, &1, &2, &3, on_cast))
+    with :error <- cast_or_change(relation, params, current, data_pk(pks),
+                                  param_pk(mod, pks), &do_cast(relation, &1, &2, &3, on_cast)) do
+      {:error, {"is invalid", [type: expected_type(relation)]}}
+    end
   end
 
   defp do_cast(meta, params, nil, allowed_actions, on_cast) do
@@ -129,15 +133,17 @@ defmodule Ecto.Changeset.Relation do
   """
   def change(%{cardinality: :one} = relation, nil, current) do
     case current && on_replace(relation, current) do
-      :error -> :error
+      :error -> {:error, {"is invalid", [type: expected_type(relation)]}}
       _ -> {:ok, nil, true}
     end
   end
 
   def change(%{related: mod} = relation, value, current) do
     get_pks = data_pk(mod.__schema__(:primary_key))
-    cast_or_change(relation, value, current, get_pks, get_pks,
-                   &do_change(relation, &1, &2, &3))
+    with :error <- cast_or_change(relation, value, current, get_pks, get_pks,
+                                  &do_change(relation, &1, &2, &3)) do
+      {:error, {"is invalid", [type: expected_type(relation)]}}
+    end
   end
 
   # This may be an insert or an update, get all fields.
@@ -451,4 +457,7 @@ defmodule Ecto.Changeset.Relation do
     do: true
   defp skip?(_changeset),
     do: false
+
+  defp expected_type(%{cardinality: :one}), do: :map
+  defp expected_type(%{cardinality: :many}), do: {:array, :map}
 end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -661,8 +661,8 @@ defmodule Ecto.Repo.Schema do
             case Relation.change(embed_or_assoc, value, empty) do
               {:ok, change, _} when change != empty ->
                 {Map.put(changes, field, change), errors}
-              {:error, reason} ->
-                {changes, [{field, reason}]}
+              {:error, error} ->
+                {changes, [{field, error}]}
               _ -> # :ignore or ok with change == empty
                 {changes, errors}
             end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -661,8 +661,8 @@ defmodule Ecto.Repo.Schema do
             case Relation.change(embed_or_assoc, value, empty) do
               {:ok, change, _} when change != empty ->
                 {Map.put(changes, field, change), errors}
-              :error ->
-                {changes, [{field, "is invalid"}]}
+              {:error, reason} ->
+                {changes, [{field, reason}]}
               _ -> # :ignore or ok with change == empty
                 {changes, errors}
             end

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -74,7 +74,7 @@ defmodule Ecto.Repo.BelongsToTest do
 
   test "handles invalid assocs from struct on insert" do
     {:error, changeset} = TestRepo.insert(%MySchema{assoc: 1})
-    assert changeset.errors == [assoc: "is invalid"]
+    assert changeset.errors == [assoc: {"is invalid", [type: :map]}]
   end
 
   test "raises on action mismatch on insert" do

--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -93,7 +93,7 @@ defmodule Ecto.Repo.EmbeddedTest do
 
   test "handles invalid embeds from struct on insert" do
     {:error, changeset} = TestRepo.insert(%MySchema{embed: 1})
-    assert changeset.errors == [embed: "is invalid"]
+    assert changeset.errors == [embed: {"is invalid", type: :map}]
   end
 
   test "returns untouched changeset on constraint mismatch on insert" do

--- a/test/ecto/repo/has_assoc_test.exs
+++ b/test/ecto/repo/has_assoc_test.exs
@@ -114,7 +114,7 @@ defmodule Ecto.Repo.HasAssocTest do
 
   test "handles invalid assocs from struct on insert" do
     {:error, changeset} = TestRepo.insert(%MySchema{assoc: 1})
-    assert changeset.errors == [assoc: "is invalid"]
+    assert changeset.errors == [assoc: {"is invalid", type: :map}]
   end
 
   test "raises on action mismatch on insert" do

--- a/test/ecto/repo/many_to_many_test.exs
+++ b/test/ecto/repo/many_to_many_test.exs
@@ -101,7 +101,7 @@ defmodule Ecto.Repo.ManyToManyTest do
 
   test "handles invalid assocs from struct on insert" do
     {:error, changeset} = TestRepo.insert(%MySchema{assocs: [1]})
-    assert changeset.errors == [assocs: "is invalid"]
+    assert changeset.errors == [assocs: {"is invalid", type: {:array, :map}}]
   end
 
   test "raises on action mismatch on insert" do


### PR DESCRIPTION
This PR intended to fix #2722, but ended up together with some slight refactoring of `Ecto.Changeset.Relation` module.

`cast/4` and `change/3` have been changed to return `{:error, Ecto.Changeset.error()}` instead of just `:error`, making error handling easier for the caller. Error messages and metadata are also encapsulated at where the data get casted/changed, making future improvements of these information, e.g based on relation type, relatively easier.