### PR TITLE
Allow :with to be given as a {module, function} tuple

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -822,8 +822,8 @@ defmodule Ecto.Changeset do
               which is used by cast_#{type}/3. You need to either:
 
                 1. implement the #{type}.changeset/2 function
-                2. pass the :with option to cast_#{type}/3 with an anonymous function that expects 2 args
-                   or an MFA.
+                2. pass the :with option to cast_#{type}/3 with an anonymous
+                   function that expects 2 args or an MFA tuple
 
               When using an inline embed, the :with option must be given
               """

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -709,8 +709,10 @@ defmodule Ecto.Changeset do
 
     * `:with` - the function to build the changeset from params.
       Defaults to the changeset/2 function in the association module.
-      This can either be an anonymous function, or a `{module, function}`
-      tuple.
+      This can either be an anonymous function, or an MFA.  If using an MFA, the
+      passed arguments are added to the default changeset and parameters arguments
+      (so for example, using `with: {Author, :special_changeset, ["hello"]` will
+      expect a function `Author.special_changeset/3` to exist.
     * `:required` - if the association is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
@@ -739,8 +741,10 @@ defmodule Ecto.Changeset do
 
     * `:with` - the function to build the changeset from params.
       Defaults to the changeset/2 function in the embed module.
-      This can either be an anonymous function, or a `{module, function}`
-      tuple.
+      This can either be an anonymous function, or an MFA.  If using an MFA, the
+      passed arguments are added to the default changeset and parameters arguments
+      (so for example, using `with: {Author, :special_changeset, ["hello"]` will
+      expect a function `Author.special_changeset/3` to exist.
     * `:required` - if the embed is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
@@ -818,7 +822,7 @@ defmodule Ecto.Changeset do
 
                 1. implement the #{type}.changeset/2 function
                 2. pass the :with option to cast_#{type}/3 with an anonymous function that expects 2 args
-                   or a {module, function} tuple.
+                   or an MFA.
 
               When using an inline embed, the :with option must be given
               """

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -740,17 +740,17 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:with` - the function to build the changeset from params.
-      Defaults to the changeset/2 function in the embed module.
-      This can either be an anonymous function, or an MFA.  If using an MFA, the
-      passed arguments are added to the default changeset and parameters arguments
-      (so for example, using `with: {Author, :special_changeset, ["hello"]` will
-      expect a function `Author.special_changeset/3` to exist.
     * `:required` - if the embed is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
-    * `:force_update_on_change` - force the parent record to be updated in the repository if
-      there is a change, defaults to true
+    * `:force_update_on_change` - force the parent record to be updated in the
+      repository if there is a change, defaults to `true`
+    * `:with` - the function to build the changeset from params. Defaults to the
+      `changeset/2` function of the embedded module. It can be changed by passing
+      an anonymous function or an MFA tuple.  If using an MFA, the default changeset
+      and parameters arguments will be prepended to the given args. For example,
+      using `with: {Author, :special_changeset, ["hello"]}` will be invoked as
+      `Author.special_changeset(changeset, params, "hello")`
   """
   def cast_embed(changeset, name, opts \\ []) when is_atom(name) do
     cast_relation(:embed, changeset, name, opts)

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -708,7 +708,9 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:with` - the function to build the changeset from params.
-      Defaults to the changeset/2 function in the association module
+      Defaults to the changeset/2 function in the association module.
+      This can either be an anonymous function, or a `{module, function}`
+      tuple.
     * `:required` - if the association is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
@@ -736,7 +738,9 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:with` - the function to build the changeset from params.
-      Defaults to the changeset/2 function in the embed module
+      Defaults to the changeset/2 function in the embed module.
+      This can either be an anonymous function, or a `{module, function}`
+      tuple.
     * `:required` - if the embed is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
@@ -814,6 +818,7 @@ defmodule Ecto.Changeset do
 
                 1. implement the #{type}.changeset/2 function
                 2. pass the :with option to cast_#{type}/3 with an anonymous function that expects 2 args
+                   or a {module, function} tuple.
 
               When using an inline embed, the :with option must be given
               """

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -707,17 +707,18 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:with` - the function to build the changeset from params.
-      Defaults to the changeset/2 function in the association module.
-      This can either be an anonymous function, or an MFA.  If using an MFA, the
-      passed arguments are added to the default changeset and parameters arguments
-      (so for example, using `with: {Author, :special_changeset, ["hello"]` will
-      expect a function `Author.special_changeset/3` to exist.
     * `:required` - if the association is a required field
     * `:required_message` - the message on failure, defaults to "can't be blank"
     * `:invalid_message` - the message on failure, defaults to "is invalid"
-    * `:force_update_on_change` - force the parent record to be updated in the repository if
-      there is a change, defaults to true
+    * `:force_update_on_change` - force the parent record to be updated in the
+      repository if there is a change, defaults to `true`
+    * `:with` - the function to build the changeset from params. Defaults to the
+      `changeset/2` function of the associated module. It can be changed by passing
+      an anonymous function or an MFA tuple.  If using an MFA, the default changeset
+      and parameters arguments will be prepended to the given args. For example,
+      using `with: {Author, :special_changeset, ["hello"]}` will be invoked as
+      `Author.special_changeset(changeset, params, "hello")`
+
   """
   def cast_assoc(changeset, name, opts \\ []) when is_atom(name) do
     cast_relation(:assoc, changeset, name, opts)

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -109,10 +109,10 @@ defmodule Ecto.Changeset.Relation do
     end
   end
 
-  defp do_cast(meta, params, struct, allowed_actions, {on_cast_module, on_cast_function})
-       when is_atom(on_cast_module) and is_atom(on_cast_function) do
+  defp do_cast(meta, params, struct, allowed_actions, {module, fun, args})
+       when is_atom(module) and is_atom(fun) and is_list(args) do
     on_cast = fn changeset, attrs ->
-      apply(on_cast_module, on_cast_function, [changeset, attrs])
+      apply(module, fun, [changeset, attrs | args])
     end
 
     do_cast(meta, params, struct, allowed_actions, on_cast)

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -109,6 +109,15 @@ defmodule Ecto.Changeset.Relation do
     end
   end
 
+  defp do_cast(meta, params, struct, allowed_actions, {on_cast_module, on_cast_function})
+       when is_atom(on_cast_module) and is_atom(on_cast_function) do
+    on_cast = fn changeset, attrs ->
+      apply(on_cast_module, on_cast_function, [changeset, attrs])
+    end
+
+    do_cast(meta, params, struct, allowed_actions, on_cast)
+  end
+
   defp do_cast(meta, params, nil, allowed_actions, on_cast) do
     {:ok,
       on_cast.(meta.__struct__.build(meta), params)

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -256,7 +256,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{"profile" => %{}}, :profile, with: {Profile, :failing_changeset, ["test"]})
 
     assert changeset.changes.profile.errors == [name: {"test", []}]
-    assert not changeset.valid?
+    refute changeset.valid?
   end
 
   test "cast has_one keeps appropriate action from changeset" do

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -62,6 +62,11 @@ defmodule Ecto.Changeset.HasAssocTest do
     def optional_changeset(schema, params) do
       Changeset.cast(schema, params, ~w(name)a)
     end
+    
+    def failing_changeset(schema, params, error_string) do
+      Changeset.cast(schema, params, ~w(name)a)
+      |> Changeset.add_error(:name, error_string)
+    end
 
     def set_action(schema, params) do
       changeset(schema, params)
@@ -245,6 +250,13 @@ defmodule Ecto.Changeset.HasAssocTest do
     assert profile.action  == :insert
     assert profile.valid?
     assert changeset.valid?
+  end
+  
+  test "cast has_one with custom changeset specified with mfa" do
+    changeset = cast(%Author{}, %{"profile" => %{}}, :profile, with: {Profile, :failing_changeset, ["test"]})
+
+    assert changeset.changes.profile.errors == [name: {"test", []}]
+    assert not changeset.valid?
   end
 
   test "cast has_one keeps appropriate action from changeset" do


### PR DESCRIPTION
I've been building an app where various forms contain multiple liveviews for particularly interactive sections. I've been passing the form into the session, and using normal form functions inside the liveview which has worked fine.

This afternoon I added `cast_assoc` to a changeset and suddenly my liveviews exploded with `** (ArgumentError) cannot deserialize #Function<15.129553521/2 in Ecto.Changeset.on_cast_default/2>, the term is not safe for deserialization` errors, because as it turns out the `:with` option of `cast_assoc` implicitly creates an anonymous function.

Therefore this pull request circumvents the problem by allowing the `:with` option to be given as a tuple of `{module_name, changeset_function_name}`, thereby making the changeset serializable if necessary.