### PR TITLE
Maybe unbreak MySQL 8 specs failing due to implicit order

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -238,13 +238,13 @@ defmodule Ecto.Integration.JoinsTest do
     assert [
              %{text: "c1", author: %{name: "Alice"}},
              %{text: "c2", author: %{name: "John"}}
-           ] = p1.comments
+           ] = Enum.sort_by(p1.comments, & &1.text)
 
     assert [
              %{text: "c3", author: %{name: "John"}},
              %{text: "c4", author: nil},
              %{text: "c5", author: %{name: "Alice"}}
-           ] = p2.comments
+           ] = Enum.sort_by(p2.comments, & &1.text)
   end
 
   test "many_to_many association join" do


### PR DESCRIPTION
I saw test failures in ecto_sql's CI such as https://github.com/elixir-ecto/ecto_sql/runs/814700353 that seem to be due to tests assuming that records are returned in a given order, but the query does not specify any order as far as I can tell.

I believe this should fix those tests, but I didn't want to go through all the hoops to get the MySQL integration tests running locally, so I haven't fully verified. Perhaps someone with everything set up could do so.
