### PR TITLE
Fixes #2884 by conditionally compiling in the surround_with/container_doc call dependent on the Elixir version.

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2747,18 +2747,15 @@ end
 defimpl Inspect, for: Ecto.Changeset do
   import Inspect.Algebra
 
+  container_doc = if(Version.match?(System.version(), ">= 1.8.0"), do: :container_doc, else: :surround_many)
+
   def inspect(changeset, opts) do
     list = for attr <- [:action, :changes, :errors, :data, :valid?] do
       {attr, Map.get(changeset, attr)}
     end
 
     # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
-    unquote(
-      if(Version.match?(System.version(), "~> 1.8.0-dev"),
-        do: quote(do: :container_doc),
-        else: quote(do: :surround_many)
-      )
-    )("#Ecto.Changeset<", list, ">", opts, fn
+    unquote(container_doc)("#Ecto.Changeset<", list, ">", opts, fn
       {:action, action}, opts   -> concat("action: ", to_doc(action, opts))
       {:changes, changes}, opts -> concat("changes: ", to_doc(changes, opts))
       {:data, data}, _opts      -> concat("data: ", to_struct(data, opts))

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2747,14 +2747,14 @@ end
 defimpl Inspect, for: Ecto.Changeset do
   import Inspect.Algebra
 
-  container_doc = if(Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many)
+  container_doc = if Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many
 
   def inspect(changeset, opts) do
     list = for attr <- [:action, :changes, :errors, :data, :valid?] do
       {attr, Map.get(changeset, attr)}
     end
 
-    # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
+    # TODO: Replace unquote with just `container_doc` when Elixir < 1.6.0 is no longer supported
     unquote(container_doc)("#Ecto.Changeset<", list, ">", opts, fn
       {:action, action}, opts   -> concat("action: ", to_doc(action, opts))
       {:changes, changes}, opts -> concat("changes: ", to_doc(changes, opts))

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2752,7 +2752,13 @@ defimpl Inspect, for: Ecto.Changeset do
       {attr, Map.get(changeset, attr)}
     end
 
-    surround_many("#Ecto.Changeset<", list, ">", opts, fn
+    # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
+    unquote(
+      if(Version.match?(System.version(), "~> 1.8.0-dev"),
+        do: quote(do: :container_doc),
+        else: quote(do: :surround_many)
+      )
+    )("#Ecto.Changeset<", list, ">", opts, fn
       {:action, action}, opts   -> concat("action: ", to_doc(action, opts))
       {:changes, changes}, opts -> concat("changes: ", to_doc(changes, opts))
       {:data, data}, _opts      -> concat("data: ", to_struct(data, opts))

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2747,7 +2747,7 @@ end
 defimpl Inspect, for: Ecto.Changeset do
   import Inspect.Algebra
 
-  container_doc = if(Version.match?(System.version(), ">= 1.8.0"), do: :container_doc, else: :surround_many)
+  container_doc = if(Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many)
 
   def inspect(changeset, opts) do
     list = for attr <- [:action, :changes, :errors, :data, :valid?] do

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -13,7 +13,13 @@ defimpl Inspect, for: Ecto.Query.DynamicExpr do
     inspected =
       Inspect.Ecto.Query.expr(expr, List.to_tuple(names), %{expr: expr, params: params})
 
-    surround_many("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str, _ -> str end)
+    # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
+    unquote(
+      if(Version.match?(System.version(), "~> 1.8.0-dev"),
+        do: quote(do: :container_doc),
+        else: quote(do: :surround_many)
+      )
+    )("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str, _ -> str end)
   end
 end
 
@@ -27,7 +33,13 @@ defimpl Inspect, for: Ecto.Query do
         string
     end)
 
-    surround_many("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
+    # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
+    unquote(
+      if(Version.match?(System.version(), "~> 1.8.0-dev"),
+        do: quote(do: :container_doc),
+        else: quote(do: :surround_many)
+      )
+    )("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
   end
 
   @doc false

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -3,7 +3,7 @@ import Kernel, except: [to_string: 1]
 
 alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr}
 
-container_doc = if(Version.match?(System.version(), ">= 1.8.0"), do: :container_doc, else: :surround_many)
+container_doc = if(Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many)
 
 defimpl Inspect, for: Ecto.Query.DynamicExpr do
   def inspect(%DynamicExpr{binding: binding} = dynamic, opts) do

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -3,6 +3,8 @@ import Kernel, except: [to_string: 1]
 
 alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr}
 
+container_doc = if(Version.match?(System.version(), ">= 1.8.0"), do: :container_doc, else: :surround_many)
+
 defimpl Inspect, for: Ecto.Query.DynamicExpr do
   def inspect(%DynamicExpr{binding: binding} = dynamic, opts) do
     {expr, binding, params, _, _} =
@@ -14,12 +16,7 @@ defimpl Inspect, for: Ecto.Query.DynamicExpr do
       Inspect.Ecto.Query.expr(expr, List.to_tuple(names), %{expr: expr, params: params})
 
     # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
-    unquote(
-      if(Version.match?(System.version(), "~> 1.8.0-dev"),
-        do: quote(do: :container_doc),
-        else: quote(do: :surround_many)
-      )
-    )("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str, _ -> str end)
+    unquote(container_doc)("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str, _ -> str end)
   end
 end
 
@@ -34,12 +31,7 @@ defimpl Inspect, for: Ecto.Query do
     end)
 
     # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
-    unquote(
-      if(Version.match?(System.version(), "~> 1.8.0-dev"),
-        do: quote(do: :container_doc),
-        else: quote(do: :surround_many)
-      )
-    )("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
+    unquote(container_doc)("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
   end
 
   @doc false

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -3,7 +3,7 @@ import Kernel, except: [to_string: 1]
 
 alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr}
 
-container_doc = if(Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many)
+container_doc = if Version.match?(System.version(), ">= 1.6.0"), do: :container_doc, else: :surround_many
 
 defimpl Inspect, for: Ecto.Query.DynamicExpr do
   def inspect(%DynamicExpr{binding: binding} = dynamic, opts) do
@@ -15,7 +15,7 @@ defimpl Inspect, for: Ecto.Query.DynamicExpr do
     inspected =
       Inspect.Ecto.Query.expr(expr, List.to_tuple(names), %{expr: expr, params: params})
 
-    # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
+    # TODO: Replace unquote with just `container_doc` when Elixir < 1.6.0 is no longer supported
     unquote(container_doc)("dynamic(", [Macro.to_string(binding), inspected], ")", opts, fn str, _ -> str end)
   end
 end
@@ -30,7 +30,7 @@ defimpl Inspect, for: Ecto.Query do
         string
     end)
 
-    # TODO: Replace unquote with just `container_doc` when Elixir < 1.8.0 is no longer supported
+    # TODO: Replace unquote with just `container_doc` when Elixir < 1.6.0 is no longer supported
     unquote(container_doc)("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
   end
 


### PR DESCRIPTION
The files are not `mix format`'d as they were not formatted to start with, however the unquote branch and call itself is formatted according to `mix format`.

The tests have been run and still pass:
```elixir
╰─➤  mix test
Compiling 16 files (.ex)
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................                                                                                                       

Finished in 15.6 seconds
75 doctests, 894 tests, 0 failures

Randomized with seed 364475
```

In addition manually checking the inspection results also appear identical.  The default separator is the one already used by the original `surround_with/5` call thus there should be no functionality changes.

Any other changes needed?  :-)