### PR TITLE
Support force dropping database introduced in PostgreSQL 13

### DIFF
--- a/lib/mix/tasks/ecto.drop.ex
+++ b/lib/mix/tasks/ecto.drop.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Ecto.Drop do
   import Mix.Ecto
 
   @shortdoc "Drops the repository storage"
-  @default_opts [force: false]
+  @default_opts [force: false, force_drop: false]
 
   @aliases [
     f: :force,
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Ecto.Drop do
 
   @switches [
     force: :boolean,
+    force_drop: :boolean,
     quiet: :boolean,
     repo: [:keep, :string],
     no_compile: :boolean,
@@ -42,6 +43,8 @@ defmodule Mix.Tasks.Ecto.Drop do
     * `-f`, `--force` - do not ask for confirmation when dropping the database.
       Configuration is asked only when `:start_permanent` is set to true
       (typically in production)
+    * `--force-drop` - force the database to be dropped even
+      if it has connections to it (requires PostgreSQL 13+)
     * `--no-compile` - do not compile before dropping
     * `--no-deps-check` - do not compile before dropping
 
@@ -71,7 +74,11 @@ defmodule Mix.Tasks.Ecto.Drop do
   end
 
   defp drop_database(repo, opts) do
-    case repo.__adapter__.storage_down(repo.config) do
+    config =
+      opts
+      |> Keyword.take([:force_drop])
+      |> Keyword.merge(repo.config)
+    case repo.__adapter__.storage_down(config) do
       :ok ->
         unless opts[:quiet] do
           Mix.shell().info "The database for #{inspect repo} has been dropped"


### PR DESCRIPTION
This is introduced in PostgreSQL 13 (https://www.postgresql.org/docs/current/sql-dropdatabase.html) and will be enabled when `--force_drop` switch is used.

This needs https://github.com/elixir-ecto/ecto_sql/pull/280.