### PR TITLE
Fix: prefix assignment for many to many associations

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -437,9 +437,11 @@ defmodule Ecto.Query.Planner do
     [%{h | on: merge_expr_and_params(:and, on, expr, params)} | t]
   end
 
-  defp rewrite_join_prefix(%{prefix: nil, source: {_, schema}} = join, nil, query)
-       when schema != nil,
-       do: %{join | prefix: schema.__schema__(:prefix) || query.prefix}
+  defp rewrite_join_prefix(%{prefix: nil, source: {_, nil}} = join, nil, query),
+    do: %{join | prefix: query.prefix}
+
+  defp rewrite_join_prefix(%{prefix: nil, source: {_, schema}} = join, nil, query),
+    do: %{join | prefix: schema.__schema__(:prefix) || query.prefix}
 
   defp rewrite_join_prefix(%{prefix: nil} = join, prefix, _query)
        when prefix != nil,


### PR DESCRIPTION
Based on this bug report: https://github.com/elixir-ecto/ecto/issues/2985

Hi, I saw this bug and decided to take a look on it. That's what I found.
`join_through` for many to many associations can be defined using a schema or a table name. 
The problem is that the `rewrite_join_prefix` method for the second case was not defined. Because of that the prefix assignment for many to many table was skipped.

It's my first PR to ecto, please let know if I'm missing something :) 