### PR TITLE
don't validate uniqueness if there is a prior error

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1832,13 +1832,16 @@ defmodule Ecto.Changeset do
       {field, get_field(changeset, field)}
     end
 
+    # No need to query if there is a prior error for the fields
+    any_prior_errors_for_fields? = Enum.any?(changeset.errors, &(elem(&1, 0) in fields))
+
     # No need to query if we haven't changed any of the fields in question
     unrelated_changes? = Enum.all?(fields, &not Map.has_key?(changeset.changes, &1))
 
     # If we don't have values for all fields, we can't query for uniqueness
     any_nil_values_for_fields? = Enum.any?(where_clause, &(&1 |> elem(1) |> is_nil()))
 
-    if unrelated_changes? || any_nil_values_for_fields? do
+    if unrelated_changes? || any_nil_values_for_fields? || any_prior_errors_for_fields? do
       changeset
     else
       query =

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1391,6 +1391,29 @@ defmodule Ecto.ChangesetTest do
       assert changeset.valid?
     end
 
+    test "does not validate uniqueness if there is any prior error on a field", context do
+      Process.put(:test_repo_all_results, context.dup_result)
+      changeset =
+        context.base_changeset
+        |> validate_length(:title, max: 3)
+        |> unsafe_validate_unique(:title, TestRepo)
+
+      refute changeset.valid?
+      assert changeset.errors == [title: {"should be at most %{count} character(s)", [count: 3, validation: :length, kind: :max, type: :string]}]
+    end
+
+    test "does not validate uniqueness if there is any prior error on a combination of fields", context do
+      Process.put(:test_repo_all_results, context.dup_result)
+      changeset =
+        context.base_changeset
+        |> validate_length(:title, max: 3)
+        |> unsafe_validate_unique([:title, :body], TestRepo)
+
+      refute changeset.valid?
+      assert changeset.errors == [title: {"should be at most %{count} character(s)", [count: 3, validation: :length, kind: :max, type: :string]}]
+    end
+
+
     test "allows setting a custom error message", context do
       Process.put(:test_repo_all_results, context.dup_result)
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1413,7 +1413,6 @@ defmodule Ecto.ChangesetTest do
       assert changeset.errors == [title: {"should be at most %{count} character(s)", [count: 3, validation: :length, kind: :max, type: :string]}]
     end
 
-
     test "allows setting a custom error message", context do
       Process.put(:test_repo_all_results, context.dup_result)
 


### PR DESCRIPTION
There is no need to validate uniqueness when there is an error on the expected unique fields

Example:

    user
    |> cast(attrs, [:name, :email])
    |> validate_format(:email, ~r/@/)
    |> unsafe_validate_unique([:email], MyApp.Repo)

if email doesn't contain at sign, we can save few database query until the email is in the correct format.