### PR TITLE
Update from/2 docs with note about bindings

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -690,8 +690,8 @@ defmodule Ecto.Query do
 
   Notice we have created a `p` variable to reference the query's
   original data source. This assumes that the original query
-  only had one source. When the given query has more than one source, a variable
-  must be given for each in the order they were bound:
+  only had one source. When the given query has more than one source,
+  positonal or named bindings may be used to access the additional sources.
 
       def published_multi(query) do
         from [p,o] in query,


### PR DESCRIPTION
I believe this change better reflects how `from/2` works. The extra source references are optional in my testing so I thought it could be changed from "must" to "may".