### PR TITLE
Fix Ecto.Changeset.t(data_type) typespec

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -288,7 +288,7 @@ defmodule Ecto.Changeset do
                         validations: [{atom, term}],
                         filters: %{optional(atom) => term},
                         action: action,
-                        types: nil | %{atom => Ecto.Type.t | Relation.t}}
+                        types: nil | %{atom => Ecto.Type.t | {:assoc, Ecto.Association.t()} | {:embed, Ecto.Embedded.t()}}
 
   @type t :: t(Ecto.Schema.t | map | nil)
   @type error :: {String.t, Keyword.t}

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -288,7 +288,7 @@ defmodule Ecto.Changeset do
                         validations: [{atom, term}],
                         filters: %{optional(atom) => term},
                         action: action,
-                        types: nil | %{atom => Ecto.Type.t}}
+                        types: nil | %{atom => Ecto.Type.t | Relation.t}}
 
   @type t :: t(Ecto.Schema.t | map | nil)
   @type error :: {String.t, Keyword.t}


### PR DESCRIPTION
The `types` field on Ecto.Changeset.t(data_type) may contain
Ecto.Changeset.Relation.t(), not only Ecto.Type.t()

Closes #3502 