### PR TITLE
use DateTime.utc_now when generating UTC timestamps

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1710,11 +1710,11 @@ defmodule Ecto.Schema do
   end
 
   def __timestamps__(:utc_datetime) do
-    DateTime.from_unix!(System.system_time(:second), :second)
+    %{DateTime.utc_now() | microsecond: {0, 0}}
   end
 
   def __timestamps__(:utc_datetime_usec) do
-    DateTime.from_unix!(System.system_time(:microsecond), :microsecond)
+    DateTime.utc_now()
   end
 
   def __timestamps__(type) do


### PR DESCRIPTION
I searched a bit but couldn't find if there was a reason Ecto wasn't using `DateTime` for this, but thought I'd open up a PR to find out 🙂

The reason I'm opening this is that `DateTime.utc_now` uses `System.os_time`, but Ecto uses `System.system_time` for UTC timestamps, and was hoping to make them consistent as I've seen some flakiness in integration tests that generate Ecto structs and do comparisons to `DateTime.utc_now`.

I do understand that neither source of time is monotonic, and both are subject to time warp, but some quick tests locally suggest there's an okay chance the two sources differ, and the proposed change makes things consistent with the `naive_` timestamps in using Elixir functions.

Ex:
```elixir
c = fn ->
  a = DateTime.from_unix!(System.system_time(:microsecond), :microsecond)
  b = DateTime.utc_now
  if DateTime.compare(a, b) == :gt do
    IO.inspect(a)
    IO.inspect(b)
    raise "hello"
  end
  [a, b]
end
for _ <- 0..100, do: c.()
~U[2019-07-26 16:06:36.701729Z]
~U[2019-07-26 16:06:36.701728Z]
** (RuntimeError) hello

d = fn ->
  a = DateTime.utc_now
  b = DateTime.utc_now
  if DateTime.compare(a, b) == :gt do
    IO.inspect(a)
    IO.inspect(b)
    raise "hi"
  end
  [a, b]
end
for _ <- 0..100, do: d.()
[
  [~U[2019-07-26 16:07:57.079719Z], ~U[2019-07-26 16:07:57.079734Z]],
  [~U[2019-07-26 16:07:57.079759Z], ~U[2019-07-26 16:07:57.079766Z]],
  [...]
  ...
]
```