### PR TITLE
Align behaviour cast for { :array, :string } with :string

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1171,6 +1171,9 @@ defmodule Ecto.Type do
   defp of_base_type?(:date, value), do: Kernel.match?(%Date{}, value)
   defp of_base_type?(_, _), do: false
 
+  defp array([nil | t], fun, acc ),
+    do: array( t, fun, [nil | acc ] )
+
   defp array([h | t], fun, acc) do
     case fun.(h) do
       {:ok, h} -> array(t, fun, [h | acc])

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -100,7 +100,7 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.embed_as({:array, @p_error_type}, :foo) == :self
 
     assert Ecto.Type.embedded_load({:array, @p_self_type}, [:foo], :json) == {:ok, [:cast]}
-    assert Ecto.Type.embedded_load({:array, @p_self_type}, [nil], :json) == {:ok, [:cast]}
+    assert Ecto.Type.embedded_load({:array, @p_self_type}, [nil], :json) == {:ok, [nil]}
     assert Ecto.Type.embedded_load({:array, @p_self_type}, nil, :json) == {:ok, nil}
     assert Ecto.Type.embedded_load({:array, @p_dump_type}, [:foo], :json) == {:ok, [:load]}
     assert Ecto.Type.embedded_load({:array, @p_dump_type}, [nil], :json) == {:ok, [:load]}
@@ -122,7 +122,7 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.dump({:array, @p_self_type}, nil) == {:ok, nil}
 
     assert Ecto.Type.cast({:array, @p_self_type}, [:foo]) == {:ok, [:cast]}
-    assert Ecto.Type.cast({:array, @p_self_type}, [nil]) == {:ok, [:cast]}
+    assert Ecto.Type.cast({:array, @p_self_type}, [nil]) == {:ok, [nil]}
     assert Ecto.Type.cast({:array, @p_self_type}, nil) == {:ok, nil}
   end
 

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -100,7 +100,7 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.embed_as({:array, @p_error_type}, :foo) == :self
 
     assert Ecto.Type.embedded_load({:array, @p_self_type}, [:foo], :json) == {:ok, [:cast]}
-    assert Ecto.Type.embedded_load({:array, @p_self_type}, [nil], :json) == {:ok, [nil]}
+    assert Ecto.Type.embedded_load({:array, @p_self_type}, [nil], :json) == {:ok, [:cast]}
     assert Ecto.Type.embedded_load({:array, @p_self_type}, nil, :json) == {:ok, nil}
     assert Ecto.Type.embedded_load({:array, @p_dump_type}, [:foo], :json) == {:ok, [:load]}
     assert Ecto.Type.embedded_load({:array, @p_dump_type}, [nil], :json) == {:ok, [:load]}
@@ -122,7 +122,7 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.dump({:array, @p_self_type}, nil) == {:ok, nil}
 
     assert Ecto.Type.cast({:array, @p_self_type}, [:foo]) == {:ok, [:cast]}
-    assert Ecto.Type.cast({:array, @p_self_type}, [nil]) == {:ok, [nil]}
+    assert Ecto.Type.cast({:array, @p_self_type}, [nil]) == {:ok, [:cast]}
     assert Ecto.Type.cast({:array, @p_self_type}, nil) == {:ok, nil}
   end
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -97,13 +97,22 @@ defmodule Ecto.TypeTest do
     assert cast({:map, :integer}, 1) == :error
   end
 
+  # be explicit about what happens with nil
+  test "simple casts" do
+    assert cast(:integer, nil ) == { :ok, nil }
+    assert cast(:integer, 3 ) == { :ok, 3 }
+    assert cast(:integer, "3" ) == { :ok, 3 }
+    assert cast(:string, "foo" ) == { :ok, "foo" }
+    assert cast(:String, nil ) == { :ok, nil }
+  end
+
   test "array" do
     assert load({:array, :integer}, [1]) == {:ok, [1]}
     assert dump({:array, :integer}, [2]) == {:ok, [2]}
     assert cast({:array, :integer}, [3]) == {:ok, [3]}
     assert cast({:array, :integer}, ["3"]) == {:ok, [3]}
-    assert cast({:array, :integer}, [3, nil]) == :error
-    assert cast({:array, :integer}, ["3", nil]) == :error
+    assert cast({:array, :integer}, [3, nil]) == { :ok, [ 3, nil ] }
+    assert cast({:array, :integer}, ["3", nil]) == { :ok, [ 3, nil ] }
   end
 
   test "custom types with array" do


### PR DESCRIPTION
In the refactor of type.ex for 3.5 a breaking change and
inconsistency was introduced:

Prior to the Type refactor:
```
3.4> Ecto.Type.cast( {:array, :string} , ["hello" , nil ])
{:ok, ["hello", nil]}
```

After the Type refactor:
```
3.5> Ecto.Type.cast( {:array, :string} , ["hello" , nil ])
:error
```

It's also an inconsistency with a cast invocation like this:
```
3.5> Ecto.Type.cast( :string, nil )
{:ok, nil}
```

After amending type.ex with this head:
```
 defp array([nil | t], fun, acc ),
    do: array( t, fun, [nil | acc ] )
```

which would resolve the `{ :array, :string }` problem,
a few test cases fail, an :integer array [3,nil] which
is a 3.5 `:error` now returns [3,nil]. The parameterized
test exhibits similar behaviour. The `:integer` behaviour
mirror the :string change.

I do believe the above array() head is the correct
and consistent behaviour given `cast( :integer, nil ) -> { :ok, nil }`.