### PR TITLE
Add Ecto.Changeset.put_change_if_exists/4 function

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -713,6 +713,23 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes.upvotes == nil
   end
 
+  test "put_change_if_exists/4" do
+    base_changeset = change(%Post{}, %{title: "foo"})
+
+    changeset = put_change_if_exists(base_changeset, :title, :body, "bar")
+    assert changeset.changes.body == "bar"
+
+    changeset = put_change_if_exists(base_changeset, :upvotes, :body, "bar")
+    assert changeset.changes == %{title: "foo"}
+
+    changeset =
+      put_change_if_exists(base_changeset, :title, :body, fn title ->
+        "#{title}: foo bar baz"
+      end)
+
+    assert changeset.changes.body == "foo: foo bar baz"
+  end
+
   test "force_change/3" do
     changeset = change(%Post{upvotes: 5})
 


### PR DESCRIPTION
This function puts a change `new_key` only if a value exists in the changeset for an existing `key`.

I have noticed that `Ecto.Changeset.get_change/3` is used very frequently in codebases to test for the presence of an existing change in a changeset, and if the change is present, to put some _other_ change, often conditional on the value of the existing change.

In practice this looks like:
```elixir
case get_change(changeset, :key) do
    nil -> changeset
    value -> put_change(changeset, :new_key, new_value)
end
```

A convenient function to put a new change if an existing one is present would be a small but highly useful addition.