### PR TITLE
Remove deprecated method call

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2169,6 +2169,7 @@ defmodule Ecto.Changeset do
     end
   end
 
+  # TODO: Remove me once we support Decimal 2.0 only
   # Support mismatch between API for Decimal.compare/2 for versions 1.6 and 2.0
   defp normalize_compare(result) do
     case result do


### PR DESCRIPTION
This PR removes the Decimal deprecation warning. 

<img width="576" alt="image" src="https://user-images.githubusercontent.com/1131944/101504263-4bc29e00-3973-11eb-9109-cb70b81f3f0b.png">

It looks like `compare` has a different API between 1.6 and 2.0 so I had to add this conversion method. It can be removed if Ecto bumps Decimal dependency to 2.0. 