### PR TITLE
update_change consistent with put_change

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1072,8 +1072,7 @@ defmodule Ecto.Changeset do
   def update_change(%Changeset{changes: changes} = changeset, key, function) when is_atom(key) do
     case Map.fetch(changes, key) do
       {:ok, value} ->
-        changes = Map.put(changes, key, function.(value))
-        %{changeset | changes: changes}
+        put_change(changeset, key, function.(value))
       :error ->
         changeset
     end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -649,6 +649,11 @@ defmodule Ecto.ChangesetTest do
       changeset(%{})
       |> update_change(:title, & &1 || "bar")
     assert changeset.changes == %{}
+
+    changeset =
+      changeset(%Post{title: "mytitle"}, %{title: "MyTitle"})
+      |> update_change(:title, &String.downcase/1)
+    assert changeset.changes == %{}
   end
 
   test "put_change/3 and delete_change/2" do


### PR DESCRIPTION
This fixes a bug that is reproduced by the included test case. `update_change` was leaving a field in the `changes` map even though that field was not being changed. The new behavior is consistent with the behavior of `put_change`.

Thanks ✨ 