### PR TITLE
Fix decimal load from JSON serialized map

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -438,6 +438,13 @@ defmodule Ecto.Type do
 
   defp same_decimal(term) when is_integer(term), do: {:ok, Decimal.new(term)}
   defp same_decimal(term) when is_float(term), do: {:ok, Decimal.from_float(term)}
+  defp same_decimal(term) when is_binary(term) do
+    case Decimal.parse(term) do
+      {:ok, decimal} -> {:ok, check_decimal!(decimal)}
+      {decimal, ""} -> {:ok, check_decimal!(decimal)}
+      :error -> :error
+    end
+  end
   defp same_decimal(%Decimal{} = term), do: {:ok, check_decimal!(term)}
   defp same_decimal(_), do: :error
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -176,12 +176,17 @@ defmodule Ecto.TypeTest do
     assert dump(:decimal, Decimal.new("1")) == {:ok, Decimal.new("1")}
     assert dump(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
     assert dump(:decimal, 1) == {:ok, Decimal.new("1")}
-    assert dump(:decimal, "1.0") == :error
+    assert dump(:decimal, "1.0") == {:ok, Decimal.new("1.0")}
     assert dump(:decimal, "bad") == :error
 
     assert_raise ArgumentError, ~r"#Decimal<NaN> is not allowed for type :decimal", fn ->
       dump(:decimal, Decimal.new("nan"))
     end
+
+    assert load(:decimal, 1) == {:ok, Decimal.new(1)}
+    assert load(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
+    assert load(:decimal, "1.0") == {:ok, Decimal.new("1.0")}
+    assert load(:decimal, Decimal.new("1.0")) == {:ok, Decimal.new("1.0")}
   end
 
   test "maybe" do


### PR DESCRIPTION
Given schemas
```
defmodule MySettings do
  use Ecto.Schema
  import Ecto.Changeset

  embedded_schema do
    field : my_decimal_field, :decimal
  end
end

defmodule MyEntity do
  schema "my_entities" do
    field :settings, :map, default: %{}
  end
end
```
storing & loading `MySettings` in Postgres JSON column
```
# store
settings_changeset = %MySettings{}
|> MySettings.changeset(%{"my_decimal_field" => "1.0"}

{:ok, data} = Ecto.Changeset.apply_action(settings_changeset, :update)

my_entity = Repo.get(MyEntity, some_id)
|> Ecto.Changeset.change(%{settings: data |> Map.from_struct()})
|> Repo.update!()

# load
my_entity = Repo.get(MyEntity, some_id)
Repo.load(MySettings, my_entity.settings)
```
results in
```
** (ArgumentError) cannot load `"1.0"` as type :decimal for field `my_decimal_field` in schema MySettings
```

