### PR TITLE
Allow custom error key in unsafe_validate_unique

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1867,7 +1867,9 @@ defmodule Ecto.Changeset do
         end
 
       if repo.one(query) do
-        add_error(changeset, hd(fields), message(opts, "has already been taken"),
+        error_key = Keyword.get(opts, :error_key, hd(fields))
+
+        add_error(changeset, error_key, message(opts, "has already been taken"),
                   validation: :unsafe_unique, fields: fields)
       else
         changeset

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1401,6 +1401,16 @@ defmodule Ecto.ChangesetTest do
                [title: {"is taken", validation: :unsafe_unique, fields: [:title]}]
     end
 
+    test "allows setting a custom error key", context do
+      Process.put(:test_repo_all_results, context.dup_result)
+
+      changeset =
+        unsafe_validate_unique(context.base_changeset, [:title], TestRepo, message: "is taken", error_key: :foo)
+
+      assert changeset.errors ==
+               [foo: {"is taken", validation: :unsafe_unique, fields: [:title]}]
+    end
+
     test "accepts a prefix option", context do
       Process.put(:test_repo_all_results, context.dup_result)
 


### PR DESCRIPTION
I think it would help to distinguish the error faster when we already have another validation for the first field.

I can update the docs if this change is accepted.