### PR TITLE
Add error clause result of rollback in multi trans

### DIFF
--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -16,6 +16,7 @@ defmodule Ecto.Repo.Transaction do
     case Ecto.Multi.__apply__(multi, name, wrap, return) do
       {:ok, values} -> {:ok, values}
       {:error, {key, error_value, values}} -> {:error, key, error_value, values}
+      {:error, error_value} -> {:error, error_value}
     end
   end
 

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -336,6 +336,16 @@ defmodule Ecto.MultiTest do
       assert :ok == data.inside_ok
     end
 
+    test "rollbacks on errors in nested function" do
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:foo, fn repo, _ ->
+          repo.rollback(:bar)
+        end)
+
+      assert {:error, :bar} = TestRepo.transaction(multi)
+    end
+
     test "does not allow repeated operations" do
       fun = fn _, _ -> {:ok, :ok} end
 


### PR DESCRIPTION
This PR adds a clause to manage errors on a failing nested rollback.

 - https://github.com/elixir-ecto/ecto/issues/2862