### PR TITLE
Remove Unnecessary INNER JOIN in Many To Many assoc_query

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -134,7 +134,7 @@ defmodule Ecto.Association do
   Returns information used by the preloader.
   """
   @callback preload_info(t) ::
-              {:assoc, t, {integer, atom}} | {:through, t, [atom]} | {:assoc, t, {integer, atom, Ecto.Type.t()}}
+              {:assoc, t, {integer, atom} | {integer, atom, Ecto.Type.t()}} | {:through, t, [atom]}
 
   @doc """
   Performs the repository change on the association.

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1139,18 +1139,17 @@ defmodule Ecto.Association.ManyToMany do
 
   @impl true
   def assoc_query(assoc, query, values) do
-    %{queryable: queryable, join_through: join_through, join_keys: join_keys, owner: owner} = assoc
-    [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
+    %{queryable: queryable, join_through: join_through, join_keys: join_keys} = assoc
+    [{join_owner_key, _}, {join_related_key, related_key}] = join_keys
 
-    # We need to go all the way using owner and query so
-    # Ecto has all the information necessary to cast fields.
-    # This also helps validate the associated schema exists all the way.
+    # We only need to join in the "join table". Preload and Ecto.assoc expressions can then filter
+    # by &1.join_owner_key in ^... to filter down to the associated entries in the related table.
     from(q in (query || queryable),
-      join: o in ^owner, on: field(o, ^owner_key) in ^values,
-      join: j in ^join_through, on: field(j, ^join_owner_key) == field(o, ^owner_key),
-      where: field(j, ^join_related_key) == field(q, ^related_key))
+      join: j in ^join_through, on: field(q, ^related_key) == field(j, ^join_related_key),
+      where: field(j, ^join_owner_key) in ^values
+    )
     |> Ecto.Association.combine_assoc_query(assoc.where)
-    |> Ecto.Association.combine_joins_query(assoc.join_where, 2)
+    |> Ecto.Association.combine_joins_query(assoc.join_where, 1)
   end
 
   @impl true
@@ -1161,8 +1160,10 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   @impl true
-  def preload_info(%{join_keys: [{_, owner_key}, {_, _}]} = refl) do
-    {:assoc, refl, {-2, owner_key}}
+  def preload_info(%{join_keys: [{join_owner_key, _}, {_, _}]} = refl) do
+    # When preloading use the last bound table (which is the join table) and the join_owner_key
+    # to filter out related entities to the owner structs we're preloading with.
+    {:assoc, refl, {-1, join_owner_key}}
   end
 
   @impl true

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -272,6 +272,12 @@ defmodule Ecto.Repo.Preloader do
     We expected a tuple but we got: #{inspect(entry)}
     """
 
+  defp related_key_to_field(query, {pos, key, field_type}) do
+    field_ast = related_key_to_field(query, {pos, key})
+
+    {:type, [], [field_ast, field_type]}
+  end
+
   defp related_key_to_field(query, {pos, key}) do
     {{:., [], [{:&, [], [related_key_pos(query, pos)]}, key]}, [], []}
   end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -828,9 +828,9 @@ defmodule Ecto.Query.PlannerTest do
       Ecto.assoc(%Post{id: 1}, :crazy_comments_with_list)
       |> normalize_with_params()
 
-    assert inspect(query) =~ "join: c2 in Ecto.Query.PlannerTest.CommentPost, on: c2.post_id == p1.id and c2.deleted == ^..."
-    assert inspect(query) =~ "where: c2.comment_id == c0.id and c0.text in ^..."
-    assert params ==  [1, true, "crazycomment1", "crazycomment2"]
+    assert inspect(query) =~ "join: c1 in Ecto.Query.PlannerTest.CommentPost, on: c0.id == c1.comment_id and c1.deleted == ^..."
+    assert inspect(query) =~ "where: c1.post_id in ^... and c0.text in ^..."
+    assert params ==  [true, 1, "crazycomment1", "crazycomment2"]
   end
 
   test "normalize: many_to_many assoc join without schema and wheres" do
@@ -844,9 +844,9 @@ defmodule Ecto.Query.PlannerTest do
       Ecto.assoc(%Post{id: 1}, :crazy_comments_without_schema)
       |> normalize_with_params()
 
-    assert inspect(query) =~ "join: c2 in \"comment_posts\", on: c2.post_id == p1.id and c2.deleted == ^..."
-    assert inspect(query) =~ "where: c2.comment_id == c0.id"
-    assert params ==  [1, true]
+    assert inspect(query) =~ "join: c1 in \"comment_posts\", on: c0.id == c1.comment_id and c1.deleted == ^..."
+    assert inspect(query) =~ "where: c1.post_id in ^..."
+    assert params ==  [true, 1]
   end
 
   test "normalize: dumps in query expressions" do


### PR DESCRIPTION
This PR closes https://github.com/elixir-ecto/ecto_sql/issues/282 which points out an unnecessary INNER JOIN which is generated when preloading (or loading with `Ecto.assoc`) a many to many association.

### Approach

I simply just changed the `assoc_query` of `Ecto.Association.ManyToMany` to join the related table to the join table. I then specify in `preload_info` that the filtering should be done using `join_owner_key` on the join table.

### Non Primary Key Associations

In the related issue I remarked that this optimization would not work if `owner_key` was not the primary key of the owner table. I realized during my implementation that this wasn't true. My assumption when I said this was that we'd need to use the primary key of the owner table to perform the preloading, but the default is actually to use the key provided in `join_keys`. To sanity check this I tested the following scenario:

```
schema "products" do
  field :sku, :string

  many_to_many :locations,
    Sample.Location,
    join_through: "skus_locations",
    join_keys: [sku: :sku, location_id: :id]

  timestamps()
end

schema "locations" do
  field :name, :string

  timestamps()
end
```

The idea here is that a SKU can be listed separately so it is not unique in the products table, but a SKU is unique in the context of inventory management. So sku is used as the join key to products to avoid redundancy. I've seen this type of modelling out in the wild in eCommerce systems.

The preload query that is generated here looks correct to me:
**Before My Change**
```
[debug] QUERY OK source="locations" db=2.2ms queue=2.5ms idle=414.8ms
SELECT l0."id", l0."name", l0."inserted_at", l0."updated_at", p1."sku" FROM "locations" AS l0 INNER JOIN "products" AS p1
ON p1."sku" = ANY($1) INNER JOIN "skus_locations" AS s2 ON s2."sku" = p1."sku" 
WHERE (s2."location_id" = l0."id") ORDER BY p1."sku" [["sku", "ski", "bro"]]
```

**With My Change**
```
[debug] QUERY OK source="locations" db=2.6ms queue=3.0ms idle=777.4ms
SELECT l0."id", l0."name", l0."inserted_at", l0."updated_at", s1."sku" FROM "locations" AS l0 INNER JOIN "skus_locations" AS s1
ON l0."id" = s1."location_id" WHERE (s1."sku" = ANY($1)) ORDER BY s1."sku" [["sku", "ski", "bro"]]
```

In an extreme case some skus may be listed 20-30+ times. The original query would be loading every single product listing for that sku unnecessarily even if the actual set we're preloading against only contains a single one of these product records.