### PR TITLE
Allow for string decimals

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -850,6 +850,7 @@ defmodule Ecto.Type do
   defp same_map(_), do: :error
 
   defp same_decimal(term) when is_integer(term), do: {:ok, Decimal.new(term)}
+  defp same_decimal(term) when is_bitstring(term), do: {:ok, Decimal.new(term)}
   defp same_decimal(term) when is_float(term), do: {:ok, Decimal.from_float(term)}
   defp same_decimal(%Decimal{} = term), do: check_decimal(term, true)
   defp same_decimal(_), do: :error

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -850,7 +850,7 @@ defmodule Ecto.Type do
   defp same_map(_), do: :error
 
   defp same_decimal(term) when is_integer(term), do: {:ok, Decimal.new(term)}
-  defp same_decimal(term) when is_bitstring(term), do: {:ok, Decimal.new(term)}
+  defp same_decimal(term) when is_binary(term), do: {:ok, Decimal.new(term)}
   defp same_decimal(term) when is_float(term), do: {:ok, Decimal.from_float(term)}
   defp same_decimal(%Decimal{} = term), do: check_decimal(term, true)
   defp same_decimal(_), do: :error

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -850,7 +850,15 @@ defmodule Ecto.Type do
   defp same_map(_), do: :error
 
   defp same_decimal(term) when is_integer(term), do: {:ok, Decimal.new(term)}
-  defp same_decimal(term) when is_binary(term), do: {:ok, Decimal.new(term)}
+
+  defp same_decimal(term) when is_binary(term) do
+    case Decimal.parse(term) do
+      {decimal, ""} -> {:ok, decimal}
+      {:ok, decimal} -> {:ok, decimal}
+      _ -> :error
+    end
+  end
+
   defp same_decimal(term) when is_float(term), do: {:ok, Decimal.from_float(term)}
   defp same_decimal(%Decimal{} = term), do: check_decimal(term, true)
   defp same_decimal(_), do: :error

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -199,7 +199,7 @@ defmodule Ecto.TypeTest do
     assert dump(:decimal, Decimal.new("1")) == {:ok, Decimal.new("1")}
     assert dump(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
     assert dump(:decimal, 1) == {:ok, Decimal.new("1")}
-    assert dump(:decimal, "1.0") == :error
+    assert dump(:decimal, "1.0") == {:ok, Decimal.new("1.0")}
     assert dump(:decimal, "bad") == :error
 
     assert_raise ArgumentError, ~r"#Decimal<NaN> is not allowed for type :decimal", fn ->
@@ -209,7 +209,7 @@ defmodule Ecto.TypeTest do
     assert load(:decimal, 1) == {:ok, Decimal.new(1)}
     assert load(:decimal, 1.0) == {:ok, Decimal.new("1.0")}
     assert load(:decimal, Decimal.new("1.0")) == {:ok, Decimal.new("1.0")}
-    assert load(:decimal, "1.0") == :error
+    assert load(:decimal, "1.0") == {:ok, Decimal.new("1.0")}
   end
 
   test "maybe" do


### PR DESCRIPTION
When using an inline embedded schema, backed by a map (jsonb column), decimal will be cast as string, but even though the Decimal libraries supports creating from strings, ecto's type does not.

This allows casting from a string for decimals