### PR TITLE
Adds `storage_status/1` callback to `Ecto.Adapters.Storage` behaviour

### DIFF
--- a/lib/ecto/adapter/storage.ex
+++ b/lib/ecto/adapter/storage.ex
@@ -36,4 +36,11 @@ defmodule Ecto.Adapter.Storage do
 
   """
   @callback storage_down(options :: Keyword.t) :: :ok | {:error, :already_down} | {:error, term}
+  
+  @doc """
+  Returns the status of a storage given by options.
+
+  Can return `:up`, `:down` or `{:error, term}` in case anything goes wrong.
+  """
+  @callback storage_status(options :: Keyword.t()) :: :up | :down | {:error, term()}
 end


### PR DESCRIPTION
Returns the status of a given `storage` for the given `options`.
Can be `:up`, `:down` or `{:error, term()}` in case anything goes wrong.

### Motivation
At least for now, it's planned to be used on a (future) Plug on `phoenix_ecto` that shows an error page when the database for a repo is not created.

Related to: elixir-ecto/ecto_sql#164

cc @josevalim