### PR TITLE
Add test for union select fields

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1026,7 +1026,7 @@ defmodule Ecto.Query.Planner do
 
     combinations =
       Enum.map query.combinations, fn {type, combination_query} ->
-        {combination_query, _} = normalize_select(combination_query)
+        {combination_query, _} = combination_query |> normalize_select() |> remove_literals()
         {type, combination_query}
       end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -569,6 +569,12 @@ defmodule Ecto.Query.PlannerTest do
            select_fields([:id, :post_title, :text, :code, :posted, :visits, :links], 0) ++
            [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
 
+    union_query = from(Post, []) |> select([p], %{title: p.title, category: "Post"})
+    query = from(Post, []) |> select([p], %{title: p.title, category: "Post"}) |> union(^union_query) |>  normalize()
+
+    union_query = query.combinations |> List.first() |> elem(1)
+    assert query.select.fields == union_query.select.fields
+
     query =
       from(Post, [])
       |> join(:inner, [_], c in Comment)


### PR DESCRIPTION
Adds a test for union select fields to verify that they are normalized equally.

I'm not quite sure if this is the cause of the missing column from unions in https://github.com/elixir-ecto/ecto/issues/2997, but I did confirm it is behaving differently from 3.0.0 (test passes) and 3.1.4 (test fails).