### PR TITLE
Add Support for Subqueries and Quantifiers in Comparison, and Exists

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -359,6 +359,11 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:over, [], [aggregate, window]]}, params_acc}
   end
 
+  def escape({quantifier, meta, [subquery]}, type, params_acc, vars, env) when quantifier in [:all, :any, :exists] do
+    {subquery, params_acc} = escape_subquery({:subquery, meta, [subquery]}, type, params_acc, vars, env)
+    {{:{}, [], [quantifier, [], [subquery]]}, params_acc}
+  end
+
   def escape({:=, _, _} = expr, _type, _params_acc, _vars, _env) do
     error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
             "The match operator is not supported: `=`. " <>

--- a/test/ecto/query/builder/filter_test.exs
+++ b/test/ecto/query/builder/filter_test.exs
@@ -75,6 +75,35 @@ defmodule Ecto.Query.Builder.FilterTest do
         [{:subquery, 0}]
     end
 
+    test "supports exists subquery expressions" do
+      s = from(p in "posts", select: 1)
+
+      %{wheres: [where]} = from(p in "posts", where: exists(s))
+
+      assert Macro.to_string(where.expr) ==
+             "exists({:subquery, 0})"
+      assert where.params ==
+             [{:subquery, 0}]
+    end
+
+    test "supports comparison with subqueries with all and any quantifiers" do
+      s = from(p in "posts", select: p.rating, order_by: [desc: p.created_at], limit: 10)
+
+      assert_quantified_subquery = fn %{wheres: [where]}, expected_quantifier ->
+        assert Macro.to_string(where.expr) ==
+               "&0.rating() >= #{expected_quantifier}({:subquery, 0})"
+
+        assert where.params ==
+                [{:subquery, 0}]
+      end
+
+      all_query = from(p in "posts", where: p.rating >= all(s))
+      any_query = from(p in "posts", where: p.rating >= any(s))
+
+      assert_quantified_subquery.(all_query, :all)
+      assert_quantified_subquery.(any_query, :any)
+    end
+
     test "raises on invalid keywords" do
       assert_raise ArgumentError, fn ->
         where(from(p in "posts"), [p], ^[{1, 2}])
@@ -86,6 +115,5 @@ defmodule Ecto.Query.Builder.FilterTest do
         where(from(p in "posts"), [p], ^[foo: nil])
       end
     end
-
   end
 end


### PR DESCRIPTION
This is my first contribution to the elixir ecosystem as a whole, and it likely won't be my last! 

This work builds on #3264 which introduced the `expr IN (subquery)` syntax to `Ecto.Query`. This laid out the groundwork for also supporting comparison operators with subqueries, including ANY and ALL [quantifiers](https://www.sqlshack.com/sql-server-universal-comparison-quantified-predicates/). I will also submit a PR to `ecto_sql` to implement the SQL in the adapters if this is merged.

Postgres, MySQL, and most others (I believe) support these operations.

### My Proposed DSL Syntax

Currently we can perform an IN subquery operation as follows
```
from(p in Post, where: p.id in subquery(some_query_expression))
```

I simply implemented comparison with quantifiers as

```
from(p in Post, where: p.rating >= all(some_query_expression))
from(p in Post, where: p.rating >= any(some_query_expression))
```
and of course `>=` can be substituted for any comparison operator! You can also re-use the same subquery syntax if you are expecting a single row to be returned from the subquery

```
avg_subquery = from(p in Post, select: avg(p.rating))
from(p in Post, where: p.rating >= subquery(avg_subquery))
```
### Implementation

I implemented this by including a `:quantifier` field in the `Ecto.SubQuery` struct. This signals to the adapter that it should include this quantifier when converting the subquery to SQL, and if the underlying database doesn't support quantifiers then it can raise an exception. 
