### PR TITLE
[do not merge]  Loading nil value from DB for array of parameterized type should resolve into empty list

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -870,6 +870,9 @@ defmodule Ecto.Type do
   def adapter_load(adapter, {:parameterized, module, params} = type, value) do
     process_loaders(adapter.loaders(module.type(params), type), {:ok, value}, adapter)
   end
+  def adapter_load(adapter, {:array, {:parameterized, _, _}}, nil) do
+    {:ok, []}
+  end
   def adapter_load(_adapter, _type, nil) do
     {:ok, nil}
   end

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -870,7 +870,7 @@ defmodule Ecto.Type do
   def adapter_load(adapter, {:parameterized, module, params} = type, value) do
     process_loaders(adapter.loaders(module.type(params), type), {:ok, value}, adapter)
   end
-  def adapter_load(adapter, {:array, {:parameterized, _, _}}, nil) do
+  def adapter_load(_adapter, {:array, {:parameterized, _, _}}, nil) do
     {:ok, []}
   end
   def adapter_load(_adapter, _type, nil) do

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -63,6 +63,9 @@ defmodule Ecto.EmbeddedTest do
     assert %UUIDSchema{uuid: ^uuid, authors: [%Author{}]} =
              Ecto.embedded_load(UUIDSchema, %{"uuid" => uuid, "authors" => [%{}]}, :json)
 
+    assert %UUIDSchema{uuid: ^uuid, authors: []} =
+             Ecto.embedded_load(UUIDSchema, %{"uuid" => uuid, "authors" => nil}, :json)
+
     assert_raise ArgumentError,
                  ~s[cannot load `"ABC"` as type Ecto.UUID for field `uuid` in schema Ecto.EmbeddedTest.UUIDSchema],
                  fn ->


### PR DESCRIPTION
Just like loading a `nil` value from DB for an `embeds_many` field is resolving into an empty list, I expect arrays of parameterized types to behave the same.

However this test seems to contradict that :
https://github.com/elixir-ecto/ecto/blob/v3.5.5/test/ecto/parameterized_type_test.exs#L107
even though my addition will not make the tests fail.

I noticed this discrepancy when working on my lib `polymorphic_embed` where I want to comply with the behavior of `embeds_one`/`embeds_many`. That is, if a `nil` value from the DB is loaded for an `embeds_many`, it resolves into `[]`. But for an array of polymorphic embeds, the `nil` value from DB just stays `nil`, and that is a difference I cannot solve in the library.

This would solve it:
```
  def adapter_load(adapter, {:array, {:parameterized, _, _}}, nil) do
    {:ok, []}
  end
  ```