### PR TITLE
Allow specifying a query for associations

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -295,6 +295,7 @@ defmodule Ecto.Association do
   """
   def related_from_query(atom, _name) when is_atom(atom), do: atom
   def related_from_query({source, schema}, _name) when is_binary(source) and is_atom(schema), do: schema
+  def related_from_query(%Ecto.Query{} = queryable, _name), do: queryable
   def related_from_query(queryable, name) do
     raise ArgumentError, "association #{inspect name} queryable must be a schema or " <>
       "a {source, schema}. got: #{inspect queryable}"


### PR DESCRIPTION
The [documentation suggests that you are allowed to specify a query instead of a schema](https://hexdocs.pm/ecto/Ecto.Schema.html#belongs_to/3-using-queries-as-associations) - when running this locally I always hit:

```elixir
def related_from_query(queryable, name) do
  raise ArgumentError, "association #{inspect name} queryable must be a schema or " <>
    "a {source, schema}. got: #{inspect queryable}"
end
```

I have changed the code to support the documentation. I tried writing a test but I couldn't get the integration tests to run:

```
$ mix test integration_test/cases/assoc.exs

== Compilation error in file integration_test/cases/assoc.exs ==
** (CompileError) integration_test/cases/assoc.exs:4: module Ecto.Integration.Case is not loaded and could not be found
    (elixir) expanding macro: Kernel.use/2
    integration_test/cases/assoc.exs:4: Ecto.Integration.AssocTest (module)
```

I'm probably doing something wrong - if someone could help me get the tests running I'll add a test showing the functionality seems to be currently broken.

Thanks.