### PR TITLE
Add `force?` option to Ecto.Changeset.cast/4

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -110,6 +110,18 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
+  test "cast/4: force option" do
+    params = %{upvotes: 0}
+
+    struct = %Post{}
+    changeset = cast(struct, params, ~w(upvotes)a, force?: true)
+    assert changeset.changes == %{upvotes: 0}
+
+    struct = %Post{upvotes: 0}
+    changeset = cast(struct, params, ~w(upvotes)a, force?: true)
+    assert changeset.changes == %{upvotes: 0}
+  end
+
   test "cast/4: with valid atom keys" do
     params = %{title: "hello", body: "world"}
     struct = %Post{}


### PR DESCRIPTION
I would like to propose `force?` option in `Ecto.Changeset.cast/4`.

IMO this option would be very helpful to deal with default field value in upsert. Let's considering the cases below:

```ex
defmodule Post do
  use Ecto.Schema

  schema "posts" do
    field :title, :string
    field :published, :boolean, default: true
  end
end

import Ecto.Changeset

params = %{title: "foo", published: true}
changeset = cast(%Post{}, params, [:title, :published])
```

In the example above, `published` in params isn't casted into `changeset.changes` because there is no change for `published` (same as default value).

This in a bit inconvenient in a way that when we use "Upserts" feature with an `Ecto.Query`, like:

```ex
params = %{title: "foo", published: true}
changeset = cast(%Post{}, params, [:title, :published])
set_values = Keyword.new(changeset.changes)

options = [
  conflict_target: [:id],
  on_conflict: Post |> update(set: ^set_values) |> where([p], p.foo_condition...)
]
```

In this case, only `title` is sent to the database because `published` is not available in `Ecto.Changeset.changes`, as described above. To ensure every attribute in `params` ends up in the database, we need to iterate and use `force_change`.

This could be less obvious to notice when we have `nil` as the default value, for example `title` in `%{title: nil}` will also be ignored in the code snippet above.

I hope `:force?` options can make this scenario like this easier to handle. Thank you.