### PR TITLE
Load applications during Repo lookup

### DIFF
--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -30,7 +30,10 @@ defmodule Mix.Ecto do
       end
 
     apps
-    |> Enum.flat_map(&Application.get_env(&1, :ecto_repos, []))
+    |> Enum.flat_map(fn app ->
+      Application.load(app)
+      Application.get_env(app, :ecto_repos, [])
+    end)
     |> Enum.uniq()
     |> case do
       [] ->


### PR DESCRIPTION
This allows using application env to specify `:ecto_repos` option.

Close elixir-ecto/ecto_sql#88