### PR TITLE
Document that Mix.Ecto.ensure_started/2 has been removed in Ecto 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,7 +195,7 @@ Although Ecto 3.0 is a major bump version, the functionality below emits depreca
   * [Ecto.Schema] `:time`, `:naive_datetime` and `:utc_datetime` no longer keep microseconds information. If you want to keep microseconds, use `:time_usec`, `:naive_datetime_usec`, `:utc_datetime_usec`
   * [Ecto.Schema] The `@schema_prefix` option now only affects the `from`/`join` of where the schema is used and no longer the whole query
   * [Ecto.Schema.Metadata] The `source` key no longer returns a tuple of the schema_prefix and the table/collection name. It now returns just the table/collection string. You can now access the schema_prefix via the `prefix` key.
-  * [Mix.Ecto] `Mix.Ecto.ensure_started/2` has been removed. However, in Ecto 2.2 the  `Mix.Ecto` module was not considered part of the public API and should not have been used but we are listing this as a backwards incompatible change to help with users relying on this function.
+  * [Mix.Ecto] `Mix.Ecto.ensure_started/2` has been removed. However, in Ecto 2.2 the  `Mix.Ecto` module was not considered part of the public API and should not have been used but we are listing this for guidance.
 
 ### Adapter changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@ Although Ecto 3.0 is a major bump version, the functionality below emits depreca
   * [Ecto.Schema] `:time`, `:naive_datetime` and `:utc_datetime` no longer keep microseconds information. If you want to keep microseconds, use `:time_usec`, `:naive_datetime_usec`, `:utc_datetime_usec`
   * [Ecto.Schema] The `@schema_prefix` option now only affects the `from`/`join` of where the schema is used and no longer the whole query
   * [Ecto.Schema.Metadata] The `source` key no longer returns a tuple of the schema_prefix and the table/collection name. It now returns just the table/collection string. You can now access the schema_prefix via the `prefix` key.
+  * [Mix.Ecto] `Mix.Ecto.ensure_started/2` has been removed. However, in Ecto 2.2 the  `Mix.Ecto` module was not considered part of the public API and should not have been used but we are listing this as a backwards incompatible change to help with users relying on this function.
 
 ### Adapter changes
 


### PR DESCRIPTION
I'm working on upgrading a production application from Ecto 2.2.11 to Ecto 3.0 and I ran into an issue because our code ran `Mix.Ecto.ensure_started/2`. After looking into it I realized that in Ecto 2.x `Mix.Ecto` was [considered private](https://github.com/elixir-ecto/ecto/issues/1586#issuecomment-233301683) and hence we shouldn't have been using this function in the first place. However, there are a number of articles online that promote this usage so I think it is worth it to mention that `ensure_started` has been removed in Ecto 3.0:

Directly uses `Mix.Ecto.ensure_started/2` and breaks in Ecto 3.0:
* https://stackoverflow.com/a/38226476/175830
* https://brainlid.org/elixir/2016/09/28/mix-task-using-ecto.html
* https://pastebin.com/fk6w99n0
* https://til.hashrocket.com/posts/k4zie79ydb-mix-tasks-accessing-the-db-with-mixecto
* https://gist.github.com/jclosure/d4d1971a7f6f8acd98e13b90130e32f5

Imports `Mix.Ecto`:
* https://stackoverflow.com/a/41796156/175830

I have gone through and added comments to the articles where possible  but I think including a note in the changelog itself would be helpful.