### PR TITLE
Remove deprecated method call

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2155,7 +2155,7 @@ defmodule Ecto.Changeset do
   end
 
   defp validate_number(field, %Decimal{} = value, message, spec_key, _spec_function, target_value) do
-    result = Decimal.cmp(value, decimal_new(target_value))
+    result = Decimal.compare(value, decimal_new(target_value))
     case decimal_compare(result, spec_key) do
       true  -> nil
       false -> [{field, {message, validation: :number, kind: spec_key, number: target_value}}]


### PR DESCRIPTION
This PR removes a deprecation warning. 

<img width="576" alt="image" src="https://user-images.githubusercontent.com/1131944/101495300-b3272080-3968-11eb-8334-8bb9fdbff8d0.png">

Decimal 1.6 which is the lowest supported version also has `compare` method available so there shouldn't be any issues.