### PR TITLE
Add missing :uses_usec tags

### DIFF
--- a/integration_test/cases/interval.exs
+++ b/integration_test/cases/interval.exs
@@ -300,6 +300,7 @@ defmodule Ecto.Integration.IntervalTest do
            TestRepo.all(from p in User, select: datetime_add(p.inserted_at, ^dec, "year"))
   end
 
+  @tag :uses_usec
   test "datetime_add with naive_datetime_usec" do
     TestRepo.insert!(%Usec{naive_datetime_usec: ~N[2014-01-01 02:00:00.000001]})
     dec = Decimal.new(1500)
@@ -319,6 +320,7 @@ defmodule Ecto.Integration.IntervalTest do
            TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^dec, "microsecond"))
   end
 
+  @tag :uses_usec
   test "datetime_add with utc_datetime_usec" do
     {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.000001], "Etc/UTC")
     TestRepo.insert!(%Usec{utc_datetime_usec: datetime})


### PR DESCRIPTION
I'm updating sqlite adapter to work with Ecto3.
I noticed that these tests are missing `@tag :uses_usec`, because they are failing as sqlite adapter doesn't support microseconds interval.

I hope it's a correct change.