### PR TITLE
Fix dynamic through assertion for has_many through assoc in integration tests

### DIFF
--- a/integration_test/cases/assoc.exs
+++ b/integration_test/cases/assoc.exs
@@ -71,7 +71,7 @@ defmodule Ecto.Integration.AssocTest do
     assert [^u2, ^u1] = TestRepo.all(query)
 
     # Dynamic through
-    Ecto.assoc([p1, p2], [:comments, :author]) |> order_by([a], a.name)
+    query = Ecto.assoc([p1, p2], [:comments, :author]) |> order_by([a], a.name)
     assert [^u2, ^u1] = TestRepo.all(query)
   end
 


### PR DESCRIPTION
Since dynamic through assertion is not matched to query - it results in two
same assertions and not testing the dynamic case.