### PR TITLE
Emit telemetry event upon Repo start

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -169,6 +169,12 @@ defmodule Ecto.Repo.Supervisor do
   def init({name, repo, otp_app, adapter, opts}) do
     case runtime_config(:supervisor, repo, otp_app, opts) do
       {:ok, opts} ->
+        :telemetry.execute(
+          [:ecto, :repo, :start],
+          %{system_time: System.system_time()},
+          %{repo: repo, opts: opts}
+        )
+
         {:ok, child, meta} = adapter.init([repo: repo] ++ opts)
         cache = Ecto.Query.Planner.new_query_cache(name)
         meta = Map.merge(meta, %{repo: repo, cache: cache})

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -170,7 +170,7 @@ defmodule Ecto.Repo.Supervisor do
     case runtime_config(:supervisor, repo, otp_app, opts) do
       {:ok, opts} ->
         :telemetry.execute(
-          [:ecto, :repo, :start],
+          [:ecto, :repo, :init],
           %{system_time: System.system_time()},
           %{repo: repo, opts: opts}
         )

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule Ecto.MixProject do
 
   defp deps do
     [
+      {:telemetry, "~> 0.4"},
       {:decimal, "~> 1.6 or ~> 2.0"},
       {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.20", only: :docs}

--- a/mix.lock
+++ b/mix.lock
@@ -7,4 +7,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
 }

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -29,14 +29,14 @@ defmodule Ecto.Repo.SupervisorTest do
   test "emits telemetry event upon repo start" do
     :telemetry.attach_many(
       :telemetry_test,
-      [[:ecto, :repo, :start]],
+      [[:ecto, :repo, :init]],
       &__MODULE__.handle_event/4,
       %{pid: self()}
     )
 
     Ecto.TestRepo.start_link(name: :telemetry_test)
 
-    assert_receive {[:ecto, :repo, :start], _, %{repo: Ecto.TestRepo, opts: opts}}
+    assert_receive {[:ecto, :repo, :init], _, %{repo: Ecto.TestRepo, opts: opts}}
     assert opts[:telemetry_prefix] == [:ecto, :test_repo]
     assert opts[:name] == :telemetry_test
 

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -22,6 +22,27 @@ defmodule Ecto.Repo.SupervisorTest do
             user: "invalid", username: "user"]
   end
 
+  def handle_event(event, measurements, metadata, %{pid: pid}) do
+    send(pid, {event, measurements, metadata})
+  end
+
+  test "emits telemetry event upon repo start" do
+    :telemetry.attach_many(
+      :telemetry_test,
+      [[:ecto, :repo, :start]],
+      &__MODULE__.handle_event/4,
+      %{pid: self()}
+    )
+
+    Ecto.TestRepo.start_link(name: :telemetry_test)
+
+    assert_receive {[:ecto, :repo, :start], _, %{repo: Ecto.TestRepo, opts: opts}}
+    assert opts[:telemetry_prefix] == [:ecto, :test_repo]
+    assert opts[:name] == :telemetry_test
+
+    :telemetry.detach(:telemetry_test)
+  end
+
   test "reads otp app configuration" do
     put_env(database: "hello")
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [])


### PR DESCRIPTION
This PR enables `telemetry` handlers to listen to an event that signals that a new `Repo` has been started. This feature enables automatic instrumentation for Repos, whose telemetry events are not knowable ahead of time.

@josevalim I tried this out in the New Relic agent and it works quite nicely. The only other thought I had was that perhaps this is a more general pattern that could be recommended by `telemetry`, which led to the thought that the event name itself could be something like `[:telemetry, :broadcast]` or something. I'm not totally sure about that, but I do like this pattern.

closes #3266 