### PR TITLE
Add association typespecs to Schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -398,6 +398,10 @@ defmodule Ecto.Schema do
   @type schema :: %{optional(atom) => any, __struct__: atom, __meta__: Metadata.t}
   @type embedded_schema :: %{optional(atom) => any, __struct__: atom}
   @type t :: schema | embedded_schema
+  @type belongs_to(t) :: t | Ecto.Association.NotLoaded.t()
+  @type has_one(t) :: t | Ecto.Association.NotLoaded.t()
+  @type has_many(t) :: [t] | Ecto.Association.NotLoaded.t()
+  @type many_to_many(t) :: [t] | Ecto.Association.NotLoaded.t()
 
   @doc false
   defmacro __using__(_) do


### PR DESCRIPTION
I keep copying this all over the place where I have Ecto, so I figured that maybe some people will find it useful.

This is an example of the usage

```elixir
@type t :: %__MODULE__{
          address: Ecto.Schema.belongs_to(Address.t())
        }
```

It will help to have a better typespec, I notice that some folks do not add `| Ecto.Association.NotLoaded.t()` which is the actual type of the field.