### PR TITLE
Fix "__schema__/1 is undefined or private" error while inspecting a schemaless changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2941,7 +2941,7 @@ defimpl Inspect, for: Ecto.Changeset do
     end
 
     redacted_fields = case data do
-      %type{} -> if function_exported?(type, :__schema__, 2), do: type.__schema__(:redact_fields), else: []
+      %type{__meta__: _} -> type.__schema__(:redact_fields)
       _ -> []
     end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2941,7 +2941,7 @@ defimpl Inspect, for: Ecto.Changeset do
     end
 
     redacted_fields = case data do
-      %type{} -> type.__schema__(:redact_fields)
+      %type{} -> if function_exported?(type, :__schema__, 2), do: type.__schema__(:redact_fields), else: []
       _ -> []
     end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1793,6 +1793,13 @@ defmodule Ecto.ChangesetTest do
       assert inspect(changeset(%{"title" => "title", "body" => "hi"})) ==
             "#Ecto.Changeset<action: nil, changes: %{body: \"hi\", title: \"title\"}, " <>
             "errors: [], data: #Ecto.ChangesetTest.Post<>, valid?: true>"
+
+      data   = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
+      params = %{"title" => "world", "upvotes" => "0"}
+
+      assert inspect(cast(data, params, ~w(title upvotes)a)) ==
+               "#Ecto.Changeset<action: nil, changes: %{title: \"world\", upvotes: 0}, " <>
+               "errors: [], data: #Ecto.ChangesetTest.NoSchemaPost<>, valid?: true>"
     end
 
     test "redacts fields marked redact: true" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -55,6 +55,10 @@ defmodule Ecto.ChangesetTest do
     end
   end
 
+  defmodule NoSchemaPost do
+    defstruct [:title, :upvotes]
+  end
+
   defp changeset(schema \\ %Post{}, params) do
     cast(schema, params, ~w(id token title body upvotes decimal color topics virtual)a)
   end
@@ -160,6 +164,19 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == []
     assert changeset.valid?
     assert apply_changes(changeset) == %{title: "world", upvotes: 0}
+  end
+
+  test "cast/4: with data struct and types" do
+    data   = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
+    params = %{"title" => "world", "upvotes" => "0"}
+
+    changeset = cast(data, params, ~w(title upvotes)a)
+    assert changeset.params == params
+    assert changeset.data  == %NoSchemaPost{title: "hello"}
+    assert changeset.changes == %{title: "world", upvotes: 0}
+    assert changeset.errors == []
+    assert changeset.valid?
+    assert apply_changes(changeset) == %NoSchemaPost{title: "world", upvotes: 0}
   end
 
   test "cast/4: with dynamic embed" do


### PR DESCRIPTION
This fixes an issue introduced in v3.5.0 (https://github.com/elixir-ecto/ecto/pull/3385) when inspecting a changeset that is based on a struct without a schema.

```elixir
defmodule NoSchemaPost do
  defstruct [:title, :upvotes]
end

data   = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
params = %{"title" => "world", "upvotes" => "0"}

data
|> cast(params, ~w(title upvotes)a)
|> IO.inspect

# got UndefinedFunctionError with message "function Ecto.ChangesetTest.NoSchemaPost.__schema__/1 is 
# undefined or private" while inspecting %{__struct__: Ecto.Changeset, action: nil, 
# changes: %{title: "world", upvotes: 0}, constraints: [], data: %Ecto.ChangesetTest.NoSchemaPost{title: "hello", upvotes: nil},
# empty_values: [""], errors: [], filters: %{}, params: %{"title" => "world", "upvotes" => "0"}, prepare: [],
# repo: nil, repo_opts: [], required: [], types: %{title: :string, upvotes: :integer}, valid?: true, validations: []}\"}
```