### PR TITLE
Add Ecto.Query.API.json_extract_path/2

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -452,6 +452,27 @@ defmodule Ecto.Query.API do
   def merge(left_map, right_map), do: doc! [left_map, right_map]
 
   @doc """
+  Returns value from the `json_field` pointed to by `path`.
+
+      from(post in Post, select: json_extract_path(post.meta, ["author", "name"]))
+
+  The query can be also rewritten as:
+
+      from(post in Post, select: post.meta["author"]["name"])
+
+  Path elements can be integers to access values in JSON arrays:
+
+      from(post in Post, select: post.meta["tags"][0]["name"])
+
+  Any element of the path can be dynamic:
+
+      field = "name"
+      from(post in Post, select: post.meta["author"][^field])
+
+  """
+  def json_extract_path(json_field, path), do: doc! [json_field, path]
+
+  @doc """
   Casts the given value to the given type at the database level.
 
   Most of the times, Ecto is able to proper cast interpolated

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -264,6 +264,10 @@ defimpl Inspect, for: Ecto.Query do
     {:type, [], [value, tag]} |> expr(names, part)
   end
 
+  defp expr_to_string({:json_extract_path, _, [expr, path]}, _, names, part) do
+    json_expr_path_to_expr(expr, path) |> expr(names, part)
+  end
+
   defp expr_to_string(_expr, string, _, _) do
     string
   end
@@ -278,6 +282,12 @@ defimpl Inspect, for: Ecto.Query do
 
   defp type_to_expr(type) do
     type
+  end
+
+  defp json_expr_path_to_expr(expr, path) do
+    Enum.reduce(path, expr, fn element, acc ->
+      {{:., [], [Access, :get]}, [], [acc, element]}
+    end)
   end
 
   defp unmerge_fragments([{:raw, s}, {:expr, v} | t], frag, args, names, part) do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -270,6 +270,17 @@ defmodule Ecto.Query.InspectTest do
       ~s{from p0 in Inspect.Post, where: fragment(title: [foo: ^"foobar"])}
   end
 
+  test "json_extract_path" do
+    assert i(from(x in Post, select: json_extract_path(x.meta, ["author"]))) ==
+             ~s{from p0 in Inspect.Post, select: p0.meta[\"author\"]}
+
+    assert i(from(x in Post, select: x.meta["author"])) ==
+             ~s{from p0 in Inspect.Post, select: p0.meta[\"author\"]}
+
+    assert i(from(x in Post, select: x.meta["author"]["name"])) ==
+             ~s{from p0 in Inspect.Post, select: p0.meta[\"author\"][\"name\"]}
+  end
+
   test "inspect all" do
     string = """
     from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), where: true, or_where: true,


### PR DESCRIPTION
Ref https://github.com/elixir-ecto/ecto/issues/3216

Ref: https://github.com/elixir-ecto/ecto_sql/pull/187

I plan to update this PR (or create a new one) with support for a similar `embed_extract_path/2` that works with embeds (we'd use it like this: `from o in Order, select: o.item.price`.)