### PR TITLE
use config_path when writing new config in ecto.gen.repo. closes #3202

### DIFF
--- a/lib/mix/tasks/ecto.gen.repo.ex
+++ b/lib/mix/tasks/ecto.gen.repo.ex
@@ -53,14 +53,14 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
         check = String.contains?(contents, "import Config")
         config_first_line = get_first_config_line(check) <> "\n"
         new_contents = config_first_line <> "\n" <> config_template(opts)
-        Mix.shell().info [:green, "* updating ", :reset, "config/config.exs"]
+        Mix.shell().info [:green, "* updating ", :reset, config_path]
         File.write! config_path, String.replace(contents, config_first_line, new_contents)
       {:error, _} ->
         config_first_line = Config |> Code.ensure_loaded?() |> get_first_config_line()
         create_file config_path, config_first_line <> "\n\n" <> config_template(opts)
     end
 
-    open?("config/config.exs")
+    open?(config_path)
 
     Mix.shell().info """
     Don't forget to add your new repo to your supervision tree

--- a/lib/mix/tasks/ecto.gen.repo.ex
+++ b/lib/mix/tasks/ecto.gen.repo.ex
@@ -54,10 +54,10 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
         config_first_line = get_first_config_line(check) <> "\n"
         new_contents = config_first_line <> "\n" <> config_template(opts)
         Mix.shell().info [:green, "* updating ", :reset, "config/config.exs"]
-        File.write! "config/config.exs", String.replace(contents, config_first_line, new_contents)
+        File.write! config_path, String.replace(contents, config_first_line, new_contents)
       {:error, _} ->
         config_first_line = Config |> Code.ensure_loaded?() |> get_first_config_line()
-        create_file "config/config.exs", config_first_line <> "\n\n" <> config_template(opts)
+        create_file config_path, config_first_line <> "\n\n" <> config_template(opts)
     end
 
     open?("config/config.exs")


### PR DESCRIPTION
# What
Should close https://github.com/elixir-ecto/ecto/issues/3202

This adds to the changes in https://github.com/elixir-ecto/ecto/commit/a8a102cfb7abe0b170acd2da248f6aefab592098 to use the same correct path when writing back the file.

## Output sample
Run from a mix application under an umbrella, now we see this output
```
pwd
==> /Users/javierevans/code/umbrella_test_umbrella/apps/repository

mix ecto.gen.repo -r Repository.Repo
==> repository
* creating lib/repository
* creating lib/repository/repo.ex
* updating ../../config/config.exs
Don't forget to add your new repo to your supervision tree
(typically in lib/repository/application.ex):

    {Repository.Repo, []}

And to add it to the list of ecto repositories in your
configuration files (so Ecto tasks work as expected):

    config :repository,
      ecto_repos: [Repository.Repo]
```
## Testing
I had some trouble figuring out how to test a different value for `config[:config_path]` so I'm asking for help to do it in a way that is in line with the tests in the project.