### PR TITLE
Fix formatting for Repo.reload docs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -675,14 +675,14 @@ defmodule Ecto.Repo do
 
   ## Example
 
-    MyRepo.reload(post)
-    %Post{}
+      MyRepo.reload(post)
+      %Post{}
 
-    MyRepo.reload([post1, post2])
-    [%Post{}, %Post{}]
+      MyRepo.reload([post1, post2])
+      [%Post{}, %Post{}]
 
-    MyRepo.reload([deleted_post, post1])
-    [nil, %Post{}]
+      MyRepo.reload([deleted_post, post1])
+      [nil, %Post{}]
   """
   @callback reload(
               (schema :: Ecto.Schema.t()) | (schemas :: [Ecto.Schema.t()]),
@@ -697,11 +697,11 @@ defmodule Ecto.Repo do
 
   ## Example
 
-    MyRepo.reload!(post)
-    %Post{}
+      MyRepo.reload!(post)
+      %Post{}
 
-    MyRepo.reload!([post1, post2])
-    [%Post{}, %Post{}]
+      MyRepo.reload!([post1, post2])
+      [%Post{}, %Post{}]
   """
   @callback reload!(
               (schema :: Ecto.Schema.t()) | (schemas :: [Ecto.Schema.t()]),


### PR DESCRIPTION
Indentation was only 2 characters instead of the 4 needed to be treated as code by ex_doc

This is what the [docs ](https://hexdocs.pm/ecto/3.5.5/Ecto.Repo.html#c:reload/2)currently look like without the formatting:
<img width="852" alt="Screen Shot 2020-11-12 at 3 31 59 PM" src="https://user-images.githubusercontent.com/9973/99017699-895f1300-24fc-11eb-9867-10bc9ecc89c4.png">
