### PR TITLE
Add Ecto.Type.Atom for safely storing atoms

### DIFF
--- a/lib/ecto/type/atom.ex
+++ b/lib/ecto/type/atom.ex
@@ -67,8 +67,6 @@ defmodule Ecto.Type.Atom do
   """
   defmacro __using__(opts) do
     values_as_atoms = Keyword.fetch!(opts, :values)
-    Enum.each(values_as_atoms, fn val -> if !is_atom(val), do: raise("values must be atoms") end)
-    values_as_strings = Enum.map(values_as_atoms, &Atom.to_string/1)
 
     load_fun =
       case Keyword.get(opts, :else, :error) do
@@ -100,7 +98,10 @@ defmodule Ecto.Type.Atom do
       use Ecto.Type
 
       @values_as_atoms unquote(values_as_atoms)
-      @values_as_strings unquote(values_as_strings)
+
+      Enum.each(@values_as_atoms, fn val -> if !is_atom(val), do: raise("values must be atoms") end)
+
+      @values_as_strings Enum.map(@values_as_atoms, &Atom.to_string/1)
 
       def type, do: :string
 

--- a/lib/ecto/type/atom.ex
+++ b/lib/ecto/type/atom.ex
@@ -1,0 +1,120 @@
+defmodule Ecto.Type.Atom do
+  @moduledoc """
+  Ecto.Type.Atom provides the ability to store atoms using the underlying :string ecto type. This
+  is done in a manner that is safe with respect to atom overflow as only specified existing atoms
+  can be loaded.
+
+  ## Examples
+
+    To define a game schema with status as an atom field:
+
+      defmodule MyApp.Games.Game do
+        use MyApp.Schema
+
+        # First define the Status atom type:
+        defmodule Status do
+          use Ecto.Type.Atom, values: [:joining, :running, :ended]
+        end
+
+        schema "games" do
+          ...
+          # Then use the Status module as the field type:
+          field :status, Status
+          ...
+        end
+      end
+
+  A helper function `values/0` is generated on the module, e.g. `Status.values()` with the above module
+  will return [:joining, :running, :ended]
+
+  An `else` option is provided to handle cases where the value being loaded is not in the specified
+  values. There are three valid values for the `else` option:
+
+    `:error` - (default if no `else` specified) returns `:error` to the ecto load request, causing it to fail.
+    `{:ok, value}` - returns the specified value to the ecto load request.
+    `:transform` - calls `transform/1` on the module, giving the value being loaded. The transform
+                function should return `:error` or `{:ok, value}`.
+
+  Note that for `{:ok, value}` in both of the second two options above, the value returned
+  in `{:ok, value}` does *not* need to be one of the specified values. This allows you to
+  return a different value, which can be cleaned up after loading, but won't be allowed to
+  be stored back to the database. This can be useful in cases where you want to handle bad
+  or deprecated values in your application code after loading.
+
+  ## Example else usage
+
+    If we wanted to return a set value like :unknown when values other than those specified are
+    loaded, we use `else: {:ok, :unknown}`:
+
+      defmodule Status do
+        use Ecto.Type.Atom, values: [:joining, :running, :ended], else: {:ok, :unknown}
+      end
+
+    And if we wanted to transform any non-specified values when loaded, we use `else: :transform`,
+    and then specify a `transform/1` function in the module.
+
+      defmodule Status do
+        use Ecto.Type.Atom, values: [:joining, :running, :ended], else: :transform
+
+        def transform("legacy value 1"), do: {:ok, :new_value_1}
+        def transform("legacy value 2"), do: {:ok, :new_value_2}
+        def transform(_), do: :errors
+      end
+
+    Note that if you do not specify a `transform/1` returning both `:error` and `{:ok, value}`, you will get a
+    dialyzer warning.
+
+  """
+  defmacro __using__(opts) do
+    values_as_atoms = Keyword.fetch!(opts, :values)
+    Enum.each(values_as_atoms, fn val -> if !is_atom(val), do: raise("values must be atoms") end)
+    values_as_strings = Enum.map(values_as_atoms, &Atom.to_string/1)
+
+    load_fun =
+      case Keyword.get(opts, :else, :error) do
+        :error ->
+          quote do
+            def load(_), do: :error
+          end
+
+        :transform ->
+          quote do
+            def load(data) do
+              case __MODULE__.transform(data) do
+                :error -> :error
+                {:ok, return} -> {:ok, return}
+              end
+            end
+          end
+
+        {:ok, return_atom} when is_atom(return_atom) ->
+          quote do
+            def load(_), do: {:ok, unquote(return_atom)}
+          end
+
+        _ ->
+          raise "`else` must be either :error, :transform, or {:ok, return_atom}"
+      end
+
+    quote do
+      use Ecto.Type
+
+      @values_as_atoms unquote(values_as_atoms)
+      @values_as_strings unquote(values_as_strings)
+
+      def type, do: :string
+
+      def values, do: @values_as_atoms
+
+      def cast(value) when value in @values_as_atoms, do: {:ok, value}
+      def cast(value) when value in @values_as_strings, do: {:ok, String.to_existing_atom(value)}
+      def cast(_), do: :error
+
+      def load(data) when data in @values_as_strings, do: {:ok, String.to_existing_atom(data)}
+      unquote(load_fun)
+
+      def dump(value) when value in @values_as_atoms, do: {:ok, Atom.to_string(value)}
+      def dump(_), do: :error
+    end
+  end
+end

--- a/test/ecto/type/atom_test.exs
+++ b/test/ecto/type/atom_test.exs
@@ -1,0 +1,140 @@
+defmodule Ecto.Type.AtomTest do
+  use ExUnit.Case
+
+  describe "Ecto.Type.Atom else: default" do
+    defmodule EctoTypeElseDefault do
+      use Ecto.Type.Atom, values: [:foo, :bar, :baz]
+    end
+
+    test "correct type" do
+      assert EctoTypeElseDefault.type() == :string
+    end
+
+    test "cast/1" do
+      assert EctoTypeElseDefault.cast(:foo) == {:ok, :foo}
+      assert EctoTypeElseDefault.cast("foo") == {:ok, :foo}
+      assert EctoTypeElseDefault.cast(:other) == :error
+    end
+
+    test "load/1" do
+      assert EctoTypeElseDefault.load("foo") == {:ok, :foo}
+      assert EctoTypeElseDefault.load("bar") == {:ok, :bar}
+      assert EctoTypeElseDefault.load("others") == :error
+    end
+
+    test "dump/1" do
+      assert EctoTypeElseDefault.dump(:foo) == {:ok, "foo"}
+      assert EctoTypeElseDefault.dump(:bar) == {:ok, "bar"}
+      assert EctoTypeElseDefault.dump(:other) == :error
+    end
+
+    test "values/0" do
+      assert EctoTypeElseDefault.values() == [:foo, :bar, :baz]
+    end
+  end
+
+  describe "Ecto.Type.Atom else: :error" do
+    defmodule EctoTypeElseError do
+      use Ecto.Type.Atom, values: [:foo, :bar, :baz], else: :error
+    end
+
+    test "correct type" do
+      assert EctoTypeElseError.type() == :string
+    end
+
+    test "cast/1" do
+      assert EctoTypeElseError.cast(:foo) == {:ok, :foo}
+      assert EctoTypeElseError.cast("foo") == {:ok, :foo}
+      assert EctoTypeElseError.cast(:other) == :error
+    end
+
+    test "load/1" do
+      assert EctoTypeElseError.load("foo") == {:ok, :foo}
+      assert EctoTypeElseError.load("bar") == {:ok, :bar}
+      assert EctoTypeElseError.load("others") == :error
+    end
+
+    test "dump/1" do
+      assert EctoTypeElseError.dump(:foo) == {:ok, "foo"}
+      assert EctoTypeElseError.dump(:bar) == {:ok, "bar"}
+      assert EctoTypeElseError.dump(:other) == :error
+    end
+
+    test "values/0" do
+      assert EctoTypeElseError.values() == [:foo, :bar, :baz]
+    end
+  end
+
+  describe "Ecto.Type.Atom else: {:ok, :bad_value}" do
+    defmodule EctoTypeElseBadValue do
+      use Ecto.Type.Atom, values: [:foo, :bar, :baz], else: {:ok, :bad_value}
+    end
+
+    test "correct type" do
+      assert EctoTypeElseBadValue.type() == :string
+    end
+
+    test "cast/1" do
+      assert EctoTypeElseBadValue.cast(:foo) == {:ok, :foo}
+      assert EctoTypeElseBadValue.cast("foo") == {:ok, :foo}
+      assert EctoTypeElseBadValue.cast(:other) == :error
+    end
+
+    test "load/1" do
+      assert EctoTypeElseBadValue.load("foo") == {:ok, :foo}
+      assert EctoTypeElseBadValue.load("bar") == {:ok, :bar}
+      assert EctoTypeElseBadValue.load("others") == {:ok, :bad_value}
+    end
+
+    test "dump/1" do
+      assert EctoTypeElseBadValue.dump(:foo) == {:ok, "foo"}
+      assert EctoTypeElseBadValue.dump(:bar) == {:ok, "bar"}
+      assert EctoTypeElseBadValue.dump(:other) == :error
+    end
+
+    test "values/0" do
+      assert EctoTypeElseBadValue.values() == [:foo, :bar, :baz]
+    end
+  end
+
+  describe "Ecto.Type.Atom else: :transform" do
+    defmodule EctoTypeElseTransform do
+      use Ecto.Type.Atom, values: [:foo, :bar, :baz], else: :transform
+
+      def transform("old_foo"), do: {:ok, :foo}
+      def transform("old_bar"), do: {:ok, :bar}
+      def transform("legacy_val"), do: {:ok, :legacy}
+      def transform(_), do: :error
+    end
+
+    test "correct type" do
+      assert EctoTypeElseTransform.type() == :string
+    end
+
+    test "cast/1" do
+      assert EctoTypeElseTransform.cast(:foo) == {:ok, :foo}
+      assert EctoTypeElseTransform.cast("foo") == {:ok, :foo}
+      assert EctoTypeElseTransform.cast(:other) == :error
+    end
+
+    test "load/1" do
+      assert EctoTypeElseTransform.load("foo") == {:ok, :foo}
+      assert EctoTypeElseTransform.load("bar") == {:ok, :bar}
+
+      assert EctoTypeElseTransform.load("old_foo") == {:ok, :foo}
+      assert EctoTypeElseTransform.load("old_bar") == {:ok, :bar}
+      assert EctoTypeElseTransform.load("legacy_val") == {:ok, :legacy}
+      assert EctoTypeElseTransform.load("others") == :error
+    end
+
+    test "dump/1" do
+      assert EctoTypeElseTransform.dump(:foo) == {:ok, "foo"}
+      assert EctoTypeElseTransform.dump(:bar) == {:ok, "bar"}
+      assert EctoTypeElseTransform.dump(:other) == :error
+    end
+
+    test "values/0" do
+      assert EctoTypeElseTransform.values() == [:foo, :bar, :baz]
+    end
+  end
+end


### PR DESCRIPTION
`Ecto.Type.Atom` provides a simple way to store atoms using the underlying `:string` ecto type. This is done in a manner that is safe with respect to atom overflow as only specified existing atoms can be loaded.

To define a game schema with status as an atom field:

```elixir
      defmodule MyApp.Games.Game do
        use MyApp.Schema

        # First define the Status atom type:
        defmodule Status do
          use Ecto.Type.Atom, values: [:joining, :running, :ended]
        end

        schema "games" do
          ...
          # Then use the Status module as the field type:
          field :status, Status
          ...
        end
      end
```

A helper function `values/0` is generated on the module, e.g. `Status.values()` with the above module will return `[:joining, :running, :ended]`.

The `else:` option allows custom behaviour in the case that the values being loaded are not in the list of allowed values.

`cast` takes the atom or a string version of the atom. The string version is useful for things like Phoenix requests, and is safe because it validates that the string represents an atom specified in `values` _before_ calling `String.to_existing_atom/1`.