### PR TITLE
Fix empty string converted to non-empty default

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -105,11 +105,13 @@ defmodule Ecto.Changeset do
   Many times, the data given on cast needs to be further pruned, specially
   regarding empty values. For example, if you are gathering data to be
   cast from the command line or through an HTML form or any other text-based
-  format, it is likely those means cannot express nil values. For
+  format, it is likely those means cannot express `nil` values. For
   those reasons, changesets include the concept of empty values, which are
-  values that will be automatically converted to the field's default value
-  on `cast/4`. Those values are stored in the changeset `empty_values` field
-  and default to `[""]`.
+  stored in the changeset `empty_values` field with a default of `[""]`. Empty
+  values are values that will be automatically converted to the field's default
+  empty value on `cast/4`. The default empty value will be the field's default
+  value if that value is included in `empty_values`. Otherwise, it will be
+  `nil`.
 
   ## Associations, embeds and on replace
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -560,7 +560,14 @@ defmodule Ecto.Changeset do
   defp cast_field(key, param_key, type, params, current, empty_values, defaults, valid?) do
     case params do
       %{^param_key => value} ->
-        value = if value in empty_values, do: Map.get(defaults, key), else: value
+        value =
+          if value in empty_values do
+            default = Map.get(defaults, key)
+            if default in empty_values, do: default, else: nil
+          else
+            value
+          end
+
         case Ecto.Type.cast(type, value) do
           {:ok, value} ->
             if Ecto.Type.equal?(type, current, value) do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -137,9 +137,9 @@ defmodule Ecto.ChangesetTest do
     params = %{"title" => "empty", "body" => nil}
     struct = %Post{title: "foo", body: "bar"}
 
-    changeset = cast(struct, params, ~w(title body)a, empty_values: ["empty"])
+    changeset = cast(struct, params, ~w(title body)a, empty_values: ["", "empty"])
     assert changeset.changes == %{title: "", body: nil}
-    assert changeset.empty_values == ["empty"]
+    assert changeset.empty_values == ["", "empty"]
   end
 
   test "cast/4: with matching empty values" do
@@ -160,7 +160,7 @@ defmodule Ecto.ChangesetTest do
     params = %{"with_default" => ""}
 
     changeset = cast(struct, params, ~w(with_default)a)
-    assert changeset.changes == %{with_default: ""}
+    assert changeset.changes == %{with_default: nil}
   end
 
   test "cast/4: with data and types" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -49,6 +49,7 @@ defmodule Ecto.ChangesetTest do
       field :published_at, :naive_datetime
       field :source, :map
       field :permalink, :string, source: :url
+      field :with_default, :string, default: "default"
       belongs_to :category, Ecto.ChangesetTest.Category, source: :cat_id
       has_many :comments, Ecto.ChangesetTest.Comment, on_replace: :delete
       has_one :comment, Ecto.ChangesetTest.Comment
@@ -147,6 +148,19 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(title body)a)
     assert changeset.changes == %{}
+  end
+
+  test "cast/4: with empty values with default" do
+    params = %{"with_default" => nil}
+    struct = %Post{}
+
+    changeset = cast(struct, params, ~w(with_default)a)
+    assert changeset.changes == %{with_default: nil}
+
+    params = %{"with_default" => ""}
+
+    changeset = cast(struct, params, ~w(with_default)a)
+    assert changeset.changes == %{with_default: ""}
   end
 
   test "cast/4: with data and types" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -150,7 +150,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes == %{}
   end
 
-  test "cast/4: with empty values with default" do
+  test "cast/4: with empty value and non-empty default" do
     params = %{"with_default" => nil}
     struct = %Post{}
 


### PR DESCRIPTION
I came across the following surprising behavior in Ecto. My schema looked like:

```elixir
defmodule MyApp.Redirect do
  use Ecto.Schema
  import Ecto.Changeset

  schema "redirects" do
    field :path, :string, default: "/"
  end

  @doc false
  def changeset(redirect, attrs) do
    redirect
    |> cast(attrs, [:path])
    |> validate_required([:path])
  end
end
```

The following worked as expected:


```elixir
changeset = MyApp.Redirect.changeset(%MyApp.Redirect{}, %{path: nil})
refute changeset.valid?
assert changeset.errors == [path: {"can't be blank", [validation: :required]}]
```

But mysteriously, `cast` was not setting the field when the value was an empty string:

```elixir
changeset = MyApp.Redirect.changeset(%MyApp.Redirect{}, %{path: ""})
assert changeset.valid?
assert Ecto.Changeset.get_field(changeset, :path) == "/"
```

It appears that Ecto is converting values from `changeset.empty_values` to the field's default value. But in this case, the field's default value does not represent an empty value. Having a default value that does not represent "empty" seems like a common use case.

This pull-request ensures that the conversion from empty value to default value will only occur if the default value is an empty value.