### PR TITLE
Allow adapter developers to specify builtin custom type overrides so integration test can be reusable.

### DIFF
--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -2,6 +2,7 @@ defmodule Ecto.Integration.Schema do
   defmacro __using__(_) do
     quote do
       use Ecto.Schema
+      alias Ecto.Integration.AdapterTypes
       type =
         Application.get_env(:ecto, :primary_key_type) ||
         raise ":primary_key_type not set in :ecto application"
@@ -35,7 +36,7 @@ defmodule Ecto.Integration.Post do
     field :visits, :integer
     field :intensity, :float
     field :bid, :binary_id
-    field :uuid, Ecto.UUID, autogenerate: true
+    field :uuid, AdapterTypes.uuid(), autogenerate: true
     field :meta, :map
     field :links, {:map, :string}
     field :intensities, {:map, :float}
@@ -163,7 +164,7 @@ defmodule Ecto.Integration.Custom do
 
   @primary_key {:bid, :binary_id, autogenerate: true}
   schema "customs" do
-    field :uuid, Ecto.UUID
+    field :uuid, AdapterTypes.uuid()
     many_to_many :customs, Ecto.Integration.Custom,
       join_through: "customs_customs", join_keys: [custom_id1: :bid, custom_id2: :bid],
       on_delete: :delete_all, on_replace: :delete
@@ -197,7 +198,7 @@ defmodule Ecto.Integration.Tag do
 
   schema "tags" do
     field :ints, {:array, :integer}
-    field :uuids, {:array, Ecto.UUID}
+    field :uuids, {:array, AdapterTypes.uuid()}
     embeds_many :items, Ecto.Integration.Item
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -2,7 +2,6 @@ defmodule Ecto.Integration.Schema do
   defmacro __using__(_) do
     quote do
       use Ecto.Schema
-      alias Ecto.Integration.AdapterTypes
       type =
         Application.get_env(:ecto, :primary_key_type) ||
         raise ":primary_key_type not set in :ecto application"
@@ -36,7 +35,7 @@ defmodule Ecto.Integration.Post do
     field :visits, :integer
     field :intensity, :float
     field :bid, :binary_id
-    field :uuid, AdapterTypes.uuid(), autogenerate: true
+    field :uuid, Ecto.Integration.TestRepo.uuid(), autogenerate: true
     field :meta, :map
     field :links, {:map, :string}
     field :intensities, {:map, :float}
@@ -164,7 +163,7 @@ defmodule Ecto.Integration.Custom do
 
   @primary_key {:bid, :binary_id, autogenerate: true}
   schema "customs" do
-    field :uuid, AdapterTypes.uuid()
+    field :uuid, Ecto.Integration.TestRepo.uuid()
     many_to_many :customs, Ecto.Integration.Custom,
       join_through: "customs_customs", join_keys: [custom_id1: :bid, custom_id2: :bid],
       on_delete: :delete_all, on_replace: :delete
@@ -198,7 +197,7 @@ defmodule Ecto.Integration.Tag do
 
   schema "tags" do
     field :ints, {:array, :integer}
-    field :uuids, {:array, AdapterTypes.uuid()}
+    field :uuids, {:array, Ecto.Integration.TestRepo.uuid()}
     embeds_many :items, Ecto.Integration.Item
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,7 @@ Logger.configure(level: :info)
 
 defmodule Ecto.Integration.AdapterTypes do
   # Builtin uuid type is Ecto.UUID, many adapters will use it, but some may use
-  # it own implmentation.
+  # it own implementation.
   def uuid, do: Ecto.UUID
 end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,12 +4,6 @@ Mix.shell(Mix.Shell.Process)
 System.put_env("ECTO_EDITOR", "")
 Logger.configure(level: :info)
 
-defmodule Ecto.Integration.AdapterTypes do
-  # Builtin uuid type is Ecto.UUID, many adapters will use it, but some may use
-  # it own implementation.
-  def uuid, do: Ecto.UUID
-end
-
 Code.require_file "support/test_repo.exs", __DIR__
 ExUnit.start()
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,12 @@ Mix.shell(Mix.Shell.Process)
 System.put_env("ECTO_EDITOR", "")
 Logger.configure(level: :info)
 
+defmodule Ecto.Integration.AdapterTypes do
+  # Builtin uuid type is Ecto.UUID, many adapters will use it, but some may use
+  # it own implmentation.
+  def uuid, do: Ecto.UUID
+end
+
 Code.require_file "support/test_repo.exs", __DIR__
 ExUnit.start()
 


### PR DESCRIPTION
As per discussion in ecto_sql [issue 62](https://github.com/elixir-ecto/ecto_sql/issues/62)

Since Ecto repo do not use PoolRepo I found this as better naming for module that should help making integration schema reusable.

In adapters `test_helper.exs` I need to implement `Ecto.Integration.AdapterTypes` like in example below

```elixir
defmodule Ecto.Integration.AdapterTypes do
  def uuid, do: Tds.Types.UUID
end
``` 

Then later in `all_test.exs` I can include integration files as we did before

```elixir
ecto = Mix.Project.deps_paths[:ecto]
Code.require_file "#{ecto}/integration_test/cases/assoc.exs", __DIR__
Code.require_file "#{ecto}/integration_test/cases/interval.exs", __DIR__
Code.require_file "#{ecto}/integration_test/cases/joins.exs", __DIR__
Code.require_file "#{ecto}/integration_test/cases/preload.exs", __DIR__
Code.require_file "#{ecto}/integration_test/cases/repo.exs", __DIR__
Code.require_file "#{ecto}/integration_test/cases/type.exs", __DIR__

Code.require_file "../sql/alter.exs", __DIR__
Code.require_file "../sql/lock.exs", __DIR__
Code.require_file "../sql/logging.exs", __DIR__
Code.require_file "../sql/migration.exs", __DIR__
Code.require_file "../sql/migrator.exs", __DIR__
Code.require_file "../sql/sandbox.exs", __DIR__
Code.require_file "../sql/sql.exs", __DIR__
Code.require_file "../sql/stream.exs", __DIR__
Code.require_file "../sql/subquery.exs", __DIR__
Code.require_file "../sql/transaction.exs", __DIR__
```

There is another thing I'd like to add if we can accept this as solution, and it is related to `text` and `ntext` types. 
* `like` is not supported in filter statement for such column (I'm not sure about full text search, but anyways that is something requires writing as a fragment)
* `distinct` is not supported for such column types

To solve above, such columns must be `varchar` or `nvarchar`.

Let me know if this is ok and if I should create another PR to slightly change integration tests for `text` column type