### PR TITLE
Support default options (such as a default prefix) for a repo

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -214,7 +214,7 @@ defmodule Ecto.Repo do
 
       def with_default_opts(opts) do
         default_opts = Process.get({__MODULE__, :default_opts}, [])
-        Keyword.merge(opts, default_opts)
+        Keyword.merge(default_opts, opts)
       end
       ## Transactions
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -200,6 +200,10 @@ defmodule Ecto.Repo do
 
       @compile {:inline, get_dynamic_repo: 0}
 
+      def default_opts(opts \\ []) do
+        Process.put({__MODULE__, :default_opts}, opts)
+      end
+
       def get_dynamic_repo() do
         Process.get({__MODULE__, :dynamic_repo}, @default_dynamic_repo)
       end
@@ -208,11 +212,15 @@ defmodule Ecto.Repo do
         Process.put({__MODULE__, :dynamic_repo}, dynamic) || @default_dynamic_repo
       end
 
+      def with_default_opts(opts) do
+        default_opts = Process.get({__MODULE__, :default_opts}, [])
+        Keyword.merge(opts, default_opts)
+      end
       ## Transactions
 
       if Ecto.Adapter.Transaction in behaviours do
         def transaction(fun_or_multi, opts \\ []) do
-          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, opts)
+          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, with_default_opts(opts))
         end
 
         def in_transaction? do
@@ -229,39 +237,39 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Schema in behaviours and not @read_only do
         def insert(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, opts)
+          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
         end
 
         def update(struct, opts \\ []) do
-          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, opts)
+          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
         end
 
         def insert_or_update(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, opts)
+          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, with_default_opts(opts))
         end
 
         def delete(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, opts)
+          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
         end
 
         def insert!(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, opts)
+          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
         end
 
         def update!(struct, opts \\ []) do
-          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, opts)
+          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
         end
 
         def insert_or_update!(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, opts)
+          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, with_default_opts(opts))
         end
 
         def delete!(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, opts)
+          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
         end
 
         def insert_all(schema_or_source, entries, opts \\ []) do
-          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, opts)
+          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, with_default_opts(opts))
         end
       end
 
@@ -270,51 +278,51 @@ defmodule Ecto.Repo do
       if Ecto.Adapter.Queryable in behaviours do
         if not @read_only do
           def update_all(queryable, updates, opts \\ []) do
-            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, opts)
+            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, with_default_opts(opts))
           end
 
           def delete_all(queryable, opts \\ []) do
-            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, opts)
+            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, with_default_opts(opts))
           end
         end
 
         def all(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.all(get_dynamic_repo(), queryable, opts)
+          Ecto.Repo.Queryable.all(get_dynamic_repo(), queryable, with_default_opts(opts))
         end
 
         def stream(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, opts)
+          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, with_default_opts(opts))
         end
 
         def get(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, opts)
+          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, with_default_opts(opts))
         end
 
         def get!(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, opts)
+          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, with_default_opts(opts))
         end
 
         def get_by(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, opts)
+          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, with_default_opts(opts))
         end
 
         def get_by!(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, opts)
+          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, with_default_opts(opts))
         end
 
         def one(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one(get_dynamic_repo(), queryable, opts)
+          Ecto.Repo.Queryable.one(get_dynamic_repo(), queryable, with_default_opts(opts))
         end
 
         def one!(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, opts)
+          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, with_default_opts(opts))
         end
 
         def aggregate(queryable, aggregate, opts \\ [])
 
         def aggregate(queryable, aggregate, opts)
             when aggregate in [:count] and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, opts)
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, with_default_opts(opts))
         end
 
         def aggregate(queryable, aggregate, field)
@@ -324,18 +332,18 @@ defmodule Ecto.Repo do
 
         def aggregate(queryable, aggregate, field, opts)
             when aggregate in @aggregates and is_atom(field) and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, opts)
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_opts(opts))
         end
 
         def exists?(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, opts)
+          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, with_default_opts(opts))
         end
 
         def preload(struct_or_structs_or_nil, preloads, opts \\ []) do
-          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, opts)
+          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, with_default_opts(opts))
         end
 
-        def prepare_query(operation, query, opts), do: {query, opts}
+        def prepare_query(operation, query, opts), do: {query, with_default_opts(opts)}
         defoverridable prepare_query: 3
       end
     end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -200,9 +200,8 @@ defmodule Ecto.Repo do
 
       @compile {:inline, get_dynamic_repo: 0}
 
-      def default_opts(opts \\ []) do
-        Process.put({__MODULE__, :default_opts}, opts)
-      end
+      def default_options(_operation_name), do: []
+      defoverridable default_options: 1
 
       def get_dynamic_repo() do
         Process.get({__MODULE__, :dynamic_repo}, @default_dynamic_repo)
@@ -212,15 +211,14 @@ defmodule Ecto.Repo do
         Process.put({__MODULE__, :dynamic_repo}, dynamic) || @default_dynamic_repo
       end
 
-      def with_default_opts(opts) do
-        default_opts = Process.get({__MODULE__, :default_opts}, [])
-        Keyword.merge(default_opts, opts)
+      def with_default_options(operation_name, opts) do
+        Keyword.merge(default_options(operation_name), opts)
       end
       ## Transactions
 
       if Ecto.Adapter.Transaction in behaviours do
         def transaction(fun_or_multi, opts \\ []) do
-          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, with_default_opts(opts))
+          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, with_default_options(:transaction, opts))
         end
 
         def in_transaction? do
@@ -237,39 +235,39 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Schema in behaviours and not @read_only do
         def insert(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
+          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, with_default_options(:insert, opts))
         end
 
         def update(struct, opts \\ []) do
-          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
+          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, with_default_options(:update, opts))
         end
 
         def insert_or_update(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, with_default_opts(opts))
+          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, with_default_options(:insert_or_update, opts))
         end
 
         def delete(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
+          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, with_default_options(:delete, opts))
         end
 
         def insert!(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
+          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:insert, opts))
         end
 
         def update!(struct, opts \\ []) do
-          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
+          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:update, opts))
         end
 
         def insert_or_update!(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, with_default_opts(opts))
+          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, with_default_options(:insert_or_update, opts))
         end
 
         def delete!(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, with_default_opts(opts))
+          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:delete, opts))
         end
 
         def insert_all(schema_or_source, entries, opts \\ []) do
-          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, with_default_opts(opts))
+          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, with_default_options(:insert_all, opts))
         end
       end
 
@@ -278,51 +276,51 @@ defmodule Ecto.Repo do
       if Ecto.Adapter.Queryable in behaviours do
         if not @read_only do
           def update_all(queryable, updates, opts \\ []) do
-            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, with_default_opts(opts))
+            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, with_default_options(:update_all, opts))
           end
 
           def delete_all(queryable, opts \\ []) do
-            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, with_default_opts(opts))
+            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, with_default_options(:delete_all, opts))
           end
         end
 
         def all(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.all(get_dynamic_repo(), queryable, with_default_opts(opts))
+          Ecto.Repo.Queryable.all(get_dynamic_repo(), queryable, with_default_options(:all, opts))
         end
 
         def stream(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, with_default_opts(opts))
+          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, with_default_options(:stream, opts))
         end
 
         def get(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, with_default_opts(opts))
+          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, with_default_options(:get, opts))
         end
 
         def get!(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, with_default_opts(opts))
+          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, with_default_options(:get, opts))
         end
 
         def get_by(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, with_default_opts(opts))
+          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, with_default_options(:get_by, opts))
         end
 
         def get_by!(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, with_default_opts(opts))
+          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, with_default_options(:get_by, opts))
         end
 
         def one(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one(get_dynamic_repo(), queryable, with_default_opts(opts))
+          Ecto.Repo.Queryable.one(get_dynamic_repo(), queryable, with_default_options(:one, opts))
         end
 
         def one!(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, with_default_opts(opts))
+          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, with_default_options(:one, opts))
         end
 
         def aggregate(queryable, aggregate, opts \\ [])
 
         def aggregate(queryable, aggregate, opts)
             when aggregate in [:count] and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, with_default_opts(opts))
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, with_default_options(:aggregate, opts))
         end
 
         def aggregate(queryable, aggregate, field)
@@ -332,18 +330,18 @@ defmodule Ecto.Repo do
 
         def aggregate(queryable, aggregate, field, opts)
             when aggregate in @aggregates and is_atom(field) and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_opts(opts))
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_options(:aggregate, opts))
         end
 
         def exists?(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, with_default_opts(opts))
+          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, with_default_options(:exists, opts))
         end
 
         def preload(struct_or_structs_or_nil, preloads, opts \\ []) do
-          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, with_default_opts(opts))
+          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, with_default_options(:preload, opts))
         end
 
-        def prepare_query(operation, query, opts), do: {query, with_default_opts(opts)}
+        def prepare_query(operation, query, opts), do: {query, with_default_options(:prepare_query, opts)}
         defoverridable prepare_query: 3
       end
     end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -220,16 +220,16 @@ defmodule Ecto.RepoTest do
     end
   end
 
+  defmodule DefaultOptionRepo do
+    use Ecto.Repo, otp_app: :ecto, adapter: Ecto.TestAdapter
+
+    def default_options(:all), do: [prefix: "all_schema"]
+    def default_options(:one), do: [prefix: "one_schema"]
+    def default_options(_), do: [prefix: "fallback_schema"]
+  end
+
   describe "default_options" do
     test "passes a default option for operation" do
-      defmodule DefaultOptionRepo do
-        use Ecto.Repo, otp_app: :ecto, adapter: Ecto.TestAdapter
-
-        def default_options(:all), do: [prefix: "all_schema"]
-        def default_options(:one), do: [prefix: "one_schema"]
-        def default_options(_), do: [prefix: "fallback_schema"]
-      end
-
       {:ok, _pid} = DefaultOptionRepo.start_link(url: "ecto://user:pass@local/hello")
       DefaultOptionRepo.all(MySchema)
       assert_received {:all, query}
@@ -247,12 +247,6 @@ defmodule Ecto.RepoTest do
 
   describe "with_default_options" do
     test "configured option for query overrides default" do
-      defmodule DefaultOptionRepo do
-        use Ecto.Repo, otp_app: :ecto, adapter: Ecto.TestAdapter
-
-        def default_options(_), do: [prefix: "different_schema"]
-      end
-
       {:ok, _pid} = DefaultOptionRepo.start_link(url: "ecto://user:pass@local/hello")
       DefaultOptionRepo.all(MySchema, prefix: "specific_schema")
       assert_received {:all, query}


### PR DESCRIPTION
Summary:

We'd like to be able to connect to a shard similar to `put_dynamic_repo` where all queries in the process will hit a particular schema without having to manually pass in the prefix on all possible queries. This also removes the need to have a repo specifically connected to the the schema (say through a `after_connect` function), which would increase the number of connections to the DB. 

Original post below: 

This is a POC (unit tests to be added if like idea). 

Problem trying to solve is not having to message pass the organization_id through the process and to not have to manually write it into every query in the application

![image](https://user-images.githubusercontent.com/5877050/77209627-56c35e80-6ac4-11ea-93f6-76c899c58839.png)


