### PR TITLE
Assign repo_opts to changeset to make it available down the chain

### DIFF
--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -704,20 +704,20 @@ defmodule Ecto.RepoTest do
     test "insert, update, insert_or_update and delete errors on invalid changeset" do
       invalid = %Ecto.Changeset{valid?: false, data: %MySchema{}}
 
-      insert = %{invalid | action: :insert, repo: TestRepo}
-      assert {:error, ^insert} = TestRepo.insert(invalid)
-      assert {:error, ^insert} = TestRepo.insert_or_update(invalid)
+      insert = %{invalid | action: :insert, repo: TestRepo, repo_opts: [prefix: "prefix"]}
+      assert {:error, ^insert} = TestRepo.insert(invalid, prefix: "prefix")
+      assert {:error, ^insert} = TestRepo.insert_or_update(invalid, prefix: "prefix")
 
-      update = %{invalid | action: :update, repo: TestRepo}
-      assert {:error, ^update} = TestRepo.update(invalid)
+      update = %{invalid | action: :update, repo: TestRepo, repo_opts: [prefix: "prefix"]}
+      assert {:error, ^update} = TestRepo.update(invalid, prefix: "prefix")
 
-      delete = %{invalid | action: :delete, repo: TestRepo}
-      assert {:error, ^delete} = TestRepo.delete(invalid)
+      delete = %{invalid | action: :delete, repo: TestRepo, repo_opts: [prefix: "prefix"]}
+      assert {:error, ^delete} = TestRepo.delete(invalid, prefix: "prefix")
 
-      ignore = %{invalid | action: :ignore, repo: TestRepo}
-      assert {:error, ^insert} = TestRepo.insert(ignore)
-      assert {:error, ^update} = TestRepo.update(ignore)
-      assert {:error, ^delete} = TestRepo.delete(ignore)
+      ignore = %{invalid | action: :ignore, repo: TestRepo, repo_opts: [prefix: "prefix"]}
+      assert {:error, ^insert} = TestRepo.insert(ignore, prefix: "prefix")
+      assert {:error, ^update} = TestRepo.update(ignore, prefix: "prefix")
+      assert {:error, ^delete} = TestRepo.delete(ignore, prefix: "prefix")
 
       assert_raise ArgumentError, ~r"a valid changeset with action :ignore was given to Ecto.TestRepo.insert/2", fn ->
         TestRepo.insert(%{ignore | valid?: true})


### PR DESCRIPTION
I'm using [Triplex](https://hexdocs.pm/triplex/readme.html) for multi-tenancy and I had an issue with the [Pow email confirmation extension](https://hexdocs.pm/pow/pow_email_confirmation.html) where it [tries to get the prefix using the repo_opts option on the changeset](https://github.com/danschultzer/pow/blob/e3f8a0638dd4ad32f61f89cf2522cc1bd81e6f5e/lib/extensions/email_confirmation/ecto/schema.ex#L77) for validating an email is unique but Ecto doesn't pass it down the line. This commit solves this.

Otherwise you need to do something like this:

```elixir
user
|> User.changeset(attrs)
|> Map.put(:repo_opts, [prefix: tenant])
|> Repo.update(prefix: tenant)
```

Instead of this
```elixir
user
|> User.changeset(attrs)
|> Repo.update(prefix: tenant)
```