### PR TITLE
Add Ecto.Query.has_named_binding?/2

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1832,7 +1832,7 @@ defmodule Ecto.Query do
   end
 
   @doc """
-  Returns `true` if query has binding with a given name, otherwise - `false`.
+  Returns `true` if query has binding with a given name, otherwise `false`.
 
   For more information on named bindings see "Named bindings" in this module doc.
   """

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1830,4 +1830,22 @@ defmodule Ecto.Query do
   defp assert_schema!(query) do
     raise Ecto.QueryError, query: query, message: "expected a from expression with a schema"
   end
+
+  @doc """
+  Returns `true` if query has binding with a given name, otherwise - `false`.
+
+  For more information on named bindings see "Named bindings" in this module doc.
+  """
+  def has_named_binding?(%Ecto.Query{aliases: aliases}, key) do
+    Map.has_key?(aliases, key)
+  end
+
+  def has_named_binding?(queryable, _key)
+      when is_atom(queryable) or is_binary(queryable) or is_tuple(queryable) do
+    false
+  end
+
+  def has_named_binding?(queryable, key) do
+    has_named_binding?(Ecto.Queryable.to_query(queryable), key)
+  end
 end

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -673,4 +673,35 @@ defmodule Ecto.QueryTest do
              ~s[#Ecto.Query<from p in \"posts\", where: fragment("héllò")>]
     end
   end
+
+  describe "has_named_binding?/1" do
+    test "returns true if query has a named binding" do
+      query =
+        from(p in "posts", as: :posts,
+          join: b in "blogs",
+          join: c in "comments", as: :comment,
+          join: l in "links", on: l.valid, as: :link)
+
+      assert has_named_binding?(query, :posts)
+      assert has_named_binding?(query, :comment)
+      assert has_named_binding?(query, :link)
+    end
+
+    test "returns false if query does not have a named binding" do
+      query = from(p in "posts")
+      refute has_named_binding?(query, :posts)
+    end
+
+    test "returns false when query is a tuple, atom or binary" do
+      refute has_named_binding?({:foo, :bar}, :posts)
+      refute has_named_binding?(:foo, :posts)
+      refute has_named_binding?("foo", :posts)
+    end
+
+    test "casts queryable to query" do
+      assert_raise Protocol.UndefinedError, "protocol Ecto.Queryable not implemented for []", fn ->
+        has_named_binding?([], :posts)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Related to #2389.

The main use case is preloading an association if it's not already preloaded:
```
  def with_preloaded_account(queryable) do
    if has_named_binding?(queryable, :account) do
      queryable
    else
      queryable
      |> join(:left, [assignment], account in assoc(assignment, :account), as: :account)
      |> preload([assignment, account: account], account: account)
    end
  end
```

We may also add a doctest with example usage:
```

  ## Examples

        iex> import Ecto.Query
        iex> query = from(p in "posts", as: :posts, \
                join: b in "blogs", \
                join: l in "links", as: :link)
        iex> has_named_binding?(query, :posts)
        true
        iex> has_named_binding?(query, :link)
        true
        iex> has_named_binding?(query, :blogs)
        false
```