### PR TITLE
Correct small typo in subquery guides

### DIFF
--- a/guides/howtos/Aggregates and subqueries.md
+++ b/guides/howtos/Aggregates and subqueries.md
@@ -79,7 +79,7 @@ inner_query =
     limit: 10
 
 query =
-  from q in subquery(query),
+  from q in subquery(inner_query),
     select: avg(q.visits)
 
 MyApp.Repo.one(query)


### PR DESCRIPTION
Noticed this while studying up.