### PR TITLE
Allow handling nil values in custom type

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -473,6 +473,10 @@ defmodule Ecto.Type do
     load_embed(embed, value, &load/2)
   end
 
+  def load(mod, nil) when is_atom(mod) do
+    if can_handle_nil?(mod), do: mod.load(nil), else: {:ok, nil}
+  end
+
   def load(_type, nil) do
     {:ok, nil}
   end
@@ -681,6 +685,11 @@ defmodule Ecto.Type do
   @spec cast(t, term) :: {:ok, term} | {:error, keyword()} | :error
   def cast({:embed, type}, value), do: cast_embed(type, value)
   def cast({:in, _type}, nil), do: :error
+
+  def cast(mod, nil) when is_atom(mod) do
+    if can_handle_nil?(mod), do: mod.cast(nil), else: {:ok, nil}
+  end
+
   def cast(_type, nil), do: {:ok, nil}
 
   def cast(type, value) do
@@ -1245,4 +1254,10 @@ defmodule Ecto.Type do
         """
     end
   end
+
+  @spec can_handle_nil?(atom) :: boolean
+  defp can_handle_nil?(mod) do
+    function_exported?(mod, :handle_nil, 0) and mod.handle_nil()
+  end
+
 end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -19,6 +19,18 @@ defmodule Ecto.TypeTest do
     def cast(_),   do: {:ok, :cast}
   end
 
+  defmodule CustomMaybe do
+    @behaviour Ecto.Type
+
+    def type, do: :any
+    def load(nil), do: {:ok, {:nothing}}
+    def cast(nil), do: {:ok, {:nothing}}
+    def dump({:nothing}), do: {:ok, nil}
+
+    def handle_nil, do: true
+  end
+
+
   defmodule Schema do
     use Ecto.Schema
 
@@ -119,6 +131,12 @@ defmodule Ecto.TypeTest do
 
     assert load({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) == {:ok, %{"a" => :used}}
     assert dump({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) == {:ok, %{"a" => :used}}
+  end
+
+  test "custom types that can handle nil" do
+    assert load(CustomMaybe, nil) == {:ok, {:nothing}}
+    assert cast(CustomMaybe, nil) == {:ok, {:nothing}}
+    assert dump(CustomMaybe, {:nothing}) == {:ok, nil}
   end
 
   test "dump with custom function" do


### PR DESCRIPTION
I had a similar type as mentioned: in https://github.com/elixir-ecto/ecto/issues/2576
Although the documentation clearly states that `nil` is bypassed, it's not clear why?
It is clearly an edge case, but  I'd still like to propose an _opt in_ mechanism to allow custom types to handle nil values if they really want to.