### PR TITLE
Add examples for limiting preloads in docs

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1853,6 +1853,19 @@ defmodule Ecto.Query do
                  where: l.inserted_at > c.updated_at,
                  preload: [comments: {c, likes: l}]
 
+  Applying a limit to the association can be achieved with `inner_lateral_join`:
+
+      Repo.all from p in Post, as: :post,
+                 join: c in assoc(p, :comments),
+                 inner_lateral_join: top_five in subquery(
+                   from Comment,
+                   where: [post_id: parent_as(:post).id],
+                   order_by: :popularity,
+                   limit: 5,
+                   select: [:id]
+                 ), on: top_five.id == c.id,
+                 preload: [comments: c]
+
   ## Preload queries
 
   Preload also allows queries to be given, allowing you to filter or


### PR DESCRIPTION
Recently I was searching for advice on how to achieve a preload with a limit applied, eg posts with top 5 comments preloaded.

The `preload/3` docs call out that naively applying a `limit` to a preload query will not work, as it applies to the whole result set, not each post.

I found there is a lot of outdated advice on the web on this topic:

[How to address the issue with limits on preloaded associations using Ecto?](https://elixirforum.com/t/how-to-address-the-issue-with-limits-on-preloaded-associations-using-ecto/13163/7)
[Limit preloading associations](https://elixirforum.com/t/limit-preloading-associations/15961)
[Preloading top comments for posts in Ecto](https://elixirforum.com/t/preloading-top-comments-for-posts-in-ecto/1052/22)
[How to batch load with Absinthe Relay while supporting first: x and after_cursor?](https://elixirforum.com/t/how-to-batch-load-with-absinthe-relay-while-supporting-first-x-and-after-cursor/14918/4)

With the recent support for accessing named bindings in subqueries, there's no longer a need for `fragment` to perform a lateral join, and the window functions API can also be used to perform a 'top N per category' query.

This PR adds examples for solving the preload with limit problem using both a lateral join with named bindings, and using the `row_number` window function.

Having these examples in the docs should hopefully make them easier to find.
