### PR TITLE
Query caching error with subqueries

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -536,10 +536,7 @@ defmodule Ecto.Query.Planner do
 
   defp merge_cache(:from, _query, from, {cache, params}, _operation, _adapter) do
     {key, params} = source_cache(from, params)
-    cacheable? =
-    case is_list(key) do
-      true -> !has_nocache?(key)
-      false -> key != :nocache
+    cacheable? = !has_nocache?(key)
   end
   {merge_cache(key, cache, cacheable?), params}
   end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -537,8 +537,7 @@ defmodule Ecto.Query.Planner do
   defp merge_cache(:from, _query, from, {cache, params}, _operation, _adapter) do
     {key, params} = source_cache(from, params)
     cacheable? = !has_nocache?(key)
-  end
-  {merge_cache(key, cache, cacheable?), params}
+    {merge_cache(key, cache, cacheable?), params}
   end
 
   defp merge_cache(kind, query, expr, {cache, params}, _operation, adapter)
@@ -651,20 +650,10 @@ defmodule Ecto.Query.Planner do
   defp merge_cache(_left, :nocache, true), do: :nocache
   defp merge_cache(left, right, true),     do: [left|right]
 
-  defp has_nocache?([head | tail]) do
-    case head == :nocache do
-      true -> true
-      false -> has_nocache?(tail)
-    end
-  end
-
-  defp has_nocache?([]) do
-    false
-  end
-
-  defp has_nocache?(cache) do
-    cache == :nocache
-  end
+  defp has_nocache?([:nocache | _]), do: true
+  defp has_nocache?([_ | tail]), do: has_nocache?(tail)
+  defp has_nocache?([]), do: false
+  defp has_nocache?(cache), do: cache == :nocache
 
   defp finalize_cache(_query, _operation, :nocache) do
     :nocache


### PR DESCRIPTION
https://github.com/elixir-ecto/ecto/issues/3110

Subquerys with unions mistakenly think the query is cached when
it has different number of interpolated parameters, causing an
incorrect number of params exception.

Checking that :nocache actually exists in the list, and to not try
to use the cache if it exists.