### PR TITLE
Added a warning for when an Ecto Schema does not contain a changeset/2 function

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -401,9 +401,9 @@ defmodule Ecto.Schema do
 
   alias Ecto.Schema.Metadata
 
-  @type source :: String.t
-  @type prefix :: String.t | nil
-  @type schema :: %{optional(atom) => any, __struct__: atom, __meta__: Metadata.t}
+  @type source :: String.t()
+  @type prefix :: String.t() | nil
+  @type schema :: %{optional(atom) => any, __struct__: atom, __meta__: Metadata.t()}
   @type embedded_schema :: %{optional(atom) => any, __struct__: atom}
   @type t :: schema | embedded_schema
 
@@ -412,6 +412,7 @@ defmodule Ecto.Schema do
     quote do
       import Ecto.Schema, only: [schema: 2, embedded_schema: 1]
 
+      @before_compile Ecto.Schema
       @primary_key nil
       @timestamps_opts []
       @foreign_key_type :id
@@ -430,6 +431,34 @@ defmodule Ecto.Schema do
     end
   end
 
+  @doc false
+  defmacro __before_compile__(env) do
+    unless Module.defines?(env.module, {:changeset, 2}) do
+      message = """
+      The function changeset/2 required by Ecto Schema does not exist \
+      (in module #{inspect(env.module)}).
+      We will inject a default implementation for now:
+        def changeset(_, _) do
+          %unquote(env.module()){}
+          |> Ecto.Changeset.change()
+        end
+      You can copy the implementation above or define your own.
+      """
+
+      IO.warn(message, [])
+
+      quote do
+        @doc false
+        def changeset(_, _) do
+          %unquote(env.module()){}
+          |> Ecto.Changeset.change()
+        end
+
+        defoverridable changeset: 2
+      end
+    end
+  end
+
   @doc """
   Defines an embedded schema with the given field definitions.
 
@@ -442,7 +471,7 @@ defmodule Ecto.Schema do
   to `:binary_id` but such can be configured with the
   `@primary_key` attribute.
   """
-  defmacro embedded_schema([do: block]) do
+  defmacro embedded_schema(do: block) do
     schema(nil, false, :binary_id, block)
   end
 
@@ -453,7 +482,7 @@ defmodule Ecto.Schema do
   internal Ecto state. This field always has a `Ecto.Schema.Metadata` struct
   as value and can be manipulated with the `Ecto.put_meta/2` function.
   """
-  defmacro schema(source, [do: block]) do
+  defmacro schema(source, do: block) do
     schema(source, true, :id, block)
   end
 
@@ -464,7 +493,7 @@ defmodule Ecto.Schema do
         Module.register_attribute(__MODULE__, :changeset_fields, accumulate: true)
         Module.register_attribute(__MODULE__, :struct_fields, accumulate: true)
 
-        meta?  = unquote(meta?)
+        meta? = unquote(meta?)
         source = unquote(source)
         prefix = @schema_prefix
 
@@ -475,7 +504,7 @@ defmodule Ecto.Schema do
 
         if meta? do
           unless is_binary(source) do
-            raise ArgumentError, "schema source must be a string, got: #{inspect source}"
+            raise ArgumentError, "schema source must be a string, got: #{inspect(source)}"
           end
 
           meta = %Metadata{state: :built, source: source, prefix: prefix, schema: __MODULE__}
@@ -490,9 +519,11 @@ defmodule Ecto.Schema do
           case @primary_key do
             false ->
               []
+
             {name, type, opts} ->
               Ecto.Schema.__field__(__MODULE__, name, type, [primary_key: true] ++ opts)
               [name]
+
             other ->
               raise ArgumentError, "@primary_key must be false or {name, type, opts}"
           end
@@ -507,13 +538,13 @@ defmodule Ecto.Schema do
 
     postlude =
       quote unquote: false do
-        primary_key_fields = @ecto_primary_keys |> Enum.reverse
-        autogenerate = @ecto_autogenerate |> Enum.reverse
-        autoupdate = @ecto_autoupdate |> Enum.reverse
-        fields = @ecto_fields |> Enum.reverse
-        field_sources = @ecto_field_sources |> Enum.reverse
-        assocs = @ecto_assocs |> Enum.reverse
-        embeds = @ecto_embeds |> Enum.reverse
+        primary_key_fields = @ecto_primary_keys |> Enum.reverse()
+        autogenerate = @ecto_autogenerate |> Enum.reverse()
+        autoupdate = @ecto_autoupdate |> Enum.reverse()
+        fields = @ecto_fields |> Enum.reverse()
+        field_sources = @ecto_field_sources |> Enum.reverse()
+        assocs = @ecto_assocs |> Enum.reverse()
+        embeds = @ecto_embeds |> Enum.reverse()
         loaded = Ecto.Schema.__loaded__(__MODULE__, @struct_fields)
 
         defstruct @struct_fields
@@ -640,7 +671,11 @@ defmodule Ecto.Schema do
 
       cond do
         inserted_at && updated_at ->
-          Module.put_attribute(__MODULE__, :ecto_autogenerate, {[inserted_at, updated_at], autogen})
+          Module.put_attribute(
+            __MODULE__,
+            :ecto_autogenerate,
+            {[inserted_at, updated_at], autogen}
+          )
 
         inserted_at ->
           Module.put_attribute(__MODULE__, :ecto_autogenerate, {[inserted_at], autogen})
@@ -859,6 +894,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_many(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__has_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -943,6 +979,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_one(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__has_one__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1162,6 +1199,7 @@ defmodule Ecto.Schema do
   """
   defmacro belongs_to(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__belongs_to__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1397,6 +1435,7 @@ defmodule Ecto.Schema do
   """
   defmacro many_to_many(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__many_to_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1535,6 +1574,7 @@ defmodule Ecto.Schema do
 
   defmacro embeds_one(name, schema, opts) do
     schema = expand_alias(schema, __CALLER__)
+
     quote do
       Ecto.Schema.__embeds_one__(__MODULE__, unquote(name), unquote(schema), unquote(opts))
     end
@@ -1547,7 +1587,14 @@ defmodule Ecto.Schema do
   """
   defmacro embeds_one(name, schema, opts, do: block) do
     quote do
-      {schema, opts} = Ecto.Schema.__embeds_module__(__ENV__, unquote(schema), unquote(opts), unquote(Macro.escape(block)))
+      {schema, opts} =
+        Ecto.Schema.__embeds_module__(
+          __ENV__,
+          unquote(schema),
+          unquote(opts),
+          unquote(Macro.escape(block))
+        )
+
       Ecto.Schema.__embeds_one__(__MODULE__, unquote(name), schema, opts)
     end
   end
@@ -1695,6 +1742,7 @@ defmodule Ecto.Schema do
 
   defmacro embeds_many(name, schema, opts) do
     schema = expand_alias(schema, __CALLER__)
+
     quote do
       Ecto.Schema.__embeds_many__(__MODULE__, unquote(name), unquote(schema), unquote(opts))
     end
@@ -1707,7 +1755,14 @@ defmodule Ecto.Schema do
   """
   defmacro embeds_many(name, schema, opts, do: block) do
     quote do
-      {schema, opts} = Ecto.Schema.__embeds_module__(__ENV__, unquote(schema), unquote(opts), unquote(Macro.escape(block)))
+      {schema, opts} =
+        Ecto.Schema.__embeds_module__(
+          __ENV__,
+          unquote(schema),
+          unquote(opts),
+          unquote(Macro.escape(block))
+        )
+
       Ecto.Schema.__embeds_many__(__MODULE__, unquote(name), schema, opts)
     end
   end
@@ -1723,7 +1778,7 @@ defmodule Ecto.Schema do
   the association name, the association module (that implements
   `Ecto.Association` callbacks) and a keyword list of options.
   """
-  @spec association(module, :one | :many, atom(), module, Keyword.t) :: Ecto.Association.t
+  @spec association(module, :one | :many, atom(), module, Keyword.t()) :: Ecto.Association.t()
   def association(schema, cardinality, name, association, opts) do
     not_loaded = %Ecto.Association.NotLoaded{
       __owner__: schema,
@@ -1796,8 +1851,10 @@ defmodule Ecto.Schema do
       case gen = opts[:autogenerate] do
         {_, _, _} ->
           store_mfa_autogenerate!(mod, name, type, gen)
+
         true ->
           store_type_autogenerate!(mod, name, source || name, type, pk?)
+
         _ ->
           :ok
       end
@@ -1814,7 +1871,15 @@ defmodule Ecto.Schema do
     end
   end
 
-  @valid_has_options [:foreign_key, :references, :through, :on_delete, :defaults, :on_replace, :where]
+  @valid_has_options [
+    :foreign_key,
+    :references,
+    :through,
+    :on_delete,
+    :defaults,
+    :on_replace,
+    :where
+  ]
 
   @doc false
   def __has_many__(mod, name, queryable, opts) do
@@ -1823,8 +1888,7 @@ defmodule Ecto.Schema do
     if is_list(queryable) and Keyword.has_key?(queryable, :through) do
       association(mod, :many, name, Ecto.Association.HasThrough, queryable)
     else
-      struct =
-        association(mod, :many, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
+      struct = association(mod, :many, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
       Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
     end
   end
@@ -1836,16 +1900,24 @@ defmodule Ecto.Schema do
     if is_list(queryable) and Keyword.has_key?(queryable, :through) do
       association(mod, :one, name, Ecto.Association.HasThrough, queryable)
     else
-      struct =
-        association(mod, :one, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
+      struct = association(mod, :one, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
       Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
     end
   end
 
   # :primary_key is valid here to support associative entity
   # https://en.wikipedia.org/wiki/Associative_entity
-  @valid_belongs_to_options [:foreign_key, :references, :define_field, :type,
-                             :on_replace, :defaults, :primary_key, :source, :where]
+  @valid_belongs_to_options [
+    :foreign_key,
+    :references,
+    :define_field,
+    :type,
+    :on_replace,
+    :defaults,
+    :primary_key,
+    :source,
+    :where
+  ]
 
   @doc false
   def __belongs_to__(mod, name, queryable, opts) do
@@ -1855,7 +1927,8 @@ defmodule Ecto.Schema do
     foreign_key_type = opts[:type] || Module.get_attribute(mod, :foreign_key_type)
 
     if name == Keyword.get(opts, :foreign_key) do
-      raise ArgumentError, "foreign_key #{inspect name} must be distinct from corresponding association name"
+      raise ArgumentError,
+            "foreign_key #{inspect(name)} must be distinct from corresponding association name"
     end
 
     if Keyword.get(opts, :define_field, true) do
@@ -1864,11 +1937,20 @@ defmodule Ecto.Schema do
 
     struct =
       association(mod, :one, name, Ecto.Association.BelongsTo, [queryable: queryable] ++ opts)
+
     Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
   end
 
-  @valid_many_to_many_options [:join_through, :join_keys, :on_delete, :defaults, :on_replace,
-                               :unique, :where, :join_through_where]
+  @valid_many_to_many_options [
+    :join_through,
+    :join_keys,
+    :on_delete,
+    :defaults,
+    :on_replace,
+    :unique,
+    :where,
+    :join_through_where
+  ]
 
   @doc false
   def __many_to_many__(mod, name, queryable, opts) do
@@ -1876,6 +1958,7 @@ defmodule Ecto.Schema do
 
     struct =
       association(mod, :many, name, Ecto.Association.ManyToMany, [queryable: queryable] ++ opts)
+
     Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
   end
 
@@ -1933,8 +2016,10 @@ defmodule Ecto.Schema do
             :ok
 
           {:error, message} ->
-            IO.warn "invalid association `#{assoc.field}` in schema #{inspect module}: #{message}",
-                    Macro.Env.stacktrace(env)
+            IO.warn(
+              "invalid association `#{assoc.field}` in schema #{inspect(module)}: #{message}",
+              Macro.Env.stacktrace(env)
+            )
         end
       end
     end
@@ -2009,7 +2094,7 @@ defmodule Ecto.Schema do
   ## Private
 
   defp embed(mod, cardinality, name, schema, opts) do
-    opts   = [cardinality: cardinality, related: schema] ++ opts
+    opts = [cardinality: cardinality, related: schema] ++ opts
     struct = Ecto.Embedded.struct(mod, name, opts)
 
     define_field(mod, name, {:embed, struct}, opts)
@@ -2020,34 +2105,37 @@ defmodule Ecto.Schema do
     fields = Module.get_attribute(mod, :struct_fields)
 
     if List.keyfind(fields, name, 0) do
-      raise ArgumentError, "field/association #{inspect name} is already set on schema"
+      raise ArgumentError, "field/association #{inspect(name)} is already set on schema"
     end
 
     Module.put_attribute(mod, :struct_fields, {name, assoc})
   end
 
   defp check_options!(opts, valid, fun_arity) do
-    case Enum.find(opts, fn {k, _} -> not(k in valid) end) do
-      {k, _} -> raise ArgumentError, "invalid option #{inspect k} for #{fun_arity}"
+    case Enum.find(opts, fn {k, _} -> not (k in valid) end) do
+      {k, _} -> raise ArgumentError, "invalid option #{inspect(k)} for #{fun_arity}"
       nil -> :ok
     end
   end
 
   defp check_field_type!(name, :datetime, _opts) do
-    raise ArgumentError, "invalid type :datetime for field #{inspect name}. " <>
-                           "You probably meant to choose one between :naive_datetime " <>
-                           "(no time zone information) or :utc_datetime (time zone is set to UTC)"
+    raise ArgumentError,
+          "invalid type :datetime for field #{inspect(name)}. " <>
+            "You probably meant to choose one between :naive_datetime " <>
+            "(no time zone information) or :utc_datetime (time zone is set to UTC)"
   end
 
   defp check_field_type!(name, {:embed, _}, _opts) do
-    raise ArgumentError, "cannot declare field #{inspect name} as embed. Use embeds_one/many instead"
+    raise ArgumentError,
+          "cannot declare field #{inspect(name)} as embed. Use embeds_one/many instead"
   end
 
   defp check_field_type!(name, type, opts) do
     cond do
       type == :any and !opts[:virtual] ->
-        raise ArgumentError, "only virtual fields can have type :any, " <>
-                             "invalid type for field #{inspect name}"
+        raise ArgumentError,
+              "only virtual fields can have type :any, " <>
+                "invalid type for field #{inspect(name)}"
 
       Ecto.Type.primitive?(type) ->
         type
@@ -2057,11 +2145,11 @@ defmodule Ecto.Schema do
 
       is_atom(type) and function_exported?(type, :__schema__, 1) ->
         raise ArgumentError,
-          "schema #{inspect type} is not a valid type for field #{inspect name}." <>
-          " Did you mean to use belongs_to, has_one, has_many, embeds_one, or embeds_many instead?"
+              "schema #{inspect(type)} is not a valid type for field #{inspect(name)}." <>
+                " Did you mean to use belongs_to, has_one, has_many, embeds_one, or embeds_many instead?"
 
       true ->
-        raise ArgumentError, "invalid or unknown type #{inspect type} for field #{inspect name}"
+        raise ArgumentError, "invalid or unknown type #{inspect(type)} for field #{inspect(name)}"
     end
   end
 
@@ -2078,22 +2166,28 @@ defmodule Ecto.Schema do
       id = autogenerate_id(type) ->
         cond do
           not pk? ->
-            raise ArgumentError, "only primary keys allow :autogenerate for type #{inspect type}, " <>
-                                 "field #{inspect name} is not a primary key"
+            raise ArgumentError,
+                  "only primary keys allow :autogenerate for type #{inspect(type)}, " <>
+                    "field #{inspect(name)} is not a primary key"
+
           Module.get_attribute(mod, :ecto_autogenerate_id) ->
-            raise ArgumentError, "only one primary key with ID type may be marked as autogenerated"
+            raise ArgumentError,
+                  "only one primary key with ID type may be marked as autogenerated"
+
           true ->
             Module.put_attribute(mod, :ecto_autogenerate_id, {name, source, id})
         end
 
       Ecto.Type.primitive?(type) ->
-        raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "primitive type #{inspect type}"
+        raise ArgumentError,
+              "field #{inspect(name)} does not support :autogenerate because it uses a " <>
+                "primitive type #{inspect(type)}"
 
       # Note the custom type has already been loaded in check_type!/3
       not function_exported?(type, :autogenerate, 0) ->
-        raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "custom type #{inspect type} that does not define autogenerate/0"
+        raise ArgumentError,
+              "field #{inspect(name)} does not support :autogenerate because it uses a " <>
+                "custom type #{inspect(type)} that does not define autogenerate/0"
 
       true ->
         Module.put_attribute(mod, :ecto_autogenerate, {[name], {type, :autogenerate, []}})
@@ -2107,6 +2201,7 @@ defmodule Ecto.Schema do
 
   defp expand_alias({:__aliases__, _, _} = ast, env),
     do: Macro.expand(ast, %{env | function: {:__schema__, 2}})
+
   defp expand_alias(ast, _env),
     do: ast
 end


### PR DESCRIPTION
This addresses issue #2734

I apologize if I'm missing any standards and welcome edits and comments.