### PR TITLE
Support for integer values in Ecto.Enum

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -54,9 +54,15 @@ defmodule Ecto.Enum do
               Enum.all?(values, &is_atom/1)) or
              (Keyword.keyword?(values) and Enum.all?(Keyword.values(values), &is_integer/1)) do
       raise ArgumentError, """
-      Ecto.Enum types must have a values option specified as a list of atoms. For example:
+      Ecto.Enum types must have a values option specified as a list of atoms or a keyword list with a mapping from atoms to values.
+
+      For example:
 
           field :my_field, Ecto.Enum, values: [:foo, :bar]
+
+      or
+
+          field :my_field, Ecto.Enum, values: [foo: 1, bar: 2, baz: 5]
       """
     end
 

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -67,7 +67,7 @@ defmodule Ecto.Enum do
     else
       on_load = Map.new(values, fn {key, val} -> {val, key} end)
       on_dump = Enum.into(values, %{})
-      %{on_load: on_load, on_dump: on_dump, values: values}
+      %{on_load: on_load, on_dump: on_dump, values: Keyword.keys(values)}
     end
   end
 
@@ -114,14 +114,9 @@ defmodule Ecto.Enum do
     rescue
       _ in UndefinedFunctionError -> raise ArgumentError, "#{inspect schema} is not an Ecto schema"
     else
-      %{^field => {:parameterized, Ecto.Enum, %{values: values}}} ->
-        (Keyword.keyword?(values) && Keyword.keys(values)) || values
-
-      %{^field => {_, {:parameterized, Ecto.Enum, %{values: values}}}} ->
-        (Keyword.keyword?(values) && Keyword.keys(values)) || values
-
-      %{} ->
-        raise ArgumentError, "#{field} is not an Ecto.Enum field"
+      %{^field => {:parameterized, Ecto.Enum, %{values: values}}} -> values
+      %{^field => {_, {:parameterized, Ecto.Enum, %{values: values}}}} -> values
+      %{} -> raise ArgumentError, "#{field} is not an Ecto.Enum field"
     end
   end
 end

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -42,7 +42,7 @@ defmodule Ecto.EnumTest do
                 %{
                   on_dump: %{bar: 2, baz: 5, foo: 1},
                   on_load: %{2 => :bar, 5 => :baz, 1 => :foo},
-                  values: [foo: 1, bar: 2, baz: 5]
+                  values: [:foo, :bar, :baz]
                 }}
 
       assert EnumSchema.__schema__(:type, :my_integer_enums) ==
@@ -52,7 +52,7 @@ defmodule Ecto.EnumTest do
                   %{
                     on_dump: %{bar: 2, baz: 5, foo: 1},
                     on_load: %{2 => :bar, 5 => :baz, 1 => :foo},
-                    values: [foo: 1, bar: 2, baz: 5]
+                    values: [:foo, :bar, :baz]
                   }}
                }
     end

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -12,6 +12,8 @@ defmodule Ecto.EnumTest do
       field :my_enums, {:array, Ecto.Enum}, values: [:foo, :bar, :baz]
       field :my_integer_enum, Ecto.Enum, values: [foo: 1, bar: 2, baz: 5]
       field :my_integer_enums, {:array, Ecto.Enum}, values: [foo: 1, bar: 2, baz: 5]
+      field :my_string_enum, Ecto.Enum, values: [foo: "fooo", bar: "baar", baz: "baaz"]
+      field :my_string_enums, {:array, Ecto.Enum}, values: [foo: "fooo", bar: "baar", baz: "baaz"]
       field :virtual_enum, Ecto.Enum, values: [:foo, :bar, :baz], virtual: true
     end
   end
@@ -55,6 +57,25 @@ defmodule Ecto.EnumTest do
                     values: [:foo, :bar, :baz]
                   }}
                }
+
+      assert EnumSchema.__schema__(:type, :my_string_enum) ==
+               {:parameterized, Ecto.Enum,
+                %{
+                  on_dump: %{bar: "baar", baz: "baaz", foo: "fooo"},
+                  on_load: %{"baar" => :bar, "baaz" => :baz, "fooo" => :foo},
+                  values: [:foo, :bar, :baz]
+                }}
+
+      assert EnumSchema.__schema__(:type, :my_string_enums) ==
+               {
+                 :array,
+                 {:parameterized, Ecto.Enum,
+                  %{
+                    on_dump: %{bar: "baar", baz: "baaz", foo: "fooo"},
+                    on_load: %{"baar" => :bar, "baaz" => :baz, "fooo" => :foo},
+                    values: [:foo, :bar, :baz]
+                  }}
+               }
     end
 
     test "bad values" do
@@ -93,6 +114,12 @@ defmodule Ecto.EnumTest do
 
       assert %Changeset{valid?: true, changes: %{my_enums: [:foo]}} =
                Changeset.cast(%EnumSchema{}, %{my_enums: ["foo"]}, [:my_enums])
+
+      assert %Changeset{valid?: true, changes: %{my_string_enum: :foo}} =
+               Changeset.cast(%EnumSchema{}, %{my_string_enum: "fooo"}, [:my_string_enum])
+
+      assert %Changeset{valid?: true, changes: %{my_string_enums: [:foo]}} =
+               Changeset.cast(%EnumSchema{}, %{my_string_enums: ["fooo"]}, [:my_string_enums])
     end
 
     test "casts integers" do
@@ -127,6 +154,22 @@ defmodule Ecto.EnumTest do
                changes: %{},
                errors: [my_enums: {"is invalid", [type: ^type, validation: :cast]}]
              } = Changeset.cast(%EnumSchema{}, %{my_enums: ["bar2"]}, [:my_enums])
+
+      type = EnumSchema.__schema__(:type, :my_string_enum)
+
+      assert %Changeset{
+               valid?: false,
+               changes: %{},
+               errors: [my_string_enum: {"is invalid", [type: ^type, validation: :cast]}]
+             } = Changeset.cast(%EnumSchema{}, %{my_string_enum: "baar2"}, [:my_string_enum])
+
+      type = EnumSchema.__schema__(:type, :my_string_enums)
+
+      assert %Changeset{
+               valid?: false,
+               changes: %{},
+               errors: [my_string_enums: {"is invalid", [type: ^type, validation: :cast]}]
+             } = Changeset.cast(%EnumSchema{}, %{my_string_enums: ["baar2"]}, [:my_string_enums])
     end
 
     test "rejects bad integers" do
@@ -174,6 +217,16 @@ defmodule Ecto.EnumTest do
       assert %EnumSchema{my_enums: [:foo]} = TestRepo.insert!(%EnumSchema{my_enums: [:foo]})
       assert_receive {:insert, %{fields: [my_enums: ["foo"]]}}
 
+      assert %EnumSchema{my_string_enum: :foo} =
+               TestRepo.insert!(%EnumSchema{my_string_enum: :foo})
+
+      assert_receive {:insert, %{fields: [my_string_enum: "fooo"]}}
+
+      assert %EnumSchema{my_string_enums: [:foo]} =
+               TestRepo.insert!(%EnumSchema{my_string_enums: [:foo]})
+
+      assert_receive {:insert, %{fields: [my_string_enums: ["fooo"]]}}
+
       assert %EnumSchema{my_integer_enum: :foo} =
                TestRepo.insert!(%EnumSchema{my_integer_enum: :foo})
 
@@ -207,6 +260,17 @@ defmodule Ecto.EnumTest do
       refute_received _
     end
 
+    test "rejects invalid mapped string value" do
+      msg =
+        ~r"value `\[:a, :b, :c\]` for `Ecto.EnumTest.EnumSchema.my_string_enum` in `insert` does not match type"
+
+      assert_raise Ecto.ChangeError, msg, fn ->
+        TestRepo.insert!(%EnumSchema{my_string_enum: [:a, :b, :c]})
+      end
+
+      refute_received _
+    end
+
     test "rejects invalid integer value" do
       msg =
         ~r"value `\[1, 2, 3\]` for `Ecto.EnumTest.EnumSchema.my_integer_enum` in `insert` does not match type"
@@ -221,16 +285,22 @@ defmodule Ecto.EnumTest do
 
   describe "load" do
     test "loads valid values" do
-      Process.put(:test_repo_all_results, {1, [[1, "foo", nil, nil, nil, nil]]})
+      Process.put(:test_repo_all_results, {1, [[1, "foo", nil, nil, nil, nil, nil]]})
       assert [%Ecto.EnumTest.EnumSchema{my_enum: :foo}] = TestRepo.all(EnumSchema)
 
-      Process.put(:test_repo_all_results, {1, [[1, nil, ["foo"], nil, nil, nil]]})
+      Process.put(:test_repo_all_results, {1, [[1, nil, ["foo"], nil, nil, nil, nil]]})
       assert [%Ecto.EnumTest.EnumSchema{my_enums: [:foo]}] = TestRepo.all(EnumSchema)
 
-      Process.put(:test_repo_all_results, {1, [[1, nil, nil, 1, nil, nil]]})
+      Process.put(:test_repo_all_results, {1, [[1, nil, nil, nil, nil, "fooo", nil]]})
+      assert [%Ecto.EnumTest.EnumSchema{my_string_enum: :foo}] = TestRepo.all(EnumSchema)
+
+      Process.put(:test_repo_all_results, {1, [[1, nil, nil, nil, nil, nil, ["fooo"], nil]]})
+      assert [%Ecto.EnumTest.EnumSchema{my_string_enums: [:foo]}] = TestRepo.all(EnumSchema)
+
+      Process.put(:test_repo_all_results, {1, [[1, nil, nil, 1, nil, nil, nil]]})
       assert [%Ecto.EnumTest.EnumSchema{my_integer_enum: :foo}] = TestRepo.all(EnumSchema)
 
-      Process.put(:test_repo_all_results, {1, [[1, nil, nil, nil, [1], nil]]})
+      Process.put(:test_repo_all_results, {1, [[1, nil, nil, nil, [1], nil, nil]]})
       assert [%Ecto.EnumTest.EnumSchema{my_integer_enums: [:foo]}] = TestRepo.all(EnumSchema)
     end
 
@@ -247,6 +317,8 @@ defmodule Ecto.EnumTest do
     test "returns correct values" do
       assert Ecto.Enum.values(EnumSchema, :my_enum) == [:foo, :bar, :baz]
       assert Ecto.Enum.values(EnumSchema, :my_enums) == [:foo, :bar, :baz]
+      assert Ecto.Enum.values(EnumSchema, :my_string_enum) == [:foo, :bar, :baz]
+      assert Ecto.Enum.values(EnumSchema, :my_string_enums) == [:foo, :bar, :baz]
       assert Ecto.Enum.values(EnumSchema, :my_integer_enum) == [:foo, :bar, :baz]
       assert Ecto.Enum.values(EnumSchema, :my_integer_enums) == [:foo, :bar, :baz]
       assert Ecto.Enum.values(EnumSchema, :virtual_enum) == [:foo, :bar, :baz]


### PR DESCRIPTION
Currently Ecto.Enum has support for mapping string database values to atoms like this:

```field :status, Ecto.Enum, values: [:foo, :bar, :baz]```

I have added support for mapping integer database values to atoms in with a syntax like this:

```field :status, Ecto.Enum, values: [foo: 1, bar: 2, baz: 5]```

