### PR TITLE
Parse decimal floats with Decimal.from_float instead of Decimal.new

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -319,6 +319,10 @@ defmodule Ecto.Type do
     end
   end
 
+  def dump(:decimal, term, _dumper) when is_float(term) do
+    {:ok, Decimal.from_float(term)}
+  end
+
   def dump(:decimal, term, _dumper) when is_number(term) do
     {:ok, Decimal.new(term)}
   end
@@ -582,6 +586,9 @@ defmodule Ecto.Type do
 
   def cast(:decimal, term) when is_binary(term) do
     Decimal.parse(term)
+  end
+  def cast(:decimal, term) when is_float(term) do
+    {:ok, Decimal.from_float(term)}
   end
   def cast(:decimal, term) when is_number(term) do
     {:ok, Decimal.new(term)}


### PR DESCRIPTION
- v2.2.* currently uses `Decimal.new/1` to cast and dump all decimal numbers, including float, which triggers a deprecation warning:
```
 warning: passing float to Decimal.new/1 is deprecated as floats have inherent inaccuracy. Use Decimal.from_float/1 or Decimal.cast/1 instead
```
- v3.* already uses `Decimal.from_float/1`
- This pull request adds the usage of `Decimal.from_float/1` to v2.2.*