### PR TITLE
add support for field/2 as first element of type/2 and alias as second element of type/2

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -409,7 +409,7 @@ defmodule Ecto.Query.Builder do
   defp escape_with_type(expr, type, params_acc, vars, env) do
     type = validate_type!(type, vars, env)
     {expr, params_acc} = escape(expr, type, params_acc, vars, env)
-    {{:{}, [], [:type, [], [expr, type]]}, params_acc}
+    {{:{}, [], [:type, [], [expr, Macro.escape(type)]]}, params_acc}
   end
 
   defp wrap_nil(params, {:{}, _, [:^, _, [ix]]}), do: wrap_nil(params, ix, [])

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -30,6 +30,9 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do type(&0.y, :decimal) end), []} ==
           escape(quote do type(field(x, :y), :decimal) end, [x: 0], __ENV__)
 
+    assert {Macro.escape(quote do type(&0.y, Ecto.UUID) end), []} ==
+          escape(quote do type(field(x, :y), ^Ecto.UUID) end, [x: 0], __ENV__)
+
     assert {Macro.escape(quote do avg(0) end), []} ==
            escape(quote do avg(0) end, [], __ENV__)
 


### PR DESCRIPTION
I'm not sure if `validate_type!` is the correct place to expand the alias to a module atom, but it seems to work and not blow up any tests in ecto/ecto_sql

https://github.com/elixir-ecto/ecto/issues/2835