### PR TITLE
Fix phrasing in custom type example

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -46,10 +46,9 @@ defmodule Ecto.Type do
         # Everything else is a failure though
         def cast(_), do: :error
 
-        # When loading data from the database, we are guaranteed to
-        # receive a map (as databases are strict) and we will
-        # just put the data back into an URI struct to be stored
-        # in the loaded schema struct.
+        # When loading data from the database, as long as it's a map,
+        # we just put the data back into an URI struct to be stored in
+        # the loaded schema struct.
         def load(data) when is_map(data) do
           data =
             for {key, val} <- data do


### PR DESCRIPTION
The phrasing of this example is misleading. It implies that the **database** will ensure we get back a map, which is wrong. **Ecto** or its adapters ensure we get back a map when using Ecto's `:map` type. However, in practice, adapters use column types that are not that strict to store `:map`, like `jsonb` in PostgreSQL, which can contain any valid JSON value (e.g. a boolean, a string or an array).

The `is_map` guard in this example ensures we get back a map, not the database.

>  Following a discussion in the `ecto` channel in Elixir's Slack, between 20 Nov 10:14 PM CET and now.