### PR TITLE
Feat/dynamic table naming

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -349,11 +349,15 @@ defmodule Ecto.Association do
       iex> Ecto.Association.related_from_query(Schema, :comments_v1)
       Schema
 
+      iex> Ecto.Association.related_from_query({&Kernel.inspect/1, Schema}, :comments_v1)
+      Schema
+
       iex> Ecto.Association.related_from_query("wrong", :comments_v1)
       ** (ArgumentError) association :comments_v1 queryable must be a schema or a {source, schema}. got: "wrong"
   """
   def related_from_query(atom, _name) when is_atom(atom), do: atom
   def related_from_query({source, schema}, _name) when is_binary(source) and is_atom(schema), do: schema
+  def related_from_query({source_generator, schema}, _name) when is_function(source_generator) and is_atom(schema), do: schema
   def related_from_query(queryable, name) do
     raise ArgumentError, "association #{inspect name} queryable must be a schema or " <>
       "a {source, schema}. got: #{inspect queryable}"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2760,6 +2760,8 @@ defmodule Ecto.Changeset do
 
   defp get_source(%{data: %{__meta__: %{source: source}}}) when is_binary(source),
     do: source
+  defp get_source(%{data: %{__meta__: %{source: source}} = data}) when is_function(source),
+    do: source.(data)
   defp get_source(%{data: data}), do:
     raise ArgumentError, "cannot add constraint to changeset because it does not have a source, got: #{inspect data}"
 


### PR DESCRIPTION
A POC implementation of today's [dynamic table naming proposal](https://groups.google.com/forum/#!topic/elixir-ecto/bg276jrXL9Q) on the mailing list.

**Status**
- [x] supports `{&Mod.fun/1, Mod}` syntax in schema definitions
- [x] computes relevant table names when inserting / updating / destroying models
- [x] supports foreign key constraints

**Related Work**
- [ ] update documentation to reflect the new functionality
- [ ] supports casting data to additional columns known at runtime, e.g. via [Postgres' inheritance model](https://www.postgresql.org/docs/current/ddl-inherit.html)
- [ ] supports loading data from additional columns at runtime

I am not yet sure if the Related Work items belong in this PR. Feedback very much appreciated!