### PR TITLE
Add ParameterizedType

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -1,0 +1,61 @@
+defmodule Ecto.Enum do
+  @moduledoc """
+  Ecto.Enum is used to safely store an atom field in Ecto.
+
+    field "foo", Ecto.Enum, values: [:foo, :bar, :baz]
+
+  `values:` must be a list of atoms. String values will be cast to atoms safely and only if the atom
+  exists in the list (otherwise an error will be raised). Attempting to load any string not represented
+  by an atom in the list of values will result in an error.
+
+  """
+  use Ecto.ParameterizedType
+
+  def type(_params), do: :string
+
+  def init(opts) do
+    values = Keyword.get(opts, :values, nil)
+
+    if !is_list(values) || !Enum.all?(values, &is_atom/1) do
+      raise ArgumentError, "Ecto.Enum types must have a values option specified as a list of atoms, e.g. field :my_field, Ecto.Enum, values: [:foo, :bar]"
+    end
+
+    user_to_db = Map.new(values, &{&1, Atom.to_string(&1)})
+    db_to_user = Map.new(values, &{Atom.to_string(&1), &1})
+    %{user_to_db: user_to_db, db_to_user: db_to_user}
+  end
+
+  def cast(data, params) do
+    case params do
+      %{db_to_user: %{^data => as_atom}} -> {:ok, as_atom}
+      %{user_to_db: %{^data => _}} -> {:ok, data}
+      _ -> :error
+    end
+  end
+
+  def load(nil, _, _), do: {:ok, nil}
+
+  def load(data, _loader, %{db_to_user: db_to_user}) do
+    case db_to_user do
+      %{^data => as_atom} -> {:ok, as_atom}
+      _ -> :error
+    end
+  end
+
+  def dump(nil, _, _), do: {:ok, nil}
+
+  def dump(data, _dumper, %{user_to_db: user_to_db}) do
+    case user_to_db do
+      %{^data => as_string} -> {:ok, as_string}
+      _ -> :error
+    end
+  end
+
+  def equal?(a, b, _params) do
+    a == b
+  end
+
+  def embed_as(_, _) do
+    :dump
+  end
+end

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -1,0 +1,99 @@
+defmodule Ecto.ParameterizedType do
+  @moduledoc """
+  Parameterized types are Ecto types that can be customized per field.
+
+  Paramterized types allow a set of options to be specified in the schema
+  which are initialized on compilation and passed to the callback functions
+  as the last argument. 
+
+  For example, `field :foo, :string` behaves the same for every field.
+  On the other hand, `field :foo, Ecto.Enum, values: [:foo, :bar, :baz]`
+  will likely have a different set of values per field.
+
+  Note that options are specified as a keyword, but it is idiomatic to
+  convert them to maps inside `c:init/1` for easier pattern matching in
+  other callbacks.
+
+  Parameterized types are a superset of regualr types. In other words,
+  with parameterized types you can do everything a regular type does,
+  and more. For example, parameterized types can handle `nil` values
+  in both `load` and `dump` callbacks, they can customize `cast` behavior
+  per query and per changeset, and also control how values are embedded.
+  
+  However, parameterized types are also more complex. Therefore, if
+  everything you need to achieve can be done with basic types, they
+  should be preferred to parameterized ones.
+
+  ## Examples
+
+  To create a parameterized type, create a module as shown below:
+
+    defmodule MyApp.MyType do
+        use Ecto.ParameterizedType
+
+        def type(_params), do: :string
+
+        def init(opts) do
+          validate_opts(opts)
+          Enum.into(opts, %{})
+        end
+
+        def cast(data, params) do
+          ...
+          cast_data
+        end
+
+        def load(data, _loader, params) do
+          ...
+          {:ok, loaded_data}
+        end
+
+        def dump(data, dumper, params) do
+          ...
+          {:ok, dumped_data}
+        end
+
+        def equal?(a, b, _params) do
+          a == b
+        end
+      end
+
+  To use this type in a schema field, specify the type and parameters like this:
+
+      schema "foo" do
+        field "bar", MyApp.MyType, opt1: :baz, opt2: :boo
+      end
+
+  """
+
+  @type opts :: keyword()
+
+  @type params :: term()
+
+  @callback init(opts :: opts()) :: params()
+
+  @callback cast(data :: term, params :: params()) ::
+              {:ok, term} | {:error, keyword()} | :error
+
+  @callback load(value :: any(), loader :: function(), params :: params()) :: {:ok, value :: any()} | :error
+
+  @callback dump(value :: any(), dumper :: function(), params :: params()) :: {:ok, value :: any()} | :error
+
+  @callback type(params :: params()) :: Ecto.Type.t()
+
+  @callback equal?(value1 :: any(), value2 :: any(), params :: params()) :: boolean()
+
+  @callback embed_as(format :: atom(), params :: params()) :: :self | :dump
+
+  @doc false
+  defmacro __using__(_) do
+    quote location: :keep do
+      @behaviour Ecto.ParameterizedType
+      # TODO: Make both equal? and embed_as specific only to parameterized types
+      def embed_as(_, _), do: :self
+      # TODO: evaluate if we should keep this once we add cast/3 and change/3
+      def equal?(term1, term2, _params), do: term1 == term2
+      defoverridable embed_as: 2, equal?: 3
+    end
+  end
+end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1771,7 +1771,7 @@ defmodule Ecto.Schema do
 
   @doc false
   def __field__(mod, name, type, opts) do
-    check_field_type!(name, type, type, opts)
+    type = check_field_type!(mod, name, type, opts)
     Module.put_attribute(mod, :changeset_fields, {name, type})
     define_field(mod, name, type, opts)
   end
@@ -2035,20 +2035,21 @@ defmodule Ecto.Schema do
     end
   end
 
-  defp check_field_type!(name, :datetime, _, _opts) do
+  defp check_field_type!(_mod, name, :datetime, _opts) do
     raise ArgumentError, "invalid type :datetime for field #{inspect name}. " <>
                            "You probably meant to choose one between :naive_datetime " <>
                            "(no time zone information) or :utc_datetime (time zone is set to UTC)"
   end
 
-  defp check_field_type!(name, type, full_type, opts) do
+  defp check_field_type!(mod, name, type, opts) do
     cond do
       type == :any and !opts[:virtual] ->
         raise ArgumentError, "only virtual fields can have type :any, " <>
                              "invalid type for field #{inspect name}"
 
-      inner_type = inner_from_composite(type, name) ->
-        check_field_type!(name, inner_type, type, opts)
+      composite?(type, name) ->
+        {outer_type, inner_type} = type
+        {outer_type, check_field_type!(mod, name, inner_type, opts)}
 
       Ecto.Type.base?(type) ->
         type
@@ -2056,27 +2057,30 @@ defmodule Ecto.Schema do
       is_atom(type) and Code.ensure_compiled(type) == {:module, type} and function_exported?(type, :type, 0) ->
         type
 
+      is_atom(type) and Code.ensure_compiled(type) == {:module, type} and function_exported?(type, :type, 1) ->
+        {:parameterized, type, type.init(Keyword.merge(opts, field: name, schema: mod))}
+
       is_atom(type) and function_exported?(type, :__schema__, 1) ->
         raise ArgumentError,
-          "schema #{inspect full_type} is not a valid type for field #{inspect name}." <>
+          "schema #{inspect type} is not a valid type for field #{inspect name}." <>
           " Did you mean to use belongs_to, has_one, has_many, embeds_one, or embeds_many instead?"
 
       true ->
-        raise ArgumentError, "invalid or unknown type #{inspect full_type} for field #{inspect name}"
+        raise ArgumentError, "invalid or unknown type #{inspect type} for field #{inspect name}"
     end
   end
 
-  defp inner_from_composite({composite, inner_type} = type, name) do
+  defp composite?({composite, _} = type, name) do
     if Ecto.Type.composite?(composite) do
-      inner_type
+      true
     else
       raise ArgumentError,
-        "invalid or unknown composite #{inspect type} for field #{inspect name}" <>
-        " Did you mean to use array or map as first element of tuple instead?"
+        "invalid or unknown composite #{inspect type} for field #{inspect name}. " <>
+        "Did you mean to use array or map as first element of tuple instead?"
     end
   end
 
-  defp inner_from_composite(_type, _name), do: false
+  defp composite?(_type, _name), do: false
 
   defp store_mfa_autogenerate!(mod, name, type, mfa) do
     if autogenerate_id(type) do

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Ecto.MixProject do
       elixir: "~> 1.7",
       deps: deps(),
       consolidate_protocols: Mix.env() != :test,
+      elixirc_paths: elixirc_paths(Mix.env()),
 
       # Hex
       description: "A toolkit for data mapping and language integrated query for Elixir",
@@ -117,4 +118,7 @@ defmodule Ecto.MixProject do
       "How-To's": ~r/guides\/howtos\/.?/
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -1,0 +1,109 @@
+defmodule Ecto.EnumTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Changeset
+  alias Ecto.TestRepo
+
+  defmodule EnumSchema do
+    use Ecto.Schema
+
+    schema "my_schema" do
+      field :my_enum, Ecto.Enum, values: [:foo, :bar, :baz]
+    end
+  end
+
+  describe "Ecto.Enum" do
+    test "schema" do
+      assert EnumSchema.__schema__(:type, :my_enum) ==
+          {:parameterized,
+              Ecto.Enum,
+              %{db_to_user: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
+              user_to_db: %{bar: "bar", baz: "baz", foo: "foo"}}}
+    end
+
+    test "bad values" do
+      bad_enum_values_error = "Ecto.Enum types must have a values option specified " <>
+            "as a list of atoms, e.g. field :my_field, Ecto.Enum, values: [:foo, :bar]"
+      assert_raise ArgumentError, bad_enum_values_error, fn ->
+        defmodule SchemaInvalidEnumValues do
+          use Ecto.Schema
+
+          schema "invalidvalues" do
+            field :name, Ecto.Enum
+          end
+        end
+      end
+
+      assert_raise ArgumentError, bad_enum_values_error, fn ->
+        defmodule SchemaInvalidEnumValues do
+          use Ecto.Schema
+
+          schema "invalidvalues" do
+            field :name, Ecto.Enum, values: ["foo", "bar"]
+          end
+        end
+      end
+    end
+  end
+
+  describe "cast" do
+    test "casts strings" do
+      assert %Changeset{valid?: true, changes: %{my_enum: :foo}} =
+        Changeset.cast(%EnumSchema{}, %{my_enum: "foo"}, [:my_enum])
+    end
+
+    test "casts atoms" do
+      assert %Changeset{valid?: true, changes: %{my_enum: :bar}} =
+        Changeset.cast(%EnumSchema{}, %{my_enum: :bar}, [:my_enum])
+    end
+
+    test "rejects bad strings" do
+      type = EnumSchema.__schema__(:type, :my_enum)
+      assert %Changeset{valid?: false, changes: %{}, errors: [my_enum: {"is invalid", [type: ^type, validation: :cast]}]} =
+        Changeset.cast(%EnumSchema{}, %{my_enum: "bar2"}, [:my_enum])
+    end
+
+    test "rejects bad atoms" do
+      type = EnumSchema.__schema__(:type, :my_enum)
+      assert %Changeset{valid?: false, changes: %{}, errors: [my_enum: {"is invalid", [type: ^type, validation: :cast]}]} =
+        Changeset.cast(%EnumSchema{}, %{my_enum: :bar2}, [:my_enum])
+    end
+  end
+
+  describe "dump" do
+    test "accepts valid values" do
+      assert %EnumSchema{my_enum: :foo} = TestRepo.insert!(%EnumSchema{my_enum: :foo})
+      assert_receive {:insert, %{fields: [my_enum: "foo"]}}
+    end
+
+    test "rejects invalid atom" do
+      msg = "value `:foo2` for `Ecto.EnumTest.EnumSchema.my_enum` in `insert` does not match type #{inspect EnumSchema.__schema__(:type, :my_enum)}"
+      assert_raise Ecto.ChangeError, msg, fn ->
+        TestRepo.insert!(%EnumSchema{my_enum: :foo2})
+      end
+      refute_received _
+    end
+
+    test "rejects invalid value" do
+      msg = "value `[:a, :b, :c]` for `Ecto.EnumTest.EnumSchema.my_enum` in `insert` does not match type #{inspect EnumSchema.__schema__(:type, :my_enum)}"
+      assert_raise Ecto.ChangeError, msg, fn ->
+        TestRepo.insert!(%EnumSchema{my_enum: [:a, :b, :c]})
+      end
+      refute_received _
+    end
+  end
+
+  describe "load" do
+    test "loads valid values" do
+      Process.put(:test_repo_all_results, {1, [[1, "foo", nil]]})
+      assert [%Ecto.EnumTest.EnumSchema{my_enum: :foo}] = TestRepo.all(EnumSchema)
+    end
+
+    test "reject invalid values" do
+      Process.put(:test_repo_all_results, {1, [[1, "foo2", nil]]})
+      assert_raise ArgumentError, ~r/cannot load `\"foo2\"` as type/, fn ->
+        TestRepo.all(EnumSchema)
+      end
+    end
+  end
+end

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -1,0 +1,163 @@
+defmodule Ecto.ParameterizedTypeTest do
+  use ExUnit.Case, async: true
+
+  defmodule MyParameterizedType do
+    use Ecto.ParameterizedType
+
+    @params %{some_param: :some_param_value}
+
+    def params, do: @params
+
+    def init([some_opt: :some_opt_value, field: :my_type, schema: _]), do: @params
+    def type(@params), do: :custom
+    def load(_, _, @params), do: {:ok, :load}
+    def dump( _, _, @params),  do: {:ok, :dump}
+    def cast( _, @params),  do: {:ok, :cast}
+    def equal?(true, _, @params), do: true
+    def equal?(_, _, @params), do: false
+    def embed_as(_, @params), do: :dump
+  end
+
+  defmodule Schema do
+    use Ecto.Schema
+
+    @primary_key {:id, :binary_id, autogenerate: true}
+    schema "" do
+      field :my_type, MyParameterizedType, some_opt: :some_opt_value
+    end
+  end
+
+  defmodule MyErrorParameterizedType do
+    use Ecto.ParameterizedType
+
+    def init(_), do: %{}
+    def type(_), do: :custom
+    def load(_, _, _), do: :error
+    def dump( _, _, _),  do: :error
+    def cast( _, _),  do: :error
+    def equal?(true, _, _), do: true
+    def equal?(_, _, _), do: false
+    def embed_as(_, _), do: :self
+  end
+
+  test "init" do
+    assert Schema.__schema__(:type, :my_type) ==
+      {:parameterized, Ecto.ParameterizedTypeTest.MyParameterizedType, %{some_param: :some_param_value}}
+  end
+
+  @p_type {:parameterized, MyParameterizedType, MyParameterizedType.params()}
+  @p_error_type {:parameterized, MyErrorParameterizedType, %{}}
+
+  test "parameterized type" do
+    assert Ecto.Type.type(@p_type) == :custom
+
+    assert Ecto.Type.embed_as(@p_type, :foo) == :dump
+
+    assert Ecto.Type.embedded_load(@p_type, :foo, :json) == {:ok, :load}
+    assert Ecto.Type.embedded_load(@p_type, nil,  :json) == {:ok, :load}
+
+    assert Ecto.Type.embedded_dump(@p_type, :foo,  :json) == {:ok, :dump}
+    assert Ecto.Type.embedded_dump(@p_type, nil, :json) == {:ok, :dump}
+
+    assert Ecto.Type.load(@p_type, :foo) == {:ok, :load}
+    assert Ecto.Type.load(@p_type, nil) == {:ok, :load}
+
+    assert Ecto.Type.dump(@p_type, :foo) == {:ok, :dump}
+    assert Ecto.Type.dump(@p_type, nil) == {:ok, :dump}
+
+    assert Ecto.Type.cast(@p_type, :foo) == {:ok, :cast}
+    assert Ecto.Type.cast(@p_type, nil) == {:ok, :cast}
+  end
+
+  test "parameterized type error" do
+    assert Ecto.Type.type(@p_error_type) == :custom
+
+    assert Ecto.Type.embed_as(@p_error_type, :foo) == :self
+
+    assert Ecto.Type.embedded_load(@p_error_type, :foo, :json) == :error
+    assert Ecto.Type.embedded_load(@p_error_type, nil,  :json) == :error
+
+    assert Ecto.Type.embedded_dump(@p_error_type, :foo,  :json) == {:ok, :foo}
+    assert Ecto.Type.embedded_dump(@p_error_type, nil, :json) == {:ok, nil}
+
+    assert Ecto.Type.load(@p_error_type, :foo) == :error
+    assert Ecto.Type.load(@p_error_type, nil) == :error
+
+    assert Ecto.Type.dump(@p_error_type, :foo) == :error
+    assert Ecto.Type.dump(@p_error_type, nil) == :error
+
+    assert Ecto.Type.cast(@p_error_type, :foo) == :error
+    assert Ecto.Type.cast(@p_error_type, nil) == :error
+  end
+
+  # TODO: Resolve issue with arrays of parameterized types or delete tests
+  @tag :skip
+  test "parameterized type with array" do
+    assert Ecto.Type.embed_as({:array, @p_type}, :foo) == :self
+
+    assert Ecto.Type.embedded_load({:array, @p_type}, [:foo], :json) == {:ok, [:load]}
+    assert Ecto.Type.embedded_load({:array, @p_type}, [nil], :json) == {:ok, [:load]}
+    assert Ecto.Type.embedded_load({:array, @p_type}, nil, :json) == {:ok, nil}
+
+    assert Ecto.Type.embedded_dump({:array, @p_type}, [:foo], :json) == {:ok, [:dump]}
+    assert Ecto.Type.embedded_dump({:array, @p_type}, [nil], :json) == {:ok, [:dump]}
+    assert Ecto.Type.embedded_dump({:array, @p_type}, nil, :json) == {:ok, nil}
+
+    assert Ecto.Type.load({:array, @p_type}, [:foo]) == {:ok, [:load]}
+    assert Ecto.Type.load({:array, @p_type}, [nil]) == {:ok, [:load]}
+    assert Ecto.Type.load({:array, @p_type}, nil) == {:ok, nil}
+
+    assert Ecto.Type.dump({:array, @p_type}, [:foo]) == {:ok, [:dump]}
+    assert Ecto.Type.dump({:array, @p_type}, [nil]) == {:ok, [:dump]}
+    assert Ecto.Type.dump({:array, @p_type}, nil) == {:ok, nil}
+
+    assert Ecto.Type.cast({:array, @p_type}, [:foo]) == {:ok, [:cast]}
+    assert Ecto.Type.cast({:array, @p_type}, [nil]) == {:ok, [:cast]}
+    assert Ecto.Type.cast({:array, @p_type}, nil) == {:ok, nil}
+  end
+
+  # TODO: Resolve issue with map of parameterized types or delete tests
+  @tag :skip
+  test "parameterized type with map" do
+    assert Ecto.Type.embed_as({:map, @p_type}, :foo) == :self
+
+    assert Ecto.Type.embedded_load({:map, @p_type}, %{"x" => "foo"}, :json) == {:ok, %{"x" => :load}}
+    assert Ecto.Type.embedded_load({:map, @p_type}, %{"x" => nil}, :json) == {:ok, %{"x" => :load}}
+    assert Ecto.Type.embedded_load({:map, @p_type}, nil, :json) == {:ok, nil}
+
+    assert Ecto.Type.embedded_dump({:map, @p_type}, %{"x" => "foo"}, :json) == {:ok, %{"x" => :dump}}
+    assert Ecto.Type.embedded_dump({:map, @p_type}, %{"x" => nil}, :json) == {:ok, %{"x" => :dump}}
+    assert Ecto.Type.embedded_dump({:map, @p_type}, nil, :json) == {:ok, nil}
+
+    assert Ecto.Type.load({:map, @p_type}, %{"x" => "foo"}) == {:ok, %{"x" => :load}}
+    assert Ecto.Type.load({:map, @p_type}, %{"x" => nil}) == {:ok, %{"x" => :load}}
+    assert Ecto.Type.load({:map, @p_type}, nil) == {:ok, nil}
+
+    assert Ecto.Type.dump({:map, @p_type}, %{"x" => "foo"}) == {:ok, %{"x" => :dump}}
+    assert Ecto.Type.dump({:map, @p_type}, %{"x" => nil}) == {:ok, %{"x" => :dump}}
+    assert Ecto.Type.dump({:map, @p_type}, nil) == {:ok, %{"x" => :dump}}
+
+    assert Ecto.Type.cast({:map, @p_type}, %{"x" => "foo"}) == {:ok, %{"x" => :cast}}
+    assert Ecto.Type.cast({:map, @p_type}, %{"x" => nil}) == {:ok, %{"x" => :cast}}
+    assert Ecto.Type.cast({:map, @p_type}, nil) == {:ok, %{"x" => :cast}}
+  end
+
+  # TODO: Resolve issue with maybe of parameterized type or delete tests
+  @tag :skip
+  test "parameterized type with maybe" do
+    assert Ecto.Type.embedded_load({:maybe, @p_type}, :foo, :json) == {:ok, :load}
+    assert Ecto.Type.embedded_load({:maybe, @p_error_type}, :foo,  :json) == {:ok, :foo}
+
+    assert Ecto.Type.embedded_dump({:maybe, @p_type}, :foo,  :json) == {:ok, :dump}
+    assert Ecto.Type.embedded_dump({:maybe, @p_error_type}, :foo, :json) == {:ok, :foo}
+
+    assert Ecto.Type.load({:maybe, @p_type}, :foo) == {:ok, :load}
+    assert Ecto.Type.load({:maybe, @p_error_type}, :foo) == {:ok, :foo}
+
+    assert Ecto.Type.dump({:maybe, @p_type}, :foo) == {:ok, :dump}
+    assert Ecto.Type.dump({:maybe, @p_error_type}, :foo) == {:ok, :foo}
+
+    assert Ecto.Type.cast({:maybe, @p_type}, :foo) == {:ok, :cast}
+    assert Ecto.Type.cast({:maybe, @p_error_type}, :foo) == {:ok, :foo}
+  end
+end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -378,7 +378,7 @@ defmodule Ecto.SchemaTest do
       end
     end
 
-    assert_raise ArgumentError, "invalid or unknown type {:array, :jsonb} for field :name", fn ->
+    assert_raise ArgumentError, "invalid or unknown type :jsonb for field :name", fn ->
       defmodule SchemaInvalidFieldType do
         use Ecto.Schema
 


### PR DESCRIPTION
This is v1 of `ParameterizedType` as outlined in [this comment](https://github.com/elixir-ecto/ecto/pull/3339#issuecomment-670081678) on a previous iteration of this work. `ParameterizedType` is added, and `Ecto.Type.Enum` is added in `test` as the validation implementation of ParameterizedType (to be promoted to `lib` in a follow up PR).

@josevalim I modified the Embedded changes in the previous commit slightly, as all of the ParameterizedType callbacks have the options/config as the final argument, not the first (making them read left-to-right closer to the Ecto.Type callbacks).