### PR TITLE
UUID cast error

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -730,6 +730,7 @@ defmodule Ecto.Type do
   defp cast_fun({:in, type}), do: &array(&1, cast_fun(type), [])
   defp cast_fun({:array, type}), do: &array(&1, cast_fun(type), [])
   defp cast_fun({:map, type}), do: &map(&1, cast_fun(type), %{})
+  defp cast_fun(:uuid), do: &Ecto.UUID.cast(&1)
   defp cast_fun(mod) when is_atom(mod), do: &mod.cast(&1)
 
   defp cast_integer(term) when is_binary(term) do

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -80,19 +80,33 @@ defmodule Ecto.Type do
   import Kernel, except: [match?: 2]
 
   @typedoc "An Ecto type, primitive or custom."
-  @type t         :: primitive | custom
+  @type t :: primitive | custom
 
   @typedoc "Primitive Ecto types (handled by Ecto)."
   @type primitive :: base | composite
 
   @typedoc "Custom types are represented by user-defined modules."
-  @type custom    :: module
+  @type custom :: module
 
-  @typep base      :: :integer | :float | :boolean | :string | :map |
-                      :binary | :decimal | :id | :binary_id |
-                      :utc_datetime | :naive_datetime | :date | :time | :any |
-                      :utc_datetime_usec | :naive_datetime_usec | :time_usec
-  @typep composite :: {:array, t} | {:map, t} | {:embed, Ecto.Embedded.t} | {:in, t}
+  @typep base ::
+           :integer
+           | :float
+           | :boolean
+           | :string
+           | :map
+           | :binary
+           | :decimal
+           | :id
+           | :binary_id
+           | :utc_datetime
+           | :naive_datetime
+           | :date
+           | :time
+           | :any
+           | :utc_datetime_usec
+           | :naive_datetime_usec
+           | :time_usec
+  @typep composite :: {:array, t} | {:map, t} | {:embed, Ecto.Embedded.t()} | {:in, t}
 
   @base ~w(
     integer float decimal boolean string map binary id binary_id any
@@ -264,7 +278,7 @@ defmodule Ecto.Type do
     end
   end
 
-  defp do_match?(_left, :any),  do: true
+  defp do_match?(_left, :any), do: true
   defp do_match?(:any, _right), do: true
   defp do_match?({outer, left}, {outer, right}), do: match?(left, right)
   defp do_match?({:array, :any}, {:embed, %{cardinality: :many}}), do: true
@@ -397,8 +411,8 @@ defmodule Ecto.Type do
   defp dump_time_usec(%Time{} = term), do: {:ok, check_usec!(term, :time_usec)}
   defp dump_time_usec(_), do: :error
 
-  defp dump_naive_datetime(%NaiveDateTime{} = term), do:
-    {:ok, check_no_usec!(term, :naive_datetime)}
+  defp dump_naive_datetime(%NaiveDateTime{} = term),
+    do: {:ok, check_no_usec!(term, :naive_datetime)}
 
   defp dump_naive_datetime(_), do: :error
 
@@ -421,13 +435,13 @@ defmodule Ecto.Type do
 
   defp dump_utc_datetime_usec(_), do: :error
 
-  defp dump_embed(%{cardinality: :one, related: schema, field: field},
-                  value, fun) when is_map(value) do
+  defp dump_embed(%{cardinality: :one, related: schema, field: field}, value, fun)
+       when is_map(value) do
     {:ok, dump_embed(field, schema, value, schema.__schema__(:dump), fun)}
   end
 
-  defp dump_embed(%{cardinality: :many, related: schema, field: field},
-                  value, fun) when is_list(value) do
+  defp dump_embed(%{cardinality: :many, related: schema, field: field}, value, fun)
+       when is_list(value) do
     types = schema.__schema__(:dump)
     {:ok, Enum.map(value, &dump_embed(field, schema, &1, types, fun))}
   end
@@ -443,15 +457,17 @@ defmodule Ecto.Type do
       case dumper.(type, value) do
         {:ok, value} ->
           Map.put(acc, source, value)
+
         :error ->
-          raise ArgumentError, "cannot dump `#{inspect value}` as type #{inspect type} " <>
-                               "for field `#{field}` in schema #{inspect schema}"
+          raise ArgumentError,
+                "cannot dump `#{inspect(value)}` as type #{inspect(type)} " <>
+                  "for field `#{field}` in schema #{inspect(schema)}"
       end
     end)
   end
 
   defp dump_embed(field, _schema, value, _types, _fun) do
-    raise ArgumentError, "cannot dump embed `#{field}`, invalid value: #{inspect value}"
+    raise ArgumentError, "cannot dump embed `#{field}`, invalid value: #{inspect(value)}"
   end
 
   @doc """
@@ -544,7 +560,9 @@ defmodule Ecto.Type do
   # the adapter will either explicitly error (Postgres) or it will
   # accept the data (MySQL), which is fine as we always assume UTC
   defp load_naive_datetime(%DateTime{} = datetime),
-    do: {:ok, datetime |> check_utc_timezone!(:naive_datetime) |> DateTime.to_naive() |> truncate_usec()}
+    do:
+      {:ok,
+       datetime |> check_utc_timezone!(:naive_datetime) |> DateTime.to_naive() |> truncate_usec()}
 
   defp load_naive_datetime(%NaiveDateTime{} = naive_datetime),
     do: {:ok, truncate_usec(naive_datetime)}
@@ -552,7 +570,9 @@ defmodule Ecto.Type do
   defp load_naive_datetime(_), do: :error
 
   defp load_naive_datetime_usec(%DateTime{} = datetime),
-    do: {:ok, datetime |> check_utc_timezone!(:naive_datetime_usec) |> DateTime.to_naive() |> pad_usec()}
+    do:
+      {:ok,
+       datetime |> check_utc_timezone!(:naive_datetime_usec) |> DateTime.to_naive() |> pad_usec()}
 
   defp load_naive_datetime_usec(%NaiveDateTime{} = naive_datetime),
     do: {:ok, pad_usec(naive_datetime)}
@@ -581,15 +601,15 @@ defmodule Ecto.Type do
 
   defp load_embed(%{cardinality: :one}, nil, _fun), do: {:ok, nil}
 
-  defp load_embed(%{cardinality: :one, related: schema, field: field},
-                  value, fun) when is_map(value) do
+  defp load_embed(%{cardinality: :one, related: schema, field: field}, value, fun)
+       when is_map(value) do
     {:ok, load_embed(field, schema, value, fun)}
   end
 
   defp load_embed(%{cardinality: :many}, nil, _fun), do: {:ok, []}
 
-  defp load_embed(%{cardinality: :many, related: schema, field: field},
-                  value, fun) when is_list(value) do
+  defp load_embed(%{cardinality: :many, related: schema, field: field}, value, fun)
+       when is_list(value) do
     {:ok, Enum.map(value, &load_embed(field, schema, &1, fun))}
   end
 
@@ -602,7 +622,7 @@ defmodule Ecto.Type do
   end
 
   defp load_embed(field, _schema, value, _fun) do
-    raise ArgumentError, "cannot load embed `#{field}`, invalid value: #{inspect value}"
+    raise ArgumentError, "cannot load embed `#{field}`, invalid value: #{inspect(value)}"
   end
 
   @doc """
@@ -677,6 +697,9 @@ defmodule Ecto.Type do
       iex> cast(:string, [1, 2, 3])
       :error
 
+      iex> cast(:uuid, "240d1a54-2f3d-43a4-85b9-3ef5ac702feb")
+      {:ok, "240d1a54-2f3d-43a4-85b9-3ef5ac702feb"}
+
   """
   @spec cast(t, term) :: {:ok, term} | {:error, keyword()} | :error
   def cast({:embed, type}, value), do: cast_embed(type, value)
@@ -730,7 +753,7 @@ defmodule Ecto.Type do
   defp cast_float(term) when is_integer(term), do: {:ok, :erlang.float(term)}
   defp cast_float(_), do: :error
 
-  defp cast_boolean(term) when term in ~w(true 1),  do: {:ok, true}
+  defp cast_boolean(term) when term in ~w(true 1), do: {:ok, true}
   defp cast_boolean(term) when term in ~w(false 0), do: {:ok, false}
   defp cast_boolean(term) when is_boolean(term), do: {:ok, term}
   defp cast_boolean(_), do: :error
@@ -753,11 +776,13 @@ defmodule Ecto.Type do
   end
 
   defp cast_embed(%{cardinality: :one}, nil), do: {:ok, nil}
+
   defp cast_embed(%{cardinality: :one, related: schema}, %{__struct__: schema} = struct) do
     {:ok, struct}
   end
 
   defp cast_embed(%{cardinality: :many}, nil), do: {:ok, []}
+
   defp cast_embed(%{cardinality: :many, related: schema}, value) when is_list(value) do
     if Enum.all?(value, &Kernel.match?(%{__struct__: ^schema}, &1)) do
       {:ok, value}
@@ -783,9 +808,11 @@ defmodule Ecto.Type do
   def adapter_load(_adapter, {:embed, embed}, nil) do
     load_embed(embed, nil, &load/2)
   end
+
   def adapter_load(_adapter, _type, nil) do
     {:ok, nil}
   end
+
   def adapter_load(adapter, type, value) do
     if of_base_type?(type, value) do
       {:ok, value}
@@ -796,25 +823,32 @@ defmodule Ecto.Type do
 
   defp process_loaders(_, :error, _adapter),
     do: :error
-  defp process_loaders([fun|t], {:ok, value}, adapter) when is_function(fun),
+
+  defp process_loaders([fun | t], {:ok, value}, adapter) when is_function(fun),
     do: process_loaders(t, fun.(value), adapter)
-  defp process_loaders([type|t], {:ok, value}, adapter),
+
+  defp process_loaders([type | t], {:ok, value}, adapter),
     do: process_loaders(t, load(type, value, &adapter_load(adapter, &1, &2)), adapter)
+
   defp process_loaders([], {:ok, _} = acc, _adapter),
     do: acc
 
   @doc false
   def adapter_dump(_adapter, type, nil),
     do: dump(type, nil)
+
   def adapter_dump(adapter, type, value),
     do: process_dumpers(adapter.dumpers(type(type), type), {:ok, value}, adapter)
 
   defp process_dumpers(_, :error, _adapter),
     do: :error
-  defp process_dumpers([fun|t], {:ok, value}, adapter) when is_function(fun),
+
+  defp process_dumpers([fun | t], {:ok, value}, adapter) when is_function(fun),
     do: process_dumpers(t, fun.(value), adapter)
-  defp process_dumpers([type|t], {:ok, value}, adapter),
+
+  defp process_dumpers([type | t], {:ok, value}, adapter),
     do: process_dumpers(t, dump(type, value, &adapter_dump(adapter, &1, &2)), adapter)
+
   defp process_dumpers([], {:ok, _} = acc, _adapter),
     do: acc
 
@@ -824,6 +858,7 @@ defmodule Ecto.Type do
     case Date.from_iso8601(binary) do
       {:ok, _} = ok ->
         ok
+
       {:error, _} ->
         case NaiveDateTime.from_iso8601(binary) do
           {:ok, naive_datetime} -> {:ok, NaiveDateTime.to_date(naive_datetime)}
@@ -831,23 +866,30 @@ defmodule Ecto.Type do
         end
     end
   end
+
   defp cast_date(%{"year" => empty, "month" => empty, "day" => empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_date(%{year: empty, month: empty, day: empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_date(%{"year" => year, "month" => month, "day" => day}),
     do: cast_date(to_i(year), to_i(month), to_i(day))
+
   defp cast_date(%{year: year, month: month, day: day}),
     do: cast_date(to_i(year), to_i(month), to_i(day))
+
   defp cast_date(_),
     do: :error
 
-  defp cast_date(year, month, day) when is_integer(year) and is_integer(month) and is_integer(day) do
+  defp cast_date(year, month, day)
+       when is_integer(year) and is_integer(month) and is_integer(day) do
     case Date.new(year, month, day) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_date(_, _, _),
     do: :error
 
@@ -855,39 +897,66 @@ defmodule Ecto.Type do
 
   defp cast_time(<<hour::2-bytes, ?:, minute::2-bytes>>),
     do: cast_time(to_i(hour), to_i(minute), 0, nil)
+
   defp cast_time(binary) when is_binary(binary) do
     case Time.from_iso8601(binary) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_time(%{"hour" => empty, "minute" => empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_time(%{hour: empty, minute: empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_time(%{"hour" => hour, "minute" => minute} = map),
-    do: cast_time(to_i(hour), to_i(minute), to_i(Map.get(map, "second")), to_i(Map.get(map, "microsecond")))
-  defp cast_time(%{hour: hour, minute: minute, second: second, microsecond: {microsecond, precision}}),
-    do: cast_time(to_i(hour), to_i(minute), to_i(second), {to_i(microsecond), to_i(precision)})
+    do:
+      cast_time(
+        to_i(hour),
+        to_i(minute),
+        to_i(Map.get(map, "second")),
+        to_i(Map.get(map, "microsecond"))
+      )
+
+  defp cast_time(%{
+         hour: hour,
+         minute: minute,
+         second: second,
+         microsecond: {microsecond, precision}
+       }),
+       do: cast_time(to_i(hour), to_i(minute), to_i(second), {to_i(microsecond), to_i(precision)})
+
   defp cast_time(%{hour: hour, minute: minute} = map),
-    do: cast_time(to_i(hour), to_i(minute), to_i(Map.get(map, :second)), to_i(Map.get(map, :microsecond)))
+    do:
+      cast_time(
+        to_i(hour),
+        to_i(minute),
+        to_i(Map.get(map, :second)),
+        to_i(Map.get(map, :microsecond))
+      )
+
   defp cast_time(_),
     do: :error
 
   defp cast_time(hour, minute, sec, usec) when is_integer(usec) do
     cast_time(hour, minute, sec, {usec, 6})
   end
+
   defp cast_time(hour, minute, sec, nil) do
     cast_time(hour, minute, sec, {0, 0})
   end
+
   defp cast_time(hour, minute, sec, {usec, precision})
        when is_integer(hour) and is_integer(minute) and
-            (is_integer(sec) or is_nil(sec)) and is_integer(usec) and is_integer(precision) do
+              (is_integer(sec) or is_nil(sec)) and is_integer(usec) and is_integer(precision) do
     case Time.new(hour, minute, sec || 0, {usec, precision}) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_time(_, _, _, _) do
     :error
   end
@@ -900,7 +969,10 @@ defmodule Ecto.Type do
     end
   end
 
-  defp cast_naive_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:, minute::2-bytes>>)
+  defp cast_naive_datetime(
+         <<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:,
+           minute::2-bytes>>
+       )
        when sep in [?\s, ?T] do
     case NaiveDateTime.new(to_i(year), to_i(month), to_i(day), to_i(hour), to_i(minute), 0) do
       {:ok, _} = ok -> ok
@@ -915,13 +987,19 @@ defmodule Ecto.Type do
     end
   end
 
-  defp cast_naive_datetime(%{"year" => empty, "month" => empty, "day" => empty,
-                             "hour" => empty, "minute" => empty}) when empty in ["", nil],
-    do: {:ok, nil}
+  defp cast_naive_datetime(%{
+         "year" => empty,
+         "month" => empty,
+         "day" => empty,
+         "hour" => empty,
+         "minute" => empty
+       })
+       when empty in ["", nil],
+       do: {:ok, nil}
 
-  defp cast_naive_datetime(%{year: empty, month: empty, day: empty,
-                             hour: empty, minute: empty}) when empty in ["", nil],
-    do: {:ok, nil}
+  defp cast_naive_datetime(%{year: empty, month: empty, day: empty, hour: empty, minute: empty})
+       when empty in ["", nil],
+       do: {:ok, nil}
 
   defp cast_naive_datetime(%{} = map) do
     with {:ok, date} <- cast_date(map),
@@ -945,7 +1023,10 @@ defmodule Ecto.Type do
     end
   end
 
-  defp cast_utc_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:, minute::2-bytes>>)
+  defp cast_utc_datetime(
+         <<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:,
+           minute::2-bytes>>
+       )
        when sep in [?\s, ?T] do
     case NaiveDateTime.new(to_i(year), to_i(month), to_i(day), to_i(hour), to_i(minute), 0) do
       {:ok, naive_datetime} -> {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
@@ -955,28 +1036,37 @@ defmodule Ecto.Type do
 
   defp cast_utc_datetime(binary) when is_binary(binary) do
     case DateTime.from_iso8601(binary) do
-      {:ok, datetime, _offset} -> {:ok, datetime}
+      {:ok, datetime, _offset} ->
+        {:ok, datetime}
+
       {:error, :missing_offset} ->
         case NaiveDateTime.from_iso8601(binary) do
           {:ok, naive_datetime} -> {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
           {:error, _} -> :error
         end
-      {:error, _} -> :error
+
+      {:error, _} ->
+        :error
     end
   end
+
   defp cast_utc_datetime(%DateTime{time_zone: "Etc/UTC"} = datetime), do: {:ok, datetime}
+
   defp cast_utc_datetime(%DateTime{} = datetime) do
-    case (datetime |> DateTime.to_unix(:microsecond) |> DateTime.from_unix(:microsecond)) do
+    case datetime |> DateTime.to_unix(:microsecond) |> DateTime.from_unix(:microsecond) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_utc_datetime(value) do
     case cast_naive_datetime(value) do
       {:ok, %NaiveDateTime{} = naive_datetime} ->
         {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
+
       {:ok, _} = ok ->
         ok
+
       :error ->
         :error
     end
@@ -1010,7 +1100,10 @@ defmodule Ecto.Type do
   defp equal_fun(:decimal), do: &equal_decimal?/2
   defp equal_fun(t) when t in [:time, :time_usec], do: &equal_time?/2
   defp equal_fun(t) when t in [:utc_datetime, :utc_datetime_usec], do: &equal_utc_datetime?/2
-  defp equal_fun(t) when t in [:naive_datetime, :naive_datetime_usec], do: &equal_naive_datetime?/2
+
+  defp equal_fun(t) when t in [:naive_datetime, :naive_datetime_usec],
+    do: &equal_naive_datetime?/2
+
   defp equal_fun(t) when t in @base, do: nil
 
   defp equal_fun({:array, type}) do
@@ -1042,6 +1135,7 @@ defmodule Ecto.Type do
 
   defp equal_naive_datetime?(%NaiveDateTime{} = a, %NaiveDateTime{} = b),
     do: NaiveDateTime.compare(a, b) == :eq
+
   defp equal_naive_datetime?(_, _),
     do: false
 
@@ -1124,6 +1218,7 @@ defmodule Ecto.Type do
   defp map([{key, nil} | t], fun, acc) do
     map(t, fun, Map.put(acc, key, nil))
   end
+
   defp map([{key, value} | t], fun, acc) do
     case fun.(value) do
       {:ok, value} -> map(t, fun, Map.put(acc, key, value))
@@ -1172,6 +1267,7 @@ defmodule Ecto.Type do
 
   defp to_i(nil), do: nil
   defp to_i(int) when is_integer(int), do: int
+
   defp to_i(bin) when is_binary(bin) do
     case Integer.parse(bin) do
       {int, ""} -> int
@@ -1208,7 +1304,7 @@ defmodule Ecto.Type do
 
   defp check_utc_timezone!(datetime, kind) do
     raise ArgumentError,
-          "#{inspect kind} expects the time zone to be \"Etc/UTC\", got `#{inspect(datetime)}`"
+          "#{inspect(kind)} expects the time zone to be \"Etc/UTC\", got `#{inspect(datetime)}`"
   end
 
   defp check_usec!(%{microsecond: {_, 6}} = datetime, _kind), do: datetime


### PR DESCRIPTION
We encountered the following error with UUID casting:
```elixir
[error] #PID<0.1267.0> running OurAppWeb.Endpoint (connection #PID<0.1266.0>, stream id 1) terminated
Server: localhost:4000 (http)
Request: GET /api/v1/redacted_resources
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function :uuid.cast/1 is undefined (module :uuid is not available)
        :uuid.cast("a72e8643-5f6a-4882-a419-88be227479d2")
        (ecto_sql) lib/ecto/adapters/sql.ex:554: anonymous fn/2 in Ecto.Adapters.SQL.load_embed/2
        (ecto) lib/ecto/type.ex:1159: Ecto.Type.map/4
        (ecto) lib/ecto/type.ex:800: Ecto.Type.process_loaders/3
        (ecto) lib/ecto/repo/queryable.ex:339: Ecto.Repo.Queryable.struct_load!/6
        (ecto) lib/ecto/repo/queryable.ex:201: anonymous fn/5 in Ecto.Repo.Queryable.preprocessor/3
        (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
        (ecto) lib/ecto/repo/queryable.ex:158: Ecto.Repo.Queryable.execute/4
        (ecto) lib/ecto/repo/queryable.ex:18: Ecto.Repo.Queryable.all/3
        (scrivener_ecto) lib/scrivener/paginater/ecto/query.ex:28: Scrivener.Paginater.Ecto.Query.paginate/2
...
```

This PR appears to fix it.