### PR TITLE
Support preloading associations in embedded schemas

### DIFF
--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -6,6 +6,7 @@ defmodule Ecto.Integration.PreloadTest do
 
   alias Ecto.Integration.Post
   alias Ecto.Integration.Comment
+  alias Ecto.Integration.Item
   alias Ecto.Integration.Permalink
   alias Ecto.Integration.User
   alias Ecto.Integration.Custom
@@ -654,6 +655,19 @@ defmodule Ecto.Integration.PreloadTest do
     assert [%Comment{id: ^cid1}, %Comment{id: ^cid2}] = p1.comments |> sort_by_id
     assert [%Comment{id: ^cid3}, %Comment{id: ^cid4}] = p2.comments |> sort_by_id
     assert [] = p3.comments
+  end
+
+
+  test "preload belongs_to in embedded_schema" do
+    %User{id: uid1} = TestRepo.insert!(%User{name: "1"})
+    item = %Item{user_id: uid1}
+
+    # Starts as not loaded
+    assert %Ecto.Association.NotLoaded{} = item.user
+
+    # Now we preload it
+    item = TestRepo.preload(item, :user)
+    assert %User{id: uid1} = item.user
   end
 
   defp sort_by_id(values) do

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -215,6 +215,7 @@ defmodule Ecto.Integration.Item do
   This module is used to test:
 
     * Embedding
+    * Preloading associations in embedded schemas
 
   """
   use Ecto.Schema
@@ -226,6 +227,8 @@ defmodule Ecto.Integration.Item do
 
     embeds_one :primary_color, Ecto.Integration.ItemColor
     embeds_many :secondary_colors, Ecto.Integration.ItemColor
+
+    belongs_to :user, Ecto.Integration.User
   end
 end
 

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -86,8 +86,11 @@ defmodule Ecto.Repo.Preloader do
       {:ok, prefix} ->
         prefix
       :error ->
-        %{__meta__: %{prefix: prefix}} = sample
-        prefix
+        case sample do
+          %{__meta__: %{prefix: prefix}} -> prefix
+          # Must be an embedded schema
+          _ -> nil
+        end
     end
   end
 


### PR DESCRIPTION
Embedded schema structs do not have a `__meta__` key, so the old code failed with:

```
no match of right hand side value: %MyApp.EmbeddedThing{...
```

If the struct(s) given to preload do not have `__meta__`, it seems safe to use `nil` as `prefix`.

----

Contrived use case: `Post` _embeds_ many `Comment`s. `Comment` (an embedded schema) belongs to an author `User`.

```elixir
defmodule User do
  schema "users" do
    field :name, :string
  end
end

defmodule Post do
  schema "posts" do
    embeds_many :comments, Comment
  end
end

defmodule Comment do
  embedded_schema "posts" do
    field :message, :string
    belongs_to :author, User
  end
end

# If I have a `Comment` struct, I'd like to be able to preload its `author
comment = Repo.get(Comment, comment_id) |> Repo.preload(:author)
```



----

Related issues: #3238, #1837