### PR TITLE
Add `not_equal_to` option for `validate_number`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -305,6 +305,7 @@ defmodule Ecto.Changeset do
     less_than_or_equal_to:    {&<=/2, "must be less than or equal to %{number}"},
     greater_than_or_equal_to: {&>=/2, "must be greater than or equal to %{number}"},
     equal_to:                 {&==/2, "must be equal to %{number}"},
+    not_equal_to:             {&!=/2, "must be not equal to %{number}"},
   }
 
   @relations [:embed, :assoc]
@@ -1986,12 +1987,14 @@ defmodule Ecto.Changeset do
     * `:less_than_or_equal_to`
     * `:greater_than_or_equal_to`
     * `:equal_to`
+    * `:not_equal_to`
     * `:message` - the message on failure, defaults to one of:
       * "must be less than %{number}"
       * "must be greater than %{number}"
       * "must be less than or equal to %{number}"
       * "must be greater than or equal to %{number}"
       * "must be equal to %{number}"
+      * "must be not equal to %{number}"
 
   ## Examples
 
@@ -2043,8 +2046,8 @@ defmodule Ecto.Changeset do
   defp decimal_new(term) when is_float(term), do: Decimal.from_float(term)
   defp decimal_new(term), do: Decimal.new(term)
 
-  defp decimal_compare(:lt, spec), do: spec in [:less_than, :less_than_or_equal_to]
-  defp decimal_compare(:gt, spec), do: spec in [:greater_than, :greater_than_or_equal_to]
+  defp decimal_compare(:lt, spec), do: spec in [:less_than, :less_than_or_equal_to, :not_equal_to]
+  defp decimal_compare(:gt, spec), do: spec in [:greater_than, :greater_than_or_equal_to, :not_equal_to]
   defp decimal_compare(:eq, spec), do: spec in [:equal_to, :less_than_or_equal_to, :greater_than_or_equal_to]
 
   @doc """

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1095,6 +1095,13 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == [upvotes: {"must be greater than %{number}", validation: :number, kind: :greater_than, number: 0}]
     assert validations(changeset) == [upvotes: {:number, [greater_than: 0]}]
 
+    # Non equality error
+    changeset = changeset(%{"upvotes" => 1})
+                |> validate_number(:upvotes, not_equal_to: 1)
+    refute changeset.valid?
+    assert changeset.errors == [upvotes: {"must be not equal to %{number}", validation: :number, kind: :not_equal_to, number: 1}]
+    assert validations(changeset) == [upvotes: {:number, [not_equal_to: 1]}]
+
     # Multiple validations
     changeset = changeset(%{"upvotes" => 3})
                 |> validate_number(:upvotes, greater_than: 0, less_than: 100)

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1127,6 +1127,10 @@ defmodule Ecto.ChangesetTest do
                 |> validate_number(:decimal, equal_to: Decimal.new(-1))
     assert changeset.valid?
 
+    changeset = changeset(%{"decimal" => Decimal.new(0)})
+                |> validate_number(:decimal, not_equal_to: Decimal.new(-1))
+    assert changeset.valid?
+
     changeset = changeset(%{"decimal" => Decimal.new(-3)})
                 |> validate_number(:decimal, less_than_or_equal_to: Decimal.new(-1))
     assert changeset.valid?


### PR DESCRIPTION
This checks for inequality with given parameter. It is useful in
situations when we want to disallow one particular value. For example
imagine that we want to define table to store value income and outcome
in some account. It make sense to be positive (income) or negative
(outcome), but it makes no sense to store operation that has value equal
to `0`, with this change we can simply:

```elixir
validate_number(changeset, :diff, not_equal_to: 0)
```