### PR TITLE
Update Self-referencing many to many.md

### DIFF
--- a/guides/howtos/Self-referencing many to many.md
+++ b/guides/howtos/Self-referencing many to many.md
@@ -10,7 +10,8 @@ Let's imagine we are building a system that supports a model for relationships b
 defmodule MyApp.Accounts.Person do
   use Ecto.Schema
   
-  alias MyApp.Relationships.{Person, Relationship}
+  alias MyApp.Accounts.Person
+  alias MyApp.Relationships.Relationship
 
   schema "people" do
     field :name, :string


### PR DESCRIPTION
Hi,

I think the way the example is, and how we've implemented showcasing the separation of concerns, we would need to `alias MyApp.Accounts.Person` because we have the Person module separated from the Relationships context by being under the Accounts module. 😊

♥