### PR TITLE
Add docs for Ecto.Type on it's usage with preloads

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -80,6 +80,79 @@ defmodule Ecto.Type do
 
   Note: `nil` values are always bypassed and cannot be handled by
   custom types.
+  
+  ## Custom types and preloads
+  
+  Imagine the id of your schema is an auto incrementing number.
+  Since it's auto incrementing nature could allow them to enumerate
+  the contents of your service, you don't may not want your
+  users to know it, so you send an encoded version of the id to
+  them.
+  
+  An Ecto type could handle the conversion between the encoded
+  version of the id and it's representation in the database.
+  For the sake of simplicity we'll use base64 encoding in this
+  example:
+  
+      defmodule EncodedId do
+        use Ecto.Type
+        
+        def type, do: :id
+        
+        def cast(id) when is_integer(id) do
+          {:ok, Base.encode64(id)}
+        end
+        def cast(_), do: :error
+        
+        def dump(id) when is_binary(id) do
+          Base.decode64(id)
+        end
+        
+        def load(id) when is_integer(id) do
+          {:ok, Base.encode64(id)}
+        end
+      end
+  
+  To use it as the type for the id in our schema, we can use the
+  `@primary_key` module attribute:
+  
+      defmodule BlogPost do
+        use Ecto.Schema
+        
+        @primary_key {:id, EncodedId, autogenerate: true}
+        schema "posts" do
+          belongs_to :author, Author, type: EncodedId
+          field :content, :string
+        end
+      end
+      
+      defmodule Author do
+        use Ecto.Schema
+        
+        @primary_key {:id, EncodedId, autogenerate: true}
+        schema "authors" do
+          field :name, :string
+          has_many :posts, BlogPost
+        end
+      end
+  
+  The `@primary_key` attribute will tell ecto which type to
+  use for the id.
+  
+  Note the `type: EncodedId` option given to `belongs_to` in
+  the `BlogPost` schema. By default, Ecto will treat
+  associations as if their keys were `:integer`s. Our primary
+  keys are a custom type, so when Ecto tries to cast those
+  ids, it will fail. So we need to tell it how to handle
+  the types of the foreign keys via the `:type` option in
+  `belongs_to`, or by using the `@foreign_key_type` at the
+  top of the schema to apply it to every `belong_to`
+  association.
+  
+  Now the ids will be represented as encoded strings in
+  our codebase, not leaking to our users, and their
+  auto incremented number representation remains untouched
+  in the database.
   """
 
   import Kernel, except: [match?: 2]

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -100,7 +100,7 @@ defmodule Ecto.Type do
         def type, do: :id
         
         def cast(id) when is_integer(id) do
-          {:ok, Base.encode64(id)}
+          {:ok, encode_id(id)}
         end
         def cast(_), do: :error
         
@@ -109,7 +109,13 @@ defmodule Ecto.Type do
         end
         
         def load(id) when is_integer(id) do
-          {:ok, Base.encode64(id)}
+          {:ok, encode_id(id)}
+        end
+        
+        defp encode_id(id) do
+          id
+          |> Integer.to_string()
+          |> Base.encode64
         end
       end
   


### PR DESCRIPTION
I recently had an issue when using a custom Ecto.Type as primary key and trying to preload associations.
I posted the details [in this thread](https://elixirforum.com/t/ecto-custom-type-issue-value-list-of-ids-in-where-cannot-be-cast-to-type-in-id-in-query/34325) of the elixir forums while I was trying to figure it out what was the cause.

The issue was that, when using a custom Ecto.Type as primary key, it needs to be used also in the `:type` option of `Ecto.Schema.belongs_to`, otherwise Ecto will fail to cast the list of ids and will fail with an error that's not very obvious:

```elixir
[error] Task #PID<0.11545.0> started from #PID<0.11541.0> terminating
** (Ecto.Query.CastError) deps/ecto/lib/ecto/association.ex:623: value `["KV3A8", "Ja344", "8n43V", "304Ko"]` in `where` cannot be cast to type {:in, :id} in query:

from r0 in Embers.Reactions.Reaction,
  where: r0.post_id in ^["KV3A8", "Ja344", "8n43V", "304Ko"],
  order_by: [asc: r0.post_id],
  select: {r0.post_id, r0}
```

This wasn't obvious to me, mainly because documentation on custom type definition and usage is scattered between the `Ecto.Type` docs and the `Ecto.Schema` module attributes and `Ecto.Schema.belongs_to` options and it can be hard to figure out how everything fits together.

This PR adds a short example of this kind of usage to the `Ecto.Type` docs to make the relationship a little bit clearer.