### PR TITLE
Fix CaseClauseError when casting a decimal with a binary remainder

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -722,6 +722,8 @@ defmodule Ecto.Type do
 
       iex> cast(:decimal, Decimal.new("1.0"))
       {:ok, Decimal.new("1.0")}
+      iex> cast(:decimal, "1.0bad")
+      :error
 
       iex> cast({:array, :integer}, [1, 2, 3])
       {:ok, [1, 2, 3]}
@@ -817,6 +819,7 @@ defmodule Ecto.Type do
     case Decimal.parse(term) do
       {:ok, decimal} -> check_decimal(decimal, false)
       {decimal, ""} -> check_decimal(decimal, false)
+      {_, remainder} when is_binary(remainder) and byte_size(remainder) > 0 -> :error
       :error -> :error
     end
   end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -190,6 +190,7 @@ defmodule Ecto.TypeTest do
     assert cast(:decimal, 1) == {:ok, Decimal.new("1")}
     assert cast(:decimal, Decimal.new("1")) == {:ok, Decimal.new("1")}
     assert cast(:decimal, "nan") == :error
+    assert cast(:decimal, "1.0bad") == :error
 
     assert_raise ArgumentError, ~r"#Decimal<NaN> is not allowed for type :decimal", fn ->
       cast(:decimal, Decimal.new("NaN"))


### PR DESCRIPTION
Fixes a CaseClauseError when casting a binary to decimal when the binary ends with non-numeric characters (such as `"1.0bad"`). This only occurs when using Ecto with Decimal 2.x.

### Current Behavior

Ecto 3.5.2 and Decimal 1.x (expected):
```
iex(1)> Ecto.Type.cast(:decimal, "1.0bad")
:error
```

Ecto 3.5.2 and Decimal 2.x:
```
iex(1)> Ecto.Type.cast(:decimal, "1.0bad")
** (CaseClauseError) no case clause matching: {#Decimal<1.0>, "bad"}
    (ecto 3.5.2) lib/ecto/type.ex:817: Ecto.Type.cast_decimal/1
```

### Expected Behavior

Ecto 3.5.2 and Decimal 2.x:
```
iex(1)> Ecto.Type.cast(:decimal, "1.0bad")
:error
```