### PR TITLE
Allow :with to be given as a {module, function} tuple

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -708,7 +708,9 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:with` - the function to build the changeset from params.
-      Defaults to the changeset/2 function in the association module
+      Defaults to the changeset/2 function in the association module.
+      This can either be an anonymous function, or a `{module, function}`
+      tuple.
     * `:required` - if the association is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
@@ -736,7 +738,9 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:with` - the function to build the changeset from params.
-      Defaults to the changeset/2 function in the embed module
+      Defaults to the changeset/2 function in the embed module.
+      This can either be an anonymous function, or a `{module, function}`
+      tuple.
     * `:required` - if the embed is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
@@ -814,6 +818,7 @@ defmodule Ecto.Changeset do
 
                 1. implement the #{type}.changeset/2 function
                 2. pass the :with option to cast_#{type}/3 with an anonymous function that expects 2 args
+                   or a {module, function} tuple.
 
               When using an inline embed, the :with option must be given
               """
@@ -2097,17 +2102,18 @@ defmodule Ecto.Changeset do
   defp decimal_compare(:eq, spec), do: spec in [:equal_to, :less_than_or_equal_to, :greater_than_or_equal_to]
 
   @doc """
-  Validates that the given field matches the confirmation
-  parameter of that field.
+  Validates that the given parameter matches its confirmation.
 
   By calling `validate_confirmation(changeset, :email)`, this
   validation will check if both "email" and "email_confirmation"
-  in the parameter map matches.
+  in the parameter map matches. Note this validation only looks
+  at the parameters themselves, never the fields in the schema.
+  As such as, the "email_confirmation" field does not need to be
+  added as a virtual field in your schema.
 
-  Note that if the confirmation field is nil or missing, by default this does
-  not add a validation error. You can specify that the confirmation field is
-  required in the options (see below). Note "email_confirmation" does not need
-  to be added as a virtual field in your schema.
+  Note that if the confirmation field is nil or missing, this does
+  not add a validation error. You can specify that the confirmation
+  parameter is required in the options (see below).
 
   ## Options
 
@@ -2161,11 +2167,11 @@ defmodule Ecto.Changeset do
   end
 
   @doc """
-  Validates the given parameter was given as true.
+  Validates the given parameter is true.
 
-  This validation is used to check for one specific parameter being true
-  and as such does not require the field to effectively exist in the schema
-  or the data being validated.
+  Note this validation only checks the parameter itself is true, never
+  the field in the schema. That's because acceptance parameters do not need
+  to be persisted, as by definition they would always be stored as `true`.
 
   ## Options
 

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -109,6 +109,15 @@ defmodule Ecto.Changeset.Relation do
     end
   end
 
+  defp do_cast(meta, params, struct, allowed_actions, {on_cast_module, on_cast_function})
+       when is_atom(on_cast_module) and is_atom(on_cast_function) do
+    on_cast = fn changeset, attrs ->
+      apply(on_cast_module, on_cast_function, [changeset, attrs])
+    end
+
+    do_cast(meta, params, struct, allowed_actions, on_cast)
+  end
+
   defp do_cast(meta, params, nil, allowed_actions, on_cast) do
     {:ok,
       on_cast.(meta.__struct__.build(meta), params)


### PR DESCRIPTION
I've been building an app where various forms contain multiple `liveview`s for particularly interactive sections.  I've been passing the form into the session, and using normal form functions inside the liveview which has worked fine.

This afternoon I added `cast_assoc` to a changeset and suddenly my `liveview`s exploded with `** (ArgumentError) cannot deserialize #Function<15.129553521/2 in Ecto.Changeset.on_cast_default/2>, the term is not safe for deserialization` errors, because as it turns out the `:with` option of `cast_assoc` implicitly creates an anonymous function.

Therefore this pull request circumvents the problem by allowing the `:with` option to be given as a tuple of `{module_name, changeset_function_name}`, thereby making the changeset serializable if necessary.