### PR TITLE
Remove deprecated example

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -676,8 +676,6 @@ defmodule Ecto.Repo do
 
       MyRepo.update_all(Post, inc: [visits: 1])
 
-      MyRepo.update_all(Post, [inc: [visits: 1]], [returning: [:visits]])
-
       from(p in Post, where: p.id < 10)
       |> MyRepo.update_all(set: [title: "New title"])
 


### PR DESCRIPTION
Now that the `returning` option is deprecated, we should probably remove
it from the documentation.