### PR TITLE
improve doc on conflict_target option of insert/2

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1126,8 +1126,11 @@ defmodule Ecto.Repo do
     * `:conflict_target` - A list of column names to verify for conflicts.
       It is expected those columns to have unique indexes on them that may conflict.
       If none is specified, the conflict target is left up to the database.
-      May also be `{:constraint, constraint_name_as_atom}` in databases
-      that support the "ON CONSTRAINT" expression, such as PostgreSQL.
+      It may also be `{:constraint, constraint_name_as_atom}` in databases
+      that support the "ON CONSTRAINT" expression, such as PostgreSQL, or
+      `{:unsafe_fragment, binary_fragment}` to pass any expression to the
+      database without any sanitization, such as
+      `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
     * `:stale_error_field` - The field where stale errors will be added in
       the returning changeset. This option can be used to avoid raising
       `Ecto.StaleEntryError`.


### PR DESCRIPTION
The documentation for `insert/2` regarding `conflict_target` wasn't up to date anymore. I only copied over the newer description from `insert_all/3`.