### PR TITLE
Raise ArgumentError when default has invalid type

### DIFF
--- a/integration_test/support/types.exs
+++ b/integration_test/support/types.exs
@@ -47,6 +47,7 @@ defmodule ParameterizedPrefixedString do
   end
 
   def load(string, _, %{prefix: prefix}), do: {:ok, prefix <> "-" <> string}
+  def dump(nil, _, _), do: {:ok, nil}
   def dump(data, _, %{prefix: _prefix}), do: {:ok, data |> String.split("-") |> List.last()}
   def embed_as(_, _), do: :dump
 end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1809,6 +1809,7 @@ defmodule Ecto.Schema do
     virtual? = opts[:virtual] || false
     pk? = opts[:primary_key] || false
     put_struct_field(mod, name, Keyword.get(opts, :default))
+    validate_default!(type, opts[:default])
 
     if Keyword.get(opts, :redact, false) do
       Module.put_attribute(mod, :ecto_redact_fields, name)
@@ -2060,6 +2061,30 @@ defmodule Ecto.Schema do
 
     Module.put_attribute(mod, :struct_fields, {name, assoc})
   end
+
+  defp validate_default!(_, nil), do: :ok
+  defp validate_default!(_, []), do: :ok
+
+  defp validate_default!({:parameterized, mod, _} = type, value) do 
+    case Ecto.Type.dump(type, value, &mod.dump/2) do 
+      {:ok, _} ->
+        :ok
+      _ ->
+        invalid_default_error(type, value)
+    end
+  end
+
+  defp validate_default!(type, value) do 
+    case Ecto.Type.dump(type, value) do 
+      {:ok, _} ->
+        :ok
+      _ ->
+        invalid_default_error(type, value)
+    end
+  end
+
+  defp invalid_default_error(type, value), do: 
+    raise ArgumentError, "value #{inspect(value)} is invalid for type #{inspect(type)}, can't set default"
 
   defp check_options!(opts, valid, fun_arity) do
     type = Keyword.get(opts, :type)

--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -89,6 +89,8 @@ defmodule Ecto.Repo.AutogenerateTest do
 
     def load(uuid, _, %{prefix: prefix}), do: {:ok, prefix <> @separator <> uuid}
 
+    def dump(nil, _, _), do: {:ok, nil}
+
     def dump(data, _, %{prefix: _prefix}),
       do: {:ok, data |> String.split(@separator) |> List.last()}
 
@@ -114,6 +116,7 @@ defmodule Ecto.Repo.AutogenerateTest do
 
     def load(id, _, %{prefix: prefix}), do: {:ok, prefix <> @separator <> to_string(id)}
 
+    def dump(nil, _, _), do: {:ok, nil}
     def dump(data, _, %{prefix: _prefix}),
       do: {:ok, data |> String.split(@separator) |> List.last() |> Integer.parse()}
   end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -381,18 +381,6 @@ defmodule Ecto.SchemaTest do
         end
       end
     end
-
-    # this won't work, as the ParameterizedPrefixedString raises upon receiving
-    # a non-string input
-    assert_raise ArgumentError, ~s/value 1 is invalid for type ..., can't set default/, fn ->
-      defmodule SchemaInvalidDefault do
-        use Ecto.Schema
-
-        schema "invalid_default" do
-          field :count, ParameterizedPrefixedString, prefix: "ref", default: 1
-        end
-      end
-    end
   end
 
   test "invalid field type" do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -361,6 +361,40 @@ defmodule Ecto.SchemaTest do
     end
   end
 
+  test "default of invalid type" do
+    assert_raise ArgumentError, ~s/value "1" is invalid for type :integer, can't set default/, fn ->
+      defmodule SchemaInvalidDefault do
+        use Ecto.Schema
+
+        schema "invalid_default" do
+          field :count, :integer, default: "1"
+        end
+      end
+    end
+
+    assert_raise ArgumentError, ~s/value 1 is invalid for type :string, can't set default/, fn ->
+      defmodule SchemaInvalidDefault do
+        use Ecto.Schema
+
+        schema "invalid_default" do
+          field :count, :string, default: 1
+        end
+      end
+    end
+
+    # this won't work, as the ParameterizedPrefixedString raises upon receiving
+    # a non-string input
+    assert_raise ArgumentError, ~s/value 1 is invalid for type ..., can't set default/, fn ->
+      defmodule SchemaInvalidDefault do
+        use Ecto.Schema
+
+        schema "invalid_default" do
+          field :count, ParameterizedPrefixedString, prefix: "ref", default: 1
+        end
+      end
+    end
+  end
+
   test "invalid field type" do
     assert_raise ArgumentError, "invalid or unknown type {:apa} for field :name", fn ->
       defmodule SchemaInvalidFieldType do


### PR DESCRIPTION
This is achieved through a dump on the default value. We ignore nil
values and empty lists. Parameterized types use their own dump
implementation.

I added a failing test so we can discuss something: I noticed some
parameterized types will raise on `dump` if the input is not of the
expected type. What shall we do in this scenario? Catch those
errors and build the default argument error?