### PR TITLE
Added supported interval values for query api

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -18,6 +18,12 @@ defmodule Ecto.Query.API do
   Furthermore, it is possible to define your own macros and
   use them in Ecto queries (see docs for `fragment/1`).
 
+  ## Intervals
+
+  Ecto supports following values for `interval` option: `year`, `month`, `week`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`.
+
+  `Date/Time` functions like `datetime_add/3`, `date_add/3`, `from_now/2`, `ago/2` take `interval` as an option.
+
   ## Window API
 
   Ecto also supports many of the windows functions found
@@ -244,6 +250,8 @@ defmodule Ecto.Query.API do
   Adds a given interval to a date.
 
   See `datetime_add/3` for more information.
+
+  See [Intervals](#module-intervals) for supported `interval` values.
   """
   def date_add(date, count, interval), do: doc! [date, count, interval]
 
@@ -252,6 +260,8 @@ defmodule Ecto.Query.API do
 
   The current time in UTC is retrieved from Elixir and
   not from the database.
+
+  See [Intervals](#module-intervals) for supported `interval` values.
 
   ## Examples
 
@@ -265,6 +275,8 @@ defmodule Ecto.Query.API do
 
   The current time in UTC is retrieved from Elixir and
   not from the database.
+
+  See [Intervals](#module-intervals) for supported `interval` values.
 
   ## Examples
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -241,8 +241,7 @@ defmodule Ecto.Query.API do
   from the current datetime and compared it with the `p.published_at`.
   If you want to perform operations on date, `date_add/3` could be used.
 
-  The following intervals are supported: year, month, week, day, hour,
-  minute, second, millisecond and microsecond.
+  See [Intervals](#module-intervals) for supported `interval` values.
   """
   def datetime_add(datetime, count, interval), do: doc! [datetime, count, interval]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -20,9 +20,12 @@ defmodule Ecto.Query.API do
 
   ## Intervals
 
-  Ecto supports following values for `interval` option: `year`, `month`, `week`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`.
+  Ecto supports following values for `interval` option: `"year"`, `"month"`,
+  `"week"`, `"day"`, `"hour"`, `"minute"`, `"second"`, `"millisecond"`, and
+  `"microsecond"`.
 
-  `Date/Time` functions like `datetime_add/3`, `date_add/3`, `from_now/2`, `ago/2` take `interval` as an option.
+  `Date`/`Time` functions like `datetime_add/3`, `date_add/3`, `from_now/2`,
+  `ago/2` take `interval` as an argument.
 
   ## Window API
 


### PR DESCRIPTION
This PR adds documentation for supported `interval` values based on the discussion in this [issue](https://github.com/elixir-ecto/ecto/issues/3329).

#### Overview of changes:
 - Created new section `Intervals`. Added supported `interval` values in this section.
 - Hyperlinked `Intervals` section for following functions: `date_add/3`, `from_now/2`, `ago/2`
 - Removed existing `interval` values information from `datetime_add/3` and replaced with link for `Intervals` section to maintain uniformity.

I noticed that documentation of function [datetime_add/3](https://hexdocs.pm/ecto/Ecto.Query.API.html#datetime_add/3) already has information for supported `interval` values. But this information is not replicated for other functions. So I **removed** existing information and **replaced with a hyperlink** for `Intervals` section. I think having this information in one place(`Intervals` section) will be easier to maintain and update.

I locally built the docs and verified the `Intervals` sections and the hyperlinks. 

Let me know if this PR looks ok.