### PR TITLE
Removing prefixed table name from constraints (see ecto_sql #175)

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -677,6 +677,8 @@ defmodule Ecto.Repo.Schema do
   defp constraints_to_errors(%{constraints: user_constraints, errors: errors} = changeset, action, constraints) do
     constraint_errors =
       Enum.map constraints, fn {type, constraint} ->
+        constraint = constraint |> String.split(".") |> Enum.at(-1)
+
         user_constraint =
           Enum.find(user_constraints, fn c ->
             case {c.type, c.constraint,  c.match} do


### PR DESCRIPTION
Hello,

i have reported this issue here: https://github.com/elixir-ecto/ecto_sql/issues/175 and i am not sure if this is the correct way of submitting my suggested fix for that in ecto.

Nevertheless, this fixes the issue in a backward compatible way. 

I have checked the documentation for mysql and postgres and "." seems to be a character which is not allowed for naming indexes.
