### PR TITLE
Fixing issues in code examples

### DIFF
--- a/guides/howtos/Composable transactions with Multi.md
+++ b/guides/howtos/Composable transactions with Multi.md
@@ -171,7 +171,7 @@ defmodule MyApp.Post do
     []
   end
   defp insert_and_get_all(names) do
-    timestamp = NaiveDateTime.truncate(NaiveDateTime.utc_now, :second)
+    timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
     maps = Enum.map(names, &%{name: &1, inserted_at: timestamp, updated_at: timestamp})
     Repo.insert_all MyApp.Tag, maps, on_conflict: :nothing
     Repo.all from t in MyApp.Tag, where: t.name in ^names
@@ -241,7 +241,7 @@ defp insert_and_get_all_tags(_changes, params) do
     [] ->
       {:ok, []}
     names ->
-      timestamp = NaiveDateTime.truncate(NaiveDateTime.utc_now, :second)
+      timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
       maps = Enum.map(names, &%{name: &1, inserted_at: timestamp, updated_at: timestamp})
       Repo.insert_all(Tag, maps, on_conflict: :nothing)
       query = from t in Tag, where: t.name in ^names

--- a/guides/howtos/Composable transactions with Multi.md
+++ b/guides/howtos/Composable transactions with Multi.md
@@ -171,7 +171,8 @@ defmodule MyApp.Post do
     []
   end
   defp insert_and_get_all(names) do
-    maps = Enum.map(names, &%{name: &1})
+    timestamp = NaiveDateTime.truncate(NaiveDateTime.utc_now, :second)
+    maps = Enum.map(names, &%{name: &1, inserted_at: timestamp, updated_at: timestamp})
     Repo.insert_all MyApp.Tag, maps, on_conflict: :nothing
     Repo.all from t in MyApp.Tag, where: t.name in ^names
   end
@@ -239,8 +240,9 @@ defp insert_and_get_all_tags(_changes, params) do
   case MyApp.Tag.parse(params["tags"]) do
     [] ->
       {:ok, []}
-    tags ->
-      maps = Enum.map(names, &%{name: &1})
+    names ->
+      timestamp = NaiveDateTime.truncate(NaiveDateTime.utc_now, :second)
+      maps = Enum.map(names, &%{name: &1, inserted_at: timestamp, updated_at: timestamp})
       Repo.insert_all(Tag, maps, on_conflict: :nothing)
       query = from t in Tag, where: t.name in ^names
       {:ok, Repo.all(query)}


### PR DESCRIPTION
On `insert_and_get_all_tags()`, inside the case, for consistency, it should expect `names`. If you put `tags`, it will give an error (is not expecting it). Or you can change all to tags, could make more sense semantically speaking.

For some reason, which I don't know why yet, `timestamps()` expects that you truncate the second off the `NativeDateTime` given format. If not, it will give you an error.