### PR TITLE
Improve docs at Ecto.Changeset.validate_subset/4

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1970,8 +1970,10 @@ defmodule Ecto.Changeset do
   end
 
   @doc ~S"""
-  Validates a change, of type enum, is a subset of the given enumerable. Like
-  `validate_inclusion/4` for lists.
+  Validates a change, of type enum, is a subset of the given enumerable. 
+
+  If you need to validate if a value is inside a given enumerable, you
+  should use `validate_inclusion/4` instead.
 
   ## Options
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1972,8 +1972,9 @@ defmodule Ecto.Changeset do
   @doc ~S"""
   Validates a change, of type enum, is a subset of the given enumerable. 
 
-  If you need to validate if a value is inside a given enumerable, you
-  should use `validate_inclusion/4` instead.
+  This validates if a list of values belongs to the given enumerable.
+  If you need to validate if a single value is inside the given enumerable,
+  you should use `validate_inclusion/4` instead.
 
   ## Options
 


### PR DESCRIPTION
Although `subset` seems clear enough, it may be easy to mistake the
use-case for this function with `validate_inclusion`, as shown in #3138.
This commit removes the unnecessary reference of `validate_inclusion/4`
and adds a tip about the `validate_inclusion/4` use-case.