### PR TITLE
Ecto.Query.dynamic/2 breaks bindings order when subquery present and binded values are not literals

### DIFF
--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -59,6 +59,7 @@ defmodule Ecto.Query.Builder.Dynamic do
           {%Ecto.Query.DynamicExpr{binding: new_binding} = dynamic, _} ->
             binding = if length(new_binding) > length(binding), do: new_binding, else: binding
             expand(query, dynamic, {binding, params, subqueries, count})
+          
           param ->
             {{:^, meta, [count]}, {binding, [param | params], subqueries, count + 1}}
         end
@@ -66,7 +67,7 @@ defmodule Ecto.Query.Builder.Dynamic do
       {:subquery, i}, {binding, params, subqueries, count} ->
         subquery = Enum.fetch!(dynamic_subqueries, i)
         ix = length(subqueries)
-        {{:subquery, ix}, {binding, [{:subquery, ix} | params], [subquery | subqueries], count}}
+        {{:subquery, ix}, {binding, [{:subquery, ix} | params], [subquery | subqueries], count + 1}}
 
       expr, acc ->
         {expr, acc}

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -289,7 +289,7 @@ defimpl Inspect, for: Ecto.Query do
     json_expr_path_to_expr(expr, path) |> expr(names, part)
   end
 
-  defp expr_to_string({:{}, [], [:subquery, i]}, _string, _names, %BooleanExpr{subqueries: subqueries}) do
+  defp expr_to_string({:{}, [], [:subquery, i]}, _string, _names, %{subqueries: subqueries}) do
     # We were supposed to match on {:subquery, i} but Elixir incorrectly
     # translates those to `:{}` when converting to string.
     # See https://github.com/elixir-lang/elixir/blob/27bd9ffcc607b74ce56b547cb6ba92c9012c317c/lib/elixir/lib/macro.ex#L932

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -1,7 +1,7 @@
 import Inspect.Algebra
 import Kernel, except: [to_string: 1]
 
-alias Ecto.Query.{BooleanExpr, DynamicExpr, JoinExpr, QueryExpr, WithExpr}
+alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr, WithExpr}
 
 defimpl Inspect, for: Ecto.Query.DynamicExpr do
   def inspect(%DynamicExpr{binding: binding} = dynamic, opts) do

--- a/test/ecto/query/builder/dynamic_test.exs
+++ b/test/ecto/query/builder/dynamic_test.exs
@@ -40,10 +40,10 @@ defmodule Ecto.Query.Builder.DynamicTest do
       dynamic = dynamic([p], p.sq in subquery(query()))
       dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")
       dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
-      assert {expr, binding, params, [subquery], _, _} = fully_expand(query(), dynamic)
+      assert {expr, binding, params, [_subquery], _, _} = fully_expand(query(), dynamic)
       assert Macro.to_string(binding) == "[p]"
       assert Macro.to_string(expr) ==
-             "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.bar2() in {:subquery, 0} or &0.bar3() == ^3) and &0.baz() == ^4"
+             "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.sq() in {:subquery, 0} or &0.bar3() == ^3) and &0.baz() == ^4"
       assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {:subquery, 0},
                         {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
     end

--- a/test/ecto/query/builder/dynamic_test.exs
+++ b/test/ecto/query/builder/dynamic_test.exs
@@ -36,6 +36,18 @@ defmodule Ecto.Query.Builder.DynamicTest do
       assert params == [{1, {0, :foo}}, {2, {0, :bar}}, {3, {0, :baz}}]
     end
 
+    test "with subquery and dynamic interpolation" do
+      dynamic = dynamic([p], p.sq in subquery(query()))
+      dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")
+      dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
+      assert {expr, binding, params, [subquery], _, _} = fully_expand(query(), dynamic)
+      assert Macro.to_string(binding) == "[p]"
+      assert Macro.to_string(expr) ==
+             "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.bar2() in {:subquery, 0} or &0.bar3() == ^3) and &0.baz() == ^4"
+      assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {:subquery, 0},
+                        {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
+    end
+    
     test "with nested dynamic interpolation" do
       dynamic = dynamic([p], p.bar2 == ^"bar2")
       dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -48,6 +48,11 @@ defmodule Ecto.Query.InspectTest do
     dynamic = dynamic([o, b], b.user_id == ^1 or ^false)
     assert inspect(dynamic([o], o.type == ^2 and ^dynamic)) ==
            "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or ^false))"
+
+    sq = from(Post, [])
+    dynamic = dynamic([o, b], b.user_id == ^1 or b.user_id in subquery(sq))
+    assert inspect(dynamic([o], o.type == ^2 and ^dynamic)) ==
+           "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or b.user_id in ...))"
   end
 
   test "invalid query" do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -52,7 +52,7 @@ defmodule Ecto.Query.InspectTest do
     sq = from(Post, [])
     dynamic = dynamic([o, b], b.user_id == ^1 or b.user_id in subquery(sq))
     assert inspect(dynamic([o], o.type == ^2 and ^dynamic)) ==
-           "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or b.user_id in ...))"
+           "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or b.user_id in subquery(from p0 in Inspect.Post)))"
   end
 
   test "invalid query" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -810,6 +810,78 @@ defmodule Ecto.QueryTest do
     end
   end
 
+  describe "dynamic/2" do
+    test "can be used to merge two dynamics" do
+      left = dynamic([posts], posts.is_public == true)
+      right = dynamic([posts], posts.is_draft == false)
+      
+      assert inspect(dynamic(^left and ^right)) == 
+        inspect(dynamic([posts], posts.is_public == true and posts.is_draft == false))
+      
+      assert inspect(dynamic(^left or ^right)) == 
+        inspect(dynamic([posts], posts.is_public == true or posts.is_draft == false))
+    end
+      
+    test "can be used to merge dynamics with subquery" do
+      subquery = 
+        from c in "comments", 
+          where: c.commented_by == ^Ecto.UUID.generate(), 
+          select: c.post_id
+      
+      dynamic = dynamic([posts], posts.is_public == true)
+      dynamic_with_subquery = dynamic([posts], posts.id in subquery(subquery))
+      
+      assert inspect(dynamic(^dynamic and ^dynamic_with_subquery)) == 
+        inspect(dynamic([posts], posts.is_public == true and posts.id in subquery(subquery)))
+      
+      assert inspect(dynamic(^dynamic_with_subquery or ^dynamic)) == 
+        inspect(dynamic([posts], posts.id in subquery(subquery) or posts.is_public == true))
+    end
+    
+    test "can be used to merge two dynamics with named bindings" do
+      left = dynamic([post: post], post.is_public == true)
+      right = dynamic([post: post], post.is_draft == false)
+      
+      query = from p in "post", as: :post
+      
+      assert inspect(where(query, ^dynamic(^left and ^right))) ==
+        inspect(where(query, [post: post], post.is_public == true and post.is_draft == false))
+    end
+    
+    test "can be used to merge two dynamics with subquery that reuse named binding" do
+      subquery = 
+        from c in "comments", 
+          where: c.commented_by == ^Ecto.UUID.generate(), 
+          select: c.post_id
+
+      dynamic = dynamic([post: post], post.is_public == ^true)
+      dynamic_with_subquery = dynamic([post: post], post.id in subquery(subquery))
+      dynamic_not_in = dynamic([post: post], post.foo not in ^[1, 2, 3])
+      
+      query = from p in "post", as: :post
+      
+      assert inspect(where(query, ^dynamic(^dynamic and ^dynamic_with_subquery))) ==
+        inspect(where(query, [post: post], post.is_public == ^true and post.id in subquery(subquery)))
+      
+      assert inspect(where(query, ^dynamic(^dynamic_with_subquery or ^dynamic))) ==
+        inspect(where(query, [post: post], post.id in subquery(subquery) or post.is_public == ^true))
+      
+      assert inspect(where(query, ^dynamic(^dynamic_with_subquery and ^dynamic and ^dynamic_not_in))) ==
+        inspect(where(query, [post: post], post.id in subquery(subquery) and post.is_public == ^true and post.foo not in [1, 2, 3]))
+    end
+    
+    test "merges with precedence" do
+      left = dynamic([posts], posts.is_public == true)
+      right = dynamic([posts], posts.is_draft == false)
+      
+      assert inspect(dynamic(^left or ^left and ^right)) == 
+        inspect(dynamic([posts], posts.is_public == true or (posts.is_public == true and posts.is_draft == false)))
+      
+      assert inspect(dynamic(^left and ^left or ^right)) == 
+        inspect(dynamic([posts], (posts.is_public == true and posts.is_public == true) or posts.is_draft == false))
+    end
+  end
+  
   describe "fragment/1" do
     test "raises at runtime when interpolation is not a keyword list" do
       assert_raise ArgumentError, ~r/fragment\(...\) does not allow strings to be interpolated/s, fn ->

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -867,7 +867,7 @@ defmodule Ecto.QueryTest do
         inspect(where(query, [post: post], post.id in subquery(subquery) or post.is_public == ^true))
       
       assert inspect(where(query, ^dynamic(^dynamic_with_subquery and ^dynamic and ^dynamic_not_in))) ==
-        inspect(where(query, [post: post], post.id in subquery(subquery) and post.is_public == ^true and post.foo not in [1, 2, 3]))
+        inspect(where(query, [post: post], post.id in subquery(subquery) and post.is_public == ^true and post.foo not in ^[1, 2, 3]))
     end
     
     test "merges with precedence" do


### PR DESCRIPTION
I've added a test to showcase a bug, it was discovered during refactoring where we started to use dynamic to filter our queries and tests failed because `dynamic(^left and ^right)` produced incorrect value:
```
# Test code
IO.puts(" * left #{inspect(left)} \n * right #{inspect(right)}")
merged = dynamic(^left and ^right)
IO.puts("merged = #{inspect(merged)}")

# Result 
 * left dynamic([conference: conference], conference.id in {:subquery, 0}) 
 * right dynamic([conference: conference], conference.has_active_calls == ^false)
merged = dynamic([conference: conference], conference.id in {:subquery, 0} and conference.has_active_calls == ^:subquery)
```

^ here we can see that `has_active_calls` which had a boolean value is off and started to use subquery from the left part. Initially, I felt like it's an inspect protocol bug but looking further here is a `BoolExpr` from a query that was built:

```
%{
    __struct__: Ecto.Query.BooleanExpr,
    expr: {:and, [],
    [
        {:and, [],
        [
        {:in, [],
            [{{:., [], [{:&, [], [0]}, :id]}, [], []}, {:subquery, 0}]},
        {:==, [],
            [
            {{:., [], [{:&, [], [0]}, :has_active_calls]}, [], []},
            {:^, [], [0]}
            ]}
        ]},
        {:not, [],
        [
        {:in, [],
            [
            {{:., [], [{:&, [], [0]}, :owner_assignment_id]}, [], []},
            {:^, [], [1]}
            ]}
        ]}
    ]},
    op: :and,
    params: [
        {:subquery, 0},
        {false, {0, :has_active_calls}},
        {["7984183b-4f64-4a08-b8a6-36788957c22c"],
        {:in, {0, :owner_assignment_id}}}
    ],
    subqueries: [
        %{
            __struct__: Ecto.SubQuery,
            ...
        }
    ]
}
```

^ here we can see that `params` in `Ecto.Query` struct is a merged result from params and subqueries, where subqueries took first place. It shifted positions for rest of bindings but in `expr` we have an AST that has position-dependent bindings that are off now. 

And an exception that would be raised if such bug happens:
```
       :erlang.length(false)
       (elixir 1.11.2) lib/enum.ex:1521: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.11.2) lib/enum.ex:1521: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.11.2) lib/enum.ex:1521: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.11.2) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
       (elixir 1.11.2) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto 3.5.5) lib/ecto/adapter/queryable.ex:110: Ecto.Adapter.Queryable.prepare_query/3
       (ecto_sql 3.5.3) lib/ecto/adapters/sql.ex:235: Ecto.Adapters.SQL.to_sql/3
```

P.S.: I've added much more tests than needed but because I've already written them decided to keep them if you would like to merge them too.