### PR TITLE
belongs_to with ParameterizedType

### DIFF
--- a/integration_test/support/types.exs
+++ b/integration_test/support/types.exs
@@ -32,3 +32,13 @@ defmodule WrappedInteger do
   def load(integer), do: {:ok, {:int, integer}}
   def dump({:int, integer}), do: {:ok, integer}
 end
+
+defmodule ParameterizedPrefixedString do
+  use Ecto.ParameterizedType
+  def init(opts), do: Enum.into(opts, %{})
+  def type(_), do: :string
+  def cast(string, %{prefix: _}), do: {:ok, string |> String.split("-") |> List.last()}
+  def dump(string, _, %{prefix: _prefix} = opts), do: cast(string, opts)
+  def load(string, _, %{prefix: prefix}), do: {:ok, prefix <> "-" <> string}
+  def embed_as(_, _), do: :dump
+end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2055,9 +2055,15 @@ defmodule Ecto.Schema do
   end
 
   defp check_options!(opts, valid, fun_arity) do
-    case Enum.find(opts, fn {k, _} -> not(k in valid) end) do
-      {k, _} -> raise ArgumentError, "invalid option #{inspect k} for #{fun_arity}"
-      nil -> :ok
+    type = Keyword.get(opts, :type)
+
+    if is_atom(type) and Code.ensure_compiled(type) == {:module, type} and function_exported?(type, :type, 1) do
+      :ok
+    else
+      case Enum.find(opts, fn {k, _} -> not(k in valid) end) do
+        {k, _} -> raise ArgumentError, "invalid option #{inspect k} for #{fun_arity}"
+        nil -> :ok
+      end
     end
   end
 


### PR DESCRIPTION
#3434 

makes belongs_to function accepts options for ParameterizedType other that the default ones.

I assume that once the options passed to the belongs_to fields are valid, the field is right initiated as we see in the `check_field_type!` function.