### PR TITLE
Convert `enum` error field to list to always impl String.Chars

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1830,7 +1830,7 @@ defmodule Ecto.Changeset do
     validate_change changeset, field, {:inclusion, data}, fn _, value ->
       if value in data,
         do: [],
-        else: [{field, {message(opts, "is invalid"), [validation: :inclusion, enum: data]}}]
+        else: [{field, {message(opts, "is invalid"), [validation: :inclusion, enum: Enum.to_list(data)]}}]
     end
   end
 
@@ -1852,7 +1852,7 @@ defmodule Ecto.Changeset do
   def validate_subset(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:subset, data}, fn _, value ->
       case Enum.any?(value, fn(x) -> not(x in data) end) do
-        true -> [{field, {message(opts, "has an invalid entry"), [validation: :subset, enum: data]}}]
+        true -> [{field, {message(opts, "has an invalid entry"), [validation: :subset, enum: Enum.to_list(data)]}}]
         false -> []
       end
     end
@@ -1874,7 +1874,7 @@ defmodule Ecto.Changeset do
   def validate_exclusion(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:exclusion, data}, fn _, value ->
       if value in data, do:
-        [{field, {message(opts, "is reserved"), [validation: :exclusion, enum: data]}}], else: []
+        [{field, {message(opts, "is reserved"), [validation: :exclusion, enum: Enum.to_list(data)]}}], else: []
     end
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -915,6 +915,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
     assert changeset.errors == [title: {"yada", [validation: :inclusion, enum: ~w(world)]}]
+
+    changeset =
+      changeset(%{"title" => "hello"})
+      |> validate_inclusion(:title, MapSet.new(["world"]))
+    refute changeset.valid?
+    assert changeset.errors == [title: {"is invalid", [validation: :inclusion, enum: ~w(world)]}]
+    assert validations(changeset) == [title: {:inclusion, MapSet.new(["world"])}]
   end
 
   test "validate_subset/3" do
@@ -936,6 +943,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"topics" => ["laptop"]})
       |> validate_subset(:topics, ~w(cat dog), message: "yada")
     assert changeset.errors == [topics: {"yada", [validation: :subset, enum: ~w(cat dog)]}]
+
+    changeset =
+      changeset(%{"topics" => ["cat", "laptop"]})
+      |> validate_subset(:topics, MapSet.new(["cat", "dog"]))
+    refute changeset.valid?
+    assert changeset.errors == [topics: {"has an invalid entry", [validation: :subset, enum: ~w(cat dog)]}]
+    assert validations(changeset) == [topics: {:subset, MapSet.new(["cat", "dog"])}]
   end
 
   test "validate_exclusion/3" do
@@ -957,6 +971,13 @@ defmodule Ecto.ChangesetTest do
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world), message: "yada")
     assert changeset.errors == [title: {"yada", [validation: :exclusion, enum: ~w(world)]}]
+
+    changeset =
+      changeset(%{"title" => "world"})
+      |> validate_exclusion(:title, MapSet.new(["world"]))
+    refute changeset.valid?
+    assert changeset.errors == [title: {"is reserved", [validation: :exclusion, enum: ~w(world)]}]
+    assert validations(changeset) == [title: {:exclusion, MapSet.new(["world"])}]
   end
 
   test "validate_length/3 with string" do


### PR DESCRIPTION
Returning the enum as is means that the field may not always implement
`String.Chars`, a protocol that downstream code (such as Phoenix)
depended upon.

Closes https://github.com/elixir-ecto/ecto/issues/2991