### PR TITLE
fix load binary id array error

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -496,6 +496,10 @@ defmodule Ecto.Type do
     {:ok, nil}
   end
 
+  def load({:array, :binary_id}, value, loader) do
+    array(value, &loader.(:binary_id, &1), [])
+  end
+
   def load(type, value, _loader) do
     load_fun(type).(value)
   end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -171,6 +171,14 @@ defmodule Ecto.TypeTest do
   @uuid_string "bfe0888c-5c59-4bb3-adfd-71f0b85d3db7"
   @uuid_binary <<191, 224, 136, 140, 92, 89, 75, 179, 173, 253, 113, 240, 184, 93, 61, 183>>
 
+  test "binary_id with array" do
+    assert adapter_load(Ecto.TestAdapter, {:array, :binary_id}, [@uuid_binary]) ==
+             {:ok, [@uuid_string]}
+
+    assert adapter_dump(Ecto.TestAdapter, {:array, :binary_id}, [@uuid_string]) ==
+             {:ok, [@uuid_binary]}
+  end
+
   test "embeds_one" do
     embed = %Ecto.Embedded{field: :embed, cardinality: :one,
                            owner: __MODULE__, related: Schema}


### PR DESCRIPTION
Related issue: #2830 

Like the issue says, Ecto 3.0 can't transform binary_id in an array to the printable string.

### Reason

In Ecto 3.0, the type `:binary_id` is specially handled: 
1) Through adapter.loaders, the type `:binary_id` has becomes to `[Ecto.UUID, :bianry_id]` 
2) Then load twice for each `Ecto.UUID` and `:binary_id`

The result is correct because it calls the function `Ecto.UUID.load/1` during the first load.  But `{:array, :binary_id}` is not specially handled. The function `dump_binary/1` just returns what it receives.

### Solution

Like Ecto 2.x, pattern match the `{:array, :binary_id}` and handle the value of each of the array.