### PR TITLE
adding missing insert

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -381,6 +381,9 @@ defmodule Ecto.Integration.TypeTest do
   @tag :decimal_type
   @tag :decimal_precision
   test "decimal type cast" do
+    decimal = Decimal.new("1.0")
+    TestRepo.insert!(%Post{cost: decimal})
+
     assert TestRepo.all(from p in Post, select: type(2 + ^"2", p.cost)) == [Decimal.new("4")]
     assert TestRepo.all(from p in Post, select: type(2.0 + ^"2", p.cost)) == [Decimal.new("4.0")]
   end


### PR DESCRIPTION
During previous test case adoption for mssql adapter, mistakenly one insert is left out during refactoring, so test is failing for pg and myxql adapters.

This PR should fix this test