### PR TITLE
Fix error message for embeds `:on_replace` option

### DIFF
--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -47,7 +47,7 @@ defmodule Ecto.Embedded do
     unless opts[:on_replace] in on_replace_opts do
       raise ArgumentError, "invalid `:on_replace` option for #{inspect Keyword.fetch!(opts, :field)}. " <>
         "The only valid options are: " <>
-        Enum.map_join(@on_replace_opts, ", ", &"`#{inspect &1}`")
+        Enum.map_join(on_replace_opts, ", ", &"`#{inspect &1}`")
     end
 
     struct(%Embedded{}, opts)


### PR DESCRIPTION
Trivial bugfix. Allow me also to ask a quick question:

It seems that this doesn't work:

```
attrs = %{
  metadata_embed: %{foo: "a", bar: "b"}
}

%Article{metadata_embed: %MetadataEmbed{bar: "c"}}
|> Article.changeset(attrs)
|> Repo.insert()
```

With `:on_replace` set to `:update`.

I will have the error 
> got action :update in changeset for embedded MyApp.MetadataEmbed while inserting

If I try with an association instead of an embed, I will have a no primary key error.

Which means we are not allowed to have a new (i.e. without ID/unloaded) **nested** struct, and at the same time receive attrs for this nested entity when casting, for an insert. It will either mark the changeset as :update (embed) or raise a no primary key error (has_one/belongs_to).