### PR TITLE
Add bang UUID conversion methods

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -134,6 +134,17 @@ defmodule Ecto.UUID do
   defp d(_),  do: throw(:error)
 
   @doc """
+  Same as `dump/1` but raises `Ecto.ArgumentError` on invalid arguments.
+  """
+  @spec dump!(t | raw | any) :: t
+  def dump!(value) do
+    case dump(value) do
+      {:ok, uuid} -> uuid
+      :error -> raise ArgumentError, "cannot dump given UUID to binary: #{inspect(value)}"
+    end
+  end
+
+  @doc """
   Converts a binary UUID into a string.
   """
   @spec load(raw | any) :: {:ok, t} | :error
@@ -145,6 +156,17 @@ defmodule Ecto.UUID do
                          "Maybe you wanted to declare :uuid as your database field?"
   end
   def load(_), do: :error
+
+  @doc """
+  Same as `load/1` but raises `Ecto.ArgumentError` on invalid arguments.
+  """
+  @spec load!(t | raw | any) :: t
+  def load!(value) do
+    case load(value) do
+      {:ok, uuid} -> uuid
+      :error -> raise ArgumentError, "cannot load given binary as UUID: #{inspect(value)}"
+    end
+  end
 
   @doc """
   Generates a version 4 (random) UUID.

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -4,6 +4,7 @@ defmodule Ecto.UUIDTest do
   @test_uuid "601d74e4-a8d3-4b6e-8365-eddb4c893327"
   @test_uuid_upper_case "601D74E4-A8D3-4B6E-8365-EDDB4C893327"
   @test_uuid_invalid_characters "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  @test_uuid_invalid_format "xxxxxxxx-xxxx"
   @test_uuid_null "00000000-0000-0000-0000-000000000000"
   @test_uuid_binary <<0x60, 0x1D, 0x74, 0xE4, 0xA8, 0xD3, 0x4B, 0x6E,
                       0x83, 0x65, 0xED, 0xDB, 0x4C, 0x89, 0x33, 0x27>>
@@ -32,9 +33,29 @@ defmodule Ecto.UUIDTest do
     end
   end
 
+  test "load!" do
+    assert Ecto.UUID.load!(@test_uuid_binary) == @test_uuid
+
+    assert_raise ArgumentError, ~r"cannot load given binary as UUID:", fn ->
+      Ecto.UUID.load!(@test_uuid_invalid_format)
+    end
+  end
+
   test "dump" do
     assert Ecto.UUID.dump(@test_uuid) == {:ok, @test_uuid_binary}
     assert Ecto.UUID.dump(@test_uuid_binary) == :error
+  end
+
+  test "dump!" do
+    assert Ecto.UUID.dump!(@test_uuid) == @test_uuid_binary
+
+    assert_raise ArgumentError, ~r"cannot dump given UUID to binary:", fn ->
+      Ecto.UUID.dump!(@test_uuid_binary)
+    end
+
+    assert_raise ArgumentError, ~r"cannot dump given UUID to binary:", fn ->
+      Ecto.UUID.dump!(@test_uuid_invalid_characters)
+    end
   end
 
   test "generate" do


### PR DESCRIPTION
This PR adds bang versions of `load` and `dump` methods for converting UUID string to binary and other way around. I found them missing when doing UUID queries in console. I.e:

```
Repo.all(from a in Area, where: a.user_id == ^(Ecto.UUID.dump("6bfb65d2-a539-44b7-866b-53f764da3a91") |> elem(1)))
```

instead of a simpler:

```
Repo.all(from a in Area, where: a.user_id == ^(Ecto.UUID.dump!("6bfb65d2-a539-44b7-866b-53f764da3a91"))
```
