### PR TITLE
Add validations to json_extract_path/2

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -318,6 +318,14 @@ defmodule Ecto.Integration.TypeTest do
   end
 
   @tag :map_type
+  @tag :json_extract_path
+  test "json_extract_path with embeds" do
+    post = %Post{items: [%{valid_at: ~D[2020-01-01]}]}
+    TestRepo.insert!(post)
+    assert TestRepo.one(from p in Post, select: p.items[0]["valid_at"]) == "2020-01-01"
+  end
+
+  @tag :map_type
   @tag :map_type_schemaless
   test "embeds one with custom type" do
     item = %Item{price: 123, reference: "PREFIX-EXAMPLE"}

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -60,6 +60,7 @@ defmodule Ecto.Integration.Post do
     has_many :users_comments, through: [:users, :comments]
     has_many :comments_authors_permalinks, through: [:comments_authors, :permalink]
     has_one :post_user_composite_pk, Ecto.Integration.PostUserCompositePk
+    embeds_many :items, Ecto.Integration.Item
     timestamps()
   end
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -469,6 +469,12 @@ defmodule Ecto.Query.API do
       field = "name"
       from(post in Post, select: post.meta["author"][^field])
 
+  **Warning**: the underlying data in the JSON column is returned without any
+  additional decoding, e.g. datetimes (which are encoded as strings) are
+  returned as strings. This also means that queries like:
+  `where: post.meta["published_at"] > from_now(-1, "day")` may return incorrect
+  results or fail as the underlying database may try to compare e.g. `json` with
+  `date` types. Use `type/2` to force the types on the database level.
   """
   def json_extract_path(json_field, path), do: doc! [json_field, path]
 


### PR DESCRIPTION
Follow up on https://github.com/elixir-ecto/ecto/pull/3245
Closes https://github.com/elixir-ecto/ecto/issues/3216

When the query source is a schema we walk the json path and ensure we're
only accessing embeds and maps and the fields exists.