### PR TITLE
Properly match keyword lists on query planner

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -651,7 +651,7 @@ defmodule Ecto.Query.Planner do
     error! query, expr, "dynamic expressions can only be interpolated inside other " <>
                         "dynamic expressions or at the top level of where, having, update or a join's on"
   end
-  defp cast_param(_kind, query, expr, [{_, _} | _], _type, _value) do
+  defp cast_param(_kind, query, expr, [{key, _} | _], _type, _value) when is_atom(key) do
     error! query, expr, "keyword lists can only be interpolated at the top level of " <>
                         "where, having, distinct, order_by, update or a join's on"
   end


### PR DESCRIPTION
Fixes an error that happens when you try to query a list of custom ecto type which is defined as a tuple, but it's not a kw list. Eg:

```elixir
locations = [{"europe", "france"}, {"south_america", "brazil"}]
from(c in City, where: [location: locations])
```

In that case, `location` would be a custom ecto type that dumps to string, jsonb, etc. in the DB.

Let me know if that makes sense or needs more info about that use case.