### PR TITLE
Set default log level for `Ecto.LogEntry.log/1`

### DIFF
--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -46,7 +46,7 @@ defmodule Ecto.LogEntry do
   The logger call won't be removed at compile time as
   custom level is given.
   """
-  def log(entry, level, metadata \\ []) do
+  def log(entry, level \\ :debug, metadata \\ []) do
     Logger.log(level, fn -> to_iodata(entry) end, metadata)
   end
 


### PR DESCRIPTION
Previously, the following config would work:

    config :my_app, MyApp.Repo, loggers: [Ecto.LogEntry]

This config is commonly used when adding additional loggers, but still wanting
to keep the default Ecto logger.

The `log/1` function was removed in this commit
ee8a9ea002f8809825d3bd5a3bc34aa863f223ee

Which results in an exception:

 > function Ecto.LogEntry.log/1 is undefined or private. Did you mean one of:
 >
 > * log/2
 > * log/3

This commit defaults the level to `:debug`, which allows the above config to
work again.