### PR TITLE
Support {:fragment, ...} in assoc :where

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -293,6 +293,11 @@ defmodule Ecto.Association do
           expr = {:and, [], [expr, {:not, [], [{:is_nil, [], [to_field(binding, key)]}]}]}
           {expr, params, counter}
 
+        {key, {:fragment, frag}}, {expr, params, counter} when is_binary(frag) ->
+          pieces = Ecto.Query.Builder.fragment_pieces(frag, [to_field(binding, key)])
+          expr = {:and, [], [expr, {:fragment, [], pieces}]}
+          {expr, params, counter}
+
         {key, {:in, value}}, {expr, params, counter} when is_list(value) ->
           expr = {:and, [], [expr, {:in, [], [to_field(binding, key), {:^, [], [counter]}]}]}
           {expr, [{value, {:in, {binding, key}}} | params], counter + 1}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -461,6 +461,13 @@ defmodule Ecto.Query.Builder do
   defp split_fragment(<<first :: utf8, rest :: binary>>, consumed),
     do: split_fragment(rest, consumed <> <<first :: utf8>>)
 
+  @doc "Returns fragment pieces, given a fragment string and arguments."
+  def fragment_pieces(frag, args) do
+    frag
+    |> split_fragment("")
+    |> merge_fragments(args)
+  end
+
   defp escape_window_description([], params_acc, _vars, _env),
     do: {[], params_acc}
   defp escape_window_description([window_name], params_acc, _vars, _env) when is_atom(window_name),

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -764,6 +764,9 @@ defmodule Ecto.Schema do
     * `nil` - which specifies the field must be nil
     * `{:not, nil}` - which specifies the field must not be nil
     * `{:in, list}` - which specifies the field must be one of the values in a list
+    * `{:fragment, expr}` - which specifies a fragment string as the filter
+      (see `Ecto.Query.API.fragment/1`) with the field's value given to it
+      as the only argument
     * or any other value which the field is compared directly against
 
   Note the values above are distinctly different from the values you

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -40,6 +40,7 @@ defmodule Ecto.Query.PlannerTest do
       belongs_to :comment, Comment
       belongs_to :post, Post
       belongs_to :special_comment, Comment, where: [text: nil]
+      belongs_to :special_long_comment, Comment, where: [text: {:fragment, "LEN(?) > 100"}]
 
       field :deleted, :boolean
     end
@@ -288,19 +289,22 @@ defmodule Ecto.Query.PlannerTest do
                    join: c1 in assoc(p, :special_comments),
                    join: p2 in assoc(c1, :post),
                    join: cp in assoc(c1, :comment_posts),
-                   join: c2 in assoc(cp, :special_comment))
+                   join: c2 in assoc(cp, :special_comment),
+                   join: c3 in assoc(cp, :special_long_comment))
                    |> plan
                    |> elem(0)
 
-    assert [join1, join2, join3, join4] = query.joins
+    assert [join1, join2, join3, join4, join5] = query.joins
     assert {{"posts", _, _}, {"comments", _, _}, {"posts", _, _},
-            {"comment_posts", _, _}, {"comments", _, _}} = query.sources
+            {"comment_posts", _, _}, {"comments", _, _}, {"comments", _, _}} = query.sources
 
     assert Macro.to_string(join1.on.expr) =~
            ~r"&1.post_id\(\) == &0.id\(\) and not[\s\(]is_nil\(&1.text\(\)\)\)?"
     assert Macro.to_string(join2.on.expr) == "&2.id() == &1.post_id()"
     assert Macro.to_string(join3.on.expr) == "&3.comment_id() == &1.id()"
     assert Macro.to_string(join4.on.expr) == "&4.id() == &3.special_comment_id() and is_nil(&4.text())"
+    assert Macro.to_string(join5.on.expr) ==
+           "&5.id() == &3.special_long_comment_id() and fragment({:raw, \"LEN(\"}, {:expr, &5.text()}, {:raw, \") > 100\"})"
   end
 
   test "plan: cannot associate without schema" do


### PR DESCRIPTION
Before 3.0.5, we were using dynamic expressions with the `:where` option for filtering out associations based on the current timestamp. In my opinion this was really useful for auto-expiring rows, soft deletes, etc. After updating to 3.0.5, I think it’s a little too easy to forget to filter those rows out at query/preload time when it’s almost always needed.

Based on comments in earlier PRs, I’m under the impression the feature was removed because of compilation time problems related to the MFA tuples. (Please correct me if I’m wrong!) I’d like to propose another way to define dynamic associations at compilation time using fragments instead of dynamic expressions:

```
  where: [expires_at: {:fragment, "? > now()"}]
```

I feel like this filter would be a fairly natural extension to the existing filters like `{:in, [...]}`. A single fragment argument should cover most use cases, and more complicated filtering logic could be pushed down to the database by defining functions. (Although I don’t think doing anything more complicated is necessarily a good idea.)

I’m open to doing the work if you feel like this could be worth exploring, however I could use some guidance with how this should be handled internally because I’m not super familiar with the codebase. I hacked together something that seems to work, but crossing the `Ecto.Query.Builder` boundary feels gross and I think this needs some type checks.