### PR TITLE
add Ecto.Query.reverse_order/1 to reverse query sort

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1852,8 +1852,10 @@ defmodule Ecto.Query do
   end
 
   @doc """
-  Reverses the ordering of the query, with ASC columns becoming DESC columns
-  (and vice-versa). If the query has no order_bys, this is a no-op.
+  Reverses the ordering of the query.
+  
+  ASC columns become DESC columns (and vice-versa). If the query
+  has no order_bys, this is a no-op.
 
   ## Examples
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1805,22 +1805,10 @@ defmodule Ecto.Query do
 
   def last(%Ecto.Query{} = query, nil) do
     query = %{query | limit: limit()}
-    update_in query.order_bys, fn
-      [] ->
-        [order_by_pk(query, :desc)]
-      order_bys ->
-        for %{expr: expr} = order_by <- order_bys do
-          %{order_by | expr:
-              Enum.map(expr, fn
-                {:desc, ast} -> {:asc, ast}
-                {:desc_nulls_last, ast} -> {:asc_nulls_first, ast}
-                {:desc_nulls_first, ast} -> {:asc_nulls_last, ast}
-                {:asc, ast} -> {:desc, ast}
-                {:asc_nulls_last, ast} -> {:desc_nulls_first, ast}
-                {:asc_nulls_first, ast} -> {:desc_nulls_last, ast}
-              end)}
-        end
-    end
+    update_in(query.order_bys, fn
+      [] -> [order_by_pk(query, :desc)]
+      order_bys -> Enum.map(order_bys, &reverse_order_by/1)
+    end)
   end
   def last(queryable, nil), do: last(Ecto.Queryable.to_query(queryable), nil)
   def last(queryable, key), do: last(order_by(queryable, ^key), nil)
@@ -1861,5 +1849,35 @@ defmodule Ecto.Query do
 
   def has_named_binding?(queryable, key) do
     has_named_binding?(Ecto.Queryable.to_query(queryable), key)
+  end
+
+  @doc """
+  Reverses the ordering of the query, with ASC columns becoming DESC columns
+  (and vice-versa). If the query has no order_bys, this is a no-op.
+
+  ## Examples
+
+      query |> reverse_order |> Repo.one
+      Post |> order(asc: :id) |> reverse_order == Post |> order(desc: :id)
+  """
+  def reverse_order(%Ecto.Query{} = query) do
+    update_in(query.order_bys, fn order_bys -> Enum.map(order_bys, &reverse_order_by/1) end)
+  end
+
+  def reverse_order(queryable), do: reverse_order(Ecto.Queryable.to_query(queryable))
+
+  defp reverse_order_by(%{expr: expr} = order_by) do
+    %{
+      order_by
+      | expr:
+          Enum.map(expr, fn
+            {:desc, ast} -> {:asc, ast}
+            {:desc_nulls_last, ast} -> {:asc_nulls_first, ast}
+            {:desc_nulls_first, ast} -> {:asc_nulls_last, ast}
+            {:asc, ast} -> {:desc, ast}
+            {:asc_nulls_last, ast} -> {:desc_nulls_first, ast}
+            {:asc_nulls_first, ast} -> {:desc_nulls_last, ast}
+          end)
+    }
   end
 end

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -715,4 +715,18 @@ defmodule Ecto.QueryTest do
       end
     end
   end
+
+  describe "reverse_order/1" do
+    test "it reverses the order of a simple query" do
+      order_bys = [asc: :inserted_at, desc: :id]
+      reversed_order_bys = [desc: :inserted_at, asc: :id]
+      q = from(p in "posts")
+      assert reverse_order(order_by(q, ^order_bys)) == order_by(q, ^reversed_order_bys)
+    end
+
+    test "it is a no-op on a query with no order" do
+      q = from(p in "posts")
+      assert reverse_order(q) == q
+    end
+  end
 end

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -717,14 +717,14 @@ defmodule Ecto.QueryTest do
   end
 
   describe "reverse_order/1" do
-    test "it reverses the order of a simple query" do
+    test "reverses the order of a simple query" do
       order_bys = [asc: :inserted_at, desc: :id]
       reversed_order_bys = [desc: :inserted_at, asc: :id]
       q = from(p in "posts")
       assert reverse_order(order_by(q, ^order_bys)) == order_by(q, ^reversed_order_bys)
     end
 
-    test "it is a no-op on a query with no order" do
+    test "is a no-op on a query with no order" do
       q = from(p in "posts")
       assert reverse_order(q) == q
     end


### PR DESCRIPTION
Following [my proposal from today](https://groups.google.com/d/msgid/elixir-ecto/8402afe1-734c-429c-bb32-0d4ad84f4daf%40googlegroups.com), this PR adds a `reverse_order/1` function to `Ecto.Query`. This function reverses the order for each of the query's `order_bys`.

Most of this logic was already implemented in `last/2`, so I extracted that to a shared private function and used that from both places.

Let me know what changes I can make 😄:v: