### PR TITLE
Improve warning when a struct or similar is used with constraints

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2770,6 +2770,8 @@ defmodule Ecto.Changeset do
     do: source
   defp get_source(%{data: data}), do:
     raise ArgumentError, "cannot add constraint to changeset because it does not have a source, got: #{inspect data}"
+  defp get_source(item), do:
+    raise ArgumentError, "cannot add constraint because a changeset was not supplied, got: #{inspect item}"
 
   defp get_assoc(%{types: types}, assoc) do
     case Map.fetch(types, assoc) do


### PR DESCRIPTION
When you accidentally use a schema (or struct) with a constraint you get a cryptic pattern match error, this adds a second fallback pattern match to raise an `ArgumentError` with a more descriptive message.

I looked for a place to add a test, but the other fall back isn't tested that I could find? Happy for suggested improvements...

This originated from someone issue in the ecto channel on the elixir slack...