### PR TITLE
Parameterized type change

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1221,9 +1221,15 @@ defmodule Ecto.Changeset do
     old_value = Map.get(data, key)
 
     case type.change(old_value, new_value, params) do
-      {:ok, change} -> {Map.put(changes, key, change), errors, valid?}
-      {:error, error} -> {changes, [{key, error} | errors], false}
-      :skip -> {Map.delete(changes, key), errors, valid?}
+      {:ok, change} ->
+        {Map.put(changes, key, change), errors, valid?}
+
+      {:error, error} ->
+        {message, opts} = Keyword.pop(error, :message, "cannot be changed")
+        {changes, [{key, {message, opts}} | errors], false}
+
+      :skip ->
+        {Map.delete(changes, key), errors, valid?}
     end
   end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1220,13 +1220,13 @@ defmodule Ecto.Changeset do
   defp put_change(data, changes, errors, valid?, key, new_value, {:parameterized, type, params}) do
     old_value = Map.get(data, key)
 
-    if type.equal?(old_value, new_value, params) do
-      {Map.delete(changes, key), errors, valid?}
-    else
+    if type.equal?(old_value, new_value, params) in [:skip, false] do
       case type.change(old_value, new_value, params) do
         {:ok, change} -> {Map.put(changes, key, change), errors, valid?}
         {:error, error} -> {changes, [{key, error} | errors], false}
       end
+    else
+      {Map.delete(changes, key), errors, valid?}
     end
   end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1217,10 +1217,10 @@ defmodule Ecto.Changeset do
     raise ArgumentError, "field names given to change/put_change must be atoms, got: `#{inspect(key)}`"
   end
 
-  defp put_change(data, changes, errors, valid?, key, new_value, {:parameterized, type, params}) do
+  defp put_change(data, changes, errors, valid?, key, new_value, type) do
     old_value = Map.get(data, key)
 
-    case type.change(old_value, new_value, params) do
+    case Ecto.Type.change(type, old_value, new_value) do
       {:ok, change} ->
         {Map.put(changes, key, change), errors, valid?}
 
@@ -1230,14 +1230,6 @@ defmodule Ecto.Changeset do
 
       :skip ->
         {Map.delete(changes, key), errors, valid?}
-    end
-  end
-
-  defp put_change(data, changes, errors, valid?, key, value, type) do
-    if not Ecto.Type.equal?(type, Map.get(data, key), value) do
-      {Map.put(changes, key, value), errors, valid?}
-    else
-      {Map.delete(changes, key), errors, valid?}
     end
   end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1228,7 +1228,7 @@ defmodule Ecto.Changeset do
         {Map.put(changes, key, change), errors, false}
 
       {:ok, change, true} ->
-        {Map.put(changes, key, change), errors, true}
+        {Map.put(changes, key, change), errors, valid?}
 
       {:ok, change} ->
         {Map.put(changes, key, change), errors, valid?}

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1230,9 +1230,6 @@ defmodule Ecto.Changeset do
       {:ok, change, true} ->
         {Map.put(changes, key, change), errors, valid?}
 
-      {:ok, change} ->
-        {Map.put(changes, key, change), errors, valid?}
-
       {:error, error} ->
         {message, opts} = Keyword.pop(error, :message, "is invalid")
         {changes, [{key, {message, opts}} | errors], false}

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1220,13 +1220,10 @@ defmodule Ecto.Changeset do
   defp put_change(data, changes, errors, valid?, key, new_value, {:parameterized, type, params}) do
     old_value = Map.get(data, key)
 
-    if type.equal?(old_value, new_value, params) in [:skip, false] do
-      case type.change(old_value, new_value, params) do
-        {:ok, change} -> {Map.put(changes, key, change), errors, valid?}
-        {:error, error} -> {changes, [{key, error} | errors], false}
-      end
-    else
-      {Map.delete(changes, key), errors, valid?}
+    case type.change(old_value, new_value, params) do
+      {:ok, change} -> {Map.put(changes, key, change), errors, valid?}
+      {:error, error} -> {changes, [{key, error} | errors], false}
+      :skip -> {Map.delete(changes, key), errors, valid?}
     end
   end
 

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -41,7 +41,7 @@ defmodule Ecto.Enum do
   def change(_old_value, new_value, params) do
     case params do
       %{on_dump: %{^new_value => _}} -> {:ok, new_value}
-      _ -> {:error, {"unknown enum value", value: new_value}}
+      _ -> {:error, [message: "unknown enum value", value: new_value]}
    end
   end
 

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -38,6 +38,14 @@ defmodule Ecto.Enum do
   end
 
   @impl Ecto.ParameterizedType
+  def change(_old_value, new_value, params) do
+    case params do
+      %{on_dump: %{^new_value => _}} -> {:ok, new_value}
+      _ -> {:error, {"unknown enum value", value: new_value}}
+   end
+  end
+
+  @impl Ecto.ParameterizedType
   def cast(data, params) do
     case params do
       %{on_load: %{^data => as_atom}} -> {:ok, as_atom}

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -40,7 +40,7 @@ defmodule Ecto.Enum do
   @impl Ecto.ParameterizedType
   def change(_old_value, new_value, params) do
     case params do
-      %{on_dump: %{^new_value => _}} -> {:ok, new_value}
+      %{on_dump: %{^new_value => _}} -> {:ok, new_value, true}
       _ -> {:error, [message: "unknown enum value", value: new_value]}
    end
   end

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -17,8 +17,10 @@ defmodule Ecto.Enum do
 
   use Ecto.ParameterizedType
 
+  @impl Ecto.ParameterizedType
   def type(_params), do: :string
 
+  @impl Ecto.ParameterizedType
   def init(opts) do
     values = Keyword.get(opts, :values, nil)
 
@@ -35,6 +37,7 @@ defmodule Ecto.Enum do
     %{on_load: on_load, on_dump: on_dump}
   end
 
+  @impl Ecto.ParameterizedType
   def cast(data, params) do
     case params do
       %{on_load: %{^data => as_atom}} -> {:ok, as_atom}
@@ -43,6 +46,7 @@ defmodule Ecto.Enum do
     end
   end
 
+  @impl Ecto.ParameterizedType
   def load(nil, _, _), do: {:ok, nil}
 
   def load(data, _loader, %{on_load: on_load}) do
@@ -52,6 +56,7 @@ defmodule Ecto.Enum do
     end
   end
 
+  @impl Ecto.ParameterizedType
   def dump(nil, _, _), do: {:ok, nil}
 
   def dump(data, _dumper, %{on_dump: on_dump}) do
@@ -61,6 +66,9 @@ defmodule Ecto.Enum do
     end
   end
 
+  @impl Ecto.ParameterizedType
   def equal?(a, b, _params), do: a == b
+
+  @impl Ecto.ParameterizedType
   def embed_as(_, _), do: :self
 end

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -100,7 +100,7 @@ defmodule Ecto.ParameterizedType do
   @callback init(opts :: opts()) :: params()
 
   @callback change(old_value :: any(), new_value :: any(), params :: params()) ::
-              {:ok, new_value :: any()} | {:error, Ecto.Changeset.error()}
+              {:ok, new_value :: any()} | {:error, Ecto.Changeset.error()} | :skip
 
   @doc """
   Casts the given input to the ParameterizedType with the given parameters.
@@ -138,7 +138,7 @@ defmodule Ecto.ParameterizedType do
   @doc """
   Checks if two terms are semantically equal.
   """
-  @callback equal?(value1 :: any(), value2 :: any(), params :: params()) :: boolean() | :ignore
+  @callback equal?(value1 :: any(), value2 :: any(), params :: params()) :: boolean()
 
   @doc """
   Dictates how the type should be treated inside embeds.

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -100,7 +100,7 @@ defmodule Ecto.ParameterizedType do
   @callback init(opts :: opts()) :: params()
 
   @callback change(old_value :: any(), new_value :: any(), params :: params()) ::
-              {:ok, new_value :: any(), valid? :: boolean()} | {:ok, new_value :: any()} | {:error, keyword()} | :skip
+              {:ok, new_value :: any(), valid? :: boolean()} | {:error, keyword()} | :skip
 
   @doc """
   Casts the given input to the ParameterizedType with the given parameters.
@@ -151,7 +151,7 @@ defmodule Ecto.ParameterizedType do
   defmacro __using__(_) do
     quote location: :keep do
       @behaviour Ecto.ParameterizedType
-      def change(_old_value, new_value, _params), do: {:ok, new_value}
+      def change(_old_value, new_value, _params), do: {:ok, new_value, true}
       # TODO: Make both equal? and embed_as specific only to parameterized types
       def embed_as(_, _), do: :self
       def equal?(term1, term2, _params), do: term1 == term2

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -4,7 +4,7 @@ defmodule Ecto.ParameterizedType do
 
   Paramterized types allow a set of options to be specified in the schema
   which are initialized on compilation and passed to the callback functions
-  as the last argument. 
+  as the last argument.
 
   For example, `field :foo, :string` behaves the same for every field.
   On the other hand, `field :foo, Ecto.Enum, values: [:foo, :bar, :baz]`
@@ -19,7 +19,7 @@ defmodule Ecto.ParameterizedType do
   and more. For example, parameterized types can handle `nil` values
   in both `load` and `dump` callbacks, they can customize `cast` behavior
   per query and per changeset, and also control how values are embedded.
-  
+
   However, parameterized types are also more complex. Therefore, if
   everything you need to achieve can be done with basic types, they
   should be preferred to parameterized ones.
@@ -66,23 +66,82 @@ defmodule Ecto.ParameterizedType do
 
   """
 
+  @typedoc """
+  The keyword options passed from the Schema's field macro into `c:init/1`
+  """
   @type opts :: keyword()
 
+  @typedoc """
+  The parameters for the ParameterizedType
+
+  This is thet value passed back from `c:init/1` and subsequently passed as the last argument to all callbacks.
+  Idiomatically it is a map.
+  """
   @type params :: term()
 
+  @doc """
+  Callback to convert the options specified in  the field macro into parameters to be used in other callbacks.
+
+  This function is called at compile time, and should raise if invalid values are specified. It is idiomatic
+  that the parameters returned from this are a map. `field` and `schema` will be injected into the options
+  automatically
+
+  For example, this schema specification
+
+      schema "my_table" do
+        field :my_field, MyParameterizedType, opt1: :foo, opt2: nil
+      end
+
+  will result in the call:
+
+      MyParameterizedType.init([schema: "my_table", field: :my_field, opt1: :foo, opt2: nil])
+
+  """
   @callback init(opts :: opts()) :: params()
 
+  @doc """
+  Casts the given input to the ParameterizedType with the given parameters.
+
+  For more information on casting, see `c:Ecto.Type.cast/1`
+  """
   @callback cast(data :: term, params :: params()) ::
               {:ok, term} | {:error, keyword()} | :error
 
+  @doc """
+  Loads the given term into a ParameterizedType.
+
+  For more information on loading, see `c:Ecto.Type.load/1`
+
+  Note that this callback *will* be called when loading a `nil` value, unlike `c:Ecto.Type.load/1`.
+  """
   @callback load(value :: any(), loader :: function(), params :: params()) :: {:ok, value :: any()} | :error
 
+  @doc """
+  Dumps the given term into an Ecto native type.
+
+  For more information on dumping, see `c:Ecto.Type.dump/1`
+
+  Note that this callback *will* be called when dumping a `nil` value, unlike `c:Ecto.Type.dump/1`.
+  """
   @callback dump(value :: any(), dumper :: function(), params :: params()) :: {:ok, value :: any()} | :error
 
+  @doc """
+  Returns the underlying schema type for the ParameterizedType.
+
+  For more information on schema types, see `c:Ecto.Type.type/0`
+  """
   @callback type(params :: params()) :: Ecto.Type.t()
 
+  @doc """
+  Checks if two terms are semantically equal.
+  """
   @callback equal?(value1 :: any(), value2 :: any(), params :: params()) :: boolean()
 
+  @doc """
+  Dictates how the type should be treated inside embeds.
+
+  For more information on embedding, see `c:Ecto.Type.embed_as/1`
+  """
   @callback embed_as(format :: atom(), params :: params()) :: :self | :dump
 
   @doc false

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -100,7 +100,7 @@ defmodule Ecto.ParameterizedType do
   @callback init(opts :: opts()) :: params()
 
   @callback change(old_value :: any(), new_value :: any(), params :: params()) ::
-              {:ok, new_value :: any()} | {:error, keyword()} | :skip
+              {:ok, new_value :: any(), valid? :: boolean()} | {:ok, new_value :: any()} | {:error, keyword()} | :skip
 
   @doc """
   Casts the given input to the ParameterizedType with the given parameters.

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -138,7 +138,7 @@ defmodule Ecto.ParameterizedType do
   @doc """
   Checks if two terms are semantically equal.
   """
-  @callback equal?(value1 :: any(), value2 :: any(), params :: params()) :: boolean()
+  @callback equal?(value1 :: any(), value2 :: any(), params :: params()) :: boolean() | :ignore
 
   @doc """
   Dictates how the type should be treated inside embeds.

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -99,6 +99,9 @@ defmodule Ecto.ParameterizedType do
   """
   @callback init(opts :: opts()) :: params()
 
+  @callback change(old_value :: any(), new_value :: any(), params :: params()) ::
+              {:ok, new_value :: any()} | {:error, Ecto.Changeset.error()}
+
   @doc """
   Casts the given input to the ParameterizedType with the given parameters.
 

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -100,7 +100,7 @@ defmodule Ecto.ParameterizedType do
   @callback init(opts :: opts()) :: params()
 
   @callback change(old_value :: any(), new_value :: any(), params :: params()) ::
-              {:ok, new_value :: any()} | {:error, Ecto.Changeset.error()} | :skip
+              {:ok, new_value :: any()} | {:error, opts} | :skip
 
   @doc """
   Casts the given input to the ParameterizedType with the given parameters.

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -151,11 +151,12 @@ defmodule Ecto.ParameterizedType do
   defmacro __using__(_) do
     quote location: :keep do
       @behaviour Ecto.ParameterizedType
+      def change(_old_value, new_value, _params), do: {:ok, new_value}
       # TODO: Make both equal? and embed_as specific only to parameterized types
       def embed_as(_, _), do: :self
       # TODO: evaluate if we should keep this once we add cast/3 and change/3
       def equal?(term1, term2, _params), do: term1 == term2
-      defoverridable embed_as: 2, equal?: 3
+      defoverridable change: 3, embed_as: 2, equal?: 3
     end
   end
 end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -51,7 +51,7 @@ defmodule Ecto.Repo do
       is based on the module name, so if your module is called
       `MyApp.Repo`, the prefix will be `[:my_app, :repo]`. See the
       "Telemetry Events" section to see which events we recommend
-      adapters to publish. Note that if you multiple databases, you
+      adapters to publish. Note that if you have multiple databases, you
       should keep the `:telemetry_prefix` consistent for each repo and
       use the `:repo` property in the event metadata for distinguishing
       between repos.

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -972,6 +972,23 @@ defmodule Ecto.Type do
     end
   end
 
+  @spec change(t, term, term) :: {:ok, term} | {:error, Ecto.Changeset.error()}
+  def change(type, term1, term2) do
+    if fun = change_fun(type) do
+      fun.(term1, term2)
+    else
+      {:ok, term2}
+    end
+  end
+
+  defp change_fun({:parameterized, mod, params}) do
+    &mod.change(&1, &2, params)
+  end
+
+  defp change_fun(mod) when is_atom(mod), do: &mod.change/2
+
+  defp change_fun(_t), do: nil
+
   @doc """
   Checks if two terms are equal.
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -973,19 +973,21 @@ defmodule Ecto.Type do
   end
 
   @spec change(t, term, term) :: {:ok, term} | {:error, Ecto.Changeset.error()}
-  def change(type, term1, term2) do
-    if fun = change_fun(type) do
-      fun.(term1, term2)
-    else
-      {:ok, term2}
+  def change(type, old_value, new_value) do
+    change_fun(type).(old_value, new_value)
+  end
+
+  defp change_fun({:parameterized, mod, params}), do: &mod.change(&1, &2, params)
+
+  defp change_fun(type) do
+    fn old_value, new_value ->
+      if equal?(type, old_value, new_value) do
+        :skip
+      else
+        {:ok, new_value}
+      end
     end
   end
-
-  defp change_fun({:parameterized, mod, params}) do
-    &mod.change(&1, &2, params)
-  end
-
-  defp change_fun(_t), do: nil
 
   @doc """
   Checks if two terms are equal.

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -985,8 +985,6 @@ defmodule Ecto.Type do
     &mod.change(&1, &2, params)
   end
 
-  defp change_fun(mod) when is_atom(mod), do: &mod.change/2
-
   defp change_fun(_t), do: nil
 
   @doc """

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -988,7 +988,7 @@ defmodule Ecto.Type do
       if equal?(type, old_value, new_value) do
         :skip
       else
-        {:ok, new_value}
+        {:ok, new_value, true}
       end
     end
   end

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -47,6 +47,13 @@ defmodule Ecto.EnumTest do
     end
   end
 
+  describe "change" do
+    test "change" do
+      assert %Changeset{valid?: true, changes: %{my_enum: :foo}, errors: []} = Changeset.change(%EnumSchema{my_enum: false}, %{my_enum: :foo})
+      assert %Changeset{valid?: false, errors: [{:my_enum, {"unknown enum value", value: 1}}]} = Changeset.change(%EnumSchema{}, %{my_enum: 1})
+    end
+  end
+
   describe "cast" do
     test "casts strings" do
       assert %Changeset{valid?: true, changes: %{my_enum: :foo}} =

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -15,7 +15,7 @@ defmodule Ecto.ParameterizedTypeTest do
     def equal?(_, _, _), do: false
     def embed_as(_, %{embed: embed}), do: embed
     def change(:skip, _new, _params), do: :skip
-    def change(_old, _new, _params), do: {:ok, :change}
+    def change(_old, _new, _params), do: {:ok, :change, true}
   end
 
   defmodule Schema do

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -13,6 +13,7 @@ defmodule Ecto.ParameterizedTypeTest do
     def equal?(true, _, _), do: true
     def equal?(_, _, _), do: false
     def embed_as(_, %{embed: embed}), do: embed
+    def change(_old, _new, _params), do: {:ok, :change}
   end
 
   defmodule Schema do
@@ -35,6 +36,7 @@ defmodule Ecto.ParameterizedTypeTest do
     def equal?(true, _, _), do: true
     def equal?(_, _, _), do: false
     def embed_as(_, _), do: :self
+    def change(_old, new, _params), do: {:error, {"error message", value: new}}
   end
 
   test "init" do
@@ -71,6 +73,8 @@ defmodule Ecto.ParameterizedTypeTest do
 
     assert Ecto.Type.cast(@p_self_type, :foo) == {:ok, :cast}
     assert Ecto.Type.cast(@p_self_type, nil) == {:ok, :cast}
+
+    assert Ecto.Type.change(@p_self_type, :old, :new) == {:ok, :change}
   end
 
   test "parameterized type error" do
@@ -92,6 +96,8 @@ defmodule Ecto.ParameterizedTypeTest do
 
     assert Ecto.Type.cast(@p_error_type, :foo) == :error
     assert Ecto.Type.cast(@p_error_type, nil) == :error
+
+    assert Ecto.Type.change(@p_error_type, :old, :new) == {:error, {"error message", value: :new}}
   end
 
   test "parameterized type with array" do

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -12,9 +12,9 @@ defmodule Ecto.ParameterizedTypeTest do
     def load(_, _, _), do: {:ok, :load}
     def dump( _, _, _),  do: {:ok, :dump}
     def cast( _, _),  do: {:ok, :cast}
-    def equal?(:skip, _, _), do: :skip
-    def equal?(_, _, _), do: true
+    def equal?(_, _, _), do: false
     def embed_as(_, %{embed: embed}), do: embed
+    def change(:skip, _new, _params), do: :skip
     def change(_old, _new, _params), do: {:ok, :change}
   end
 
@@ -35,7 +35,6 @@ defmodule Ecto.ParameterizedTypeTest do
     def load(_, _, _), do: :error
     def dump( _, _, _),  do: :error
     def cast( _, _),  do: :error
-    def equal?(true, _, _), do: true
     def equal?(_, _, _), do: false
     def embed_as(_, _), do: :self
     def change(_old, new, _params), do: {:error, {"error message", value: new}}
@@ -77,9 +76,9 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.cast(@p_self_type, nil) == {:ok, :cast}
 
     skipped = Changeset.change(%Schema{my_type: :skip}, my_type: :new)
-    assert skipped.changes == %{my_type: :change}
+    assert skipped.changes == %{}
     always_equal = Changeset.change(%Schema{my_type: :old}, my_type: :new)
-    assert map_size(always_equal.changes) == 0
+    assert always_equal.changes == %{my_type: :change}
   end
 
   test "parameterized type error" do


### PR DESCRIPTION
* [x] Added `change/3` callback for `Ecto.ParameterizedType`.
* [x] Added `change/3` callback implementation for `Ecto.Enum`.
* [x] Added tests for new callback.

**TODO**:
* [x] `Ecto.Embedded` support and tests for it
* [x] Define default implementation for `change/3` on `use Ecto.ParameterizedType`
* [ ] Implement `change_fun` for arrays and maps. For arrays, we need to recursively call `change` on pair-wise. If the new_value has more entries than old_value, we need to consider the remaining entries are nil. For maps, we need similar logic and compare them based on the keys.

Related issue: #3380 

cc @josevalim @TheFirstAvenger 

Does it looks good? How should `Ecto.Embedded` work?