### PR TITLE
Provide guidance for `:telemetry_prefix` when you have multiple dbs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -51,7 +51,10 @@ defmodule Ecto.Repo do
       is based on the module name, so if your module is called
       `MyApp.Repo`, the prefix will be `[:my_app, :repo]`. See the
       "Telemetry Events" section to see which events we recommend
-      adapters to publish
+      adapters to publish. Note that if you multiple databases, you
+      should keep the `:telemetry_prefix` consistent for each repo and
+      use the `:repo` property in the event metadata for distinguishing
+      between repos.
 
   ## URLs
 


### PR DESCRIPTION
Speaking with @bryannaegele, we were incorrectly setting telemetry prefixes for our app that uses multiple databases. This should help push others in the right direction.