### PR TITLE
Add Common Table Expressions (a.k.a. CTE or WITH)

### DIFF
--- a/lib/ecto/query/builder/cte.ex
+++ b/lib/ecto/query/builder/cte.ex
@@ -1,0 +1,70 @@
+import Kernel, except: [apply: 3]
+
+defmodule Ecto.Query.Builder.CTE do
+  @moduledoc false
+
+  alias Ecto.Query.Builder
+
+  @doc """
+  Escapes the CTE name.
+
+      iex> escape(quote do: "FOO")
+      "FOO"
+  """
+
+  @spec escape(Macro.t) :: Macro.t
+  def escape(name) when is_binary(name), do: name
+
+  def escape(other) do
+    Builder.error! "`#{Macro.to_string(other)}` is not a valid CTE name. " <>
+                   "It must be a literal string"
+  end
+
+  @doc """
+  Builds a quoted expression.
+
+  The quoted expression should evaluate to a query at runtime.
+  If possible, it does all calculations at compile time to avoid
+  runtime work.
+  """
+  @spec build(Macro.t, Macro.t, Macro.t, Macro.Env.t) :: Macro.t
+  def build(query, name, {:^, _, [expr]}, env) when is_bitstring(name) do
+    expr = quote do: Ecto.Queryable.to_query(unquote(expr))
+    Builder.apply_query(query, __MODULE__, [escape(name), expr], env)
+  end
+
+  def build(query, name, {:fragment, _, _} = fragment, env) do
+    {expr, {params, :acc}} = Builder.escape(fragment, :any, {[], :acc}, [], env)
+    params = Builder.escape_params(params)
+
+    query_expr = quote do
+      %Ecto.Query.QueryExpr{
+        expr: unquote(expr),
+        params: unquote(params),
+        file: unquote(env.file),
+        line: unquote(env.line)
+      }
+    end
+
+    Builder.apply_query(query, __MODULE__, [escape(name), query_expr], env)
+  end
+
+  def build(_query, name, other, _env) do
+    Builder.error! "`#{Macro.to_string(other)}` is not a valid CTE (#{Macro.to_string(name)}). " <>
+                   "CTE must be an interpolated query, such as ^existing_query or a fragment"
+  end
+
+  @doc """
+  The callback applied by `build/4` to build the query.
+  """
+  @spec apply(Ecto.Queryable.t, bitstring, Ecto.Queryable.t) :: Ecto.Query.t
+  def apply(%Ecto.Query{with_ctes: with_expr} = query, name, with_query) do
+    with_expr = with_expr || %Ecto.Query.WithExpr{}
+    queries = List.keystore(with_expr.queries, name, 0, {name, with_query})
+    with_expr = %{with_expr | queries: queries}
+    %{query | with_ctes: with_expr}
+  end
+  def apply(query, name, with_query) do
+    apply(Ecto.Queryable.to_query(query), name, with_query)
+  end
+end

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -1,9 +1,10 @@
 import Inspect.Algebra
 import Kernel, except: [to_string: 1]
 
-alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr}
+alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr, WithExpr}
 
-container_doc = if Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many
+container_doc =
+  if Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many
 
 defimpl Inspect, for: Ecto.Query.DynamicExpr do
   def inspect(%DynamicExpr{binding: binding} = dynamic, opts) do
@@ -12,26 +13,45 @@ defimpl Inspect, for: Ecto.Query.DynamicExpr do
 
     names = for {name, _, _} <- binding, do: Atom.to_string(name)
 
-    inspected =
-      Inspect.Ecto.Query.expr(expr, List.to_tuple(names), %{expr: expr, params: params})
+    inspected = Inspect.Ecto.Query.expr(expr, List.to_tuple(names), %{expr: expr, params: params})
 
     # TODO: Replace unquote with just `container_doc` when Elixir < 1.6.0 is no longer supported
-    unquote(container_doc)("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str, _ -> str end)
+    unquote(container_doc)("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str,
+                                                                                            _ ->
+      str
+    end)
   end
 end
 
 defimpl Inspect, for: Ecto.Query do
   @doc false
   def inspect(query, opts) do
-    list = Enum.map(to_list(query), fn
-      {key, string} ->
-        concat(Atom.to_string(key) <> ": ", string)
-      string ->
-        string
-    end)
+    list =
+      Enum.map(to_list(query), fn
+        {key, string} ->
+          concat(Atom.to_string(key) <> ": ", string)
+
+        string ->
+          string
+      end)
 
     # TODO: Replace unquote with just `container_doc` when Elixir < 1.6.0 is no longer supported
-    unquote(container_doc)("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
+    result = unquote(container_doc)("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
+
+    case query.with_ctes do
+      %WithExpr{recursive: recursive, queries: [_ | _] = queries} ->
+        with_ctes =
+          Enum.map(queries, fn {name, query} ->
+            cte = __MODULE__.inspect(query, opts)
+            concat(["|> with_cte(\"" <> name <> "\", as: ", cte, ")"])
+          end)
+
+        recursive_ctes = if recursive, do: "|> recursive_ctes(true)", else: ""
+        ([result, recursive_ctes] ++ with_ctes) |> Enum.intersperse(break("\n")) |> concat()
+
+      _ ->
+        result
+    end
   end
 
   @doc false
@@ -39,6 +59,7 @@ defimpl Inspect, for: Ecto.Query do
     Enum.map_join(to_list(query), ",\n  ", fn
       {key, string} ->
         Atom.to_string(key) <> ": " <> string
+
       string ->
         string
     end)
@@ -50,7 +71,7 @@ defimpl Inspect, for: Ecto.Query do
       |> collect_sources
       |> generate_letters
       |> generate_names
-      |> List.to_tuple
+      |> List.to_tuple()
 
     from = bound_from(query.from, binding(names, 0))
     joins = joins(query.joins, names)
@@ -58,73 +79,96 @@ defimpl Inspect, for: Ecto.Query do
     assocs = assocs(query.assocs, names)
     windows = windows(query.windows, names)
     combinations = combinations(query.combinations)
- 
+
     wheres = bool_exprs(%{and: :where, or: :or_where}, query.wheres, names)
     group_bys = kw_exprs(:group_by, query.group_bys, names)
     havings = bool_exprs(%{and: :having, or: :or_having}, query.havings, names)
     order_bys = kw_exprs(:order_by, query.order_bys, names)
     updates = kw_exprs(:update, query.updates, names)
- 
+
     lock = kw_inspect(:lock, query.lock)
     limit = kw_expr(:limit, query.limit, names)
     offset = kw_expr(:offset, query.offset, names)
     select = kw_expr(:select, query.select, names)
     distinct = kw_expr(:distinct, query.distinct, names)
 
-    Enum.concat [from, joins, wheres, group_bys, havings, windows, combinations, order_bys,
-                 limit, offset, lock, distinct, updates, select, preloads, assocs]
+    Enum.concat([
+      from,
+      joins,
+      wheres,
+      group_bys,
+      havings,
+      windows,
+      combinations,
+      order_bys,
+      limit,
+      offset,
+      lock,
+      distinct,
+      updates,
+      select,
+      preloads,
+      assocs
+    ])
   end
 
   defp bound_from(nil, name), do: ["from #{name} in query"]
+
   defp bound_from(%{source: source} = from, name) do
-    ["from #{name} in #{inspect_source source}"] ++ kw_as_and_prefix(from)
+    ["from #{name} in #{inspect_source(source)}"] ++ kw_as_and_prefix(from)
   end
 
   defp inspect_source(%Ecto.Query{} = query), do: "^" <> inspect(query)
-  defp inspect_source(%Ecto.SubQuery{query: query}), do: "subquery(#{to_string query})"
-  defp inspect_source({source, nil}), do: inspect source
-  defp inspect_source({nil, schema}), do: inspect schema
+  defp inspect_source(%Ecto.SubQuery{query: query}), do: "subquery(#{to_string(query)})"
+  defp inspect_source({source, nil}), do: inspect(source)
+  defp inspect_source({nil, schema}), do: inspect(schema)
+
   defp inspect_source({source, schema} = from) do
-    inspect if source == schema.__schema__(:source), do: schema, else: from
+    inspect(if source == schema.__schema__(:source), do: schema, else: from)
   end
 
   defp joins(joins, names) do
     joins
-    |> Enum.with_index
+    |> Enum.with_index()
     |> Enum.flat_map(fn {expr, ix} -> join(expr, binding(names, expr.ix || ix + 1), names) end)
   end
 
   defp join(%JoinExpr{qual: qual, assoc: {ix, right}, on: on} = join, name, names) do
-    string = "#{name} in assoc(#{binding(names, ix)}, #{inspect right})"
+    string = "#{name} in assoc(#{binding(names, ix)}, #{inspect(right)})"
     [{join_qual(qual), string}] ++ kw_as_and_prefix(join) ++ maybe_on(on, names)
   end
 
-  defp join(%JoinExpr{qual: qual, source: {:fragment, _, _} = source, on: on} = join = part, name, names) do
+  defp join(
+         %JoinExpr{qual: qual, source: {:fragment, _, _} = source, on: on} = join = part,
+         name,
+         names
+       ) do
     string = "#{name} in #{expr(source, names, part)}"
     [{join_qual(qual), string}] ++ kw_as_and_prefix(join) ++ [on: expr(on, names)]
   end
 
   defp join(%JoinExpr{qual: qual, source: source, on: on} = join, name, names) do
-    string = "#{name} in #{inspect_source source}"
+    string = "#{name} in #{inspect_source(source)}"
     [{join_qual(qual), string}] ++ kw_as_and_prefix(join) ++ [on: expr(on, names)]
   end
 
   defp maybe_on(%QueryExpr{expr: true}, _names), do: []
   defp maybe_on(%QueryExpr{} = on, names), do: [on: expr(on, names)]
 
-  defp preloads([]),       do: []
+  defp preloads([]), do: []
   defp preloads(preloads), do: [preload: inspect(preloads)]
 
-  defp assocs([], _names),    do: []
+  defp assocs([], _names), do: []
   defp assocs(assocs, names), do: [preload: expr(assocs(assocs), names, %{})]
 
   defp assocs(assocs) do
-    Enum.map assocs, fn
+    Enum.map(assocs, fn
       {field, {idx, []}} ->
         {field, {:&, [], [idx]}}
+
       {field, {idx, children}} ->
         {field, {{:&, [], [idx]}, assocs(children)}}
-    end
+    end)
   end
 
   defp windows(windows, names) do
@@ -140,20 +184,20 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp bool_exprs(keys, exprs, names) do
-    Enum.map exprs, fn %{expr: expr, op: op} = part ->
+    Enum.map(exprs, fn %{expr: expr, op: op} = part ->
       {Map.fetch!(keys, op), expr(expr, names, part)}
-    end
+    end)
   end
 
   defp kw_exprs(key, exprs, names) do
-    Enum.map exprs, &{key, expr(&1, names)}
+    Enum.map(exprs, &{key, expr(&1, names)})
   end
 
   defp kw_expr(_key, nil, _names), do: []
-  defp kw_expr(key, expr, names),  do: [{key, expr(expr, names)}]
+  defp kw_expr(key, expr, names), do: [{key, expr(expr, names)}]
 
   defp kw_inspect(_key, nil), do: []
-  defp kw_inspect(key, val),  do: [{key, inspect(val)}]
+  defp kw_inspect(key, val), do: [{key, inspect(val)}]
 
   defp kw_as_and_prefix(%{as: as, prefix: prefix}) do
     kw_inspect(:as, as) ++ kw_inspect(:prefix, prefix)
@@ -169,7 +213,7 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   # For keyword and interpolated fragments use normal escaping
-  defp expr_to_string({:fragment, _, [{_, _}|_] = parts}, _, names, part) do
+  defp expr_to_string({:fragment, _, [{_, _} | _] = parts}, _, names, part) do
     "fragment(" <> unmerge_fragments(parts, "", [], names, part) <> ")"
   end
 
@@ -178,8 +222,10 @@ defimpl Inspect, for: Ecto.Query do
     case take do
       %{^ix => {:any, fields}} when ix == 0 ->
         Kernel.inspect(fields)
+
       %{^ix => {tag, fields}} ->
         "#{tag}(" <> binding(names, ix) <> ", " <> Kernel.inspect(fields) <> ")"
+
       _ ->
         binding(names, ix)
     end
@@ -194,13 +240,13 @@ defimpl Inspect, for: Ecto.Query do
   # In case the query had its parameters removed,
   # we use ... to express the interpolated code.
   defp expr_to_string({:^, _, [_ix, _len]}, _, _, _part) do
-    Macro.to_string {:^, [], [{:..., [], nil}]}
+    Macro.to_string({:^, [], [{:..., [], nil}]})
   end
 
   defp expr_to_string({:^, _, [ix]}, _, _, %{params: params}) do
     case Enum.at(params || [], ix) do
       {value, _type} -> "^" <> Kernel.inspect(value, charlists: :as_lists)
-      _              -> "^..."
+      _ -> "^..."
     end
   end
 
@@ -217,7 +263,7 @@ defimpl Inspect, for: Ecto.Query do
 
   # Tagged values
   defp expr_to_string(%Ecto.Query.Tagged{value: value, tag: nil}, _, _names, _) do
-    inspect value
+    inspect(value)
   end
 
   defp expr_to_string(%Ecto.Query.Tagged{value: value, tag: tag}, _, names, part) do
@@ -231,28 +277,30 @@ defimpl Inspect, for: Ecto.Query do
   defp type_to_expr({composite, type}) when is_atom(composite) do
     {composite, type_to_expr(type)}
   end
+
   defp type_to_expr({part, type}) when is_integer(part) do
     {{:., [], [{:&, [], [part]}, type]}, [], []}
   end
+
   defp type_to_expr(type) do
     type
   end
 
-  defp unmerge_fragments([{:raw, s}, {:expr, v}|t], frag, args, names, part) do
-    unmerge_fragments(t, frag <> s <> "?", [expr(v, names, part)|args], names, part)
+  defp unmerge_fragments([{:raw, s}, {:expr, v} | t], frag, args, names, part) do
+    unmerge_fragments(t, frag <> s <> "?", [expr(v, names, part) | args], names, part)
   end
 
   defp unmerge_fragments([{:raw, s}], frag, args, _names, _part) do
-    Enum.join [inspect(frag <> s)|Enum.reverse(args)], ", "
+    Enum.join([inspect(frag <> s) | Enum.reverse(args)], ", ")
   end
 
-  defp join_qual(:inner),         do: :join
+  defp join_qual(:inner), do: :join
   defp join_qual(:inner_lateral), do: :join_lateral
-  defp join_qual(:left),          do: :left_join
-  defp join_qual(:left_lateral),  do: :left_join_lateral
-  defp join_qual(:right),         do: :right_join
-  defp join_qual(:full),          do: :full_join
-  defp join_qual(:cross),         do: :cross_join
+  defp join_qual(:left), do: :left_join
+  defp join_qual(:left_lateral), do: :left_join_lateral
+  defp join_qual(:right), do: :right_join
+  defp join_qual(:full), do: :full_join
+  defp join_qual(:cross), do: :cross_join
 
   defp collect_sources(%{from: nil, joins: joins}) do
     ["query" | join_sources(joins)]
@@ -272,10 +320,13 @@ defimpl Inspect, for: Ecto.Query do
     |> Enum.map(fn
       %JoinExpr{assoc: {_var, assoc}} ->
         assoc
+
       %JoinExpr{source: {:fragment, _, _}} ->
         "fragment"
+
       %JoinExpr{source: %Ecto.Query{from: from}} ->
         from_sources(from.source)
+
       %JoinExpr{source: source} ->
         from_sources(source)
     end)
@@ -284,10 +335,10 @@ defimpl Inspect, for: Ecto.Query do
   defp generate_letters(sources) do
     Enum.map(sources, fn source ->
       source
-      |> Kernel.to_string
+      |> Kernel.to_string()
       |> normalize_source
-      |> String.first
-      |> String.downcase
+      |> String.first()
+      |> String.downcase()
     end)
   end
 
@@ -305,7 +356,8 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp normalize_source("Elixir." <> _ = source),
-    do: source |> Module.split |> List.last
+    do: source |> Module.split() |> List.last()
+
   defp normalize_source(source),
     do: source
 end

--- a/test/ecto/query/builder/cte_test.exs
+++ b/test/ecto/query/builder/cte_test.exs
@@ -1,0 +1,51 @@
+Code.require_file "../../../support/eval_helpers.exs", __DIR__
+
+defmodule Ecto.Query.Builder.CTETest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Query.Builder.CTE
+  doctest Ecto.Query.Builder.CTE
+
+  import Ecto.Query
+  import Support.EvalHelpers
+
+  test "appends multiple CTEs as interpolated query or fragment" do
+    cte1 = from(p in "tbl1")
+
+    query =
+      %Ecto.Query{}
+      |> with_cte("cte1", as: ^cte1)
+      |> with_cte("cte2", as: fragment("SELECT * FROM tbl2"))
+
+    assert [{"cte1", ^cte1}, {"cte2", %Ecto.Query.QueryExpr{expr: expr}}] = query.with_ctes.queries
+    assert {:fragment, [], [raw: "SELECT * FROM tbl2"]} = expr
+  end
+
+  test "raises on passing a query without ^" do
+    assert_raise Ecto.Query.CompileError, ~r"is not a valid CTE", fn ->
+      quote_and_eval(%Ecto.Query{} |> with_cte("cte", as: %Ecto.Query{}))
+    end
+  end
+
+  test "raises on passing a string query without fragment" do
+    assert_raise Ecto.Query.CompileError, ~r"is not a valid CTE", fn ->
+      quote_and_eval(%Ecto.Query{} |> with_cte("cte", as: "SELECT * FROM tbl"))
+    end
+  end
+
+  test "overrides existing CTE by name" do
+    cte1 = from(p in "tbl1")
+    cte2 = from(p in "tbl2")
+    query = %Ecto.Query{} |> with_cte("cte", as: ^cte1) |> with_cte("cte", as: ^cte2)
+
+    assert [{"cte", ^cte2}] = query.with_ctes.queries
+  end
+
+  test "sets and overrides recursion flag" do
+    query = %Ecto.Query{} |> recursive_ctes(true)
+    assert query.with_ctes.recursive
+
+    query = query |> recursive_ctes(false)
+    refute query.with_ctes.recursive
+  end
+end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -431,6 +431,26 @@ defmodule Ecto.Query.PlannerTest do
     assert :nocache = cache
   end
 
+  test "prepare: prepare CTEs" do
+    {%{with_ctes: with_expr}, _, cache} = Comment |> with_cte("cte", as: ^from(c in Comment)) |> plan()
+    %{queries: [{"cte", query}]} = with_expr
+    assert query.sources == {{"comments", Comment, nil}}
+    assert %Ecto.Query.SelectExpr{expr: {:&, [], [0]}} = query.select
+    assert [:all, _, {"comments", Comment, _, nil}, {"comments", Comment, _, nil}, _] = cache
+
+    {%{with_ctes: with_expr}, _, cache} = Comment |> with_cte("cte", as: ^from(c in Comment, where: c in ^[1, 2, 3])) |> plan()
+    %{queries: [{"cte", query}]} = with_expr
+    assert query.sources == {{"comments", Comment, nil}}
+    assert %Ecto.Query.SelectExpr{expr: {:&, [], [0]}} = query.select
+    assert :nocache = cache
+
+    {%{with_ctes: with_expr}, _, cache} = Comment |> with_cte("cte", as: fragment("SELECT * FROM comments WHERE id = ?", 123)) |> plan()
+    %{queries: [{"cte", query_expr}]} = with_expr
+    expr = {:fragment, [], [raw: "SELECT * FROM comments WHERE id = ", expr: 123, raw: ""]}
+    assert expr == query_expr.expr
+    assert [:all, _, {"comments", Comment, _, nil}, {:with_cte, ^expr}] = cache
+  end
+
   test "normalize: validates literal types" do
     assert_raise Ecto.QueryError, fn ->
       Comment |> where([c], c.text == 123) |> normalize()


### PR DESCRIPTION
I know it's too late for 3.0-rc but anyway :)

This enables Common Table Expressions. There are two common use cases for them:
1. Recursive queries for retrieving tree structures (e.g. category tree or virtual file tree).
2. Reusable subqueries. Useful for scoping.

API may be disputable because it's more evident to use `with` as in plain SQL instead of `cte` but it may be a mess with `Kernel.SpecialForms.with/1`. I'm open for proposals.

Complementary PR in ecto_sql: https://github.com/elixir-ecto/ecto_sql/pull/23