### PR TITLE
Add specific error when interval is not a string. Fix docs.

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -811,13 +811,16 @@ defmodule Ecto.Query.Builder do
   end
 
   @doc """
-  Called by escaper at runtime to verify that value is an atom.
+  Called by escaper at runtime to verify that value is a valid interval.
   """
   @interval ~w(year month week day hour minute second millisecond microsecond)
   def interval!(interval) when interval in @interval,
     do: interval
-  def interval!(other),
-    do: error!("invalid interval: `#{inspect other}` (expected one of #{Enum.join(@interval, ", ")})")
+  def interval!(other_string) when is_binary(other_string),
+    do: error!("invalid interval: `#{inspect other_string}` (expected one of #{Enum.join(@interval, ", ")})")
+  def interval!(not_string),
+    do: error!("invalid interval: `#{inspect not_string}` expected a string.")
+
 
   @doc """
   Negates the given number.

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -819,8 +819,7 @@ defmodule Ecto.Query.Builder do
   def interval!(other_string) when is_binary(other_string),
     do: error!("invalid interval: `#{inspect other_string}` (expected one of #{Enum.join(@interval, ", ")})")
   def interval!(not_string),
-    do: error!("invalid interval: `#{inspect not_string}` expected a string.")
-
+    do: error!("invalid interval: `#{inspect not_string}` (expected a string)")
 
   @doc """
   Negates the given number.


### PR DESCRIPTION
The error message when passing an atom into intervals is somewhat confusing if you don't immediately realize the valid intervals it is listing in the error message are strings, not atoms. For example, we spent too much time trying to figure out what was going on with this: `(Ecto.Query.CompileError) invalid interval: `:month` (expected one of year, month, week, day, hour, minute, second, millisecond, microsecond)`
Given that the most common mistake here is probably passing a "valid" interval in atom form instead of a string, this PR updates the error to catch a non-string and explicitly call out the fact that it needs to be a string. Still notes the valid strings when an invalid string is passed.

Docs also seemed to be out of date, updated them.