### PR TITLE
Document ecto log entry deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@ Although Ecto 3.0 is a major bump version, the functionality below emits depreca
   * [Ecto.Query] `join/5` now expects `on: expr` as last argument instead of simply `expr`. This was done in order to properly support the `:as`, `:hints` and `:prefix` options
   * [Ecto.Repo] The `:returning` option for `update_all` and `delete_all` has been deprecated as those statements now support `select` clauses
   * [Ecto.Repo] Passing `:adapter` via config is deprecated in favor of passing it on `use Ecto.Repo`
-  * [Ecto.Repo] The `:loggers` configuration is deprecated in favor of "Telemetry Events"
+  * [Ecto.Repo] The `:loggers` configuration (and `Ecto.LogEntry`) is deprecated in favor of "Telemetry Events"
 
 ### Backwards incompatible changes
 

--- a/lib/ecto/log_entry.ex
+++ b/lib/ecto/log_entry.ex
@@ -16,6 +16,10 @@ defmodule Ecto.LogEntry do
 
   Notice all times are stored in native unit. You must convert them to
   the proper unit by using `System.convert_time_unit/3` before logging.
+
+  Note: `Ecto.LogEntry` is currently soft-deprecated and will be hard-deprecated
+  in 3.1.x. Instead you should use "Telemetry Events" (as documented in the
+  `Ecto.Repo` docs)
   """
 
   alias Ecto.LogEntry


### PR DESCRIPTION
This is meant for a v3.0.x release (e.g. 3.0.7), but since there is no 3.0 branch I have it set for `master` right now (and is the reason for the merge conflict), alternatively we could only keep the changelog portion of the update since master removes the `Ecto.LogEntry` docs completely.