### PR TITLE
use field-defined primary_key for default has_ reference

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -50,8 +50,8 @@ defmodule Ecto.ChangesetTest do
       field :source, :map
       field :permalink, :string, source: :url
       belongs_to :category, Ecto.ChangesetTest.Category, source: :cat_id
-      has_many :comments, Ecto.ChangesetTest.Comment, on_replace: :delete
-      has_one :comment, Ecto.ChangesetTest.Comment
+      has_many :comments, Ecto.ChangesetTest.Comment, on_replace: :delete, references: :id
+      has_one :comment, Ecto.ChangesetTest.Comment, references: :id
     end
   end
 


### PR DESCRIPTION
Currently, when using `has_many` or `has_one`, the default for the `references:` option is determined entirely by the `@primary_key` value. This doesn't work for primary_key(s) that are defined by the `primary_key:` field option.

Example of when a default `references:` could default to the schema primary_key but isn't.

```
defmodule MyApp.Schema do
  defmacro __using__(_) do
    quote do
      use Ecto.Schema
      @primary_key false
    end
  end
end

defmodule MyApp.Post do
  use MyApp.Schema
  schema "posts" do
    field :id, Ecto.UUID, autogenerate: true, primary_key: true
    has_many :comments, MyApp.Comment
    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires^, references: :id
  end
end

defmodule MyApp.Comment do
  use MyApp.Schema
  schema "posts" do
    field :id, Ecto.UUID, autogenerate: true, primary_key: true
    belongs_to :post, MyApp.Post
  end
end
```

There is also an example in the tests, modified in this PR where the `has_many` `references:` is defaulted and maybe shouldn't be, given the schema has multiple primary keys. Luckily, since it's likely not a very frequent scenario and it's also a compile time check, upgrading Ecto and it "breaking" would be unlikely, a quick find, a quick fix, and have no possibility of effecting released code.

My apologies that I'm not quite sure of the preferred way to add a test for a compile time check to this PR