### PR TITLE
Fixes small typo

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -173,7 +173,7 @@ defmodule Ecto.Type do
 
   By default, the type is sent as itself, without calling
   dumping to keep the higher level representation. But
-  it can be set to `:dump` to it is dumped before encoded.
+  it can be set to `:dump` so that it is dumped before being encoded.
   """
   @callback embed_as(format :: atom) :: :self | :dump
 


### PR DESCRIPTION
Fixes a small typo in the `Ecto.Type` docs