### PR TITLE
Fix Ecto.UUID type() return

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -18,31 +18,26 @@ defmodule Ecto.UUID do
   @doc """
   The Ecto type.
   """
-  def type, do: :uuid
+  def type, do: __MODULE__
 
   @doc """
   Casts to UUID.
   """
   @spec cast(t | raw | any) :: {:ok, t} | :error
-  def cast(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
-              b1, b2, b3, b4, ?-,
-              c1, c2, c3, c4, ?-,
-              d1, d2, d3, d4, ?-,
-              e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
-    << c(a1), c(a2), c(a3), c(a4),
-       c(a5), c(a6), c(a7), c(a8), ?-,
-       c(b1), c(b2), c(b3), c(b4), ?-,
-       c(c1), c(c2), c(c3), c(c4), ?-,
-       c(d1), c(d2), c(d3), c(d4), ?-,
-       c(e1), c(e2), c(e3), c(e4),
-       c(e5), c(e6), c(e7), c(e8),
-       c(e9), c(e10), c(e11), c(e12) >>
+  def cast(
+        <<a1, a2, a3, a4, a5, a6, a7, a8, ?-, b1, b2, b3, b4, ?-, c1, c2, c3, c4, ?-, d1, d2, d3,
+          d4, ?-, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12>>
+      ) do
+    <<c(a1), c(a2), c(a3), c(a4), c(a5), c(a6), c(a7), c(a8), ?-, c(b1), c(b2), c(b3), c(b4), ?-,
+      c(c1), c(c2), c(c3), c(c4), ?-, c(d1), c(d2), c(d3), c(d4), ?-, c(e1), c(e2), c(e3), c(e4),
+      c(e5), c(e6), c(e7), c(e8), c(e9), c(e10), c(e11), c(e12)>>
   catch
     :error -> :error
   else
     casted -> {:ok, casted}
   end
-  def cast(<< _::128 >> = binary), do: encode(binary)
+
+  def cast(<<_::128>> = binary), do: encode(binary)
   def cast(_), do: :error
 
   @doc """
@@ -80,26 +75,21 @@ defmodule Ecto.UUID do
   defp c(?d), do: ?d
   defp c(?e), do: ?e
   defp c(?f), do: ?f
-  defp c(_),  do: throw(:error)
+  defp c(_), do: throw(:error)
 
   @doc """
   Converts a string representing a UUID into a binary.
   """
   @spec dump(t | any) :: {:ok, raw} | :error
-  def dump(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
-              b1, b2, b3, b4, ?-,
-              c1, c2, c3, c4, ?-,
-              d1, d2, d3, d4, ?-,
-              e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
+  def dump(
+        <<a1, a2, a3, a4, a5, a6, a7, a8, ?-, b1, b2, b3, b4, ?-, c1, c2, c3, c4, ?-, d1, d2, d3,
+          d4, ?-, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12>>
+      ) do
     try do
-      << d(a1)::4, d(a2)::4, d(a3)::4, d(a4)::4,
-         d(a5)::4, d(a6)::4, d(a7)::4, d(a8)::4,
-         d(b1)::4, d(b2)::4, d(b3)::4, d(b4)::4,
-         d(c1)::4, d(c2)::4, d(c3)::4, d(c4)::4,
-         d(d1)::4, d(d2)::4, d(d3)::4, d(d4)::4,
-         d(e1)::4, d(e2)::4, d(e3)::4, d(e4)::4,
-         d(e5)::4, d(e6)::4, d(e7)::4, d(e8)::4,
-         d(e9)::4, d(e10)::4, d(e11)::4, d(e12)::4 >>
+      <<d(a1)::4, d(a2)::4, d(a3)::4, d(a4)::4, d(a5)::4, d(a6)::4, d(a7)::4, d(a8)::4, d(b1)::4,
+        d(b2)::4, d(b3)::4, d(b4)::4, d(c1)::4, d(c2)::4, d(c3)::4, d(c4)::4, d(d1)::4, d(d2)::4,
+        d(d3)::4, d(d4)::4, d(e1)::4, d(e2)::4, d(e3)::4, d(e4)::4, d(e5)::4, d(e6)::4, d(e7)::4,
+        d(e8)::4, d(e9)::4, d(e10)::4, d(e11)::4, d(e12)::4>>
     catch
       :error -> :error
     else
@@ -107,6 +97,7 @@ defmodule Ecto.UUID do
         {:ok, binary}
     end
   end
+
   def dump(_), do: :error
 
   @compile {:inline, d: 1}
@@ -133,7 +124,7 @@ defmodule Ecto.UUID do
   defp d(?d), do: 13
   defp d(?e), do: 14
   defp d(?f), do: 15
-  defp d(_),  do: throw(:error)
+  defp d(_), do: throw(:error)
 
   @doc """
   Converts a binary UUID into a string.
@@ -142,10 +133,13 @@ defmodule Ecto.UUID do
   def load(<<_::128>> = uuid) do
     encode(uuid)
   end
+
   def load(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = string) do
-    raise ArgumentError, "trying to load string UUID as Ecto.UUID: #{inspect string}. " <>
-                         "Maybe you wanted to declare :uuid as your database field?"
+    raise ArgumentError,
+          "trying to load string UUID as Ecto.UUID: #{inspect(string)}. " <>
+            "Maybe you wanted to declare :uuid as your database field?"
   end
+
   def load(_), do: :error
 
   @doc """
@@ -170,19 +164,14 @@ defmodule Ecto.UUID do
   @doc false
   def autogenerate, do: generate()
 
-  defp encode(<< a1::4, a2::4, a3::4, a4::4,
-                 a5::4, a6::4, a7::4, a8::4,
-                 b1::4, b2::4, b3::4, b4::4,
-                 c1::4, c2::4, c3::4, c4::4,
-                 d1::4, d2::4, d3::4, d4::4,
-                 e1::4, e2::4, e3::4, e4::4,
-                 e5::4, e6::4, e7::4, e8::4,
-                 e9::4, e10::4, e11::4, e12::4 >>) do
-    << e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-,
-       e(b1), e(b2), e(b3), e(b4), ?-,
-       e(c1), e(c2), e(c3), e(c4), ?-,
-       e(d1), e(d2), e(d3), e(d4), ?-,
-       e(e1), e(e2), e(e3), e(e4), e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12) >>
+  defp encode(
+         <<a1::4, a2::4, a3::4, a4::4, a5::4, a6::4, a7::4, a8::4, b1::4, b2::4, b3::4, b4::4,
+           c1::4, c2::4, c3::4, c4::4, d1::4, d2::4, d3::4, d4::4, e1::4, e2::4, e3::4, e4::4,
+           e5::4, e6::4, e7::4, e8::4, e9::4, e10::4, e11::4, e12::4>>
+       ) do
+    <<e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-, e(b1), e(b2), e(b3), e(b4), ?-,
+      e(c1), e(c2), e(c3), e(c4), ?-, e(d1), e(d2), e(d3), e(d4), ?-, e(e1), e(e2), e(e3), e(e4),
+      e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12)>>
   catch
     :error -> :error
   else
@@ -191,16 +180,16 @@ defmodule Ecto.UUID do
 
   @compile {:inline, e: 1}
 
-  defp e(0),  do: ?0
-  defp e(1),  do: ?1
-  defp e(2),  do: ?2
-  defp e(3),  do: ?3
-  defp e(4),  do: ?4
-  defp e(5),  do: ?5
-  defp e(6),  do: ?6
-  defp e(7),  do: ?7
-  defp e(8),  do: ?8
-  defp e(9),  do: ?9
+  defp e(0), do: ?0
+  defp e(1), do: ?1
+  defp e(2), do: ?2
+  defp e(3), do: ?3
+  defp e(4), do: ?4
+  defp e(5), do: ?5
+  defp e(6), do: ?6
+  defp e(7), do: ?7
+  defp e(8), do: ?8
+  defp e(9), do: ?9
   defp e(10), do: ?a
   defp e(11), do: ?b
   defp e(12), do: ?c


### PR DESCRIPTION
Co-authored-by: Kevin Baird <kevincbaird@gmail.com>

I opened the following issue in case our fix was in the wrong direction, I do believe this is a bug though: https://github.com/elixir-ecto/ecto/issues/3046

This PR fixes the linked issue.

Main changes:

[uuid.ex ln 21.](https://github.com/elixir-ecto/ecto/compare/master...joeyrosztoczy:update-uuid-type-return?expand=1#diff-8e368fa7e9c6f93fcd82a15e705fc08cL21)

I believe that Ecto.UUID.type() should return the desired schema type (either custom or primitive). It was returning a non-custom, non-primitive value which could throw runtime errors for composite type casting.

I updated the type() doc tests to reflect that :uuid is no longer returned.

And I changed [this doc test to match](https://github.com/elixir-ecto/ecto/compare/master...joeyrosztoczy:update-uuid-type-return?expand=1#diff-68b1275ffa052929bf96ca32ea92092dR267), which should have previously failed since :uuid wasn't a primitive type.

I apologize for the noise - I checked a couple times and believe I just ran the formatter as configured, but if you'd like me to strip down to just the relevant lines or it seems like the formatting is in error please let me know.


