### PR TITLE
Add Ecto.Query.main_schema/1 function

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2019,6 +2019,23 @@ defmodule Ecto.Query do
   end
 
   @doc """
+  Returns the main Ecto.Schema of a query.
+
+  When the input schema is a bitstring `nil` is returned.
+
+  ## Examples
+
+      main_schema(Post) == Post
+
+      User |> join(:inner, [u], p in assoc(u, :posts)) |> main_schema() == User
+
+      main_schema("from u in users") == nil
+  """
+  defp main_schema(%Ecto.Query{from: %{source: {_, module}}}), do: module
+
+  defp main_schema(queryable), do: main_schema(Ecto.Queryable.to_query(queryable))
+
+  @doc """
   Reverses the ordering of the query.
 
   ASC columns become DESC columns (and vice-versa). If the query


### PR DESCRIPTION
This function returns the main schema of a given Queryable.
All cases are covered but for the bitstring query one, in that case the function returns `nil`.

I'm contributing to a library for building filters on top of ecto queries from some input data structure and I need to obtain the main schema of a given query (I need to call `__schema__` on it). I think this can be useful also for other libraries/projects so I created this PR.

If you think it can be merged I will add some tests.
