### PR TITLE
Fix support for upserts with :replace without a schema

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -615,6 +615,10 @@ defmodule Ecto.Repo.Schema do
     Enum.map(schema.__schema__(:fields), &field_source!(schema, &1))
   end
 
+  defp field_source!(nil, field) do
+    field
+  end
+
   defp field_source!(schema, field) do
     schema.__schema__(:field_source, field) ||
       raise ArgumentError, "unknown field for :on_conflict, got: #{inspect(field)}"

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -834,6 +834,18 @@ defmodule Ecto.RepoTest do
       assert_received {:insert, %{source: "my_schema", on_conflict: {^fields, [], [:id]}}}
     end
 
+    test "replaces specified fields on replace without a schema" do
+      fields = [:x, :yyy]
+      rows = [[id: 1, x: "x", yyy: "yyy"]]
+      TestRepo.insert_all(
+        "my_schema",
+        rows,
+        on_conflict: {:replace, [:x, :yyy]},
+        conflict_target: [:id]
+      )
+      assert_received {:insert_all, %{source: "my_schema", on_conflict: {^fields, [], [:id]}}, ^rows}
+    end
+
     test "raises on non-existent fields on replace" do
       assert_raise ArgumentError, "unknown field for :on_conflict, got: :unknown", fn ->
         TestRepo.insert(


### PR DESCRIPTION
Per conversation with @josevalim on the mailing list:

Calling `Repo.insert_all` with `on_conflict: {:replace, fields}` and no schema resulted in this error message:

```
** (UndefinedFunctionError) function nil.__schema__/2 is undefined
```

This was because the code was trying to look up field sources even when `insert_all` was called without a schema. This fix assures that the lookup only happens when a schema is present.