### PR TITLE
Update examples for `Repo.one/2`

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -767,11 +767,9 @@ defmodule Ecto.Repo do
 
   ## Examples
 
-      Repo.one(Post)
+      Repo.one(from p in Post, join: c in assoc(p, :comments), where: p.id == ^post_id)
 
-      Repo.one(from p in Post, where: p.like_count > 10)
-
-      query = from p in Post, where: p.like_count > 10
+      query = from p in Post, join: c in assoc(p, :comments), where: p.id == ^post_id
       Repo.one(query, prefix: "private")
   """
   @callback one(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) ::


### PR DESCRIPTION
Examples for `Repo.one/2` are misleading:

```
Repo.one(Post)
```

In the example above, the reader will expect the queryable to return multiple results, but a call to `Repo.one/2` will raise an error if it does.

```
Repo.one(from p in Post, where: p.like_count > 10)
```

In this other example, we are looking for the posts that have over 10 likes. Again, the reader will expect this will likely return multiple results.

The examples lead the reader to think that `Repo.one/2` will actually filter out the first result in case of multiple results.

What I suggest as example:

A query that has a where clause on something unique, like an id. But with a join, otherwise the reader might wonder why not use `get/3`/`get_by/3`.

In the example suggested in this PR, a post is retrieved based on its id only if it contains comments. It's not the best example; I think the `Repo.one/2` function is used for rather specific cases.

Also note that the documentation for `Repo` doesn't contain queries with `join`, `assoc`, ... and that I introduce that with this PR.