### PR TITLE
Implement Join Optimization for HasThrough Queries

### DIFF
--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -158,6 +158,14 @@ defmodule Ecto.Integration.User do
     belongs_to :custom, Ecto.Integration.Custom, references: :bid, type: :binary_id
     many_to_many :schema_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUser
     many_to_many :unique_posts, Ecto.Integration.Post, join_through: Ecto.Integration.PostUserCompositePk
+
+    has_many :related_2nd_order_posts, through: [:posts, :users, :posts]
+    has_many :users_through_schema_posts, through: [:schema_posts, :users]
+
+    has_many :v2_comments, Ecto.Integration.Comment, foreign_key: :author_id, where: [lock_version: 2]
+    has_many :v2_comments_posts, through: [:v2_comments, :post]
+    has_many :co_commenters, through: [:comments, :post, :comments_authors]
+
     timestamps(type: :utc_datetime)
   end
 end


### PR DESCRIPTION
This PR Fixes #3559

### The problem and solution

The query generated by the author of the issue is as follows:
```
SELECT DISTINCT i0."id", i0."name", i0."interruption_id", i0."inserted_at", i0."updated_at" 
FROM "interruption_logs" AS i0
INNER JOIN "device_interruptions" AS d1 ON i2."id" = d1."interruption_id" 
INNER JOIN "interruptions" AS i2 ON d1."device_id" = ANY($1) 
WHERE (i0."interruption_id" = i2."id")
```

The query that is generated references the binding for the 2nd join table in the on expression of the 1st join table. Therefore Postgres errors out. My solution is to rearrange the ON expressions in `Ecto.Query.Planner.query_to_joins/4` so that they are placed in the correct join expression. The resulting query is this:

```
SELECT DISTINCT i0."id", i0."name", i0."interruption_id", i0."inserted_at", i0."updated_at" FROM "interruption_logs" AS i0
INNER JOIN "device_interruptions" AS d1 ON d1."device_id" = ANY($1) 
INNER JOIN "interruptions" AS i2 ON i2."id" = d1."interruption_id"
WHERE (i0."interruption_id" = i2."id")
```

This query is not perfect. We can technically avoid joining `interruptions` by joining ON `interruption_logs.interruption_id = device_interruptions.interruption_id`. Making this work would probably involve significant refactoring of the way associations are chained together, so this solution is sufficient for now IMO.
