### PR TITLE
Expose the enum that was validated against in errors from enum-based validations

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1850,7 +1850,7 @@ defmodule Ecto.Changeset do
   def validate_subset(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:subset, data}, fn _, value ->
       case Enum.any?(value, fn(x) -> not(x in data) end) do
-        true -> [{field, {message(opts, "has an invalid entry"), [validation: :subset]}}]
+        true -> [{field, {message(opts, "has an invalid entry"), [validation: :subset, enum: data]}}]
         false -> []
       end
     end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1828,7 +1828,7 @@ defmodule Ecto.Changeset do
     validate_change changeset, field, {:inclusion, data}, fn _, value ->
       if value in data,
         do: [],
-        else: [{field, {message(opts, "is invalid"), [validation: :inclusion]}}]
+        else: [{field, {message(opts, "is invalid"), [validation: :inclusion, enum: data]}}]
     end
   end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1872,7 +1872,7 @@ defmodule Ecto.Changeset do
   def validate_exclusion(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:exclusion, data}, fn _, value ->
       if value in data, do:
-        [{field, {message(opts, "is reserved"), [validation: :exclusion]}}], else: []
+        [{field, {message(opts, "is reserved"), [validation: :exclusion, enum: data]}}], else: []
     end
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -908,13 +908,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world))
     refute changeset.valid?
-    assert changeset.errors == [title: {"is invalid", [validation: :inclusion]}]
+    assert changeset.errors == [title: {"is invalid", [validation: :inclusion, enum: ~w(world)]}]
     assert validations(changeset) == [title: {:inclusion, ~w(world)}]
 
     changeset =
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
-    assert changeset.errors == [title: {"yada", [validation: :inclusion]}]
+    assert changeset.errors == [title: {"yada", [validation: :inclusion, enum: ~w(world)]}]
   end
 
   test "validate_subset/3" do
@@ -1622,7 +1622,7 @@ defmodule Ecto.ChangesetTest do
       %Ecto.Changeset{validations: validations}, field, {_, [validation: :format]} ->
         validation = Keyword.get_values(validations, field)
         "field #{field} should match format #{inspect validation[:format]}"
-      %Ecto.Changeset{validations: validations}, field, {_, [validation: :inclusion]} ->
+      %Ecto.Changeset{validations: validations}, field, {_, [validation: :inclusion, enum: _]} ->
         validation = Keyword.get_values(validations, field)
         values = Enum.join(validation[:inclusion], ", ")
         "#{field} value should be in #{values}"

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -929,13 +929,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"topics" => ["cat", "laptop"]})
       |> validate_subset(:topics, ~w(cat dog))
     refute changeset.valid?
-    assert changeset.errors == [topics: {"has an invalid entry", [validation: :subset]}]
+    assert changeset.errors == [topics: {"has an invalid entry", [validation: :subset, enum: ~w(cat dog)]}]
     assert validations(changeset) == [topics: {:subset, ~w(cat dog)}]
 
     changeset =
       changeset(%{"topics" => ["laptop"]})
       |> validate_subset(:topics, ~w(cat dog), message: "yada")
-    assert changeset.errors == [topics: {"yada", [validation: :subset]}]
+    assert changeset.errors == [topics: {"yada", [validation: :subset, enum: ~w(cat dog)]}]
   end
 
   test "validate_exclusion/3" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -950,13 +950,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world))
     refute changeset.valid?
-    assert changeset.errors == [title: {"is reserved", [validation: :exclusion]}]
+    assert changeset.errors == [title: {"is reserved", [validation: :exclusion, enum: ~w(world)]}]
     assert validations(changeset) == [title: {:exclusion, ~w(world)}]
 
     changeset =
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world), message: "yada")
-    assert changeset.errors == [title: {"yada", [validation: :exclusion]}]
+    assert changeset.errors == [title: {"yada", [validation: :exclusion, enum: ~w(world)]}]
   end
 
   test "validate_length/3 with string" do


### PR DESCRIPTION
Errors in an `Ecto.Changeset` have a key, a message and additional contextual information provided in the form of a keyword list.

`Ecto.Changeset` comes bundled with a number of validations, for example `validate_inclusion/4`.

The built-in validations tend to include additional contextual information - for example, `validate_length/3` includes `count` and `kind`. So, for example, if the validation was configured to check that a field was "no more than 3" and it fails, then you will have `[count: 3, validation: :length, kind: :max]`.

There are a number of validations that validate a field against an object that implements the `Enumerable` protocol - for example `validate_inclusion/4` which checks that the field's value is included in a supplied enumerable.

However, these validations don't expose in the additional context the enumerable that the value was validated against.

This context can be valuable, for example if you want your errors to be fully machine-readable.

This exposes `[enum: enum_that_the_field_was_validated_against]`
on errors generated by `validate_inclusion/4`, `validate_exclusion/4` and `validate_subset/4`.