### PR TITLE
Fix select_merge on map with outer join

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -5,7 +5,6 @@ defmodule Ecto.Integration.RepoTest do
   import Ecto.Query
 
   alias Ecto.Integration.Post
-  alias Ecto.Integration.Post.Translation
   alias Ecto.Integration.Order
   alias Ecto.Integration.User
   alias Ecto.Integration.Comment
@@ -1238,7 +1237,8 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     test "merge" do
-      %Post{id: post_id} = TestRepo.insert!(%Post{title: "1", counter: nil})
+      date = Date.utc_today()
+      %Post{id: post_id} = TestRepo.insert!(%Post{title: "1", counter: nil, posted: date, public: false})
 
       # Merge on source
       assert [%Post{title: "2"}] =
@@ -1259,31 +1259,32 @@ defmodule Ecto.Integration.RepoTest do
              Post |> select([p], %{title: p.title}) |> select_merge([p], %{title: "2"}) |> TestRepo.all()
 
       # Merge on outer join with map
-      %Translation{} =
-        TestRepo.insert!(%Translation{locale: "en", post_id: post_id, title: "Q", summary: "Z"})
+      %Permalink{} = TestRepo.insert!(%Permalink{post_id: post_id, url: "Q", title: "Z"})
 
       # left join record is present
-      assert [%{title: "Q", summary: "Z"}] =
-               Post
-               |> Translation.with_translations("en", fields: ~w(title summary)a)
+      assert [%{url: "Q", title: "1", posted: date}] =
+               Permalink
+               |> join(:left, [l], p in Post, on: l.post_id == p.id)
+               |> select([l, p], merge(l, map(p, ^~w(title posted)a)))
                |> TestRepo.all()
 
-      assert [%{title: "Q", summary: "Z"}] =
-               Post
-               |> join(:left, [p], t in Translation, on: t.post_id == p.id and t.locale == ^"en")
-               |> select([p, t], merge(p, map(t, ^~w(title summary)a)))
+      assert [%{url: "Q", title: "1", posted: date}] =
+               Permalink
+               |> join(:left, [l], p in Post, on: l.post_id == p.id)
+               |> select_merge([_l, p], map(p, ^~w(title posted)a))
                |> TestRepo.all()
 
       # left join record is not present
-      assert [%{title: "1", summary: nil}] =
-               Post
-               |> Translation.with_translations("pt", fields: ~w(title summary)a)
+      assert [%{url: "Q", title: "Z", posted: nil}] =
+               Permalink
+               |> join(:left, [l], p in Post, on: l.post_id == p.id and p.public)
+               |> select([l, p], merge(l, map(p, ^~w(title posted)a)))
                |> TestRepo.all()
 
-      assert [%{title: "1", summary: nil}] =
-               Post
-               |> join(:left, [p], t in Translation, on: t.post_id == p.id and t.locale == ^"pt")
-               |> select([p, t], merge(p, map(t, ^~w(title summary)a)))
+      assert [%{url: "Q", title: "Z", posted: nil}] =
+               Permalink
+               |> join(:left, [l], p in Post, on: l.post_id == p.id and p.public)
+               |> select_merge([_l, p], map(p, ^~w(title posted)a))
                |> TestRepo.all()
     end
 

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -34,7 +34,6 @@ defmodule Ecto.Integration.Post do
     field :title, :string
     field :text, :binary
     field :temp, :string, default: "temp", virtual: true
-    field :summary, :string, virtual: true
     field :public, :boolean, default: true
     field :cost, :decimal
     field :visits, :integer
@@ -47,7 +46,6 @@ defmodule Ecto.Integration.Post do
     field :intensities, {:map, :float}
     field :posted, :date
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
-    has_many :translations, Ecto.Integration.Post.Translation
     # The post<->permalink relationship should be marked as uniq
     has_one :permalink, Ecto.Integration.Permalink, on_delete: :delete_all, on_replace: :delete
     has_one :update_permalink, Ecto.Integration.Permalink, foreign_key: :post_id, on_delete: :delete_all, on_replace: :update
@@ -68,44 +66,6 @@ defmodule Ecto.Integration.Post do
   def changeset(schema, params) do
     cast(schema, params, ~w(counter title text temp public cost visits
                            intensity bid uuid meta posted)a)
-  end
-end
-
-defmodule Ecto.Integration.Post.Translation do
-  @moduledoc """
-  This module is used to test:
-
-    * Select Merge with outer joins and dynamic maps.
-
-  """
-  use Ecto.Integration.Schema
-  import Ecto.Changeset
-
-  @primary_key false
-
-  schema "post_translations" do
-    field :locale, :string, primary_key: true
-    belongs_to :post, Post, primary_key: true
-
-    field :title, :string
-    field :summary, :string
-
-    timestamps()
-
-    def changeset(schema, params) do
-      cast(schema, params, ~w(post_id locale title summary)a)
-    end
-  end
-
-  def with_translations(query, locale, options \\ []) do
-    import Ecto.Query
-
-    type = Keyword.get(options, :join_type, :left)
-    fields = Keyword.get(options, :fields, ~w(title)a)
-
-    query
-    |> join(type, [p], t in __MODULE__, on: t.post_id == p.id and t.locale == ^locale)
-    |> select_merge([_p, t], map(t, ^fields))
   end
 end
 
@@ -146,6 +106,8 @@ defmodule Ecto.Integration.Permalink do
 
   schema "permalinks" do
     field :url, :string, source: :uniform_resource_locator
+    field :title, :string
+    field :posted, :date, virtual: true
     belongs_to :post, Ecto.Integration.Post, on_replace: :nilify
     belongs_to :update_post, Ecto.Integration.Post, on_replace: :update, foreign_key: :post_id, define_field: false
     belongs_to :user, Ecto.Integration.User
@@ -153,7 +115,7 @@ defmodule Ecto.Integration.Permalink do
   end
 
   def changeset(schema, params) do
-    Ecto.Changeset.cast(schema, params, [:url])
+    Ecto.Changeset.cast(schema, params, [:url, :title])
   end
 end
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1232,6 +1232,21 @@ defmodule Ecto.Query do
   being merged on must be a struct or a map. If it is a struct, the fields
   merged later on must be part of the struct, otherwise an error is raised.
 
+  If the argument to `:select_merge` is a constructed struct (`struct/2`) or
+  map (`map/2`) where the source to `struct/2` or `map/2` may be a `nil` value
+  (as in an outer join), the source will be returned unmodified.
+
+      query =
+        Post
+        |> join(:left, [p], t in Post.Translation,
+          on: t.post_id == p.id and t.locale == ^"en"
+        )
+        |> select_merge([_p, t], map(t, ^~w(title summary)a))
+
+  If there is no English translation for the post, the untranslated post
+  `title` will be returned and `summary` will be `nil`. If there is, both
+  `title` and `summary` will be the value from `Post.Translation`.
+
   `select_merge` cannot be used to set fields in associations, as
   associations are always loaded later, overriding any previous value.
   """

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -279,6 +279,15 @@ defmodule Ecto.Repo.Queryable do
         {%{}, %{}} ->
           Map.merge(left, right)
 
+        {%{}, nil} ->
+          left
+
+        {nil, %{}} ->
+          right
+
+        {nil, nil} ->
+          nil
+
         {_, %{}} ->
           raise ArgumentError,
                 "cannot merge because the left side is not a map, got: #{inspect(left)}"


### PR DESCRIPTION
Resolves #3218

Three cases have been added to merge processing:

- If the merge argument (`right`) is `nil`, return `left` unmodified. This can
  happen with a `:left_join` or `:full_join`. This is fully tested.

- If the merge source (`left`) is `nil`, return `right` unmodified. This can
  happen with a `:right_join` or `:full_join`. This is not tested.

- If both the source and argument are `nil`, return `nil`. This _probably_
  shouldn’t happen, but is currently included for completeness. This is not
  tested.