### PR TITLE
Improves documentation on Ecto.Adapter.checkout/3;

### DIFF
--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -52,8 +52,9 @@ defmodule Ecto.Adapter do
 
   If the adapter provides a pool, it is supposed to 'check out'
   one of the pool connections for the duration of the function call.
-  Which connections is checked out is not passed to the calling function, so it should be done
-  using a stateful method like the calling process' pdict (Process Dictionary),
+  Which connections is checked out is not passed to the calling function,
+  so it should be done using a stateful method like using
+  the current process' pdict (Process Dictionary),
   Process Tracking, or some kind of other lookup method.
   (Of course, make sure that this stored connection is then used
   in the implementations of e.g. `Ecto.Adapter.Queryable` and `Ecto.Adapter.Schema`.)

--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -50,14 +50,13 @@ defmodule Ecto.Adapter do
   If the adapter does not provide a pool, just calling the passed function
   and returning its result are enough.
 
-  If the adapter provides a pool, it is supposed to 'check out'
-  one of the pool connections for the duration of the function call.
-  Which connections is checked out is not passed to the calling function,
-  so it should be done using a stateful method like using
-  the current process' pdict (Process Dictionary),
-  Process Tracking, or some kind of other lookup method.
-  (Of course, make sure that this stored connection is then used
-  in the implementations of e.g. `Ecto.Adapter.Queryable` and `Ecto.Adapter.Schema`.)
+  If the adapter provides a pool, it is supposed to "check out" one of the
+  pool connections for the duration of the function call. Which connection
+  is checked out is not passed to the calling function, so it should be done
+  using a stateful method like using the current process' dictionary, process
+  tracking, or some kind of other lookup method. Make sure that this stored
+  connection is then used in the other callbacks implementations, such as
+  `Ecto.Adapter.Queryable` and `Ecto.Adapter.Schema`.
   """
   @callback checkout(adapter_meta, config :: Keyword.t(), (() -> result)) :: result when result: var
 

--- a/lib/ecto/adapter/queryable.ex
+++ b/lib/ecto/adapter/queryable.ex
@@ -1,6 +1,10 @@
 defmodule Ecto.Adapter.Queryable do
   @moduledoc """
   Specifies the query API required from adapters.
+
+  If your adapter is only able to respond to one or a couple of the query functions,
+  add custom implementations of those functions directly to the Repo
+  by using `Ecto.Adapter.__before_compile__/1` instead.
   """
 
   @typedoc "Proxy type to the adapter meta"


### PR DESCRIPTION
Fixes #2935.

- Improves documentation on Ecto.Adapter.checkout/3.
- Renames 'options' to 'config' in callback to match naming with the other callbacks in this module.
- Also adds a short notice to the module documentation of
Ecto.Adapter.Queryable (fixes #2936).

