### PR TITLE
Fix documentation where wrong variable is used

### DIFF
--- a/guides/howtos/Composable transactions with Multi.md
+++ b/guides/howtos/Composable transactions with Multi.md
@@ -29,14 +29,14 @@ Repo.transaction(fn ->
       where: [id: ^mary.id],
       update: [inc: [balance: +10]]
 
-  case Repo.update_all query do
+  case Repo.update_all mary_update do
     {1, _} ->
       john_update =
         from Account,
           where: [id: ^john.id],
           update: [inc: [balance: -10]]
 
-      case Repo.update_all query do
+      case Repo.update_all john_update do
         {1, _} -> {mary, john}
         {_, _} -> Repo.rollback({:failed_transfer, john})
       end


### PR DESCRIPTION
I was confused when reading this documentation, though I might not be understanding what the aim was here.  I see that `mary` and `john` also aren't defined, but I think those are supposed to be defined before this block.