### PR TITLE
Warn with a better error message for deprecated :returning

### DIFF
--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -110,11 +110,7 @@ defmodule Ecto.Repo.Queryable do
   defp maybe_returning(query, kind, opts) do
     case Keyword.fetch(opts, :returning) do
       {:ok, value} ->
-        IO.warn("""
-        :returning option for #{inspect(kind)} is deprecated, please specify a
-        select using `Ecto.Query.select/3` instead.
-        """)
-
+        IO.warn(":returning option for #{inspect(kind)} is deprecated, please specify a select using `Ecto.Query.select/3` instead")
         Ecto.Query.Planner.ensure_select(query, value)
 
       :error ->

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -110,7 +110,11 @@ defmodule Ecto.Repo.Queryable do
   defp maybe_returning(query, kind, opts) do
     case Keyword.fetch(opts, :returning) do
       {:ok, value} ->
-        IO.warn ":returning option for #{inspect kind} is deprecated, please specify a select instead"
+        IO.warn("""
+        :returning option for #{inspect(kind)} is deprecated, please specify a
+        select using `Ecto.Query.select/3` instead.
+        """)
+
         Ecto.Query.Planner.ensure_select(query, value)
 
       :error ->


### PR DESCRIPTION
Without this change you get a warning like:
```
warning: :returning option for :update_all is deprecated, please specify a select instead
```

Which initially led to me to think that `Repo.update_all/3` had a new `select` option. I hope that by manually spelling out `Ecto.Query.select/3` users will know where to look to know how to add the select clause, easing the upgrade to Ecto 3.

Note: I tried to follow the formatter in the section of the code that I touched.