### PR TITLE
Test factories.md: Use `struct!` to check for key validity

### DIFF
--- a/guides/howtos/Test factories.md
+++ b/guides/howtos/Test factories.md
@@ -38,7 +38,7 @@ defmodule MyApp.Factory do
   # Convenience API
 
   def build(factory_name, attributes) do
-    factory_name |> build() |> struct(attributes)
+    factory_name |> build() |> struct!(attributes)
   end
 
   def insert!(factory_name, attributes \\ []) do


### PR DESCRIPTION
I made a typo in an attribute name and this would have helped catch it.

And it's probably just a good pattern here. If someone wants to support passing in non-attributes, they can use `Keyword.delete` before passing to `struct!`.