### PR TITLE
Add notes that Ecto 3.4 requires Elixir 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 
 ## v3.4.0 (2020-03-24)
 
+v3.4 requires Elixir v1.7+.
+
 ### Enhancements
 
   * [Ecto.Query] Allow dynamic queries in CTE and improve error message


### PR DESCRIPTION
As the other versions show when the next elixir version is required, it should also be noted Ecto 3.4 requires 1.7, as per https://github.com/elixir-ecto/ecto/commit/e5908c0ed7b988c8c230502d31e278a85f3d2a68#diff-6023be6004fce4718dad3dafb576d258