### PR TITLE
Update parent_as example

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -235,7 +235,7 @@ defmodule Ecto.Query do
   not known when writing the subquery:
 
       child_query = from c in Comment, where: parent_as(:posts).id == c.post_id
-      from p in Post, as: :posts, join: c in subquery(child_query)
+      from p in Post, as: :posts, inner_lateral_join: c in subquery(child_query)
 
   ### Bindingless operations
 


### PR DESCRIPTION
Hello all, I noticed the new `parent_as` feature was added - really awesome!

I was playing with it via ecto_sql, I could be wrong but I think the example doesn't work / make sense. I think it should be a lateral join?