### PR TITLE
Allow current schema db url parameter.

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -4,6 +4,7 @@ defmodule Ecto.Repo.Supervisor do
 
   @defaults [timeout: 15000, pool_size: 10]
   @integer_url_query_params ["timeout", "pool_size"]
+  @binary_url_query_params ["currentSchema"]
 
   @doc """
   Starts the repo supervisor.
@@ -133,6 +134,9 @@ defmodule Ecto.Repo.Supervisor do
       {"ssl", "false"}, acc ->
         [{:ssl, false}] ++ acc
 
+      {key, value}, acc when key in @binary_url_query_params ->
+        [{String.to_atom(key), value}] ++ acc
+
       {key, value}, acc when key in @integer_url_query_params ->
         [{String.to_atom(key), parse_integer!(key, value, url)}] ++ acc
 
@@ -168,7 +172,7 @@ defmodule Ecto.Repo.Supervisor do
         :ignore
     end
   end
-  
+
   def start_child({mod, fun, args}, adapter, cache, meta) do
     case apply(mod, fun, args) do
       {:ok, pid} ->

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -66,7 +66,7 @@ defmodule Ecto.Repo.SupervisorTest do
   end
 
   test "parse_url query string" do
-    encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&timeout=1000&pool_size=42")
+    encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&timeout=1000&pool_size=42&currentSchema=my_schema")
     url = parse_url(encoded_url)
     assert {:password, "it+й"} in url
     assert {:username, "eric"} in url
@@ -76,6 +76,7 @@ defmodule Ecto.Repo.SupervisorTest do
     assert {:ssl, true} in url
     assert {:timeout, 1000} in url
     assert {:pool_size, 42} in url
+    assert {:currentSchema, "my_schema"} in url
   end
 
   test "parse_url returns no config when blank" do


### PR DESCRIPTION
After update to 2.2.8, currentSchema database URL parameter is not allowed anymore.

This PR allows to use this parameter.

Closes #2959.

Inspired by Resultados Digitais open source month and José Valim that we had an amazing talk today morning <3.

Contribution in pair with @lccezinha.