### PR TITLE
Consider reordered embedded children as change

### DIFF
--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -659,6 +659,12 @@ defmodule Ecto.Changeset.EmbeddedTest do
       Relation.change(embed, [], [embed_schema_changeset])
     assert changeset.action == :replace
 
+    embed_schemas = [%Post{id: 1}, %Post{id: 2}]
+    assert {:ok, [changeset1, changeset2], true} =
+      Relation.change(embed, Enum.reverse(embed_schemas), embed_schemas)
+    assert changeset1.action == :update
+    assert changeset2.action == :update
+
     assert :ignore =
       Relation.change(embed, [%{embed_schema_changeset | action: :ignore}], [embed_schema])
     assert :ignore =


### PR DESCRIPTION
**Problem**
Reordering embedded children (with no other changes) does not get persisted. For example,

```elixir
order = Repo.get!(Order, 42)
order.items
# => [%Item{id: 1, title: "Soap"}, %Item{id: 2, title: "Shampoo"}]

new_order =
  order
  |> Ecto.Changeset.change()
  |> Ecto.Changeset.put_embed(:items, Enum.reverse(order.items))
  |> Repo.update!()

new_order.items
# => [%Item{id: 1, title: "Soap"}, %Item{id: 2, title: "Shampoo"}]
```

This behaviour is understandable for relational associations, but can be surprising when you know your children are stored in a JSON column.

The simplest workaround is to add a `:position` field to every child, which feels rather extra when JSON arrays are implicitly ordered.

**Solution**
This pull request prevents strictly ordinal changes of embeds from getting flagged as `:ignore`. 

It has the added benefit of recognising the implicit order of input to `cast_embed`. So one can sort children merely by rearranging the order of DOM elements, which should make a killer Phoenix LiveView demo.

For example, casting
```elixir
order_params = %{
  "items" => [
    %{"id" => 2},
    %{"id" => 1}
  ]
}
```
will reorder existing `items` accordingly.