### PR TITLE
Add documentation for pool_size

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -43,7 +43,7 @@ defmodule Ecto.Repo do
       Defaults to `:debug`
 
     * `:pool_size` - the size of the pool used by the connection module.
-    Defaults to `10`
+      Defaults to `10`
 
     * `:telemetry_prefix` - we recommend adapters to publish events
       using the `Telemetry` library. By default, the telemetry prefix

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -33,17 +33,17 @@ defmodule Ecto.Repo do
 
     * `:priv` - the directory where to keep repository data, like
       migrations, schema and more. Defaults to "priv/YOUR_REPO".
-      It must always point to a subdirectory inside the priv directory.
+      It must always point to a subdirectory inside the priv directory
 
     * `:url` - an URL that specifies storage information. Read below
       for more information
 
     * `:log` - the log level used when logging the query with Elixir's
       Logger. If false, disables logging for that repository.
-      Defaults to `:debug`.
+      Defaults to `:debug`
 
-    * `:pool_size` - the size of pool used by the connection module.
-    Defaults to `10`.
+    * `:pool_size` - the size of the pool used by the connection module.
+    Defaults to `10`
 
     * `:telemetry_prefix` - we recommend adapters to publish events
       using the `Telemetry` library. By default, the telemetry prefix

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -42,6 +42,9 @@ defmodule Ecto.Repo do
       Logger. If false, disables logging for that repository.
       Defaults to `:debug`.
 
+    * `:pool_size` - the size of pool used by the connection module.
+    Defaults to `10`.
+
     * `:telemetry_prefix` - we recommend adapters to publish events
       using the `Telemetry` library. By default, the telemetry prefix
       is based on the module name, so if your module is called


### PR DESCRIPTION
`Ecto.Repo`'s documentation mentions `pool_size` parameter under `URL` section, but anywhere else. Considering this parameter is defaulted to `10` in `Ecto.Repo` module, I added it to the documentation.

I believe `timeout` parameter is a similar case. However, it's documented under the `Ecto.Adapters.Postgres` and `EctoAdapters.MySQL` modules.