### PR TITLE
add recommended Elixir and Erlang/OTP combinations to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,24 @@
 name: CI
 on: [pull_request, push]
 jobs:
- mix_test:
-   name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
-   strategy:
-     matrix:
-       elixir: ['1.7.4', '1.10.1']
-       include:
-         - elixir: '1.7.4'
-           otp: '19.x'
-         - elixir: '1.10.1'
-           otp: '22.x'
-   runs-on: ubuntu-16.04
-   steps:
-     - uses: actions/checkout@v1
-     - uses: actions/setup-elixir@v1
-       with:
-         otp-version: ${{ matrix.otp }}
-         elixir-version: ${{ matrix.elixir }}
-     - name: Install Dependencies
-       run: mix deps.get
-     - name: Run Tests
-       run: mix test
+  mix_test:
+    name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
+    strategy:
+      matrix:
+        elixir: ['1.7.4', '1.10.1']
+        include:
+          - elixir: '1.7.4'
+            otp: '19.x'
+          - elixir: '1.10.1'
+            otp: '22.x'
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+      - name: Install Dependencies
+        run: mix deps.get
+      - name: Run Tests
+        run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
             otp: '22.x'
     runs-on: ubuntu-16.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-elixir@v1
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-elixir@v1.4.0
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [pull_request, push]
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         elixir: ['1.7.4', '1.10.1']
@@ -11,7 +12,6 @@ jobs:
             otp: '19.x'
           - elixir: '1.10.1'
             otp: '22.x'
-    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
             otp: 20.3.8.26
           - elixir: 1.9.4
             otp: 20.3.8.26
+            warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.4
             otp: 21.3.8.16
           - elixir: 1.10.4
@@ -29,5 +30,7 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get --only test
+      - run: mix compile --warnings-as-errors
+        if: matrix.warnings_as_errors
       - name: Run tests
         run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           mix local.rebar --force
           mix deps.get --only test
       - run: mix compile --warnings-as-errors
+        env:
+          MIX_ENV: test
         if: matrix.warnings_as_errors
       - name: Run tests
         run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
             otp: 20.3.8.26
           - elixir: 1.9.4
             otp: 20.3.8.26
-            warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.4
             otp: 21.3.8.16
           - elixir: 1.10.4
@@ -30,9 +29,5 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get --only test
-      - run: mix compile --warnings-as-errors
-        env:
-          MIX_ENV: test
-        if: matrix.warnings_as_errors
       - name: Run tests
         run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
     name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         elixir: ['1.7.4', '1.10.1']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: Install Dependencies
-        run: mix deps.get
-      - name: Run Tests
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only test
+      - name: Run tests
         run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.7.4', '1.10.1']
         include:
-          - elixir: '1.7.4'
-            otp: '19.x'
-          - elixir: '1.10.1'
-            otp: '22.x'
+          - elixir: 1.7.4
+            otp: 19.3.6.13
+          - elixir: 1.8.2
+            otp: 20.3.8.26
+          - elixir: 1.9.4
+            otp: 20.3.8.26
+          - elixir: 1.10.4
+            otp: 21.3.8.16
+          - elixir: 1.10.4
+            otp: 23.0.3
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0


### PR DESCRIPTION
This pull request makes sure all recommended Elixir and Erlang/OTP combinations are run on CI.

Quoting José Valim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.