### PR TITLE
remove unused opts configuration in test

### DIFF
--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -16,7 +16,6 @@ defmodule Ecto.Repo.AutogenerateTest do
   defmodule Office do
     use Ecto.Schema
 
-    @timestamps_opts [inserted_at: :created_on]
     schema "offices" do
       field :name, :string
       belongs_to :company, Company


### PR DESCRIPTION
small cleanup after #2954.
`@timestamp_opts` set in the schema is not used at all in the tests