### PR TITLE
fix.validate_confirmation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2057,6 +2057,11 @@ defmodule Ecto.Changeset do
   By calling `validate_confirmation(changeset, :email)`, this
   validation will check if both "email" and "email_confirmation"
   in the parameter map matches.
+  
+  Note that when the field is optional, it makes sure that field 
+  is present to validate the confirmation field. Incase the field is 
+  not present and confirmation field is required it will not add error.
+  It will add the error only when the field is present. 
 
   Note that if the confirmation field is nil or missing, by default this does
   not add a validation error. You can specify that the confirmation field is
@@ -2084,11 +2089,11 @@ defmodule Ecto.Changeset do
     param = Atom.to_string(field)
     error_param = "#{param}_confirmation"
     error_field = String.to_atom(error_param)
-    value = Map.get(params, param)
+    value = Map.fetch(params, param)
 
     errors =
       case Map.fetch(params, error_param) do
-        {:ok, ^value} ->
+        ^value ->
           []
         {:ok, _} ->
           [{error_field,

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1235,6 +1235,13 @@ defmodule Ecto.ChangesetTest do
     refute changeset.valid?
     assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation]}]
 
+    # With missing change and password_confirmation where password_confirmation is required
+    # This verifiies that if field itself is optional, the confirmation field ignores even if its required
+    # So we check that the confirmation comes into action only if the field is present
+    changeset = changeset(%{})
+                |> validate_confirmation(:password, required: true)
+    assert changeset.valid?
+
     # invalid params
     changeset = changeset(:invalid)
                 |> validate_confirmation(:password)


### PR DESCRIPTION
If field is required, the code worked fine.
But when the field itself was optional, we had to make the confirmation field as optional (required: false) because if we make it required it will be invalidated when field is not provided.

Example - 

  @cast_key [
    :first_name,
    :last_name,
    :mobile_number,
    :email,
    :password,
    :password_hash
  ]
  
  @required_key @cast_key -- [:password, :password_hash]

  @primary_key {:id, :binary_id, autogenerate: true}
  schema "customers" do
    field :email, :string
    field :first_name, :string
    field :last_name, :string
    field :mobile_number, :string
    field :password, :string, virtual: true
    field :password_hash, :string
    timestamps()
  end

  def changeset(customer , attrs) do
    customer
    |> cast(attrs, @cast_key)
    |> validate_required(@required_key)
    |> validate_length(:password, min: 8, max: 26)
    |> validate_confirmation(:password, message: "does not match password", required: true)
    |> hash_password()
  end

Now In this case even if we don't pass password (as its optional ) the validation_confirmation adds error. (Fixing this issue)