### PR TITLE
Human readable UUID logs [WIP]

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -228,3 +228,12 @@ defmodule Ecto.UUID do
   defp e(14), do: ?e
   defp e(15), do: ?f
 end
+
+defimpl Inspect, for: BitString do
+  def inspect(bit_string, _opts) do
+    case Ecto.UUID.load(bit_string) do
+      {:ok, uuid} -> uuid
+      :error -> bit_string
+    end
+  end
+end


### PR DESCRIPTION
Currently UUID values displayed in logs are far from useful without manual conversion:

<img width="563" alt="image" src="https://user-images.githubusercontent.com/1131944/103344287-71ccf100-4a8e-11eb-8707-d87cd45595ef.png">

this PR displays them in the correct format:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/1131944/103344304-7e514980-4a8e-11eb-87d0-17b1c60e206f.png">

However it does not work correctly now when applied to a real project. It ends up in an endless loop. Any tips on how to implement it correctly would be welcome. Maybe adding a custom binary type for UUID values could do the trick?

I'm not sure how to proceed but I think this change would be really useful for all the projects using UUIDs. 