### PR TITLE
Add support for type+over

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -110,6 +110,10 @@ defmodule Ecto.Query.Builder do
     escape_with_type(expr, type, params_acc, vars, env)
   end
 
+  def escape({:type, _, [{:over, _, [_ | _]} = expr, type]}, _type, params_acc, vars, env) do
+    escape_with_type(expr, type, params_acc, vars, env)
+  end
+
   def escape({:type, _, [{agg, _, [_ | _]} = expr, type]}, _type, params_acc, vars, env)
       when agg in ~w(avg count max min sum)a do
     escape_with_type(expr, type, params_acc, vars, env)

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -36,6 +36,9 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do type(&0.y, :"Elixir.Ecto.UUID") end), []} ==
           escape(quote do type(field(x, :y), Ecto.UUID) end, [x: 0], {__ENV__, %{}})
 
+    assert {Macro.escape(quote do type(over(fragment({:raw, "array_agg("},{:expr, &0.id}, {:raw, ")"}), :y), {:array, :"Elixir.Ecto.UUID"}) end), []} ==
+      escape(quote do type(over(fragment("array_agg(?)", x.id), :y), {:array, Ecto.UUID}) end, [x: 0], {__ENV__, %{}})
+
     assert {Macro.escape(quote do avg(0) end), []} ==
            escape(quote do avg(0) end, [], __ENV__)
 


### PR DESCRIPTION
https://github.com/elixir-ecto/ecto/issues/2973

@josevalim I've tested exactly with your suggestion.
It generates an invalid query
```
** (Postgrex.Error) ERROR 42601 (syntax_error) syntax error at or near "OVER"
     
  query: SELECT DISTINCT ON (u0."id") u0."id", u0."name", ARRAY_AGG(p1."id") OVER "post_ids" FROM "users" AS u0 INNER JOIN "posts" AS p1 ON p1."user_id" = u0."id" WINDOW "post_ids" AS (PARTITION BY u0."id")
```
So, this version
```
type(over(fragment("ARRAY_AGG(?)", posts.id), {:array, :binary_id}), :post_ids)
```
generates correct query now.