### PR TITLE
Link Ecto.SubQuery to subquery/2 docs

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1,8 +1,8 @@
 defmodule Ecto.SubQuery do
   @moduledoc """
-  Stores subquery information.
+  A struct representing subqueries.
 
-  See `Ecto.Query.subquery/2` for more information
+  See `Ecto.Query.subquery/2` for more information.
   """
   defstruct [:query, :params, :select, :cache]
 end

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1,6 +1,8 @@
 defmodule Ecto.SubQuery do
   @moduledoc """
   Stores subquery information.
+
+  See `Ecto.Query.subquery/2` for more information
   """
   defstruct [:query, :params, :select, :cache]
 end


### PR DESCRIPTION
Link Ecto.SubQuery to https://hexdocs.pm/ecto/Ecto.Query.html#subquery/2 as it explains how to use subqueries in Ecto. 

I catch myself going to Ecto.Subquery looking for information and only then realizing I need to go the Ecto.Query.subquery/2 This makes that a little easier