### PR TITLE
Ignore empty hostname when parsing database url

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -108,17 +108,27 @@ defmodule Ecto.Repo.Supervisor do
     destructure [username, password], info.userinfo && String.split(info.userinfo, ":")
     "/" <> database = info.path
 
-    url_opts = [username: username,
-                password: password,
-                database: database,
-                hostname: info.host,
-                port:     info.port]
+    url_opts = [
+      username: username,
+      password: password,
+      database: database,
+      port: info.port
+    ]
 
+    url_opts = put_hostname_if_present(url_opts, info.host)
     query_opts = parse_uri_query(info)
 
     for {k, v} <- url_opts ++ query_opts,
         not is_nil(v),
         do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
+  end
+
+  defp put_hostname_if_present(keyword, "") do
+    keyword
+  end
+
+  defp put_hostname_if_present(keyword, hostname) when is_binary(hostname) do
+    Keyword.put(keyword, :hostname, hostname)
   end
 
   defp parse_uri_query(%URI{query: nil}),

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -37,6 +37,12 @@ defmodule Ecto.Repo.SupervisorTest do
             otp_app: :ecto, password: "hunter2", port: 12345, username: "eric"]
   end
 
+  test "ignores empty hostname" do
+    put_env(database: "hello", url: "ecto:///mydb")
+    {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, extra: "extra")
+    assert normalize(config) == [database: "mydb", extra: "extra", otp_app: :ecto]
+  end
+
   test "is no-op for nil or empty URL" do
     put_env(database: "hello", url: nil)
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [])

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -37,10 +37,12 @@ defmodule Ecto.Repo.SupervisorTest do
             otp_app: :ecto, password: "hunter2", port: 12345, username: "eric"]
   end
 
-  test "ignores empty hostname" do
-    put_env(database: "hello", url: "ecto:///mydb")
-    {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, extra: "extra")
-    assert normalize(config) == [database: "mydb", extra: "extra", otp_app: :ecto]
+  if Version.match?(System.version(), ">= 1.10.0") do
+    test "ignores empty hostname" do
+      put_env(database: "hello", url: "ecto:///mydb")
+      {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, extra: "extra")
+      assert normalize(config) == [database: "mydb", extra: "extra", otp_app: :ecto]
+    end
   end
 
   test "is no-op for nil or empty URL" do


### PR DESCRIPTION
By not putting the value into the list we give drivers a chance to use
their own default hostname.

Closes #3212.