### PR TITLE
Fix deprecation warning on build

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2149,7 +2149,7 @@ defmodule Ecto.Changeset do
   end
 
   defp validate_number(field, %Decimal{} = value, message, spec_key, _spec_function, target_value) do
-    result = Decimal.cmp(value, decimal_new(target_value))
+    result = Decimal.compare(value, decimal_new(target_value))
     case decimal_compare(result, spec_key) do
       true  -> nil
       false -> [{field, {message, validation: :number, kind: spec_key, number: target_value}}]

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Ecto.MixProject do
   defp deps do
     [
       {:telemetry, "~> 0.4"},
-      {:decimal, "~> 1.6 or ~> 2.0"},
+      {:decimal, "~> 2.0"},
       {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.20", only: :docs}
     ]


### PR DESCRIPTION
Hello there,

Just a quick fix to a deprecation warning coming from Decimal.
```
warning: Decimal.cmp/2 is deprecated. Use compare/2 instead
  lib/ecto/changeset.ex:2152: Ecto.Changeset.validate_number/6
```
Looking at the [docs](https://hexdocs.pm/decimal/readme.html#comparisons), it looks like only the name changed.