### PR TITLE
Query: proof-reading and fixing documentation.

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -18,15 +18,15 @@ defmodule Ecto.Query do
 
   Let's see a sample query:
 
-      # Imports only from/2 of Ecto.Query
+      # Imports only from/2 of Ecto.Query.
       import Ecto.Query, only: [from: 2]
 
-      # Create a query
+      # Create a query.
       query = from u in "users",
                 where: u.age > 18,
                 select: u.name
 
-      # Send the query to the repository
+      # Send the query to the repository.
       Repo.all(query)
 
   In the example above, we are directly querying the "users" table
@@ -103,7 +103,7 @@ defmodule Ecto.Query do
   `nil` comparison in filters, such as where and having, is forbidden
   and it will raise an error:
 
-      # Raises if age is nil
+      # Raises if age is nil.
       from u in User, where: u.age == ^age
 
   This is done as a security measure to avoid attacks that attempt
@@ -117,17 +117,17 @@ defmodule Ecto.Query do
   Ecto queries are composable. For example, the query above can
   actually be defined in two parts:
 
-      # Create a query
+      # Create a query.
       query = from u in User, where: u.age > 18
 
-      # Extend the query
+      # Extend the query.
       query = from u in query, select: u.name
 
   Composing queries uses the same syntax as creating a query.
   The difference is that, instead of passing a schema like `User`
-  on the right side of `in`, we passed the query itself.
+  on the right-hand side of `in`, we passed the query itself.
 
-  Any value can be used on the right-side of `in` as long as it implements
+  Any value can be used on the right-hand side of `in` as long as it implements
   the `Ecto.Queryable` protocol. For now, we know the protocol is
   implemented for both atoms (like `User`) and strings (like "users").
 
@@ -136,14 +136,14 @@ defmodule Ecto.Query do
 
   ### Positional bindings
 
-  On the left side of `in` we specify the query bindings.  This is
-  done inside from and join clauses.  In the query below `u` is a
+  On the left-hand side of `in` we specify the query bindings. This is
+  done inside `from` and `join` clauses. In the query below `u` is a
   binding and `u.age` is a field access using this binding.
 
       query = from u in User, where: u.age > 18
 
-  Bindings are not exposed from the query.  When composing queries, you
-  must specify bindings again for each refinement query.  For example,
+  Bindings are not exposed from the query. When composing queries, you
+  must specify bindings again for each refinement query. For example,
   to further narrow down the above query, we again need to tell Ecto what
   bindings to expect:
 
@@ -162,11 +162,11 @@ defmodule Ecto.Query do
   When using joins, the bindings should be matched in the order they
   are specified:
 
-      # Create a query
+      # Create a query.
       query = from p in Post,
                 join: c in Comment, on: c.post_id == p.id
 
-      # Extend the query
+      # Extend the query.
       query = from [p, c] in query,
                 select: {p.title, c.body}
 
@@ -178,11 +178,11 @@ defmodule Ecto.Query do
 
   The example above will work if the input query has 1 or 10
   bindings. As long as the number of bindings is less than the
-  number of from + joins, Ecto will match only what you have
+  number of `from`s + `join`s, Ecto will match only what you have
   specified. The first binding always matches the source given
   in `from`.
 
-  Similarly, if you are interested only on the last binding
+  Similarly, if you are interested only in the last binding
   (or the last bindings) in a query, you can use `...` to
   specify "all bindings before" and match on the last one.
 
@@ -198,8 +198,8 @@ defmodule Ecto.Query do
 
       from [p, ..., c] in posts_with_comments, select: {p.title, c.body}
 
-  In other words, `...` will include all the binding between the
-  first and the last, which may be no binding at all, one or many.
+  In other words, `...` will include all the bindings between the
+  first and the last, which may be one, many or no bindings at all.
 
   ### Named bindings
 
@@ -211,7 +211,7 @@ defmodule Ecto.Query do
         from p in query,
           join: c in Comment, as: :comment, on: c.post_id == p.id
 
-  We can refer to it by that name using a following form of
+  We can refer to it by that name using the following form of a
   bindings list:
 
       from [p, comment: c] in posts_with_comments, select: {p.title, c.body}
@@ -225,7 +225,7 @@ defmodule Ecto.Query do
   Only atoms are accepted for binding names. Named binding references
   are expected to be placed in the tail position of the bindings list.
 
-  Named bindings can also be use for late binding when use with the
+  Named bindings can also be used for late binding when used with the
   `as/1` construct, allowing you to refer to a binding that has not
   been defined yet:
 
@@ -242,7 +242,7 @@ defmodule Ecto.Query do
   on the query. Previous examples showed means of hardcoding that selection,
   but there are also ways of doing it dynamically.
       
-      # Knowing the name of the binding
+      # Knowing the name of the binding.
       def sort(query, name, field) do
         from [{^name, x}] in query, order_by: field(x, ^field)
       end
@@ -322,18 +322,18 @@ defmodule Ecto.Query do
       |> where([u], u.age > 18)
       |> select([:name])
 
-  Such allows developers to write queries using bindings only in more
+  Such a syntax allows developers to write queries using bindings only in more
   complex query expressions.
 
   This module documents each of those macros, providing examples in
   both the keywords query and pipe expression formats.
 
-  ## Query Prefix
+  ## Query prefix
 
   It is possible to set a prefix for the queries. For Postgres users,
   this will specify the schema where the table is located, while for
   MySQL users this will specify the database where the table is
-  located.  When no prefix is set, Postgres queries are assumed to be
+  located. When no prefix is set, Postgres queries are assumed to be
   in the public schema, while MySQL queries are assumed to be in the
   database set in the config for the repo.
 
@@ -431,13 +431,13 @@ defmodule Ecto.Query do
   @doc """
   Builds a dynamic query expression.
 
-  Dynamic query expressions allows developers to build queries
-  expression bit by bit so they are later interpolated in a query.
+  Dynamic query expressions allow developers to compose query
+  expressions bit by bit, so that they can be interpolated into
+  parts of a query or another dynamic expression later on.
 
   ## Examples
 
-  For example, imagine you have a set of conditions you want to
-  build your query on:
+  Imagine you have a set of conditions you want to build your query on:
 
       conditions = false
 
@@ -459,7 +459,7 @@ defmodule Ecto.Query do
 
   In the example above, we were able to build the query expressions
   bit by bit, using different bindings, and later interpolate it all
-  at once inside the query.
+  at once into the actual query.
 
   A dynamic expression can always be interpolated inside another dynamic
   expression and into the constructs described below.
@@ -475,7 +475,7 @@ defmodule Ecto.Query do
 
       from q in query, where: q.some_condition and ^conditions
 
-  Fortunately that's easily solvable by simply rewriting it to:
+  Fortunately that's easily solved by simply rewriting it to:
 
       conditions = dynamic([q], q.some_condition and ^conditions)
       from query, where: ^conditions
@@ -524,11 +524,11 @@ defmodule Ecto.Query do
 
   But this will:
 
-      from query, order_by: ^[:some_field, dynamic(...)]
+      from query, group_by: ^[:some_field, dynamic(...)]
 
   ## Updates
 
-  Dynamic is also supported inside updates, for example:
+  A `dynamic` is also supported inside updates, for example:
 
       updates = [
         set: [average: dynamic([p], p.sum / p.count)]
@@ -548,7 +548,7 @@ defmodule Ecto.Query do
 
   ## Examples
 
-      # Compare each employee's salary with the average salary in his or her department
+      # Compare each employee's salary with the average salary in his or her department.
       from e in Employee,
         select: {e.depname, e.empno, e.salary, over(avg(e.salary), :department)},
         windows: [department: [partition_by: e.depname]]
@@ -587,7 +587,7 @@ defmodule Ecto.Query do
 
   ## Examples
 
-      # compare each employee's salary for each month with his average salary for previous 3 months
+      # Compare each employee's salary for each month with his average salary for previous 3 months.
       from p in Payroll,
         select: {p.empno, p.date, p.salary, over(avg(p.salary), :prev_months)},
         windows: [prev_months: [partition_by: p.empno, order_by: p.date, frame: fragment("ROWS 3 PRECEDING EXCLUDE CURRENT ROW")]]
@@ -609,7 +609,7 @@ defmodule Ecto.Query do
 
   ## Examples
 
-      # Get the average salary of the top 10 highest salaries
+      # Get the average salary of the top 10 highest salaries.
       query = from Employee, order_by: [desc: :salary], limit: 10
       from e in subquery(query), select: avg(e.salary)
 
@@ -642,7 +642,7 @@ defmodule Ecto.Query do
         set: [sync_started_at: NaiveDateTime.utc_now()]
       )
 
-  Or as a where condition:
+  Or as a `where` condition:
 
       subset = from(p in subset, select: p.id)
       Repo.update_all(
@@ -791,7 +791,7 @@ defmodule Ecto.Query do
         where: not(is_nil(p.published_at)) and not(is_nil(o.published_at))
       end
 
-  Note the variables `p` and `o` can be named whatever you like
+  Note that the variables `p` and `o` can be named whatever you like
   as they have no importance in the query sent to the database.
   """
   defmacro from(expr, kw \\ []) do
@@ -917,7 +917,7 @@ defmodule Ecto.Query do
   Currently it is possible to join on:
 
     * an `Ecto.Schema`, such as `p in Post`
-    * an interpolated Ecto query with zero or more where clauses,
+    * an interpolated Ecto query with zero or more `where` clauses,
       such as `c in ^(from "posts", where: [public: true])`
     * an association, such as `c in assoc(post, :comments)`
     * a subquery, such as `c in subquery(another_query)`
@@ -957,7 +957,7 @@ defmodule Ecto.Query do
 
   Any key in `on` will apply to the currently joined expression.
 
-  It is also possible to interpolate an Ecto query on the right side
+  It is also possible to interpolate an Ecto query on the right-hand side
   of `in`. For example, the query above can also be written as:
 
       posts = Post
@@ -983,7 +983,7 @@ defmodule Ecto.Query do
         select: {p.title, c.text}
 
   Only simple queries with `where` expressions can be interpolated
-  in join.
+  in a join.
 
   ## Expressions examples
 
@@ -1059,7 +1059,7 @@ defmodule Ecto.Query do
                            "list of variables, got: #{Macro.to_string(binding)}"
   end
 
-  @doc """
+  @doc ~S'''
   A common table expression (CTE) also known as WITH expression.
 
   `name` must be a compile-time literal string that is being used
@@ -1081,7 +1081,7 @@ defmodule Ecto.Query do
 
   ## Options
 
-    * `:as` – the CTE query itself or a fragment
+    * `:as` - the CTE query itself or a fragment
 
   ## Recursive CTEs
 
@@ -1089,7 +1089,7 @@ defmodule Ecto.Query do
 
   In the CTE query itself use the same table name to leverage
   recursion that has been passed to the `name` argument. Make sure
-  to write a stop condition to avoid infinite recursion loop.
+  to write a stop condition to avoid an infinite recursion loop.
   Generally speaking, you should only use CTEs in Ecto for
   writing recursive queries.
 
@@ -1118,11 +1118,11 @@ defmodule Ecto.Query do
 
   It's also possible to pass a raw SQL fragment:
 
-      @raw_sql_category_tree \"""
+      @raw_sql_category_tree """
       SELECT * FROM categories WHERE c.parent_id IS NULL
       UNION ALL
       SELECT * FROM categories AS c, category_tree AS ct WHERE ct.id = c.parent_id
-      \"""
+      """
 
       Product
       |> recursive_ctes(true)
@@ -1130,7 +1130,7 @@ defmodule Ecto.Query do
       |> join(:inner, [p], c in "category_tree", on: c.id == p.category_id)
 
   If you don't have any Ecto schema pointing to the CTE table, you can pass a
-  tuple with the CTE table name as first element and an Ecto schema as second
+  tuple with the CTE table name as the first element and an Ecto schema as the second
   element. This will cast the result rows to Ecto structs as long as the Ecto
   schema maps to the same fields in the CTE table:
 
@@ -1141,20 +1141,19 @@ defmodule Ecto.Query do
       |> group_by([c], c.id)
       |> select([c, p], %{c | products_count: count(p.id)})
 
-
   Keyword syntax is not supported for this feature.
 
   ## Limitation: CTEs on schemas with source fields
 
   Ecto allows developers to say that a table in their Ecto schema
-  map to a different column in their database:
+  maps to a different column in their database:
 
       field :group_id, :integer, source: :iGroupId
 
   At the moment, using a schema with source fields in CTE may emit
   invalid queries. If you are running into such scenarios, your best
   option is to use a fragment as your CTE.
-  """
+  '''
   defmacro with_cte(query, name, as: with_query) do
     Builder.CTE.build(query, name, with_query, __CALLER__)
   end
@@ -1187,7 +1186,7 @@ defmodule Ecto.Query do
   shown in the examples below. A full schema can also be selected.
 
   There can only be one select expression in a query, if the select expression
-  is omitted, the query will by default select the full schema. If select is
+  is omitted, the query will by default select the full schema. If `select` is
   given more than once, an error is raised. Use `exclude/2` if you would like
   to remove a previous select for overriding or see `select_merge/3` for a
   limited version of `select` that is composable and can be called multiple
@@ -1308,11 +1307,11 @@ defmodule Ecto.Query do
 
   ## Keywords examples
 
-      # Returns the list of different categories in the Post schema
+      # Returns the list of different categories in the Post schema.
       from(p in Post, distinct: true, select: p.category)
 
       # If your database supports DISTINCT ON(),
-      # you can pass expressions to distinct too
+      # you can pass expressions to distinct too.
       from(p in Post,
          distinct: p.category,
          order_by: [p.date])
@@ -1322,7 +1321,7 @@ defmodule Ecto.Query do
          distinct: [desc: p.category],
          order_by: [p.date])
 
-      # Using atoms
+      # Using atoms.
       from(p in Post, distinct: :category, order_by: :date)
 
   ## Expressions example
@@ -1358,7 +1357,7 @@ defmodule Ecto.Query do
       filters = [country: "Sweden"]
       from(c in City, where: ^filters)
 
-  ## Expressions example
+  ## Expressions examples
 
       City |> where([c], c.country == "Sweden")
       City |> where(country: "Sweden")
@@ -1459,18 +1458,18 @@ defmodule Ecto.Query do
   A fragment can also be used:
 
       from c in City, order_by: [
-        # a deterministic shuffled order
+        # A deterministic shuffled order.
         fragment("? % ? DESC", c.id, ^modulus),
         desc: c.id,
       ]
 
-  ## Expressions example
+  ## Expressions examples
 
       City |> order_by([c], asc: c.name, desc: c.population)
       City |> order_by(asc: :name) # Sorts by the cities name
 
   """
-  defmacro order_by(query, binding \\ [], expr)  do
+  defmacro order_by(query, binding \\ [], expr) do
     Builder.OrderBy.build(query, binding, expr, __CALLER__)
   end
 
@@ -1481,8 +1480,8 @@ defmodule Ecto.Query do
   must be exactly the same, with the same types in the same order.
 
   Union expression returns only unique rows as if each query returned
-  distinct results. This may cause performance penalty. If you need
-  just to combine multiple result sets without removing duplicate rows
+  distinct results. This may cause a performance penalty. If you need
+  to just combine multiple result sets without removing duplicate rows
   consider using `union_all/2`.
 
   Note that the operations `order_by`, `limit` and `offset` of the
@@ -1534,8 +1533,8 @@ defmodule Ecto.Query do
   types in the same order.
 
   Except expression returns only unique rows as if each query returned
-  distinct results. This may cause performance penalty. If you need
-  just to take the difference of multiple result sets without
+  distinct results. This may cause a performance penalty. If you need
+  to just take the difference of multiple result sets without
   removing duplicate rows consider using `except_all/2`.
 
   Note that the operations `order_by`, `limit` and `offset` of the
@@ -1587,8 +1586,8 @@ defmodule Ecto.Query do
   types in the same order.
 
   Intersect expression returns only unique rows as if each query returned
-  distinct results. This may cause performance penalty. If you need
-  just to take the intersection of multiple result sets without
+  distinct results. This may cause a performance penalty. If you need
+  to just take the intersection of multiple result sets without
   removing duplicate rows consider using `intersect_all/2`.
 
   Note that the operations `order_by`, `limit` and `offset` of the
@@ -1663,7 +1662,7 @@ defmodule Ecto.Query do
 
   ## Keywords example
 
-      # Get all posts on page 4
+      # Get all posts on page 4.
       from(p in Post, limit: 10, offset: 30)
 
   ## Expressions example
@@ -1688,7 +1687,7 @@ defmodule Ecto.Query do
   Ecto also supports [optimistic
   locking](http://en.wikipedia.org/wiki/Optimistic_concurrency_control) but not
   through queries. For more information on optimistic locking, have a look at
-  the `Ecto.Changeset.optimistic_lock/3` function
+  the `Ecto.Changeset.optimistic_lock/3` function.
 
   ## Keywords example
 
@@ -1713,7 +1712,7 @@ defmodule Ecto.Query do
 
       from(u in User, update: [set: [name: "new name"]])
 
-  ## Expressions example
+  ## Expressions examples
 
       User |> update([u], set: [name: "new name"])
       User |> update(set: [name: "new name"])
@@ -1766,15 +1765,15 @@ defmodule Ecto.Query do
 
   ## Keywords examples
 
-      # Returns the number of posts in each category
+      # Returns the number of posts in each category.
       from(p in Post,
         group_by: p.category,
         select: {p.category, count(p.id)})
 
-      # Using atoms
+      # Using atoms.
       from(p in Post, group_by: :category, select: {p.category, count(p.id)})
 
-      # Using direct fields access
+      # Using direct fields access.
       from(p in Post,
         join: c in assoc(p, :category),
         group_by: [p.id, c.name])
@@ -1799,7 +1798,7 @@ defmodule Ecto.Query do
   ## Keywords example
 
       # Returns the number of posts in each category where the
-      # average number of comments is above ten
+      # average number of comments is above ten.
       from(p in Post,
         group_by: p.category,
         having: avg(p.num_comments) > 10,
@@ -1950,23 +1949,23 @@ defmodule Ecto.Query do
       with the associated entries. The associated map/struct must contain
       the "foreign_key" field. For example, if a post has many comments,
       when preloading the comments with a custom function, the function
-      will receive a list of "post_ids" as argument and it must return
+      will receive a list of "post_ids" as the argument and it must return
       maps or structs representing the comments. The maps/structs must
       include the `:post_id` field
 
     * For `has_many :through` - it behaves similarly to a regular `has_many`
-      but note that the IDs received are of the last association. Imagine
-      for example a post has many comments and each comment has an author.
+      but note that the IDs received are of the last association. Imagine,
+      for example, a post has many comments and each comment has an author.
       Therefore, a post may have many comments_authors, written as
       `has_many :comments_authors, through: [:comments, :author]`. When
       preloading authors with a custom function via `:comments_authors`,
       the function will receive the IDs of the authors as the last step
 
-    * For `many_to_many` -  the function receives the IDs of the parent
-      association and it must return a tuple with the parent id as first
-      element and the association map or struct as second. For example,
+    * For `many_to_many` - the function receives the IDs of the parent
+      association and it must return a tuple with the parent id as the first
+      element and the association map or struct as the second. For example,
       if a post has many tags, when preloading the tags with a custom
-      function, the function will receive a list of "post_ids" as argument
+      function, the function will receive a list of "post_ids" as the argument
       and it must return a tuple in the format of `{post_id, tag}`
 
   ## Keywords example
@@ -1975,7 +1974,8 @@ defmodule Ecto.Query do
       # likes for those comments.
       from(p in Post,
         preload: [comments: :likes],
-        select: p)
+        select: p
+      )
 
   ## Expressions examples
 
@@ -2055,7 +2055,7 @@ defmodule Ecto.Query do
   end
 
   @doc """
-  Returns `true` if query has binding with a given name, otherwise `false`.
+  Returns `true` if the query has a binding with the given name, otherwise `false`.
 
   For more information on named bindings see "Named bindings" in this module doc.
   """
@@ -2076,12 +2076,12 @@ defmodule Ecto.Query do
   Reverses the ordering of the query.
 
   ASC columns become DESC columns (and vice-versa). If the query
-  has no order_bys, it orders by the inverse of the primary key.
+  has no `order_by`s, it orders by the inverse of the primary key.
 
   ## Examples
 
-      query |> reverse_order |> Repo.one
-      Post |> order(asc: :id) |> reverse_order == Post |> order(desc: :id)
+      query |> reverse_order() |> Repo.one()
+      Post |> order(asc: :id) |> reverse_order() == Post |> order(desc: :id)
   """
   def reverse_order(%Ecto.Query{} = query) do
     update_in(query.order_bys, fn

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -18,15 +18,15 @@ defmodule Ecto.Query do
 
   Let's see a sample query:
 
-      # Imports only from/2 of Ecto.Query.
+      # Imports only from/2 of Ecto.Query
       import Ecto.Query, only: [from: 2]
 
-      # Create a query.
+      # Create a query
       query = from u in "users",
                 where: u.age > 18,
                 select: u.name
 
-      # Send the query to the repository.
+      # Send the query to the repository
       Repo.all(query)
 
   In the example above, we are directly querying the "users" table
@@ -103,7 +103,7 @@ defmodule Ecto.Query do
   `nil` comparison in filters, such as where and having, is forbidden
   and it will raise an error:
 
-      # Raises if age is nil.
+      # Raises if age is nil
       from u in User, where: u.age == ^age
 
   This is done as a security measure to avoid attacks that attempt
@@ -117,10 +117,10 @@ defmodule Ecto.Query do
   Ecto queries are composable. For example, the query above can
   actually be defined in two parts:
 
-      # Create a query.
+      # Create a query
       query = from u in User, where: u.age > 18
 
-      # Extend the query.
+      # Extend the query
       query = from u in query, select: u.name
 
   Composing queries uses the same syntax as creating a query.
@@ -162,11 +162,11 @@ defmodule Ecto.Query do
   When using joins, the bindings should be matched in the order they
   are specified:
 
-      # Create a query.
+      # Create a query
       query = from p in Post,
                 join: c in Comment, on: c.post_id == p.id
 
-      # Extend the query.
+      # Extend the query
       query = from [p, c] in query,
                 select: {p.title, c.body}
 
@@ -242,7 +242,7 @@ defmodule Ecto.Query do
   on the query. Previous examples showed means of hardcoding that selection,
   but there are also ways of doing it dynamically.
       
-      # Knowing the name of the binding.
+      # Knowing the name of the binding
       def sort(query, name, field) do
         from [{^name, x}] in query, order_by: field(x, ^field)
       end
@@ -548,7 +548,7 @@ defmodule Ecto.Query do
 
   ## Examples
 
-      # Compare each employee's salary with the average salary in his or her department.
+      # Compare each employee's salary with the average salary in his or her department
       from e in Employee,
         select: {e.depname, e.empno, e.salary, over(avg(e.salary), :department)},
         windows: [department: [partition_by: e.depname]]
@@ -587,7 +587,7 @@ defmodule Ecto.Query do
 
   ## Examples
 
-      # Compare each employee's salary for each month with his average salary for previous 3 months.
+      # Compare each employee's salary for each month with his average salary for previous 3 months
       from p in Payroll,
         select: {p.empno, p.date, p.salary, over(avg(p.salary), :prev_months)},
         windows: [prev_months: [partition_by: p.empno, order_by: p.date, frame: fragment("ROWS 3 PRECEDING EXCLUDE CURRENT ROW")]]
@@ -609,7 +609,7 @@ defmodule Ecto.Query do
 
   ## Examples
 
-      # Get the average salary of the top 10 highest salaries.
+      # Get the average salary of the top 10 highest salaries
       query = from Employee, order_by: [desc: :salary], limit: 10
       from e in subquery(query), select: avg(e.salary)
 
@@ -1307,11 +1307,11 @@ defmodule Ecto.Query do
 
   ## Keywords examples
 
-      # Returns the list of different categories in the Post schema.
+      # Returns the list of different categories in the Post schema
       from(p in Post, distinct: true, select: p.category)
 
       # If your database supports DISTINCT ON(),
-      # you can pass expressions to distinct too.
+      # you can pass expressions to distinct too
       from(p in Post,
          distinct: p.category,
          order_by: [p.date])
@@ -1321,7 +1321,7 @@ defmodule Ecto.Query do
          distinct: [desc: p.category],
          order_by: [p.date])
 
-      # Using atoms.
+      # Using atoms
       from(p in Post, distinct: :category, order_by: :date)
 
   ## Expressions example
@@ -1458,7 +1458,7 @@ defmodule Ecto.Query do
   A fragment can also be used:
 
       from c in City, order_by: [
-        # A deterministic shuffled order.
+        # A deterministic shuffled order
         fragment("? % ? DESC", c.id, ^modulus),
         desc: c.id,
       ]
@@ -1481,7 +1481,7 @@ defmodule Ecto.Query do
 
   Union expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
-  to just combine multiple result sets without removing duplicate rows
+  to combine multiple result sets without removing duplicate rows
   consider using `union_all/2`.
 
   Note that the operations `order_by`, `limit` and `offset` of the
@@ -1534,7 +1534,7 @@ defmodule Ecto.Query do
 
   Except expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
-  to just take the difference of multiple result sets without
+  to take the difference of multiple result sets without
   removing duplicate rows consider using `except_all/2`.
 
   Note that the operations `order_by`, `limit` and `offset` of the
@@ -1587,7 +1587,7 @@ defmodule Ecto.Query do
 
   Intersect expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
-  to just take the intersection of multiple result sets without
+  to take the intersection of multiple result sets without
   removing duplicate rows consider using `intersect_all/2`.
 
   Note that the operations `order_by`, `limit` and `offset` of the
@@ -1662,7 +1662,7 @@ defmodule Ecto.Query do
 
   ## Keywords example
 
-      # Get all posts on page 4.
+      # Get all posts on page 4
       from(p in Post, limit: 10, offset: 30)
 
   ## Expressions example
@@ -1765,15 +1765,15 @@ defmodule Ecto.Query do
 
   ## Keywords examples
 
-      # Returns the number of posts in each category.
+      # Returns the number of posts in each category
       from(p in Post,
         group_by: p.category,
         select: {p.category, count(p.id)})
 
-      # Using atoms.
+      # Using atoms
       from(p in Post, group_by: :category, select: {p.category, count(p.id)})
 
-      # Using direct fields access.
+      # Using direct fields access
       from(p in Post,
         join: c in assoc(p, :category),
         group_by: [p.id, c.name])
@@ -1798,7 +1798,7 @@ defmodule Ecto.Query do
   ## Keywords example
 
       # Returns the number of posts in each category where the
-      # average number of comments is above ten.
+      # average number of comments is above ten
       from(p in Post,
         group_by: p.category,
         having: avg(p.num_comments) > 10,


### PR DESCRIPTION
Hi!

I came across a mistake in the documentation today. I went ahead and proof-read the whole module and included other fixes and some improvements.

Feel free to edit, leave out and keep what you like. :)

By the way, in the doc for `reverse_order()` you wrote "it orders by the inverse of the primary key." Could you clarify what that means? If you had a composite primary key `{a_id, b_id}`, would it invert it and sort by `b_id` first, for example? Or what exactly is the inverse of a primary key?