### PR TITLE
Forward compatibility with Decimal v2.0

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -856,12 +856,14 @@ defmodule Ecto.Query.Builder do
   @doc """
   Negates the given number.
   """
-  def negate!(%Decimal{} = decimal) do
-    Decimal.minus(decimal)
+  # TODO: remove check when we depend on decimal v2.0
+  if Code.ensure_loaded?(Decimal) and function_exported?(Decimal, :negate, 1) do
+    def negate!(%Decimal{} = decimal), do: Decimal.negate(decimal)
+  else
+    def negate!(%Decimal{} = decimal), do: Decimal.minus(decimal)
   end
-  def negate!(number) when is_number(number) do
-    -number
-  end
+
+  def negate!(number) when is_number(number), do: -number
 
   @doc """
   Returns the type of an expression at build time.

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -823,7 +823,8 @@ defmodule Ecto.Type do
   defp cast_decimal(term) when is_binary(term) do
     case Decimal.parse(term) do
       {:ok, decimal} -> check_decimal(decimal)
-      :error -> :error
+      {decimal, ""} -> check_decimal(decimal)
+      _ -> :error
     end
   end
 
@@ -1325,8 +1326,8 @@ defmodule Ecto.Type do
     """
   end
 
-  defp check_decimal(%Decimal{coef: coef}) when coef in [:inf, :qNaN, :sNaN], do: :error
-  defp check_decimal(%Decimal{} = decimal), do: {:ok, decimal}
+  defp check_decimal(%Decimal{coef: coef} = decimal) when is_integer(coef), do: {:ok, decimal}
+  defp check_decimal(%Decimal{}), do: :error
 
   defp check_decimal!(decimal) do
     case check_decimal(decimal) do

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Ecto.MixProject do
 
   defp deps do
     [
-      {:decimal, "~> 1.6"},
+      {:decimal, "~> 1.6 or ~> 2.0"},
       {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.20", only: :docs}
     ]


### PR DESCRIPTION
We have one _compile_ warning:

    warning: Decimal.cmp/2 is deprecated. Use compare/2 instead
      lib/ecto/changeset.ex:2116: Ecto.Changeset.validate_number/6

We could make it go away with a conditional but I think it's probably ok
to leave it as is.