### PR TITLE
fix example code in guides for stopping dynamic repo

### DIFF
--- a/guides/howtos/Replicas and dynamic repositories.md
+++ b/guides/howtos/Replicas and dynamic repositories.md
@@ -250,12 +250,13 @@ default_dynamic_repo = MyApp.Repo.get_dynamic_repo()
     pool_size: 1
   )
 
+MyApp.Repo.put_dynamic_repo(repo)
+
 try do
-  MyApp.Repo.put_dynamic_repo(repo)
   MyApp.Repo.all(Post)
 after
-  MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
   MyApp.Repo.stop()
+  MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
 end
 ```
 
@@ -269,13 +270,13 @@ defmodule MyApp.Repo do
     default_dynamic_repo = get_dynamic_repo()
     start_opts = [name: nil, pool_size: 1] ++ credentials
     {:ok, repo} = MyApp.Repo.start_link(start_opts)
+    MyApp.Repo.put_dynamic_repo(repo)
 
     try do
-      MyApp.Repo.put_dynamic_repo(repo)
       callback.()
     after
-      MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
       MyApp.Repo.stop()
+      MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
     end
   end
 end

--- a/guides/howtos/Replicas and dynamic repositories.md
+++ b/guides/howtos/Replicas and dynamic repositories.md
@@ -254,8 +254,8 @@ try do
   MyApp.Repo.put_dynamic_repo(repo)
   MyApp.Repo.all(Post)
 after
-  MyApp.Repo.stop()
   MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
+  Supervisor.stop(repo)
 end
 ```
 
@@ -274,8 +274,8 @@ defmodule MyApp.Repo do
       MyApp.Repo.put_dynamic_repo(repo)
       callback.()
     after
-      MyApp.Repo.stop()
       MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
+      Supervisor.stop(repo)
     end
   end
 end

--- a/guides/howtos/Replicas and dynamic repositories.md
+++ b/guides/howtos/Replicas and dynamic repositories.md
@@ -250,13 +250,12 @@ default_dynamic_repo = MyApp.Repo.get_dynamic_repo()
     pool_size: 1
   )
 
-MyApp.Repo.put_dynamic_repo(repo)
-
 try do
+  MyApp.Repo.put_dynamic_repo(repo)
   MyApp.Repo.all(Post)
 after
-  MyApp.Repo.stop()
   MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
+  Supervisor.stop(repo)
 end
 ```
 
@@ -270,13 +269,13 @@ defmodule MyApp.Repo do
     default_dynamic_repo = get_dynamic_repo()
     start_opts = [name: nil, pool_size: 1] ++ credentials
     {:ok, repo} = MyApp.Repo.start_link(start_opts)
-    MyApp.Repo.put_dynamic_repo(repo)
 
     try do
+      MyApp.Repo.put_dynamic_repo(repo)
       callback.()
     after
-      MyApp.Repo.stop()
       MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
+      Supervisor.stop(repo)
     end
   end
 end

--- a/guides/howtos/Replicas and dynamic repositories.md
+++ b/guides/howtos/Replicas and dynamic repositories.md
@@ -255,7 +255,7 @@ try do
   MyApp.Repo.all(Post)
 after
   MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
-  Supervisor.stop(repo)
+  MyApp.Repo.stop()
 end
 ```
 
@@ -275,7 +275,7 @@ defmodule MyApp.Repo do
       callback.()
     after
       MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
-      Supervisor.stop(repo)
+      MyApp.Repo.stop()
     end
   end
 end

--- a/guides/howtos/Replicas and dynamic repositories.md
+++ b/guides/howtos/Replicas and dynamic repositories.md
@@ -254,8 +254,8 @@ try do
   MyApp.Repo.put_dynamic_repo(repo)
   MyApp.Repo.all(Post)
 after
+  MyApp.Repo.stop()
   MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
-  MyApp.Repo.stop(repo)
 end
 ```
 
@@ -274,8 +274,8 @@ defmodule MyApp.Repo do
       MyApp.Repo.put_dynamic_repo(repo)
       callback.()
     after
+      MyApp.Repo.stop()
       MyApp.Repo.put_dynamic_repo(default_dynamic_repo)
-      MyApp.Repo.stop(repo)
     end
   end
 end


### PR DESCRIPTION
The original example code results in `** (ErlangError) Erlang error: :timeout_value` because `Ecto.Repo.stop/1` accepts `timeout` not `pid`.
I think calling `Supervisor.stop/3` is one of the ways to stop the dynamic repo here.