### PR TITLE
Name Repo.index/2 first arg

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -339,7 +339,8 @@ defmodule Ecto.Repo do
   application environment. It must return `{:ok, keyword}` with the updated
   list of configuration or `:ignore` (only in the `:supervisor` case).
   """
-  @callback init(:supervisor | :runtime, config :: Keyword.t()) :: {:ok, Keyword.t()} | :ignore
+  @callback init(context :: :supervisor | :runtime, config :: Keyword.t()) ::
+              {:ok, Keyword.t()} | :ignore
 
   ## Ecto.Adapter
 


### PR DESCRIPTION
In the docs, the first argument of `Repo.index/2` was simply `arg1`. Now it will show `context`.