### PR TITLE
No need for validation query unless relevant fields were changed

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1719,8 +1719,13 @@ defmodule Ecto.Changeset do
       {field, get_field(changeset, field)}
     end
 
+    # No need to query if we haven't changed any of the fields in question
+    unrelated_changes? = fields -- Map.keys(changeset.changes) == fields
+
     # If we don't have values for all fields, we can't query for uniqueness
-    if Enum.any?(where_clause, &(&1 |> elem(1) |> is_nil())) do
+    any_nil_values_for_fields? = Enum.any?(where_clause, &(&1 |> elem(1) |> is_nil()))
+
+    if unrelated_changes? || any_nil_values_for_fields? do
       changeset
     else
       pk_pairs = pk_fields_and_values(changeset, struct)


### PR DESCRIPTION
`unsafe_validate_unique/3` performs a query to ensure that the specified
fields represent a unique combination of values in the repo. For
example, perhaps the combination of city and state must be unique.
But there's no need to perform this query if the changeset is not making
any change to city or state.

Fixes #2901