### PR TITLE
Add note about importing environment in config.exs

### DIFF
--- a/guides/introduction/Testing with Ecto.md
+++ b/guides/introduction/Testing with Ecto.md
@@ -21,7 +21,7 @@ config :my_app, MyApp.Repo,
 Thereby, we configure the database connection for our test setup.
 In this case, we use a Postgres database and set it up to use the sandbox pool that will wrap each test in a transaction.
 
-Make sure we import the configuration for the test environment at the very bottom of `config.exs`:
+Make sure we import the configuration for the test environment at the very bottom of `config/config.exs`:
 
 ```elixir
 import_config "#{Mix.env()}.exs"

--- a/guides/introduction/Testing with Ecto.md
+++ b/guides/introduction/Testing with Ecto.md
@@ -21,6 +21,12 @@ config :my_app, MyApp.Repo,
 Thereby, we configure the database connection for our test setup.
 In this case, we use a Postgres database and set it up to use the sandbox pool that will wrap each test in a transaction.
 
+Make sure we import the configuration for the test environment at the very bottom of `config.exs`:
+
+```elixir
+import_config "#{Mix.env()}.exs"
+```
+
 We also need to add an explicit statement to the end of `test/test_helper.exs` about the `sandbox` mode:
 
 ```elixir


### PR DESCRIPTION
I was following the introduction guide and got hung up, as I couldn't make the tests run:
```
** (RuntimeError) cannot invoke sandbox operation with pool DBConnection.ConnectionPool.
To use the SQL Sandbox, configure your repository pool as:

    pool: Ecto.Adapters.SQL.Sandbox

    (ecto_sql) lib/ecto/adapters/sql/sandbox.ex:490: Ecto.Adapters.SQL.Sandbox.lookup_meta!/1
    (ecto_sql) lib/ecto/adapters/sql/sandbox.ex:388: Ecto.Adapters.SQL.Sandbox.mode/2
    (elixir) lib/code.ex:813: Code.require_file/2
```

Turns out the code in `config/test.exs` never got executed, as I was using the `config.exs` from the Getting Started guide. This disconnect was not obvious for a beginner like myself who doesn't know how to elixir too well.