### PR TITLE
Fix docs. Replace explicit calls in `Ecto.Multi` to `repo` from function header.

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -324,7 +324,7 @@ defmodule Ecto.Multi do
 
       Ecto.Multi.new()
       |> Ecto.Multi.run(:post, fn _repo, _changes ->
-           {:ok, MyApp.Repo.get(Post, 1) || %Post{}}
+           {:ok, repo.get(Post, 1) || %Post{}}
          end)
       |> Ecto.Multi.insert_or_update(:update, fn %{post: post} ->
            Ecto.Changeset.change(post, title: "New title")
@@ -361,7 +361,7 @@ defmodule Ecto.Multi do
 
       Ecto.Multi.new()
       |> Ecto.Multi.run(:post, fn _repo, _changes ->
-           case MyApp.Repo.get(Post, 1) do
+           case repo.get(Post, 1) do
              nil -> {:error, :not_found}
              post -> {:ok, post}
            end


### PR DESCRIPTION
Currently:
```
|> Ecto.Multi.run(:post, fn _repo, _changes ->
     {:ok, MyApp.Repo.get(Post, 1) || %Post{}}
   end)
```

I think the `repo` argument intention was to enable injecting repo module into callback function. I think it is nice feature that complies with `explicit contract` methodology and should be enforced in docs.  So I changed references of `MyApp.Repo` to `repo`.

```
|> Ecto.Multi.run(:post, fn repo, _changes ->
     {:ok, repo.get(Post, 1) || %Post{}}
   end)
```

If this is idea is welcome I can also format this file, becase it does not compy with mix format.