### PR TITLE
Use explicit match on fetch_change!/2

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1086,7 +1086,7 @@ defmodule Ecto.Changeset do
   @spec fetch_change!(t, atom) :: term
   def fetch_change!(changeset, key) do
     case fetch_change(changeset, key) do
-      {_, value} ->
+      {:ok, value} ->
         value
 
       :error ->


### PR DESCRIPTION
Since `Ecto.Changeset.fetch_change/2` only returns `{:ok, term()} | :error`.