### PR TITLE
Expand error message for missing/extra arguments in fragment(...)

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -134,7 +134,7 @@ defmodule Ecto.Query.Builder do
 
     if length(pieces) != length(frags) + 1 do
       error! "fragment(...) expects extra arguments in the same amount of question marks in string. " <>
-      "Was given #{length(frags)} extra argument(s) but expected #{length(pieces) - 1}"
+               "It received #{length(frags)} extra argument(s) but expected #{length(pieces) - 1}"
     end
 
     {frags, params_acc} = Enum.map_reduce(frags, params_acc, &escape(&1, :any, &2, vars, env))

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -133,7 +133,8 @@ defmodule Ecto.Query.Builder do
     pieces = expand_and_split_fragment(query, env)
 
     if length(pieces) != length(frags) + 1 do
-      error! "fragment(...) expects extra arguments in the same amount of question marks in string"
+      error! "fragment(...) expects extra arguments in the same amount of question marks in string. " <>
+      "Was given #{length(frags)} extra argument(s) but expected #{length(pieces) - 1}"
     end
 
     {frags, params_acc} = Enum.map_reduce(frags, params_acc, &escape(&1, :any, &2, vars, env))

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -72,13 +72,13 @@ defmodule Ecto.Query.BuilderTest do
     end
 
     assert_raise Ecto.Query.CompileError,
-                 ~r"expects extra arguments in the same amount of question marks in string. Was given 0 extra argument\(s\) but expected 1",
+                 ~r"expects extra arguments in the same amount of question marks in string. It received 0 extra argument\(s\) but expected 1",
                  fn ->
       escape(quote do fragment("?") end, [], __ENV__)
     end
 
     assert_raise Ecto.Query.CompileError,
-                 ~r"expects extra arguments in the same amount of question marks in string. Was given 1 extra argument\(s\) but expected 0",
+                 ~r"expects extra arguments in the same amount of question marks in string. It received 1 extra argument\(s\) but expected 0",
                  fn ->
       escape(quote do fragment("", 1) end, [], __ENV__)
     end

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -71,8 +71,16 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote do fragment(:invalid) end, [], __ENV__)
     end
 
-    assert_raise Ecto.Query.CompileError, ~r"expects extra arguments in the same amount of question marks in string", fn ->
+    assert_raise Ecto.Query.CompileError,
+                 ~r"expects extra arguments in the same amount of question marks in string. Was given 0 extra argument\(s\) but expected 1",
+                 fn ->
       escape(quote do fragment("?") end, [], __ENV__)
+    end
+
+    assert_raise Ecto.Query.CompileError,
+                 ~r"expects extra arguments in the same amount of question marks in string. Was given 1 extra argument\(s\) but expected 0",
+                 fn ->
+      escape(quote do fragment("", 1) end, [], __ENV__)
     end
   end
 

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -73,15 +73,11 @@ defmodule Ecto.Query.BuilderTest do
 
     assert_raise Ecto.Query.CompileError,
                  ~r"expects extra arguments in the same amount of question marks in string. It received 0 extra argument\(s\) but expected 1",
-                 fn ->
-      escape(quote do fragment("?") end, [], __ENV__)
-    end
+                 fn -> escape(quote do fragment("?") end, [], __ENV__) end
 
     assert_raise Ecto.Query.CompileError,
                  ~r"expects extra arguments in the same amount of question marks in string. It received 1 extra argument\(s\) but expected 0",
-                 fn ->
-      escape(quote do fragment("", 1) end, [], __ENV__)
-    end
+                 fn -> escape(quote do fragment("", 1) end, [], __ENV__) end
   end
 
   test "escape over" do


### PR DESCRIPTION
Emit error message saying how many extra arguments were given
and expected when number of extra arguments does not line up with
number of question marks in fragment(...) string.