### PR TITLE
Improve error message when accidentally persisting embedded schema

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -506,6 +506,9 @@ defmodule Ecto.Repo.Schema do
                 autogen_id, opts) do
     metadata(schema, prefix, source, autogen_id, context, opts)
   end
+  defp metadata(%{__struct__: schema}, _, _) do
+    raise ArgumentError, "#{inspect(schema)} needs to be a schema with source"
+  end
 
   defp conflict_target({:constraint, constraint}, _dumper) when is_atom(constraint) do
     {:constraint, constraint}


### PR DESCRIPTION
Before:

```
iex(1)> Repo.insert(%PackageMetadata{})
** (FunctionClauseError) no function clause matching in Ecto.Repo.Schema.metadata/3

    The following arguments were given to Ecto.Repo.Schema.metadata/3:

        # 1
        %Hexpm.Repository.PackageMetadata{
          description: nil,
          extra: nil,
          id: nil,
          licenses: nil,
          links: nil,
          maintainers: nil
        }

        # 2
        {:id, :id, :binary_id}

        # 3
        [skip_transaction: true]

    Attempted function clauses (showing 1 out of 1):

        defp metadata(%{__struct__: schema, __meta__: %{context: context, source: source, prefix: prefix}}, autogen_id, opts)

    (ecto) lib/ecto/repo/schema.ex:505: Ecto.Repo.Schema.metadata/3
    (ecto) lib/ecto/repo/schema.ex:212: anonymous fn/15 in Ecto.Repo.Schema.do_insert/3
```

After:

```
iex(1)> Repo.insert(%PackageMetadata{})
** (ArgumentError) expected schema with source, got: Hexpm.Repository.PackageMetadata
    (ecto) lib/ecto/repo/schema.ex:510: Ecto.Repo.Schema.metadata/3
    (ecto) lib/ecto/repo/schema.ex:212: anonymous fn/15 in Ecto.Repo.Schema.do_insert/3
```

cc @archdragon