### PR TITLE
Don't wrap in a transaction if we're already in a transaction

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -912,7 +912,6 @@ defmodule Ecto.Repo.Schema do
     if (relations_changed? or prepare != []) and
        Keyword.get(opts, :skip_transaction) != true and
        function_exported?(adapter, :transaction, 3) and
-       function_exported?(adapter, :in_transaction?, 1) and
        not adapter.in_transaction?(adapter_meta) do
       adapter.transaction(adapter_meta, opts, fn ->
         case fun.() do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -911,7 +911,9 @@ defmodule Ecto.Repo.Schema do
   defp wrap_in_transaction(adapter, adapter_meta, opts, relations_changed?, prepare, fun) do
     if (relations_changed? or prepare != []) and
        Keyword.get(opts, :skip_transaction) != true and
-       function_exported?(adapter, :transaction, 3) do
+       function_exported?(adapter, :transaction, 3) and
+       function_exported?(adapter, :in_transaction?, 1) and
+       not adapter.in_transaction?(adapter_meta) do
       adapter.transaction(adapter_meta, opts, fn ->
         case fun.() do
           {:ok, struct} -> struct


### PR DESCRIPTION
The implicit rollback in wrap_in_transaction works well if the transaction is created by wrap_in_transaction itself, but if the function is called from a pre-existing transaction, it takes over the rollback decision from the parent context.

This change enables savepoint recovery to work following a failed insert that has embeds/relations, which is implicitly wrapped into a transaction.

Transactional integrity should not be impacted, as in the case of an error, any further calls in the transaction prior to rollback will be rejected even with this change.

Further discussion in elixir-ecto/ecto_sql#136.