### PR TITLE
Change Ecto.Changeset.apply_changes/1 to add the relation to the struct.relation_id if relation struct is persisted

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1491,7 +1491,8 @@ defmodule Ecto.Changeset do
     Enum.reduce(changes, data, fn {key, value}, acc ->
       case Map.fetch(types, key) do
         {:ok, {tag, relation}} when tag in @relations ->
-          Map.put(acc, key, Relation.apply_changes(relation, value))
+          apply_relation_changes(acc, key, relation, value)
+
         {:ok, _} ->
           Map.put(acc, key, value)
         :error ->
@@ -2951,6 +2952,17 @@ defmodule Ecto.Changeset do
         end
       {_, _}, acc ->
         acc
+    end
+  end
+
+  defp apply_relation_changes(acc, key, relation, value) do
+    relation_changed = Relation.apply_changes(relation, value)
+
+    acc = Map.put(acc, key, relation_changed)
+
+    case relation do
+      %Ecto.Association.BelongsTo{} -> Map.put(acc, relation.owner_key, relation_changed.id)
+      _ -> acc
     end
   end
 end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -745,13 +745,19 @@ defmodule Ecto.ChangesetTest do
 
   test "apply_changes/1" do
     post = %Post{}
+    category = %Category{name: "bar"}
+
     assert post.title == ""
 
-    changeset = changeset(post, %{"title" => "foo"})
+    changeset = post
+    |> changeset(%{"title" => "foo"})
+    |> put_assoc(:category, category)
+
     changed_post = apply_changes(changeset)
 
     assert changed_post.__struct__ == post.__struct__
     assert changed_post.title == "foo"
+    assert changed_post.category_id == category.id
   end
 
   describe "apply_action/2" do


### PR DESCRIPTION
I had this issue when I used the changeset to validate the changes before calling Repo.update_all
