### PR TITLE
Exclude schema field in query

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1287,7 +1287,7 @@ defmodule Ecto.Query.Planner do
         {{:value, :map}, [{:&, [], [ix]}]}
 
       {:error, {source, schema, prefix}} ->
-        {types, fields} = select_dump(schema.__schema__(:fields), schema.__schema__(:dump), ix)
+        {types, fields} = select_dump(schema.__schema__(:query_fields), schema.__schema__(:dump), ix)
         {{:source, {source, schema}, prefix || query.prefix, types}, fields}
 
       {:error, %Ecto.SubQuery{select: select} = subquery} ->

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -596,6 +596,8 @@ defmodule Ecto.Schema do
     * `:primary_key` - When true, the field is used as part of the
       composite primary key
 
+    * `load_in_query` - When true, the field will not be selected in query.
+
   """
   defmacro field(name, type \\ :string, opts \\ []) do
     quote do
@@ -1752,7 +1754,7 @@ defmodule Ecto.Schema do
         Module.put_attribute(mod, :ecto_primary_keys, name)
       end
 
-      unless opts[:query_exclude] do
+      unless opts[:load_in_query] do
         Module.put_attribute(mod, :ecto_query_fields, {name, type})
       end
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -596,7 +596,7 @@ defmodule Ecto.Schema do
     * `:primary_key` - When true, the field is used as part of the
       composite primary key
 
-    * `load_in_query` - When true, the field will not be selected in query.
+    * `load_in_query` - When false, the field will not be selected in query. default to: `true`.
 
   """
   defmacro field(name, type \\ :string, opts \\ []) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -508,14 +508,14 @@ defmodule Ecto.Schema do
 
     postlude =
       quote unquote: false do
-        primary_key_fields = @ecto_primary_keys |> Enum.reverse()
-        autogenerate = @ecto_autogenerate |> Enum.reverse()
-        autoupdate = @ecto_autoupdate |> Enum.reverse()
-        fields = @ecto_fields |> Enum.reverse()
-        query_fields = @ecto_query_fields |> Enum.reverse()
-        field_sources = @ecto_field_sources |> Enum.reverse()
-        assocs = @ecto_assocs |> Enum.reverse()
-        embeds = @ecto_embeds |> Enum.reverse()
+        primary_key_fields = @ecto_primary_keys |> Enum.reverse
+        autogenerate = @ecto_autogenerate |> Enum.reverse
+        autoupdate = @ecto_autoupdate |> Enum.reverse
+        fields = @ecto_fields |> Enum.reverse
+        query_fields = @ecto_query_fields |> Enum.reverse
+        field_sources = @ecto_field_sources |> Enum.reverse
+        assocs = @ecto_assocs |> Enum.reverse
+        embeds = @ecto_embeds |> Enum.reverse
         loaded = Ecto.Schema.__loaded__(__MODULE__, @struct_fields)
 
         defstruct @struct_fields
@@ -1762,15 +1762,7 @@ defmodule Ecto.Schema do
     end
   end
 
-  @valid_has_options [
-    :foreign_key,
-    :references,
-    :through,
-    :on_delete,
-    :defaults,
-    :on_replace,
-    :where
-  ]
+  @valid_has_options [:foreign_key, :references, :through, :on_delete, :defaults, :on_replace, :where]
 
   @doc false
   def __has_many__(mod, name, queryable, opts) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1754,7 +1754,7 @@ defmodule Ecto.Schema do
         Module.put_attribute(mod, :ecto_primary_keys, name)
       end
 
-      unless opts[:load_in_query] do
+      if Keyword.get(opts, :load_in_query, true) do
         Module.put_attribute(mod, :ecto_query_fields, {name, type})
       end
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -594,9 +594,11 @@ defmodule Ecto.Schema do
       `:read_after_writes`.
 
     * `:primary_key` - When true, the field is used as part of the
-      composite primary key
+      composite primary key.
 
-    * `load_in_query` - When false, the field will not be selected in query. default to: `true`.
+    * `:load_in_query` - When false, the field will not be loaded when
+      selecting the whole struct in a query, such as `from p in Post, select: p`.
+      Defaults to `true`.
 
   """
   defmacro field(name, type \\ :string, opts \\ []) do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -61,7 +61,7 @@ defmodule Ecto.Query.PlannerTest do
       field :posted, :naive_datetime
       field :visits, :integer
       field :links, {:array, Custom.Permalink}
-      field :payload, :map, load_in_query: true
+      field :payload, :map, load_in_query: false
 
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -61,7 +61,7 @@ defmodule Ecto.Query.PlannerTest do
       field :posted, :naive_datetime
       field :visits, :integer
       field :links, {:array, Custom.Permalink}
-      field :payload, :map, query_exclude: true
+      field :payload, :map, load_in_query: true
 
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -61,6 +61,8 @@ defmodule Ecto.Query.PlannerTest do
       field :posted, :naive_datetime
       field :visits, :integer
       field :links, {:array, Custom.Permalink}
+      field :payload, :map, query_exclude: true
+
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment
       has_many :special_comments, Ecto.Query.PlannerTest.Comment, where: [text: {:not, nil}]

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -13,6 +13,7 @@ defmodule Ecto.SchemaTest do
       field :count, :decimal, read_after_writes: true, source: :cnt
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
+      field :query_excluded_field, :string, query_exclude: true
       belongs_to :comment, Comment
       belongs_to :permalink, Permalink, define_field: false
     end
@@ -21,7 +22,8 @@ defmodule Ecto.SchemaTest do
   test "schema metadata" do
     assert Schema.__schema__(:source)             == "my schema"
     assert Schema.__schema__(:prefix)             == nil
-    assert Schema.__schema__(:fields)             == [:id, :name, :email, :count, :array, :uuid, :comment_id]
+    assert Schema.__schema__(:fields)             == [:id, :name, :email, :count, :array, :uuid, :query_excluded_field, :comment_id]
+    assert Schema.__schema__(:query_fields)       == [:id, :name, :email, :count, :array, :uuid, :comment_id]
     assert Schema.__schema__(:read_after_writes)  == [:email, :count]
     assert Schema.__schema__(:primary_key)        == [:id]
     assert Schema.__schema__(:autogenerate_id)    == {:id, :id, :id}
@@ -48,7 +50,7 @@ defmodule Ecto.SchemaTest do
   test "changeset metadata" do
     assert Schema.__changeset__ |> Map.drop([:comment, :permalink]) ==
            %{name: :string, email: :string, count: :decimal, array: {:array, :string},
-             comment_id: :id, temp: :any, id: :id, uuid: Ecto.UUID}
+             comment_id: :id, temp: :any, id: :id, uuid: Ecto.UUID, query_excluded_field: :string}
   end
 
   test "autogenerate metadata (private)" do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -13,7 +13,7 @@ defmodule Ecto.SchemaTest do
       field :count, :decimal, read_after_writes: true, source: :cnt
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
-      field :query_excluded_field, :string, query_exclude: true
+      field :query_excluded_field, :string, load_in_query: true
       belongs_to :comment, Comment
       belongs_to :permalink, Permalink, define_field: false
     end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -13,7 +13,7 @@ defmodule Ecto.SchemaTest do
       field :count, :decimal, read_after_writes: true, source: :cnt
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
-      field :query_excluded_field, :string, load_in_query: true
+      field :query_excluded_field, :string, load_in_query: false
       belongs_to :comment, Comment
       belongs_to :permalink, Permalink, define_field: false
     end


### PR DESCRIPTION
Functionality that allows to exclude a field in the queries. In my opinion, helpful when a field in table  contains a large set of data to serialize
