### PR TITLE
Accept fun on multi functions

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -470,8 +470,8 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec insert_all(t, name, schema_or_source, [map | Keyword.t], Keyword.t) :: t
-  def insert_all(multi, name, schema_or_source, entries_or_fun, opts \\ [])
+  @spec insert_all(t, name, schema_or_source | fun(schema_or_source), [map | Keyword.t] | fun([map | Keyword.t]), Keyword.t) :: t
+  def insert_all(multi, name, schema_or_source_or_fun, entries_or_fun, opts \\ [])
 
   def insert_all(multi, name, schema_fun, entries_fun, opts) when (is_function(schema_fun, 1) or is_function(entries_fun, 1)) and is_list(opts) do
     run(multi, name, operation_fun({:insert_all, schema_fun, entries_fun}, opts))
@@ -493,7 +493,7 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec update_all(t, name, Ecto.Queryable.t, Keyword.t, Keyword.t) :: t
+  @spec update_all(t, name, Ecto.Queryable.t | fun(Ecto.Queryable.t), Keyword.t | fun(Keyword.t), Keyword.t) :: t
   def update_all(multi, name, queryable_or_fun, updates_or_fun, opts \\ [])
 
   def update_all(multi, name, queryable_fun, updates_fun, opts) when (is_function(queryable_fun, 1) or is_function(updates_fun, 1)) and is_list(opts) do
@@ -531,7 +531,7 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec delete_all(t, name, Ecto.Queryable.t, Keyword.t) :: t
+  @spec delete_all(t, name, Ecto.Queryable.t | fun(Ecto.Queryable.t), Keyword.t) :: t
   def delete_all(multi, name, queryable_or_fun, opts \\ [])
 
   def delete_all(multi, name, fun, opts) when is_function(fun, 1) and is_list(opts) do

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -483,7 +483,7 @@ defmodule Ecto.Multi do
         |> Enum.map(fn comment ->
           Map.put(comment, :post_id, post.id)
         end)
-      end, [])
+      end)
       |> MyApp.Repo.transaction()
 
   """

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -665,6 +665,12 @@ defmodule Ecto.Multi do
     end
   end
 
+  defp operation_fun({:delete_all, fun}, opts) do
+    fn repo, changes ->
+      {:ok, repo.delete_all(fun.(changes), opts)}
+    end
+  end
+
   defp operation_fun({operation, fun}, opts) do
     fn repo, changes ->
       apply(repo, operation, [fun.(changes), opts])

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -252,7 +252,7 @@ defmodule Ecto.MultiTest do
   end
 
   test "delete_all fun" do
-    fun = fn _changes -> {:ok, Comment} end
+    fun = fn _changes -> Comment end
 
     multi =
       Multi.new()
@@ -260,6 +260,11 @@ defmodule Ecto.MultiTest do
 
     assert multi.names == MapSet.new([:fun])
     assert [{:fun, {:run, _fun}}] = multi.operations
+
+    assert {:ok, changes} = TestRepo.transaction(multi)
+    assert_received {:transaction, _}
+
+    assert changes[:fun] == {1, nil}
   end
 
   test "append/prepend without repetition" do

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -207,7 +207,7 @@ defmodule Ecto.MultiTest do
     assert query   == Ecto.Queryable.to_query(Comment)
   end
 
-  test "delete_all" do
+  test "delete_all schema" do
     multi =
       Multi.new()
       |> Multi.delete_all(:comments, Comment)
@@ -215,6 +215,17 @@ defmodule Ecto.MultiTest do
     assert multi.names == MapSet.new([:comments])
     assert [{:comments, {:delete_all, query, []}}] = multi.operations
     assert query == Ecto.Queryable.to_query(Comment)
+  end
+
+  test "delete_all fun" do
+    fun = fn _changes -> {:ok, Comment} end
+
+    multi =
+      Multi.new()
+      |> Multi.delete_all(:fun, fun)
+
+      assert multi.names == MapSet.new([:fun])
+      assert [{:fun, {:run, _fun}}] = multi.operations
   end
 
   test "append/prepend without repetition" do

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -196,6 +196,18 @@ defmodule Ecto.MultiTest do
     assert [{:comments, {:insert_all, Comment, [[x: 2]], []}}] = multi.operations
   end
 
+  test "insert_all fun" do
+    fun_schema = fn _changes -> {:ok, Comment} end
+    fun_entries = fn _changes -> {:ok, [[x: 2]]} end
+
+    multi =
+      Multi.new()
+      |> Multi.insert_all(:fun, fun_schema, fun_entries)
+
+    assert multi.names == MapSet.new([:fun])
+    assert [{:fun, {:run, _fun}}] = multi.operations
+  end
+
   test "update_all" do
     multi =
       Multi.new()
@@ -204,7 +216,19 @@ defmodule Ecto.MultiTest do
     assert multi.names == MapSet.new([:comments])
     assert [{:comments, {:update_all, query, updates, []}}] = multi.operations
     assert updates == [set: [x: 2]]
-    assert query   == Ecto.Queryable.to_query(Comment)
+    assert query == Ecto.Queryable.to_query(Comment)
+  end
+
+  test "update_all fun" do
+    fun_queryable = fn _changes -> {:ok, Comment} end
+    fun_updates = fn _changes -> {:ok, set: [x: 2]} end
+
+    multi =
+      Multi.new()
+      |> Multi.update_all(:fun, fun_queryable, fun_updates)
+
+    assert multi.names == MapSet.new([:fun])
+    assert [{:fun, {:run, _fun}}] = multi.operations
   end
 
   test "delete_all schema" do
@@ -224,8 +248,8 @@ defmodule Ecto.MultiTest do
       Multi.new()
       |> Multi.delete_all(:fun, fun)
 
-      assert multi.names == MapSet.new([:fun])
-      assert [{:fun, {:run, _fun}}] = multi.operations
+    assert multi.names == MapSet.new([:fun])
+    assert [{:fun, {:run, _fun}}] = multi.operations
   end
 
   test "append/prepend without repetition" do


### PR DESCRIPTION
The functions `insert_all/5`, `update_all/5` and `delete_all/4` do not accept a fun as argument. So we are not able to build the params from the previous changes of the multi. These changes were proposed at the mailing list https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/elixir-ecto/cr7IREEpdgU/nbXN_Gn2CAAJ.

With the changes in the PR the following combinations are possible:

```elixir
Ecto.Multi.insert_all(multi, name, schema_or_source, entries)
Ecto.Multi.insert_all(multi, name, schema_or_source, fn changes -> entries end)
Ecto.Multi.insert_all(multi, name, fn changes -> schema_or_source end, entries)
Ecto.Multi.insert_all(multi, name, fn changes -> schema_or_source end, fn changes -> entries end)

Ecto.Multi.delete_all(multi, name, queryable)
Ecto.Multi.delete_all(multi, name, fn changes -> queryable end)

Ecto.Multi.update_all(multi, name, queryable, updates)
Ecto.Multi.update_all(multi, name, fn changes -> queryable end, updates)
Ecto.Multi.update_all(multi, name, queryable, fn changes -> updates end)
Ecto.Multi.update_all(multi, name, fn changes -> queryable end, fn changes -> updates end)
```

With these multi functions become more flexible, and in more parity with the other multi function like `insert/3` or `delete/3`.