### PR TITLE
Correct type signature of Changeset.cast

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -456,7 +456,7 @@ defmodule Ecto.Changeset do
   """
   @spec cast(Ecto.Schema.t | t | {data, types},
              %{binary => term} | %{atom => term} | :invalid,
-             [String.t | atom],
+             [atom],
              Keyword.t) :: t
   def cast(data, params, permitted, opts \\ [])
 


### PR DESCRIPTION
The implementation of `Changeset.cast` explicitly checks that all keys in the `permitted` list are atoms https://github.com/elixir-ecto/ecto/blob/fb6bae393e7522d0e0d514fc2e8b2930cccd62dd/lib/ecto/changeset.ex#L489 and raise otherwise.
Type spec allowed either atoms or strings there which is incorrect. I got confused today because it appears in the generated documentation https://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4
This PR fixes the type spec.