### PR TITLE
Add custom composite types

### DIFF
--- a/integration_test/support/types.exs
+++ b/integration_test/support/types.exs
@@ -14,3 +14,15 @@ defmodule Custom.Permalink do
   def load(integer) when is_integer(integer), do: {:ok, integer}
   def dump(integer) when is_integer(integer), do: {:ok, integer}
 end
+
+defmodule Custom.Composite do
+  def type, do: :any
+
+  def cast(nil), do: {:ok, :none}
+  def cast(value), do: {:ok, {:some, value}}
+
+  def load(nil), do: {:ok, :none}
+  def load(value), do: {:ok, {:some, value}}
+  def dump({:some, value}), do: {:ok, value}
+  def dump(:none), do: {:ok, nil}
+end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2013,7 +2013,10 @@ defmodule Ecto.Schema do
       Ecto.Type.primitive?(type) ->
         type
 
-      is_atom(type) and Code.ensure_compiled?(type) and function_exported?(type, :type, 0) ->
+      custom_type?(type) ->
+        type
+
+      composite_type?(type) ->
         type
 
       is_atom(type) and function_exported?(type, :__schema__, 1) ->
@@ -2024,6 +2027,16 @@ defmodule Ecto.Schema do
       true ->
         raise ArgumentError, "invalid or unknown type #{inspect type} for field #{inspect name}"
     end
+  end
+
+  defp composite_type?({wrapper, type}) do
+    custom_type?(wrapper) || custom_type?(type)
+  end
+
+  defp composite_type?(_), do: false
+
+  defp custom_type?(type) do
+    is_atom(type) and Code.ensure_compiled?(type) and function_exported?(type, :type, 0)
   end
 
   defp store_mfa_autogenerate!(mod, name, type, mfa) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -305,6 +305,14 @@ defmodule Ecto.Type do
 
   """
   @spec dump(t, term) :: {:ok, term} | :error
+
+  def dump({custom_composite, type}, value) when custom_composite not in @composite do
+    case dump_fun(custom_composite).(value) do
+      {:ok, term} -> dump(type, term)
+      :error -> :error
+    end
+  end
+
   def dump(_type, nil) do
     {:ok, nil}
   end
@@ -471,6 +479,13 @@ defmodule Ecto.Type do
   @spec load(t, term) :: {:ok, term} | :error
   def load({:embed, embed}, value) do
     load_embed(embed, value, &load/2)
+  end
+
+  def load({custom_composite, type}, value) when custom_composite not in @composite do
+    case load(type, value) do
+      {:ok, term} -> load_fun(custom_composite).(term)
+      :error -> :error
+    end
   end
 
   def load(_type, nil) do
@@ -681,6 +696,14 @@ defmodule Ecto.Type do
   @spec cast(t, term) :: {:ok, term} | {:error, keyword()} | :error
   def cast({:embed, type}, value), do: cast_embed(type, value)
   def cast({:in, _type}, nil), do: :error
+
+  def cast({custom_composite, type}, value) when custom_composite not in @composite do
+    case cast(type, value) do
+      {:ok, term} -> cast_fun(custom_composite).(term)
+      :error -> :error
+    end
+  end
+
   def cast(_type, nil), do: {:ok, nil}
 
   def cast(type, value) do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -14,6 +14,7 @@ defmodule Ecto.SchemaTest do
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
       field :query_excluded_field, :string, load_in_query: false
+      field :custom_composite, {Custom.Composite, :string}
       belongs_to :comment, Comment
       belongs_to :permalink, Permalink, define_field: false
     end
@@ -22,8 +23,8 @@ defmodule Ecto.SchemaTest do
   test "schema metadata" do
     assert Schema.__schema__(:source)             == "my schema"
     assert Schema.__schema__(:prefix)             == nil
-    assert Schema.__schema__(:fields)             == [:id, :name, :email, :count, :array, :uuid, :query_excluded_field, :comment_id]
-    assert Schema.__schema__(:query_fields)       == [:id, :name, :email, :count, :array, :uuid, :comment_id]
+    assert Schema.__schema__(:fields)             == [:id, :name, :email, :count, :array, :uuid, :query_excluded_field, :custom_composite, :comment_id]
+    assert Schema.__schema__(:query_fields)       == [:id, :name, :email, :count, :array, :uuid, :custom_composite, :comment_id]
     assert Schema.__schema__(:read_after_writes)  == [:email, :count]
     assert Schema.__schema__(:primary_key)        == [:id]
     assert Schema.__schema__(:autogenerate_id)    == {:id, :id, :id}
@@ -50,7 +51,7 @@ defmodule Ecto.SchemaTest do
   test "changeset metadata" do
     assert Schema.__changeset__ |> Map.drop([:comment, :permalink]) ==
            %{name: :string, email: :string, count: :decimal, array: {:array, :string},
-             comment_id: :id, temp: :any, id: :id, uuid: Ecto.UUID, query_excluded_field: :string}
+             comment_id: :id, temp: :any, id: :id, uuid: Ecto.UUID, custom_composite: {Custom.Composite, :string}, query_excluded_field: :string}
   end
 
   test "autogenerate metadata (private)" do


### PR DESCRIPTION
For example, it allows a schema with:

```
schema "my schema" do
  field :field_a, {CustomType, :string}
end
```

There was originally an issue for this https://github.com/elixir-ecto/ecto/issues/1871#issuecomment-302340748:

I'm looking for early feedback before I proceed any further to make sure that I'm heading in the right direction and that a PR for this feature would be accepted. Thank you!