### PR TITLE
Allow CTEs in update_all queries

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -881,13 +881,13 @@ defmodule Ecto.Query.Planner do
     {nil, counter}
   end
 
-  defp validate_and_increment(:with_cte, query, with_expr, counter, operation, adapter) do
-    fun = &validate_and_increment(&1, &2, &3, &4, operation, adapter)
+  defp validate_and_increment(:with_cte, query, with_expr, counter, _operation, adapter) do
+    fun = &validate_and_increment(&1, &2, &3, &4, :all, adapter)
 
     {queries, counter} =
       Enum.reduce with_expr.queries, {[], counter}, fn
         {name, %Ecto.Query{} = query}, {queries, counter} ->
-          {query, counter} = traverse_exprs(query, operation, counter, fun)
+          {query, counter} = traverse_exprs(query, :all, counter, fun)
           {query, _} = normalize_select(query) |> remove_literals()
           {_, select} = subquery_select(query, adapter)
           keys = select |> subquery_types() |> Keyword.keys()

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1419,7 +1419,7 @@ defmodule Ecto.Query.Planner do
     exprs =
       case operation do
         :all -> @all_exprs
-        :update_all -> @update_all_exprs
+        :update_all -> (@update_all_exprs ++ @all_exprs) |> Enum.uniq()
         :delete_all -> @delete_all_exprs
       end
 
@@ -1540,10 +1540,10 @@ defmodule Ecto.Query.Planner do
     case query do
       %Ecto.Query{order_bys: [], limit: nil, offset: nil, group_bys: [],
                   havings: [], preloads: [], assocs: [], distinct: nil, lock: nil,
-                  windows: [], combinations: [], with_ctes: nil} ->
+                  windows: [], combinations: []} ->
         query
       _ ->
-        error! query, "`#{operation}` allows only `where` and `join` expressions. " <>
+        error! query, "`#{operation}` allows only `with_cte`, `where` and `join` expressions. " <>
                       "You can exclude unwanted expressions from a query by using " <>
                       "Ecto.Query.exclude/2. Error found"
     end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -811,7 +811,7 @@ defmodule Ecto.Query.PlannerTest do
       |> normalize(:update_all)
     end
 
-    message = ~r"`update_all` allows only `where` and `join` expressions"
+    message = ~r"`update_all` allows only `with_cte`, `where` and `join` expressions"
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, order_by: p.title, update: [set: [title: "foo"]]) |> normalize(:update_all)
     end
@@ -823,7 +823,7 @@ defmodule Ecto.Query.PlannerTest do
       from(p in Post, update: [set: [name: "foo"]]) |> normalize(:delete_all)
     end
 
-    message = ~r"`delete_all` allows only `where` and `join` expressions"
+    message = ~r"`delete_all` allows only `with_cte`, `where` and `join` expressions"
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, order_by: p.title) |> normalize(:delete_all)
     end


### PR DESCRIPTION
This PR is to enable #3052 such that CTEs may be used in `update_all` queries.

The initial implementation is a minimal hack, hopefully someone can assist in getting to a clean solution.

The changes are:

1) Relax the validation in `Ecto.Query.Planner.assert_only_filter_expressions!` to allow non-nil `with_ctes` in a query.

2) The `Ecto.Query.Planner.traverse_exprs` function processes all query expressions as well as the existing update expressions. Without this change, the `params` list returned from `Ecto.Query.Planner.plan_cache` would not include any parameters intended to be used in the CTE.

Based on my limited understand of the query planner module, maybe something needs to be modified in [merge_cache/6](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query/planner.ex#L607-L625) ?

Corresponding changes to ecto_sql in https://github.com/elixir-ecto/ecto_sql/pull/125