### PR TITLE
The subsequent `select_merge` overrides expression bindings

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -354,9 +354,25 @@ defmodule Ecto.Query do
   The prefixes set in the query will be preserved when loading data.
   """
 
-  defstruct [prefix: nil, sources: nil, from: nil, joins: [], aliases: %{}, wheres: [], select: nil,
-             order_bys: [], limit: nil, offset: nil, group_bys: [], combinations: [], updates: [],
-             havings: [], preloads: [], assocs: [], distinct: nil, lock: nil, windows: []]
+  defstruct prefix: nil,
+            sources: nil,
+            from: nil,
+            joins: [],
+            aliases: %{},
+            wheres: [],
+            select: nil,
+            order_bys: [],
+            limit: nil,
+            offset: nil,
+            group_bys: [],
+            combinations: [],
+            updates: [],
+            havings: [],
+            preloads: [],
+            assocs: [],
+            distinct: nil,
+            lock: nil,
+            windows: []
 
   defmodule FromExpr do
     @moduledoc false
@@ -385,7 +401,19 @@ defmodule Ecto.Query do
 
   defmodule JoinExpr do
     @moduledoc false
-    defstruct [:qual, :source, :on, :file, :line, :assoc, :as, :ix, :prefix, params: [], hints: []]
+    defstruct [
+      :qual,
+      :source,
+      :on,
+      :file,
+      :line,
+      :assoc,
+      :as,
+      :ix,
+      :prefix,
+      params: [],
+      hints: []
+    ]
   end
 
   defmodule Tagged do
@@ -400,8 +428,22 @@ defmodule Ecto.Query do
   @opaque dynamic :: %DynamicExpr{}
 
   alias Ecto.Query.Builder
-  alias Ecto.Query.Builder.{Distinct, Dynamic, Filter, From, GroupBy, Join, Windows,
-                            LimitOffset, Lock, OrderBy, Preload, Select, Update}
+
+  alias Ecto.Query.Builder.{
+    Distinct,
+    Dynamic,
+    Filter,
+    From,
+    GroupBy,
+    Join,
+    Windows,
+    LimitOffset,
+    Lock,
+    OrderBy,
+    Preload,
+    Select,
+    Update
+  }
 
   @doc """
   Builds a dynamic query expression.
@@ -576,9 +618,13 @@ defmodule Ecto.Query do
   """
   def subquery(query, opts \\ []) do
     subquery = wrap_in_subquery(query)
+
     case Keyword.fetch(opts, :prefix) do
-      {:ok, prefix} when is_binary(prefix) or is_nil(prefix) -> put_in(subquery.query.prefix, prefix)
-      :error -> subquery
+      {:ok, prefix} when is_binary(prefix) or is_nil(prefix) ->
+        put_in(subquery.query.prefix, prefix)
+
+      :error ->
+        subquery
     end
   end
 
@@ -586,8 +632,16 @@ defmodule Ecto.Query do
   defp wrap_in_subquery(%Ecto.Query{} = query), do: %Ecto.SubQuery{query: query}
   defp wrap_in_subquery(queryable), do: %Ecto.SubQuery{query: Ecto.Queryable.to_query(queryable)}
 
-  @joins [:join, :inner_join, :cross_join, :left_join, :right_join, :full_join,
-          :inner_lateral_join, :left_lateral_join]
+  @joins [
+    :join,
+    :inner_join,
+    :cross_join,
+    :left_join,
+    :right_join,
+    :full_join,
+    :inner_lateral_join,
+    :left_lateral_join
+  ]
 
   @doc """
   Resets a previously set field on a query.
@@ -630,10 +684,12 @@ defmodule Ecto.Query do
   def exclude(query, field), do: do_exclude(Ecto.Queryable.to_query(query), field)
 
   defp do_exclude(%Ecto.Query{} = query, :join), do: %{query | joins: []}
+
   defp do_exclude(%Ecto.Query{} = query, join_keyword) when join_keyword in @joins do
     qual = join_qual(join_keyword)
     %{query | joins: Enum.reject(query.joins, &(&1.qual == qual))}
   end
+
   defp do_exclude(%Ecto.Query{} = query, :where), do: %{query | wheres: []}
   defp do_exclude(%Ecto.Query{} = query, :order_by), do: %{query | order_bys: []}
   defp do_exclude(%Ecto.Query{} = query, :group_by), do: %{query | group_bys: []}
@@ -716,7 +772,7 @@ defmodule Ecto.Query do
   @binds [:where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge]
 
-  defp from([{type, expr}|t], env, count_bind, quoted, binds) when type in @binds do
+  defp from([{type, expr} | t], env, count_bind, quoted, binds) when type in @binds do
     # If all bindings are integer indexes keep AST Macro expandable to %Query{},
     # otherwise ensure that quoted code is evaluated before macro call
     quoted =
@@ -734,7 +790,7 @@ defmodule Ecto.Query do
     from(t, env, count_bind, quoted, binds)
   end
 
-  defp from([{type, expr}|t], env, count_bind, quoted, binds) when type in @no_binds do
+  defp from([{type, expr} | t], env, count_bind, quoted, binds) when type in @no_binds do
     quoted =
       quote do
         Ecto.Query.unquote(type)(unquote(quoted), unquote(expr))
@@ -743,7 +799,7 @@ defmodule Ecto.Query do
     from(t, env, count_bind, quoted, binds)
   end
 
-  defp from([{join, expr}|t], env, count_bind, quoted, binds) when join in @joins do
+  defp from([{join, expr} | t], env, count_bind, quoted, binds) when join in @joins do
     qual = join_qual(join)
     {t, on, as, prefix, hints} = collect_on(t, nil, nil, nil, nil)
 
@@ -753,16 +809,17 @@ defmodule Ecto.Query do
     from(t, env, count_bind, quoted, to_query_binds(binds))
   end
 
-  defp from([{:on, _value}|_], _env, _count_bind, _quoted, _binds) do
-    Builder.error! "`on` keyword must immediately follow a join"
+  defp from([{:on, _value} | _], _env, _count_bind, _quoted, _binds) do
+    Builder.error!("`on` keyword must immediately follow a join")
   end
 
-  defp from([{key, _value}|_], _env, _count_bind, _quoted, _binds) when key in @from_join_opts do
-    Builder.error! "`#{key}` keyword must immediately follow a from/join"
+  defp from([{key, _value} | _], _env, _count_bind, _quoted, _binds)
+       when key in @from_join_opts do
+    Builder.error!("`#{key}` keyword must immediately follow a from/join")
   end
 
-  defp from([{key, _value}|_], _env, _count_bind, _quoted, _binds) do
-    Builder.error! "unsupported #{inspect key} in keyword query expression"
+  defp from([{key, _value} | _], _env, _count_bind, _quoted, _binds) do
+    Builder.error!("unsupported #{inspect(key)} in keyword query expression")
   end
 
   defp from([], _env, _count_bind, quoted, _binds) do
@@ -789,23 +846,31 @@ defmodule Ecto.Query do
 
   defp collect_on([{:on, on} | t], nil, as, prefix, hints),
     do: collect_on(t, on, as, prefix, hints)
+
   defp collect_on([{:on, expr} | t], on, as, prefix, hints),
     do: collect_on(t, {:and, [], [on, expr]}, as, prefix, hints)
+
   defp collect_on(t, on, as, prefix, hints),
     do: {t, on, as, prefix, hints}
 
   defp collect_as_and_prefix_and_hints([{:as, as} | t], nil, prefix, hints),
     do: collect_as_and_prefix_and_hints(t, as, prefix, hints)
+
   defp collect_as_and_prefix_and_hints([{:as, _} | _], _, _, _),
-    do: Builder.error! "`as` keyword was given more than once to the same from/join"
+    do: Builder.error!("`as` keyword was given more than once to the same from/join")
+
   defp collect_as_and_prefix_and_hints([{:prefix, prefix} | t], as, nil, hints),
     do: collect_as_and_prefix_and_hints(t, as, prefix, hints)
+
   defp collect_as_and_prefix_and_hints([{:prefix, _} | _], _, _, _),
-    do: Builder.error! "`prefix` keyword was given more than once to the same from/join"
+    do: Builder.error!("`prefix` keyword was given more than once to the same from/join")
+
   defp collect_as_and_prefix_and_hints([{:hints, hints} | t], as, prefix, nil),
     do: collect_as_and_prefix_and_hints(t, as, prefix, hints)
+
   defp collect_as_and_prefix_and_hints([{:hints, _} | _], _, _, _),
-    do: Builder.error! "`hints` keyword was given more than once to the same from/join"
+    do: Builder.error!("`hints` keyword was given more than once to the same from/join")
+
   defp collect_as_and_prefix_and_hints(t, as, prefix, hints),
     do: {t, as, prefix, hints}
 
@@ -950,8 +1015,9 @@ defmodule Ecto.Query do
     {t, on, as, prefix, hints} = collect_on(opts, nil, nil, nil, nil)
 
     with [{key, _} | _] <- t do
-      raise ArgumentError, "invalid option `#{key}` passed to Ecto.Query.join/5, " <>
-                             "valid options are: #{inspect(@join_opts)}"
+      raise ArgumentError,
+            "invalid option `#{key}` passed to Ecto.Query.join/5, " <>
+              "valid options are: #{inspect(@join_opts)}"
     end
 
     query
@@ -1235,7 +1301,7 @@ defmodule Ecto.Query do
       City |> order_by(asc: :name) # Sorts by the cities name
 
   """
-  defmacro order_by(query, binding \\ [], expr)  do
+  defmacro order_by(query, binding \\ [], expr) do
     OrderBy.build(query, binding, expr, __CALLER__)
   end
 
@@ -1743,13 +1809,16 @@ defmodule Ecto.Query do
 
   def first(%Ecto.Query{} = query, nil) do
     query = %{query | limit: limit()}
+
     case query do
       %{order_bys: []} ->
         %{query | order_bys: [order_by_pk(query, :asc)]}
+
       %{} ->
         query
     end
   end
+
   def first(queryable, nil), do: first(Ecto.Queryable.to_query(queryable), nil)
   def first(queryable, key), do: first(order_by(queryable, ^key), nil)
 
@@ -1780,12 +1849,15 @@ defmodule Ecto.Query do
 
   defp order_by_pk(query, dir) do
     schema = assert_schema!(query)
-    pks    = schema.__schema__(:primary_key)
-    expr   = for pk <- pks, do: {dir, field(0, pk)}
+    pks = schema.__schema__(:primary_key)
+    expr = for pk <- pks, do: {dir, field(0, pk)}
     %QueryExpr{expr: expr, file: __ENV__.file, line: __ENV__.line}
   end
 
-  defp assert_schema!(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}}) when schema != nil, do: schema
+  defp assert_schema!(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}})
+       when schema != nil,
+       do: schema
+
   defp assert_schema!(query) do
     raise Ecto.QueryError, query: query, message: "expected a from expression with a schema"
   end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -23,7 +23,7 @@ defmodule Ecto.Query.Builder.Select do
       {{:{}, [], [:&, [], [0]]}, {[], %{}}}
 
   """
-  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{}}}
+  @spec escape(Macro.t(), Keyword.t(), Macro.Env.t()) :: {Macro.t(), {list, %{}}}
   def escape(other, vars, env) do
     if take?(other) do
       {{:{}, [], [:&, [], [0]]}, {[], %{0 => {:any, other}}}}
@@ -67,7 +67,11 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   defp escape({:merge, _, [_left, right]}, _params_take, _vars, _env) do
-    Builder.error! "expected the second argument of merge/2 in select to be a map, got: `#{Macro.to_string(right)}`"
+    Builder.error!(
+      "expected the second argument of merge/2 in select to be a map, got: `#{
+        Macro.to_string(right)
+      }`"
+    )
   end
 
   # Map
@@ -99,16 +103,17 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   defp escape_pairs(pairs, params_take, vars, env) do
-    Enum.map_reduce pairs, params_take, fn({k, v}, acc) ->
+    Enum.map_reduce(pairs, params_take, fn {k, v}, acc ->
       {k, acc} = escape_key(k, acc, vars, env)
       {v, acc} = escape(v, acc, vars, env)
       {{k, v}, acc}
-    end
+    end)
   end
 
   defp escape_key(k, params_take, _vars, _env) when is_atom(k) do
     {k, params_take}
   end
+
   defp escape_key(k, params_take, vars, env) do
     escape(k, params_take, vars, env)
   end
@@ -118,13 +123,17 @@ defmodule Ecto.Query.Builder.Select do
       Ecto.Query.Builder.Select.fields!(unquote(tag), unquote(interpolated))
     end
   end
+
   defp escape_fields(expr, tag, env) do
     case Macro.expand(expr, env) do
       fields when is_list(fields) ->
         fields
+
       _ ->
-        Builder.error! "`#{tag}/2` in `select` expects either a literal or " <>
-          "an interpolated list of atom fields"
+        Builder.error!(
+          "`#{tag}/2` in `select` expects either a literal or " <>
+            "an interpolated list of atom fields"
+        )
     end
   end
 
@@ -136,16 +145,17 @@ defmodule Ecto.Query.Builder.Select do
       fields
     else
       raise ArgumentError,
-        "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect fields}`"
+            "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect(fields)}`"
     end
   end
 
   defp take?(fields) do
-    is_list(fields) and Enum.all?(fields, fn
-      {k, v} when is_atom(k) -> take?(List.wrap(v))
-      k when is_atom(k) -> true
-      _ -> false
-    end)
+    is_list(fields) and
+      Enum.all?(fields, fn
+        {k, v} when is_atom(k) -> take?(List.wrap(v))
+        k when is_atom(k) -> true
+        _ -> false
+      end)
   end
 
   @doc """
@@ -154,6 +164,7 @@ defmodule Ecto.Query.Builder.Select do
   def select!(kind, query, fields, file, line) do
     take = %{0 => {:any, fields!(:select, fields)}}
     expr = %Ecto.Query.SelectExpr{expr: {:&, [], [0]}, take: take, file: file, line: line}
+
     if kind == :select do
       apply(query, expr)
     else
@@ -168,12 +179,17 @@ defmodule Ecto.Query.Builder.Select do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(:select | :merge, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(:select | :merge, Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
 
   def build(kind, query, _binding, {:^, _, [var]}, env) do
     quote do
-      Ecto.Query.Builder.Select.select!(unquote(kind), unquote(query), unquote(var),
-                                        unquote(env.file), unquote(env.line))
+      Ecto.Query.Builder.Select.select!(
+        unquote(kind),
+        unquote(query),
+        unquote(var),
+        unquote(env.file),
+        unquote(env.line)
+      )
     end
   end
 
@@ -181,14 +197,16 @@ defmodule Ecto.Query.Builder.Select do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, take}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
-    take   = {:%{}, [], Map.to_list(take)}
+    take = {:%{}, [], Map.to_list(take)}
 
-    select = quote do: %Ecto.Query.SelectExpr{
-                         expr: unquote(expr),
-                         params: unquote(params),
-                         file: unquote(env.file),
-                         line: unquote(env.line),
-                         take: unquote(take)}
+    select =
+      quote do: %Ecto.Query.SelectExpr{
+              expr: unquote(expr),
+              params: unquote(params),
+              file: unquote(env.file),
+              line: unquote(env.line),
+              take: unquote(take)
+            }
 
     if kind == :select do
       Builder.apply_query(query, __MODULE__, [select], env)
@@ -203,13 +221,15 @@ defmodule Ecto.Query.Builder.Select do
   @doc """
   The callback applied by `build/5` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
   def apply(%Ecto.Query{select: nil} = query, expr) do
     %{query | select: expr}
   end
+
   def apply(%Ecto.Query{}, _expr) do
-    Builder.error! "only one select expression is allowed in query"
+    Builder.error!("only one select expression is allowed in query")
   end
+
   def apply(query, expr) do
     apply(Ecto.Queryable.to_query(query), expr)
   end
@@ -220,10 +240,32 @@ defmodule Ecto.Query.Builder.Select do
   def merge(%Ecto.Query{select: nil} = query, new_select) do
     merge(query, new_select, {:&, [], [0]}, [], %{}, new_select)
   end
+
   def merge(%Ecto.Query{select: old_select} = query, new_select) do
+    new_select =
+      with {
+             %Ecto.Query.SelectExpr{expr: {:%{}, [], expr_list}} = new_select_expr,
+             %Ecto.Query.SelectExpr{
+               expr: {:merge, [], [{:&, [], [0]}, {:%{}, [], [_ | _] = list}]}
+             }
+           } <- {new_select, query.select} do
+        len = length(list)
+
+        expr_list =
+          Enum.map(expr_list, fn
+            {{:^, [], [ix]}, {{:., [], [{:&, [], [tix]}, name]}, [], []}} ->
+              {{:^, [], [ix + len]}, {{:., [], [{:&, [], [tix]}, name]}, [], []}}
+          end)
+
+        %Ecto.Query.SelectExpr{new_select_expr | expr: {:%{}, [], expr_list}}
+      else
+        _ -> new_select
+      end
+
     %{expr: old_expr, params: old_params, take: old_take} = old_select
     merge(query, old_select, old_expr, old_params, old_take, new_select)
   end
+
   def merge(query, expr) do
     merge(Ecto.Queryable.to_query(query), expr)
   end
@@ -239,7 +281,8 @@ defmodule Ecto.Query.Builder.Select do
         {{:source, meta, ix}, {:source, _, ix}} ->
           {:&, meta, [ix]}
 
-        {{:struct, meta, name, old_fields}, {:map, _, [_ | _] = new_fields}} when old_params == [] ->
+        {{:struct, meta, name, old_fields}, {:map, _, [_ | _] = new_fields}}
+        when old_params == [] ->
           {:%, meta, [name, {:%{}, meta, Keyword.merge(old_fields, new_fields)}]}
 
         {{:map, meta, old_fields}, {:map, _, new_fields}} when old_params == [] ->
@@ -262,9 +305,10 @@ defmodule Ecto.Query.Builder.Select do
       end
 
     select = %{
-      select | expr: expr,
-               params: old_params ++ new_params,
-               take: merge_take(old_expr, old_take, new_take)
+      select
+      | expr: expr,
+        params: old_params ++ new_params,
+        take: merge_take(old_expr, old_take, new_take)
     }
 
     %{query | select: select}
@@ -343,8 +387,11 @@ defmodule Ecto.Query.Builder.Select do
   defp merge_take_kind(_, kind, kind), do: kind
   defp merge_take_kind(_, :any, kind), do: kind
   defp merge_take_kind(_, kind, :any), do: kind
+
   defp merge_take_kind(binding, old, new) do
-    Builder.error! "cannot select_merge because the binding at position #{binding} " <>
-                   "was previously specified as a `#{old}` and later as `#{new}`"
+    Builder.error!(
+      "cannot select_merge because the binding at position #{binding} " <>
+        "was previously specified as a `#{old}` and later as `#{new}`"
+    )
   end
 end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -23,7 +23,7 @@ defmodule Ecto.Query.Builder.Select do
       {{:{}, [], [:&, [], [0]]}, {[], %{}}}
 
   """
-  @spec escape(Macro.t(), Keyword.t(), Macro.Env.t()) :: {Macro.t(), {list, %{}}}
+  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{}}}
   def escape(other, vars, env) do
     if take?(other) do
       {{:{}, [], [:&, [], [0]]}, {[], %{0 => {:any, other}}}}
@@ -67,11 +67,7 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   defp escape({:merge, _, [_left, right]}, _params_take, _vars, _env) do
-    Builder.error!(
-      "expected the second argument of merge/2 in select to be a map, got: `#{
-        Macro.to_string(right)
-      }`"
-    )
+    Builder.error! "expected the second argument of merge/2 in select to be a map, got: `#{Macro.to_string(right)}`"
   end
 
   # Map
@@ -103,17 +99,16 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   defp escape_pairs(pairs, params_take, vars, env) do
-    Enum.map_reduce(pairs, params_take, fn {k, v}, acc ->
+    Enum.map_reduce pairs, params_take, fn({k, v}, acc) ->
       {k, acc} = escape_key(k, acc, vars, env)
       {v, acc} = escape(v, acc, vars, env)
       {{k, v}, acc}
-    end)
+    end
   end
 
   defp escape_key(k, params_take, _vars, _env) when is_atom(k) do
     {k, params_take}
   end
-
   defp escape_key(k, params_take, vars, env) do
     escape(k, params_take, vars, env)
   end
@@ -123,17 +118,13 @@ defmodule Ecto.Query.Builder.Select do
       Ecto.Query.Builder.Select.fields!(unquote(tag), unquote(interpolated))
     end
   end
-
   defp escape_fields(expr, tag, env) do
     case Macro.expand(expr, env) do
       fields when is_list(fields) ->
         fields
-
       _ ->
-        Builder.error!(
-          "`#{tag}/2` in `select` expects either a literal or " <>
-            "an interpolated list of atom fields"
-        )
+        Builder.error! "`#{tag}/2` in `select` expects either a literal or " <>
+          "an interpolated list of atom fields"
     end
   end
 
@@ -145,17 +136,16 @@ defmodule Ecto.Query.Builder.Select do
       fields
     else
       raise ArgumentError,
-            "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect(fields)}`"
+        "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect fields}`"
     end
   end
 
   defp take?(fields) do
-    is_list(fields) and
-      Enum.all?(fields, fn
-        {k, v} when is_atom(k) -> take?(List.wrap(v))
-        k when is_atom(k) -> true
-        _ -> false
-      end)
+    is_list(fields) and Enum.all?(fields, fn
+      {k, v} when is_atom(k) -> take?(List.wrap(v))
+      k when is_atom(k) -> true
+      _ -> false
+    end)
   end
 
   @doc """
@@ -164,7 +154,6 @@ defmodule Ecto.Query.Builder.Select do
   def select!(kind, query, fields, file, line) do
     take = %{0 => {:any, fields!(:select, fields)}}
     expr = %Ecto.Query.SelectExpr{expr: {:&, [], [0]}, take: take, file: file, line: line}
-
     if kind == :select do
       apply(query, expr)
     else
@@ -179,17 +168,12 @@ defmodule Ecto.Query.Builder.Select do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(:select | :merge, Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
+  @spec build(:select | :merge, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
 
   def build(kind, query, _binding, {:^, _, [var]}, env) do
     quote do
-      Ecto.Query.Builder.Select.select!(
-        unquote(kind),
-        unquote(query),
-        unquote(var),
-        unquote(env.file),
-        unquote(env.line)
-      )
+      Ecto.Query.Builder.Select.select!(unquote(kind), unquote(query), unquote(var),
+                                        unquote(env.file), unquote(env.line))
     end
   end
 
@@ -197,16 +181,14 @@ defmodule Ecto.Query.Builder.Select do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, take}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
-    take = {:%{}, [], Map.to_list(take)}
+    take   = {:%{}, [], Map.to_list(take)}
 
-    select =
-      quote do: %Ecto.Query.SelectExpr{
-              expr: unquote(expr),
-              params: unquote(params),
-              file: unquote(env.file),
-              line: unquote(env.line),
-              take: unquote(take)
-            }
+    select = quote do: %Ecto.Query.SelectExpr{
+                         expr: unquote(expr),
+                         params: unquote(params),
+                         file: unquote(env.file),
+                         line: unquote(env.line),
+                         take: unquote(take)}
 
     if kind == :select do
       Builder.apply_query(query, __MODULE__, [select], env)
@@ -221,15 +203,13 @@ defmodule Ecto.Query.Builder.Select do
   @doc """
   The callback applied by `build/5` to build the query.
   """
-  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
+  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
   def apply(%Ecto.Query{select: nil} = query, expr) do
     %{query | select: expr}
   end
-
   def apply(%Ecto.Query{}, _expr) do
-    Builder.error!("only one select expression is allowed in query")
+    Builder.error! "only one select expression is allowed in query"
   end
-
   def apply(query, expr) do
     apply(Ecto.Queryable.to_query(query), expr)
   end
@@ -240,7 +220,6 @@ defmodule Ecto.Query.Builder.Select do
   def merge(%Ecto.Query{select: nil} = query, new_select) do
     merge(query, new_select, {:&, [], [0]}, [], %{}, new_select)
   end
-
   def merge(%Ecto.Query{select: old_select} = query, new_select) do
     new_select =
       with {
@@ -250,13 +229,13 @@ defmodule Ecto.Query.Builder.Select do
              }
            } <- {new_select, query.select} do
         len = length(list)
-
+ 
         expr_list =
           Enum.map(expr_list, fn
             {{:^, [], [ix]}, {{:., [], [{:&, [], [tix]}, name]}, [], []}} ->
               {{:^, [], [ix + len]}, {{:., [], [{:&, [], [tix]}, name]}, [], []}}
           end)
-
+ 
         %Ecto.Query.SelectExpr{new_select_expr | expr: {:%{}, [], expr_list}}
       else
         _ -> new_select
@@ -265,7 +244,6 @@ defmodule Ecto.Query.Builder.Select do
     %{expr: old_expr, params: old_params, take: old_take} = old_select
     merge(query, old_select, old_expr, old_params, old_take, new_select)
   end
-
   def merge(query, expr) do
     merge(Ecto.Queryable.to_query(query), expr)
   end
@@ -281,8 +259,7 @@ defmodule Ecto.Query.Builder.Select do
         {{:source, meta, ix}, {:source, _, ix}} ->
           {:&, meta, [ix]}
 
-        {{:struct, meta, name, old_fields}, {:map, _, [_ | _] = new_fields}}
-        when old_params == [] ->
+        {{:struct, meta, name, old_fields}, {:map, _, [_ | _] = new_fields}} when old_params == [] ->
           {:%, meta, [name, {:%{}, meta, Keyword.merge(old_fields, new_fields)}]}
 
         {{:map, meta, old_fields}, {:map, _, new_fields}} when old_params == [] ->
@@ -305,10 +282,9 @@ defmodule Ecto.Query.Builder.Select do
       end
 
     select = %{
-      select
-      | expr: expr,
-        params: old_params ++ new_params,
-        take: merge_take(old_expr, old_take, new_take)
+      select | expr: expr,
+               params: old_params ++ new_params,
+               take: merge_take(old_expr, old_take, new_take)
     }
 
     %{query | select: select}
@@ -387,11 +363,8 @@ defmodule Ecto.Query.Builder.Select do
   defp merge_take_kind(_, kind, kind), do: kind
   defp merge_take_kind(_, :any, kind), do: kind
   defp merge_take_kind(_, kind, :any), do: kind
-
   defp merge_take_kind(binding, old, new) do
-    Builder.error!(
-      "cannot select_merge because the binding at position #{binding} " <>
-        "was previously specified as a `#{old}` and later as `#{new}`"
-    )
+    Builder.error! "cannot select_merge because the binding at position #{binding} " <>
+                   "was previously specified as a `#{old}` and later as `#{new}`"
   end
 end


### PR DESCRIPTION
Steps to reproduce: see the test. Basically, it produces what is shown in red below.
```diff
select:
  merge(
    merge(map(p0, [:title, :body]), %{^"title" => map(p0, [:title, :body]).title}),
+    %{^"body" => map(p0, [:title, :body]).body})
-   %{^"title" => map(p0, [:title, :body]).body})
```
I was unable to introduce the concise solution without bringing many changes, but the below might be treated as a temporary workaround. It seems to happen on a consequtive merges only.

Related to #2979. Originally posted on https://stackoverflow.com/questions/55719195/elixir-ecto-multi-insert-all.