### PR TITLE
Improve the documentation around defining primary keys

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -187,22 +187,22 @@ defmodule Ecto.Schema do
   auto-generation of the id. This is often the case for primary keys
   in relational databases which are auto-incremented.
 
-  Besides `:id` and `:binary_id`, which are often used by primary
-  and foreign keys, Ecto provides a huge variety of types to be used
-  by any column.
-  
-  There are two ways to define primary keys in ecto: Using the `@primary_key`
+  There are two ways to define primary keys in Ecto: using the `@primary_key`
   module attribute and using `primary_key: true` as option for `field/3` in
   your schema definition. They are not mutually exclusive and can be used
   together.
   
   Using `@primary_key` should be prefered for single field primary keys and
-  sharing primary key defintions between multiple schemas using macros.
+  sharing primary key definitions between multiple schemas using macros.
 
   Ecto also supports composite primary keys, which is where you need to use
   `primary_key: true` for the fields in your schema. This usually goes along 
   with setting `@primary_key false` to disable generation of additional 
   primary key fields.
+
+  Besides `:id` and `:binary_id`, which are often used by primary
+  and foreign keys, Ecto provides a huge variety of types to be used
+  by any field.
 
   ## Types and casting
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -109,9 +109,8 @@ defmodule Ecto.Schema do
     * `@primary_key` - configures the schema primary key. It expects
       a tuple `{field_name, type, options}` with the primary key field
       name, type (typically `:id` or `:binary_id`, but can be any type) and
-      options. Defaults to `{:id, :id, autogenerate: true}`. When set
-      to `false`, does not define a primary key in the schema unless
-      composite keys are defined using the options of `field`.
+      options. It also accepts `false` to disable the generation of a primary
+      key field. Defaults to `{:id, :id, autogenerate: true}`. 
 
     * `@schema_prefix` - configures the schema prefix. Defaults to `nil`,
       which generates structs and queries without prefix. When set, the
@@ -191,10 +190,19 @@ defmodule Ecto.Schema do
   Besides `:id` and `:binary_id`, which are often used by primary
   and foreign keys, Ecto provides a huge variety of types to be used
   by any column.
+  
+  There are two ways to define primary keys in ecto: Using the `@primary_key`
+  module attribute and using `primary_key: true` as option for `field/3` in
+  your schema definition. They are not mutually exclusive and can be used
+  together.
+  
+  Using `@primary_key` should be prefered for single field primary keys and
+  sharing primary key defintions between multiple schemas using macros.
 
-  Ecto also supports composite primary keys. This is achieved by declaring
-  a `@primary_key`, as usual, and then passing the `primary_key: true` option
-  to any of the composite fields.
+  Ecto also supports composite primary keys, which is where you need to use
+  `primary_key: true` for the fields in your schema. This usually goes along 
+  with setting `@primary_key false` to disable generation of additional 
+  primary key fields.
 
   ## Types and casting
 


### PR DESCRIPTION
I had a conversion with @ccapndave on slack about primary keys in ecto and we found the last sentence of the `@primary_key` section to be confusing. We both though `false` would refer to `autogenerate: false`. Also the `unless composite keys are defined …` part didn't make matters clearer. 

I tried to make both parts cleaner by shifting the default to the end and only talking about "generation of a primary key" in the context of `@primary_key false` – skipping the part about `field/3` having an option to make an explicitly created field a primary key. 

In favor of removing the complexity there I added a few paragraphs to the "Primary key" section of the docs, which explains when to use `@primary_key` and/or `primary_key: true` on `field/3`.