### PR TITLE
do not override explictly set autoupdate fields

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1143,7 +1143,7 @@ defmodule Ecto.Changeset do
 
   defp put_change(data, changes, errors, valid?, key, value, type) do
     cond do
-      not Ecto.Type.equal?(type, Map.get(data, key), value) ->
+      not Ecto.Type.equal?(type, Map.get(data, key), value) || autoupdate_field?(data, key) ->
         {Map.put(changes, key, value), errors, valid?}
 
       Map.has_key?(changes, key) ->
@@ -1152,6 +1152,18 @@ defmodule Ecto.Changeset do
       true ->
         {changes, errors, valid?}
     end
+  end
+
+  defp autoupdate_field?(%{__struct__: struct}, key) do
+    autoupdate_fields =
+      struct.__schema__(:autoupdate)
+      |> Enum.flat_map(&elem(&1, 0))
+
+    Enum.member?(autoupdate_fields, key)
+  end
+
+  defp autoupdate_field?(_, _key) do
+    false
   end
 
   @doc """

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -52,6 +52,8 @@ defmodule Ecto.ChangesetTest do
       belongs_to :category, Ecto.ChangesetTest.Category, source: :cat_id
       has_many :comments, Ecto.ChangesetTest.Comment, on_replace: :delete
       has_one :comment, Ecto.ChangesetTest.Comment
+
+      timestamps()
     end
   end
 
@@ -657,7 +659,8 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "put_change/3 and delete_change/2" do
-    base_changeset = change(%Post{upvotes: 5})
+    naive_datetime = ~N[2000-01-01 00:00:00]
+    base_changeset = change(%Post{upvotes: 5, updated_at: naive_datetime})
 
     changeset = put_change(base_changeset, :title, "foo")
     assert changeset.changes.title == "foo"
@@ -679,6 +682,9 @@ defmodule Ecto.ChangesetTest do
 
     changeset = put_change(base_changeset, :upvotes, nil)
     assert changeset.changes.upvotes == nil
+
+    changeset = put_change(base_changeset, :updated_at, naive_datetime)
+    assert changeset.changes.updated_at == naive_datetime
   end
 
   test "force_change/3" do

--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -167,6 +167,16 @@ defmodule Ecto.Repo.AutogenerateTest do
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {0, 0}} = default.updated_on
   end
 
+  test "does not override custom updated_on value" do
+    default = TestRepo.insert!(%Manager{company_id: 1})
+
+    :timer.sleep(1000)
+
+    changeset = Ecto.Changeset.change(default, updated_on: default.updated_on, company_id: 2)
+    updated_default = TestRepo.update!(changeset)
+    assert updated_default.updated_on == default.updated_on
+  end
+
   test "sets the timestamps type to naive_datetime" do
     default = TestRepo.insert!(%NaiveMod{})
     assert %NaiveDateTime{microsecond: {0, 0}} = default.inserted_at


### PR DESCRIPTION
(For a schema using timestamps) if the updated_at field isn't set, Ecto will
autoupdate it. If it's part of the changeset, Ecto will use that value.
The issue is that when putting changes, Ecto will not add identical values.
If during an update, the updated_at field is set to the models (original)
updated_at value, it will not be part of the changeset. If another value is
changed (so the schema has changes), the updated_at field will (potentially)
have a different value (depending on the timing of the update call). As the
field was being explicitly set to a specific value, this was surprising.

This fix forces the updated_at field to be added to the changeset, even when
it's identical to the original value. I assumed this logic would apply to
all autoupdated fields, and not just timestamps.