### PR TITLE
Expose the type that was validated in errors generated by `Changeset.validate_length/3`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1953,27 +1953,27 @@ defmodule Ecto.Changeset do
 
   defp wrong_length(_type, value, value, _opts), do: nil
   defp wrong_length(:string, _length, value, opts), do:
-    {message(opts, "should be %{count} character(s)"), count: value, validation: :length, kind: :is}
+    {message(opts, "should be %{count} character(s)"), count: value, validation: :length, kind: :is, type: :string}
   defp wrong_length(:binary, _length, value, opts), do:
-    {message(opts, "should be %{count} byte(s)"), count: value, validation: :length, kind: :is}
+    {message(opts, "should be %{count} byte(s)"), count: value, validation: :length, kind: :is, type: :binary}
   defp wrong_length(:list, _length, value, opts), do:
-    {message(opts, "should have %{count} item(s)"), count: value, validation: :length, kind: :is}
+    {message(opts, "should have %{count} item(s)"), count: value, validation: :length, kind: :is, type: :list}
 
   defp too_short(_type, length, value, _opts) when length >= value, do: nil
   defp too_short(:string, _length, value, opts), do:
-    {message(opts, "should be at least %{count} character(s)"), count: value, validation: :length, kind: :min}
+    {message(opts, "should be at least %{count} character(s)"), count: value, validation: :length, kind: :min, type: :string}
   defp too_short(:binary, _length, value, opts), do:
-    {message(opts, "should be at least %{count} byte(s)"), count: value, validation: :length, kind: :min}
+    {message(opts, "should be at least %{count} byte(s)"), count: value, validation: :length, kind: :min, type: :binary}
   defp too_short(:list, _length, value, opts), do:
-    {message(opts, "should have at least %{count} item(s)"), count: value, validation: :length, kind: :min}
+    {message(opts, "should have at least %{count} item(s)"), count: value, validation: :length, kind: :min, type: :list}
 
   defp too_long(_type, length, value, _opts) when length <= value, do: nil
   defp too_long(:string, _length, value, opts), do:
-    {message(opts, "should be at most %{count} character(s)"), count: value, validation: :length, kind: :max}
+    {message(opts, "should be at most %{count} character(s)"), count: value, validation: :length, kind: :max, type: :string}
   defp too_long(:binary, _length, value, opts), do:
-    {message(opts, "should be at most %{count} byte(s)"), count: value, validation: :length, kind: :max}
+    {message(opts, "should be at most %{count} byte(s)"), count: value, validation: :length, kind: :max, type: :binary}
   defp too_long(:list, _length, value, opts), do:
-    {message(opts, "should have at most %{count} item(s)"), count: value, validation: :length, kind: :max}
+    {message(opts, "should have at most %{count} item(s)"), count: value, validation: :length, kind: :max, type: :list}
 
   @doc """
   Validates the properties of a number.
@@ -2326,7 +2326,7 @@ defmodule Ecto.Changeset do
     * `:match` - how the changeset constraint name is matched against the
       repo constraint, may be `:exact`, `:suffix` or `:prefix`. Defaults to `:exact`.
       `:suffix` matches any repo constraint which `ends_with?` `:name`
-       to this changeset constraint. 
+       to this changeset constraint.
       `:prefix` matches any repo constraint which `starts_with?` `:name`
        to this changeset constraint.
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -968,25 +968,25 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, min: 6)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :length, kind: :min}]
+    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :length, kind: :min, type: :string}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, max: 4)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :length, kind: :max}]
+    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :length, kind: :max, type: :string}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be %{count} character(s)", count: 10, validation: :length, kind: :is}]
+    assert changeset.errors == [title: {"should be %{count} character(s)", count: 10, validation: :length, kind: :is, type: :string}]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
-    assert changeset.errors == [title: {"yada", count: 10, validation: :length, kind: :is}]
+    assert changeset.errors == [title: {"yada", count: 10, validation: :length, kind: :is, type: :string}]
 
     changeset = changeset(%{"title" => "\u0065\u0301"}) |> validate_length(:title, max: 1)
     assert changeset.valid?
 
     changeset = changeset(%{"title" => "\u0065\u0301"}) |> validate_length(:title, max: 1, count: :codepoints)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 1, validation: :length, kind: :max}]
+    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 1, validation: :length, kind: :max, type: :string}]
   end
 
   test "validate_length/3 with binary" do
@@ -1016,7 +1016,7 @@ defmodule Ecto.ChangesetTest do
 
     assert changeset.errors == [
              body:
-               {"should be at least %{count} byte(s)", count: 6, validation: :length, kind: :min}
+               {"should be at least %{count} byte(s)", count: 6, validation: :length, kind: :min, type: :binary}
            ]
 
     changeset =
@@ -1025,7 +1025,7 @@ defmodule Ecto.ChangesetTest do
     refute changeset.valid?
 
     assert changeset.errors == [
-             body: {"should be at most %{count} byte(s)", count: 4, validation: :length, kind: :max}
+             body: {"should be at most %{count} byte(s)", count: 4, validation: :length, kind: :max, type: :binary}
            ]
 
     changeset =
@@ -1034,14 +1034,14 @@ defmodule Ecto.ChangesetTest do
     refute changeset.valid?
 
     assert changeset.errors == [
-             body: {"should be %{count} byte(s)", count: 10, validation: :length, kind: :is}
+             body: {"should be %{count} byte(s)", count: 10, validation: :length, kind: :is, type: :binary}
            ]
 
     changeset =
       changeset(%{"body" => <<0, 1, 2, 3, 4>>})
       |> validate_length(:body, count: :bytes, is: 10, message: "yada")
 
-    assert changeset.errors == [body: {"yada", count: 10, validation: :length, kind: :is}]
+    assert changeset.errors == [body: {"yada", count: 10, validation: :length, kind: :is, type: :binary}]
   end
 
   test "validate_length/3 with list" do
@@ -1058,24 +1058,24 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 6, foo: true)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :length, kind: :min}]
+    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :length, kind: :min, type: :list}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, max: 2)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :length, kind: :max}]
+    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :length, kind: :max, type: :list}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have %{count} item(s)", count: 10, validation: :length, kind: :is}]
+    assert changeset.errors == [topics: {"should have %{count} item(s)", count: 10, validation: :length, kind: :is, type: :list}]
 
     changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10, message: "yada")
-    assert changeset.errors == [topics: {"yada", count: 10, validation: :length, kind: :is}]
+    assert changeset.errors == [topics: {"yada", count: 10, validation: :length, kind: :is, type: :list}]
   end
 
   test "validate_length/3 with associations" do
     post = %Post{comments: [%Comment{id: 1}]}
     changeset = change(post) |> put_assoc(:comments, []) |> validate_length(:comments, min: 1)
-    assert changeset.errors == [comments: {"should have at least %{count} item(s)", count: 1, validation: :length, kind: :min}]
+    assert changeset.errors == [comments: {"should have at least %{count} item(s)", count: 1, validation: :length, kind: :min, type: :list}]
 
     changeset = change(post) |> put_assoc(:comments, [%Comment{id: 2}, %Comment{id: 3}]) |> validate_length(:comments, max: 2)
     assert changeset.valid?
@@ -1600,7 +1600,7 @@ defmodule Ecto.ChangesetTest do
       %Ecto.Changeset{}, field, {_, [name: "your title"]} ->
         "value in #{field} is taken"
         |> String.upcase()
-      %Ecto.Changeset{}, field, {_, [count: 3, validation: :length, kind: :min] = keys} ->
+      %Ecto.Changeset{}, field, {_, [count: 3, validation: :length, kind: :min, type: :string] = keys} ->
         "should be at least #{keys[:count]} character(s) in field #{field}"
         |> String.upcase()
       %Ecto.Changeset{validations: validations}, field, {_, [validation: :format]} ->


### PR DESCRIPTION
Errors in an `Ecto.Changeset` have a key, a message and additional contextual information provided in the form of a keyword list.

`Ecto.Changeset` comes bundled with a number of validations, for example `validate_length/3`.

The built-in validations tend to include additional contextual information - for example, `validate_length/3` includes `count` and `kind`. So, for example, if the validation was configured to check that a field was "no more than 3" and it fails, then you will have `[count: 3, validation: :length, kind: :max]`.

The `validate_length` validation is interesting, because it can operate on strings, binaries and lists. However, it doesn't expose in the additional context what type of data was validated.

This context can be valuable, for example if you want your errors to be fully machine-readable.

This exposes `[type: :string]`, `[type: :list]` or `[type: :binary]`, as appropriate, on the error.