### PR TITLE
fixes race condition Ecto.Repo.Supervisor if adapter needs compiling

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -67,7 +67,7 @@ defmodule Ecto.Repo.Supervisor do
       raise ArgumentError, "missing :adapter option on use Ecto.Repo"
     end
 
-    unless Code.ensure_loaded?(adapter) do
+    unless Code.ensure_compiled?(adapter) do
       raise ArgumentError, "adapter #{inspect adapter} was not compiled, " <>
                            "ensure it is correct and it is included as a project dependency"
     end


### PR DESCRIPTION
- Follow-up of #2822

- Previously, `Ecto.Repo.Supervisor ` uses `Core.ensure_loaded?/1` which could cause errors when the adapter is not yet compiled.

- See https://hexdocs.pm/elixir/Code.html#ensure_loaded/1-code-loading-on-the-erlang-vm

  > When invoked, ensure_compiled/1 halts the compilation of the caller until the module given to `ensure_compiled/1` becomes available or all files for the current project have been compiled. If compilation finishes and the module is not available, an error tuple is returned.