### PR TITLE
Document stale errors opts for insert_or_update/2

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1046,6 +1046,12 @@ defmodule Ecto.Repo do
     * `:prefix` - The prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). This overrides the prefix set
       in the struct.
+    * `:stale_error_field` - The field where stale errors will be added in
+      the returning changeset. This option can be used to avoid raising
+      `Ecto.StaleEntryError`. Only applies to updates.
+    * `:stale_error_message` - The message to add to the configured
+      `:stale_error_field` when stale errors happen, defaults to "is stale".
+      Only applies to updates.
 
   See the "Shared options" section at the module documentation.
 


### PR DESCRIPTION
https://hexdocs.pm/ecto/Ecto.Repo.html#c:update/2 shows how to deal with StaleEntryErrors when you want to catch them instead of letting it raise. `insert_or_update/2` was missing this information. 

I've added this and made a note that it only applies to updates, inserts should never have stale errors.