### PR TITLE
add rollover logic for default incremeter in optimistic_lock

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1401,7 +1401,7 @@ defmodule Ecto.ChangesetTest do
 
   ## Locks
 
-  test "optimistic_lock/3 with changeset" do
+  test "optimistic_lock/3 with changeset with default incremeter" do
     changeset = changeset(%{}) |> optimistic_lock(:upvotes)
     assert changeset.filters == %{upvotes: 0}
     assert changeset.changes == %{upvotes: 1}
@@ -1409,7 +1409,20 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%Post{upvotes: 2}, %{upvotes: 1}) |> optimistic_lock(:upvotes)
     assert changeset.filters == %{upvotes: 1}
     assert changeset.changes == %{upvotes: 2}
-  end
+
+    # Assert default incrememt will rollover to 1 when the current one is equal or graeter than 2_147_483_647
+    changeset = changeset(%Post{upvotes: 2_147_483_647}, %{}) |> optimistic_lock(:upvotes)
+    assert changeset.filters == %{upvotes: 2_147_483_647}
+    assert changeset.changes == %{upvotes: 1}
+
+    changeset = changeset(%Post{upvotes: 3_147_483_647}, %{}) |> optimistic_lock(:upvotes)
+    assert changeset.filters == %{upvotes: 3_147_483_647}
+    assert changeset.changes == %{upvotes: 1}
+
+    changeset = changeset(%Post{upvotes: 2_147_483_647}, %{upvotes: 2_147_483_648}) |> optimistic_lock(:upvotes)
+    assert changeset.filters == %{upvotes: 2_147_483_648}
+    assert changeset.changes == %{upvotes: 1}
+ end
 
   test "optimistic_lock/3 with struct" do
     changeset = %Post{} |> optimistic_lock(:upvotes)

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1410,7 +1410,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.filters == %{upvotes: 1}
     assert changeset.changes == %{upvotes: 2}
 
-    # Assert default incrememt will rollover to 1 when the current one is equal or graeter than 2_147_483_647
+    # Assert default increment will rollover to 1 when the current one is equal or graeter than 2_147_483_647
     changeset = changeset(%Post{upvotes: 2_147_483_647}, %{}) |> optimistic_lock(:upvotes)
     assert changeset.filters == %{upvotes: 2_147_483_647}
     assert changeset.changes == %{upvotes: 1}


### PR DESCRIPTION
As discussed in the previous [issue](https://github.com/elixir-ecto/ecto/issues/3103), this PR is for avoiding an exception when the lock version exceed the PostgresSQL and MySQL signed integer size limit.