### PR TITLE
Hierarchical relationships example swaps columns

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -740,7 +740,7 @@ defmodule Ecto.Schema do
         schema "comments" do
           field :content, :string
           field :parent_id, :integer
-          belongs_to :parent, Comment, foreign_key: :id, references: :parent_id, define_field: false
+          belongs_to :parent, Comment, foreign_key: :parent_id, references: :id, define_field: false
           has_many :children, Comment, foreign_key: :parent_id, references: :id
         end
       end


### PR DESCRIPTION
I was having issues when testing the hierarchical relationship in a Phoenix app I was building.  

It turns out doing `Repo.preload(parent, :parent)` would have the parent load the child, and having `Repo.preload(child, :parent)` would load `nil`.  (Where `parent` has `parent_id` set to `nil` and `child` has `parent_id` set to `parent`'s id.)

Swapping the columns like I did here makes things function correctly.