### PR TITLE
Disable moduledoc for embedded schemas

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1836,6 +1836,8 @@ defmodule Ecto.Schema do
 
     block =
       quote do
+        @moduledoc false
+
         use Ecto.Schema
 
         @primary_key unquote(Macro.escape(pk))


### PR DESCRIPTION
Firstly, thanks for Ecto! It's awesome!!! 

I make use of embedded schemas quite a bit, and I find that the generated ex_docs are a bit noisy from all the generated modules. This change makes it so that embedded schemas do not show up in the ex_doc generated module lists.