### PR TITLE
Show meaningful error in case of doubled schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -453,7 +453,7 @@ defmodule Ecto.Schema do
   `@primary_key` attribute.
   """
   defmacro embedded_schema([do: block]) do
-    schema(nil, false, :binary_id, block)
+    schema(__ENV__, nil, false, :binary_id, block)
   end
 
   @doc """
@@ -464,12 +464,20 @@ defmodule Ecto.Schema do
   as value and can be manipulated with the `Ecto.put_meta/2` function.
   """
   defmacro schema(source, [do: block]) do
-    schema(source, true, :id, block)
+    schema(__ENV__, source, true, :id, block)
   end
 
-  defp schema(source, meta?, type, block) do
+  defp schema(caller, source, meta?, type, block) do
     prelude =
       quote do
+        if Module.get_attribute(__MODULE__, :ecto_schema_defined) do
+          raise """
+          Schema already defined for #{inspect(__MODULE__)} on line #{@ecto_schema_defined}
+          """
+        end
+
+        @ecto_schema_defined unquote(caller.line)
+
         @after_compile Ecto.Schema
         Module.register_attribute(__MODULE__, :changeset_fields, accumulate: true)
         Module.register_attribute(__MODULE__, :struct_fields, accumulate: true)

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -453,7 +453,7 @@ defmodule Ecto.Schema do
   `@primary_key` attribute.
   """
   defmacro embedded_schema([do: block]) do
-    schema(__ENV__, nil, false, :binary_id, block)
+    schema(__CALLER__, nil, false, :binary_id, block)
   end
 
   @doc """
@@ -464,7 +464,7 @@ defmodule Ecto.Schema do
   as value and can be manipulated with the `Ecto.put_meta/2` function.
   """
   defmacro schema(source, [do: block]) do
-    schema(__ENV__, source, true, :id, block)
+    schema(__CALLER__, source, true, :id, block)
   end
 
   defp schema(caller, source, meta?, type, block) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -470,10 +470,8 @@ defmodule Ecto.Schema do
   defp schema(caller, source, meta?, type, block) do
     prelude =
       quote do
-        if Module.get_attribute(__MODULE__, :ecto_schema_defined) do
-          raise """
-          Schema already defined for #{inspect(__MODULE__)} on line #{@ecto_schema_defined}
-          """
+        if line = Module.get_attribute(__MODULE__, :ecto_schema_defined) do
+          raise "schema already defined for #{inspect(__MODULE__)} on line #{line}"
         end
 
         @ecto_schema_defined unquote(caller.line)

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -687,24 +687,23 @@ defmodule Ecto.SchemaTest do
   end
 
   test "defining schema twice will result with meaningfull error" do
-    quoted =
-      quote do
-        defmodule DoubleSchema do
-          use Ecto.Schema
+    quoted = """
+    defmodule DoubleSchema do
+      use Ecto.Schema
 
-          schema "my schema" do
-            field :name, :string
-          end
-
-          schema "my schema" do
-            field :name, :string
-          end
-        end
+      schema "my schema" do
+        field :name, :string
       end
-    message = ~r/^Schema already defined for DoubleSchema on line \d+$/
+
+      schema "my schema" do
+        field :name, :string
+      end
+    end
+    """
+    message = "schema already defined for DoubleSchema on line 4"
 
     assert_raise RuntimeError, message, fn ->
-      Code.compile_quoted(quoted)
+      Code.compile_string(quoted, "example.ex")
     end
   end
 end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -685,4 +685,26 @@ defmodule Ecto.SchemaTest do
       end
     end
   end
+
+  test "defining schema twice will result with meaningfull error" do
+    quoted =
+      quote do
+        defmodule DoubleSchema do
+          use Ecto.Schema
+
+          schema "my schema" do
+            field :name, :string
+          end
+
+          schema "my schema" do
+            field :name, :string
+          end
+        end
+      end
+    message = ~r/^Schema already defined for DoubleSchema on line \d+$/
+
+    assert_raise RuntimeError, message, fn ->
+      Code.compile_quoted(quoted)
+    end
+  end
 end


### PR DESCRIPTION
Earlier it returned information about `id` being defined twice, which could be confusing for the users as in most cases this field wasn't defined anywhere. Now it will raise `RuntimeError` with meaningful error that contain line with first schema.