### PR TITLE
delete_all via repo in assoc

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1126,7 +1126,7 @@ defmodule Ecto.Association.ManyToMany do
                field(j, ^join_related_key) == ^related_value
 
     query = Map.put(query, :prefix, owner.__meta__.prefix)
-    Ecto.Repo.Queryable.delete_all repo, query, opts
+    repo.delete_all(query, opts)
     {:ok, nil}
   end
 

--- a/test/ecto/repo/many_to_many_test.exs
+++ b/test/ecto/repo/many_to_many_test.exs
@@ -514,20 +514,4 @@ defmodule Ecto.Repo.ManyToManyTest do
     refute_received {:rollback, _}
     refute_received {:insert_all, _, _}
   end
-
-  describe "dynamic repo" do
-    test "removing assocs on update preserving parent schema prefix" do
-      {:ok, pid} = TestRepo.start_link(name: :dynamic_repo)
-      TestRepo.put_dynamic_repo(pid)
-
-      assoc = %MyAssoc{x: "xyz", id: 1}
-      changeset =
-        %MySchema{id: 1, assocs: [assoc]}
-        |> Ecto.put_meta(prefix: "prefix")
-        |> Ecto.Changeset.change
-        |> Ecto.Changeset.put_assoc(:assocs, [])
-      TestRepo.update!(changeset)
-      assert_received {:delete_all, %{prefix: "prefix", from: %{source: {"schemas_assocs", _}}}}
-    end
-  end
 end


### PR DESCRIPTION
We have fallback to `Ecto.TestRepo` default in `get_dynamic_repo/0` so it will always pass due to `Ecto.TestRepo.start_link()` is started at the beginning of tests, you can change `Ecto.TestRepo.start_link()` to `Ecto.TestRepo.start_link(name: :other)` in `helper_test.exs` to verify, anyway this test scenario is correct. 

I'm afraid that there are 2 other direct calls to `Ecto.Repo.Queryable.delete_all/3` or `Ecto.Repo.Queryable.update_all/3` in `lib/ecto/association.ex` but they are not covered by tests, so I'm not changing them.

```
test dynamic repo removing assocs on update preserving parent schema prefix (Ecto.Repo.ManyToManyTest)
     test/ecto/repo/many_to_many_test.exs:519
     ** (RuntimeError) could not lookup Ecto.TestRepo because it was not started or it does not exist
     code: TestRepo.update!(changeset)
     stacktrace:
       (ecto) lib/ecto/repo/registry.ex:18: Ecto.Repo.Registry.lookup/1
       (ecto) lib/ecto/repo/queryable.ex:131: Ecto.Repo.Queryable.execute/4
       (ecto) lib/ecto/association.ex:1133: Ecto.Association.ManyToMany.on_repo_change/5
       (ecto) lib/ecto/association.ex:427: anonymous fn/8 in Ecto.Association.on_repo_change/7
       (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto) lib/ecto/association.ex:423: Ecto.Association.on_repo_change/7
       (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto) lib/ecto/association.ex:387: Ecto.Association.on_repo_change/4
       (ecto) lib/ecto/repo/schema.ex:837: Ecto.Repo.Schema.process_children/5
       (ecto) lib/ecto/repo/schema.ex:914: anonymous fn/3 in Ecto.Repo.Schema.wrap_in_transaction/6
       test/support/test_repo.exs:116: Ecto.TestAdapter.transaction/3
       (ecto) lib/ecto/repo/schema.ex:177: Ecto.Repo.Schema.update!/4
       test/ecto/repo/many_to_many_test.exs:529: (test)
```