### PR TITLE
Fix migration example in constraints guide

### DIFF
--- a/guides/howtos/Constraints and Upserts.md
+++ b/guides/howtos/Constraints and Upserts.md
@@ -8,13 +8,13 @@ Imagine we are building an application that has blog posts and such posts may ha
 
 ```elixir
 create table(:posts) do
-  add :title
-  add :body
+  add :title, :string
+  add :body, :text
   timestamps()
 end
 
 create table(:tags) do
-  add :name
+  add :name, :string
   timestamps()
 end
 


### PR DESCRIPTION
There is no `Ecto.Migration.add/1`