### PR TITLE
Improve exception message for Ecto.Query as right-side value of in operator

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -48,7 +48,7 @@ defmodule Ecto.QueryError do
 
     message =
       case hint do
-        {:ok, text} -> message <> "\n\n" <> text
+        {:ok, text} -> message <> "\n" <> text
         _ -> message
       end
 

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -28,6 +28,7 @@ defmodule Ecto.QueryError do
   def exception(opts) do
     message = Keyword.fetch!(opts, :message)
     query   = Keyword.fetch!(opts, :query)
+    hint    = Keyword.fetch(opts, :hint)
     message = """
     #{message} in query:
 
@@ -43,6 +44,12 @@ defmodule Ecto.QueryError do
         Exception.format_file_line(relative, line) <> " " <> message
       else
         message
+      end
+
+    message =
+      case hint do
+        {:ok, text} -> message <> "\n\n" <> text
+        _ -> message
       end
 
     %__MODULE__{message: message}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1644,7 +1644,6 @@ defmodule Ecto.Query.Planner do
     case Ecto.Type.cast(type, v) do
       {:ok, v} ->
         {:ok, v}
-
       _ ->
         {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"}
     end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -745,7 +745,6 @@ defmodule Ecto.Query.Planner do
     try do
       case cast_param(kind, type, v, adapter) do
         {:ok, v} -> v
-        {:error, {error, hint}} -> error! query, expr, error, hint
         {:error, error} -> error! query, expr, error
       end
     catch
@@ -1643,8 +1642,11 @@ defmodule Ecto.Query.Planner do
 
   defp cast_param(kind, type, v) do
     case Ecto.Type.cast(type, v) do
-      {:ok, v} -> {:ok, v}
-      _ -> {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"}
+      {:ok, v} ->
+        {:ok, v}
+
+      _ ->
+        {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"}
     end
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -741,6 +741,7 @@ defmodule Ecto.Query.Planner do
     try do
       case cast_param(kind, type, v, adapter) do
         {:ok, v} -> v
+        {:error, {error, hint}} -> error! query, expr, error, hint
         {:error, error} -> error! query, expr, error
       end
     catch
@@ -1638,11 +1639,26 @@ defmodule Ecto.Query.Planner do
 
   defp cast_param(kind, type, v) do
     case Ecto.Type.cast(type, v) do
-      {:ok, v} ->
-        {:ok, v}
-      _ ->
-        {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"}
+      {:ok, v} -> {:ok, v}
+      _ -> {:error, cast_error(kind, type, v)}
     end
+  end
+
+  defp cast_error(kind, {:in, _} = type, %Ecto.Query{} = v) do
+    hint = """
+    `%Ecto.Query{}` struct is not supported as right-side value of `in` operator.
+    Did you mean to use `subquery(query)` instead?
+    """
+
+    {cast_error_message(kind, type, v), hint}
+  end
+
+  defp cast_error(kind, type, v) do
+    cast_error_message(kind, type, v)
+  end
+
+  defp cast_error_message(kind, type, v) do
+    "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"
   end
 
   defp dump_param(adapter, type, v) do
@@ -1738,5 +1754,9 @@ defmodule Ecto.Query.Planner do
 
   defp error!(query, expr, message) do
     raise Ecto.QueryError, message: message, query: query, file: expr.file, line: expr.line
+  end
+
+  defp error!(query, expr, message, hint) do
+    raise Ecto.QueryError, message: message, query: query, file: expr.file, line: expr.line, hint: hint
   end
 end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -162,6 +162,17 @@ defmodule Ecto.Query.PlannerTest do
     assert Exception.message(exception) =~ "where: p0.title == ^1"
   end
 
+  test "plan: Ecto.Query struct as right-side value of in operator" do
+    query = from(Post)
+
+    exception = assert_raise Ecto.Query.CastError, fn ->
+      plan(Post |> where([p], p.id in ^query))
+    end
+
+    assert Exception.message(exception) =~ "`%Ecto.Query{}` struct is not supported as right-side value of `in` operator."
+    assert Exception.message(exception) =~ "Did you mean to use `subquery(query)` instead?"
+  end
+
   test "plan: raises readable error on dynamic expressions/keyword lists" do
     dynamic = dynamic([p], p.id == ^"1")
     {_query, params, _key} = plan(Post |> where([p], ^dynamic))

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -165,11 +165,11 @@ defmodule Ecto.Query.PlannerTest do
   test "plan: Ecto.Query struct as right-side value of in operator" do
     query = from(Post)
 
-    exception = assert_raise Ecto.Query.CastError, fn ->
+    exception = assert_raise Ecto.QueryError, fn ->
       plan(Post |> where([p], p.id in ^query))
     end
 
-    assert Exception.message(exception) =~ "`%Ecto.Query{}` struct is not supported as right-side value of `in` operator."
+    assert Exception.message(exception) =~ "`%Ecto.Query{}` struct is not supported as right-side value of `in` operator"
     assert Exception.message(exception) =~ "Did you mean to use `subquery(query)` instead?"
   end
 


### PR DESCRIPTION
For consistency I did not want to break into cases this part:
https://github.com/elixir-ecto/ecto/blob/f5c2de8b30a33138bcedf09356aedc0908fb35b7/lib/ecto/exceptions.ex#L31-L35

Instead I changed code to pass optional `hint` message which is added at end of `exception` message:
>`%Ecto.Query{}` struct is not supported as right-side value of `in` operator.
Did you mean to use `subquery(query)` instead?

cc @josevalim and @AndrewDryga 
Closes: #3361 