### PR TITLE
Add `cast` clause for nil values on Ecto.Enum

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -60,6 +60,8 @@ defmodule Ecto.Enum do
   end
 
   @impl true
+  def cast(nil, _params), do: {:ok, nil}
+
   def cast(data, params) do
     case params do
       %{on_load: %{^data => as_atom}} -> {:ok, as_atom}


### PR DESCRIPTION
Embedded schemas rely on `cast/2` instead of `load/3`, which implies the
need for this clause.

Closes #3466 

I'm still not 100% sure this is the correct approach, but it is up for review :)