### PR TITLE
Prevent *.DS_Store files from slipping into Hex packages

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule Ecto.MixProject do
       maintainers: ["Eric Meadows-Jönsson", "José Valim", "James Fish", "Michał Muskała"],
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/elixir-ecto/ecto"},
+      exclude_patterns: [~r/\W\.DS_Store$/],
       files:
         ~w(.formatter.exs mix.exs README.md CHANGELOG.md lib) ++
           ~w(integration_test/cases integration_test/support)


### PR DESCRIPTION
Prevent Apple Desktop Services Store (`*.DS_Store`) files from slipping into Hex packages using the `exclude_patterns` package option introduced in https://github.com/hexpm/hex/pull/512.

Ecto 3.3.2 has 6 such files, as can be [seen here](https://diff.hex.pm/diff/ecto/3.3.1..3.3.2) or in the follow:
```shell
$ mix new foo
$ cd foo
# add {:ecto, "~> 3.0"} to deps in mix.exs
$ mix deps.get
$ find deps/ecto -name '*.DS_Store'
deps/ecto/lib/.DS_Store
deps/ecto/lib/ecto/adapter/.DS_Store
deps/ecto/lib/ecto/.DS_Store
deps/ecto/lib/ecto/query/.DS_Store
deps/ecto/lib/mix/.DS_Store
deps/ecto/lib/mix/tasks/.DS_Store
```