### PR TITLE
Proposal: add support for EXPLAIN statement

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -876,6 +876,9 @@ defmodule Ecto.Query.Planner do
       :all ->
         assert_no_update!(query, operation)
         assert_valid_combinations!(query)
+      :explain ->
+        assert_no_update!(query, operation)
+        assert_valid_combinations!(query)
       :update_all ->
         assert_update!(query, operation)
         assert_only_filter_expressions!(query, operation)
@@ -1563,6 +1566,7 @@ defmodule Ecto.Query.Planner do
     exprs =
       case operation do
         :all -> @all_exprs
+        :explain -> @all_exprs
         :update_all -> @update_all_exprs
         :delete_all -> @delete_all_exprs
       end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -370,6 +370,10 @@ defmodule Ecto.Repo do
 
         def prepare_query(operation, query, opts), do: {query, opts}
         defoverridable prepare_query: 3
+
+        def explain(queryable, opts \\ []) do
+          Ecto.Repo.Queryable.explain(get_dynamic_repo(), queryable, opts)
+        end
       end
     end
   end
@@ -541,7 +545,7 @@ defmodule Ecto.Repo do
   ## Ecto.Adapter.Queryable
 
   @optional_callbacks get: 3, get!: 3, get_by: 3, get_by!: 3, aggregate: 3, aggregate: 4, exists?: 2,
-                      one: 2, one!: 2, preload: 3, all: 2, stream: 2, update_all: 3, delete_all: 2
+                      one: 2, one!: 2, preload: 3, all: 2, stream: 2, update_all: 3, delete_all: 2, explain: 2
 
   @doc """
   Fetches a single struct from the data store where the primary key matches the
@@ -1515,9 +1519,9 @@ defmodule Ecto.Repo do
         MyRepo.update!(change(alice, balance: alice.balance - 10))
         MyRepo.update!(change(bob, balance: bob.balance + 10))
       end)
-      
+
       # When passing a function of arity 1, it receives the repository itself
-      MyRepo.transaction(fn repo -> 
+      MyRepo.transaction(fn repo ->
         repo.insert!(%Post{})
       end)
 
@@ -1570,4 +1574,6 @@ defmodule Ecto.Repo do
   The transaction will return the value given as `{:error, value}`.
   """
   @callback rollback(value :: any) :: no_return
+
+  @callback explain(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) :: binary() | nil
 end


### PR DESCRIPTION
During development a very common process is to optimize complex queries by using the `EXPLAIN` sql statement, which as for now requires to play with `to_sql`, copy & paste, manually building the query and calling it on a SQL client. This PR proposes to add `Repo.explain/2` function to ease this process and improve the developer experience.

Of course It's just a WIP to gather feedback of the core team, as it's missing:

- [ ] Maybe improve the function return? current output is just a string like `"Seq Scan on barebones b0  (cost=0.00..30.40 rows=2040 width=4)"`
- [ ] Call EXPLAIN inside a transaction to avoid side effects
- [ ] Support other statements besides SELECT
- [ ] Pass options to the EXPLAIN statement
- [ ] Implement callback for all adapters
- [ ] Improve tests

ecto-sql implementation: https://github.com/elixir-ecto/ecto_sql/pull/231

Please note I'm not an expert in Ecto internals so it may not be the best possible implementation.