### PR TITLE
Allow for `Repo.transaction` to receive a arity one function, which is supplied the repo

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1386,6 +1386,7 @@ defmodule Ecto.Repo do
         MyRepo.update!(change(bob, balance: bob.balance + 10))
       end)
       
+      # When passing a function of arity 1, it receives the repository itself
       MyRepo.transaction(fn repo -> 
         repo.insert!(%Post{})
       end)

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1340,6 +1340,11 @@ defmodule Ecto.Repo do
 
   ## Use with function
 
+  `c:transaction/2` can be called with both a function of arity
+  zero or one. The arity zero function will just be executed as is,
+  while the arity one function will receive the repo of the transaction
+  as it's first argument, similar to `Ecto.Multi.run`.
+
   If an unhandled error occurs the transaction will be rolled back
   and the error will bubble up from the transaction function.
   If no error occurred the transaction will be committed when the
@@ -1376,9 +1381,9 @@ defmodule Ecto.Repo do
 
       import Ecto.Changeset, only: [change: 2]
 
-      MyRepo.transaction(fn ->
-        MyRepo.update!(change(alice, balance: alice.balance - 10))
-        MyRepo.update!(change(bob, balance: bob.balance + 10))
+      MyRepo.transaction(fn repo ->
+        repo.update!(change(alice, balance: alice.balance - 10))
+        repo.update!(change(bob, balance: bob.balance + 10))
       end)
 
       # Roll back a transaction explicitly

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1343,7 +1343,7 @@ defmodule Ecto.Repo do
   `c:transaction/2` can be called with both a function of arity
   zero or one. The arity zero function will just be executed as is,
   while the arity one function will receive the repo of the transaction
-  as it's first argument, similar to `Ecto.Multi.run`.
+  as its first argument, similar to `Ecto.Multi.run`.
 
   If an unhandled error occurs the transaction will be rolled back
   and the error will bubble up from the transaction function.
@@ -1382,8 +1382,12 @@ defmodule Ecto.Repo do
       import Ecto.Changeset, only: [change: 2]
 
       MyRepo.transaction(fn repo ->
-        repo.update!(change(alice, balance: alice.balance - 10))
-        repo.update!(change(bob, balance: bob.balance + 10))
+        MyRepo.update!(change(alice, balance: alice.balance - 10))
+        MyRepo.update!(change(bob, balance: bob.balance + 10))
+      end)
+      
+      MyRepo.transaction(fn repo -> 
+        repo.insert!(%Post{})
       end)
 
       # Roll back a transaction explicitly

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1381,7 +1381,7 @@ defmodule Ecto.Repo do
 
       import Ecto.Changeset, only: [change: 2]
 
-      MyRepo.transaction(fn repo ->
+      MyRepo.transaction(fn ->
         MyRepo.update!(change(alice, balance: alice.balance - 10))
         MyRepo.update!(change(bob, balance: bob.balance + 10))
       end)

--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -6,6 +6,11 @@ defmodule Ecto.Repo.Transaction do
     {adapter, meta} = Ecto.Repo.Registry.lookup(name)
     adapter.transaction(meta, opts, fun)
   end
+  
+  def transaction(repo, name, fun, opts) when is_function(fun, 1) do
+    {adapter, meta} = Ecto.Repo.Registry.lookup(name)
+    adapter.transaction(meta, opts, fn -> fun.(repo) end)
+  end
 
   def transaction(repo, name, %Ecto.Multi{} = multi, opts) do
     {adapter, meta} = Ecto.Repo.Registry.lookup(name)

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1171,7 +1171,7 @@ defmodule Ecto.RepoTest do
   end
 
   describe "transaction" do
-    test "a arity zero function will be executed any it's value returned" do
+    test "an arity zero function will be executed any it's value returned" do
       fun = fn -> :ok end
       assert {:ok, :ok} = TestRepo.transaction(fun)
       assert_received {:transaction, _}

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1169,4 +1169,19 @@ defmodule Ecto.RepoTest do
       refute function_exported?(ReadOnlyRepo, :delete_all, 2)
     end
   end
+
+  describe "transaction" do
+    test "a arity zero function will be executed any it's value returned" do
+      fun = fn -> :ok end
+      assert {:ok, :ok} = TestRepo.transaction(fun)
+      assert_received {:transaction, _}
+    end
+
+    test "an arity one function will be passed the repo as first argument" do
+      fun = fn repo -> repo end
+
+      assert {:ok, TestRepo} = TestRepo.transaction(fun)
+      assert_received {:transaction, _}
+    end
+  end
 end


### PR DESCRIPTION
I feel this would align the behaviour of `Repo.transaction` functions to the ones of `Ecto.Multi.run` functions. I was just talking to @benwilson512 about an API in his fable library, which would return a function or ecto.multi based on the inputs and would always be piped into `Repo.transaction`. Currently only the `Ecto.Multi` based API wouldn't need to know the actual repo used, while the one returning a functions can't work the same way.

Edit: I'm aware that test are missing, maybe a issue would've been good before the pr :)