### PR TITLE
Also expand_alias on Schema field

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -617,6 +617,7 @@ defmodule Ecto.Schema do
 
   """
   defmacro field(name, type \\ :string, opts \\ []) do
+    type = expand_alias(type, __CALLER__)
     quote do
       Ecto.Schema.__field__(__MODULE__, unquote(name), unquote(type), unquote(opts))
     end


### PR DESCRIPTION
Ref the original PR that introduces expand_alias: https://github.com/elixir-ecto/ecto/pull/1670

When the type is a custom Ecto.Type, this will now create a runtime dependency on the type module instead of a compile time dependency.