### PR TITLE
Update changeset.ex unique_constraint docs for partitioned table

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2514,6 +2514,7 @@ defmodule Ecto.Changeset do
       |> unique_constraint(:email, name: :users_email_company_id_index)
   
   ### Partitioning
+
   If your table is partitioned, then your unique index might look different
   per partition - Postgres adds p<number> to the middle of your key, like:
   

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2512,6 +2512,21 @@ defmodule Ecto.Changeset do
       # In the changeset function
       cast(user, params, [:email])
       |> unique_constraint(:email, name: :users_email_company_id_index)
+  
+  ### Partitioning
+  If your table is partitioned, then your unique index might look different
+  per partition - Postgres adds p<number> to the middle of your key, like:
+  
+      users_p0_email_key
+      users_p1_email_key
+      ...
+      users_p99_email_key
+      
+  In this case you can use the name and suffix options together to match on
+  these dynamic indexes, like:
+      
+      cast(user, params, [:email])
+      |> unique_constraint(:email, name: :email_key, match: :suffix)
 
   ## Case sensitivity
 


### PR DESCRIPTION
fixes #3168 

Add documentation for when a table is partitioned and show it as an example for using the unique_constraint suffix option
