### PR TITLE
Improve handling of arrays with empty values

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -581,7 +581,7 @@ defmodule Ecto.Changeset do
     end
   end
 
-  defp strip_empty_values_from_list?(value, {:array, _}, empty_values) do
+  defp strip_empty_values_from_list?(value, {:array, _}, empty_values) when is_list(value) do
     Enum.reject(value, &Enum.member?(empty_values, &1))
   end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -590,11 +590,7 @@ defmodule Ecto.Changeset do
   end
 
   defp get_default_if_empty(value, key, empty_values, defaults) do
-    if value in empty_values do
-      Map.get(defaults, key)
-    else
-      value
-    end
+    if value in empty_values, do: Map.get(defaults, key), else: value
   end
 
   defp convert_params(params) do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -153,7 +153,7 @@ defmodule Ecto.ChangesetTest do
     params = %{"topics" => [""]}
     struct = %Post{topics: []}
 
-    changeset = cast(struct, params, ~w(topics)a) |> IO.inspect()
+    changeset = cast(struct, params, ~w(topics)a)
     assert changeset.changes == %{}
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -149,6 +149,14 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes == %{}
   end
 
+  test "cast/4: with empty values in a list" do
+    params = %{"topics" => [""]}
+    struct = %Post{topics: []}
+
+    changeset = cast(struct, params, ~w(topics)a) |> IO.inspect()
+    assert changeset.changes == %{}
+  end
+
   test "cast/4: with data and types" do
     data   = {%{title: "hello"}, %{title: :string, upvotes: :integer}}
     params = %{"title" => "world", "upvotes" => "0"}


### PR DESCRIPTION
The primary issue here is that Ecto removes `""` as empty, but doesn't filter `[""]` to `[]` as well. This PR changes that behaviour.

**Question** should `[]` be considered an "empty value" as well (ie. `@empty_values ["" []]`)?
