### PR TITLE
Allow aggregating over `*`

### DIFF
--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -198,6 +198,10 @@ defmodule Ecto.RepoTest do
       TestRepo.aggregate(MySchema, :count, :id)
       assert_received {:all, query}
       assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
+
+      TestRepo.aggregate(MySchema, :count, :*)
+      assert_received {:all, query}
+      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count()>"
     end
 
     test "aggregates handle a prefix option" do


### PR DESCRIPTION
This is done to provide similar API to `Ecto.Query.API.count/0` as
counting over `*` is faster in some DB than counting over column, even
when column is `NOT NULL` and indexed.

Close #3175