### PR TITLE
Add support for has_many/has_one order_by

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -232,47 +232,27 @@ defmodule Ecto.Association do
     do: combine_assoc_query(assoc, queryable)
 
   def combine_assoc_query(assoc, queryable) do
-    do_combine_assoc_query(Map.to_list(assoc), queryable)
+    queryable
+    |> where_assoc_query(assoc)
+    |> order_by_assoc_query(assoc)
   end
 
-  def do_combine_assoc_query([], queryable), do: queryable
+  def where_assoc_query(queryable, %{where: nil}), do: queryable
+  def where_assoc_query(queryable, %{where: []}), do: queryable
 
-  def do_combine_assoc_query([{:where, nil} | rest], queryable) do
-    do_combine_assoc_query(rest, queryable)
-  end
-
-  def do_combine_assoc_query([{:where, []} | rest], queryable) do
-    do_combine_assoc_query(rest, queryable)
-  end
-
-  def do_combine_assoc_query([{:where, {module, function, args}} | rest], queryable) do
+  def where_assoc_query(queryable, %{where: {module, function, args}}) do
     where = apply(module, function, args)
-    queryable = Ecto.Query.where(queryable, _, ^where)
-
-    do_combine_assoc_query(rest, queryable)
+    Ecto.Query.where(queryable, _, ^where)
   end
 
-  def do_combine_assoc_query([{:where, where} | rest], queryable) do
-    queryable = Ecto.Query.where(queryable, _, ^where)
+  def order_by_assoc_query(queryable, %{order_by: nil}), do: queryable
+  def order_by_assoc_query(queryable, %{order_by: []}), do: queryable
 
-    do_combine_assoc_query(rest, queryable)
+  def order_by_assoc_query(queryable, %{order_by: order_by}) do
+    Ecto.Query.order_by(queryable, [], ^order_by)
   end
 
-  def do_combine_assoc_query([{:order_by, nil} | rest], queryable) do
-    do_combine_assoc_query(rest, queryable)
-  end
-
-  def do_combine_assoc_query([{:order_by, []} | rest], queryable) do
-    do_combine_assoc_query(rest, queryable)
-  end
-
-  def do_combine_assoc_query([{:order_by, order_by} | rest], queryable) do
-    queryable = Ecto.Query.order_by(queryable, [], ^order_by)
-
-    do_combine_assoc_query(rest, queryable)
-  end
-
-  def do_combine_assoc_query([_ | rest], queryable), do: do_combine_assoc_query(rest, queryable)
+  def order_by_assoc_query(queryable, _), do: queryable
 
   defp assoc_to_where(%{on: %QueryExpr{} = on}) do
     on

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -474,7 +474,8 @@ defmodule Ecto.Association.Has do
   @on_replace_opts [:raise, :mark_as_invalid, :delete, :nilify]
   @has_one_on_replace_opts @on_replace_opts ++ [:update]
   defstruct [:cardinality, :field, :owner, :related, :owner_key, :related_key, :on_cast,
-             :queryable, :on_delete, :on_replace, :where, unique: true, defaults: [], relationship: :child]
+             :queryable, :on_delete, :on_replace, :where, :order_by, unique: true,
+             defaults: [], relationship: :child]
 
   @doc false
   def after_compile_validation(%{queryable: queryable, related_key: related_key}, env) do
@@ -540,7 +541,8 @@ defmodule Ecto.Association.Has do
       on_delete: on_delete,
       on_replace: on_replace,
       defaults: opts[:defaults] || [],
-      where: opts[:where]
+      where: opts[:where],
+      order_by: opts[:order_by]
     }
   end
 
@@ -566,13 +568,15 @@ defmodule Ecto.Association.Has do
   @doc false
   def assoc_query(%{related_key: related_key} = assoc, query, [value]) do
     from x in Ecto.Association.combine_assoc_query(assoc, query),
-      where: field(x, ^related_key) == ^value
+      where: field(x, ^related_key) == ^value,
+      order_by: ^assoc.order_by
   end
 
   @doc false
   def assoc_query(%{related_key: related_key} = assoc, query, values) do
     from x in Ecto.Association.combine_assoc_query(assoc, query),
-      where: field(x, ^related_key) in ^values
+      where: field(x, ^related_key) in ^values,
+      order_by: ^assoc.order_by
   end
 
   @doc false

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1816,7 +1816,7 @@ defmodule Ecto.Schema do
     end
   end
 
-  @valid_has_options [:foreign_key, :references, :through, :on_delete, :defaults, :on_replace, :where]
+  @valid_has_options [:foreign_key, :references, :through, :on_delete, :defaults, :on_replace, :where, :order_by]
 
   @doc false
   def __has_many__(mod, name, queryable, opts) do


### PR DESCRIPTION
I originally opened https://github.com/elixir-ecto/ecto/pull/2852 in an effort to add support for allowing queries as associations (it was mentioned in the docs but not in code). After a quick discussion I realised that the problem was much larger than I thought. In https://github.com/elixir-ecto/ecto/pull/2852 I mentioned that I could also solve my problem if I was allowed to `order_by` when defining a `has_one` / `has_many` association - this PR is the code for that.

I have only looked at this from a querying point of view, specifically preloads and `Ecto.assoc`. I started looking through the code for building schemas via `Ecto.assoc` but realised it's probably not necessary (not like `where`). I was surprised by how simple the implementation was (based on https://github.com/elixir-ecto/ecto/pull/2852#issuecomment-444403862) which leads me to believe I haven't covered all the required cases to get this merged.

I'm also missing tests but I wanted to get an idea if I was on the right path before proceeding much further.

Any feedback would be appreciated.

Thanks.