### PR TITLE
Add Multi.inspect/1,2

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -630,15 +630,30 @@ defmodule Ecto.Multi do
 
   All options for IO.inspect/2 are supported, it also support the following ones:
 
-    * `:only` - A list of fields to inspect, will print the entire map by
-      default.
+    * `:only` - A field or a list of fields to inspect, will print the entire
+      map by default.
 
-  ## Example
+  ## Examples
 
       Ecto.Multi.new()
-      |> Ecto.Multi.insert(:person, changeset)
+      |> Ecto.Multi.insert(:person_a, changeset)
+      |> Ecto.Multi.insert(:person_b, changeset)
       |> Ecto.Multi.inspect()
       |> MyApp.Repo.transaction()
+
+  Prints:
+      %{person_a: %Person{...}, person_b: %Person{...}}
+
+  We can use the `:only` option to limit which fields will be printed:
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.insert(:person_a, changeset)
+      |> Ecto.Multi.insert(:person_b, changeset)
+      |> Ecto.Multi.inspect(only: :person_a)
+      |> MyApp.Repo.transaction()
+
+  Prints:
+      %{person_a: %Person{...}}
 
   """
   @spec inspect(t, name, keyword()) :: t
@@ -690,7 +705,7 @@ defmodule Ecto.Multi do
     opts = Keyword.merge([label: Atom.to_string(name)], opts)
 
     if opts[:only] do
-      acc |> Map.take(opts[:only]) |> IO.inspect(opts)
+      acc |> Map.take(List.wrap(opts[:only])) |> IO.inspect(opts)
     else
       IO.inspect(acc, opts)
     end

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -197,11 +197,11 @@ defmodule Ecto.Multi do
         raise ArgumentError, """
         error when merging the following Ecto.Multi structs:
 
-        #{inspect lhs}
+        #{Kernel.inspect lhs}
 
-        #{inspect rhs}
+        #{Kernel.inspect rhs}
 
-        both declared operations: #{inspect common}
+        both declared operations: #{Kernel.inspect common}
         """
     end
   end
@@ -410,7 +410,7 @@ defmodule Ecto.Multi do
 
   defp put_action(%{action: original}, action) do
     raise ArgumentError, "you provided a changeset with an action already set " <>
-      "to #{inspect original} when trying to #{action} it"
+      "to #{Kernel.inspect original} when trying to #{action} it"
   end
 
   @doc """
@@ -578,7 +578,7 @@ defmodule Ecto.Multi do
   defp add_operation(%Multi{} = multi, name, operation) do
     %{operations: operations, names: names} = multi
     if MapSet.member?(names, name) do
-      raise "#{inspect name} is already a member of the Ecto.Multi: \n#{inspect multi}"
+      raise "#{Kernel.inspect name} is already a member of the Ecto.Multi: \n#{Kernel.inspect multi}"
     else
       %{multi | operations: [{name, operation} | operations],
                 names: MapSet.put(names, name)}
@@ -656,9 +656,9 @@ defmodule Ecto.Multi do
       %{person_a: %Person{...}}
 
   """
-  @spec inspect(t, name, Keyword.t) :: t
-  def inspect(multi, name, opts \\ []) do
-    add_operation(multi, name, {:inspect, opts})
+  @spec inspect(t, Keyword.t) :: t
+  def inspect(multi, opts \\ []) do
+    Map.update!(multi, :operations, &[{:inspect, {:inspect, opts}} | &1])
   end
 
   @doc false
@@ -701,9 +701,7 @@ defmodule Ecto.Multi do
     end
   end
 
-  defp apply_operation({name, {:inspect, opts}}, _repo, _wrap_, _return, {acc, names}) do
-    opts = Keyword.merge([label: Atom.to_string(name)], opts)
-
+  defp apply_operation({_name, {:inspect, opts}}, _repo, _wrap_, _return, {acc, names}) do
     if opts[:only] do
       acc |> Map.take(List.wrap(opts[:only])) |> IO.inspect(opts)
     else
@@ -720,7 +718,7 @@ defmodule Ecto.Multi do
       {:error, value} ->
         return.({name, value, acc})
       other ->
-        raise "expected Ecto.Multi callback named `#{inspect name}` to return either {:ok, value} or {:error, value}, got: #{inspect other}"
+        raise "expected Ecto.Multi callback named `#{Kernel.inspect name}` to return either {:ok, value} or {:error, value}, got: #{Kernel.inspect other}"
     end
   end
 
@@ -752,7 +750,7 @@ defmodule Ecto.Multi do
         {Map.merge(changes, new_changes), MapSet.union(names, new_names)}
       common ->
         raise "cannot merge multi, the following operations were found in " <>
-          "both Ecto.Multi: #{inspect common}"
+          "both Ecto.Multi: #{Kernel.inspect common}"
     end
   end
 

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -622,8 +622,14 @@ defmodule Ecto.Multi do
   @doc """
   Peeks results from a Multi
 
-  The name is shown as a label to the inspect, options are passed directly
-  to `IO.inspect/2`. Custom labels are supported through the `label` option.
+  By default, the name is shown as a label to the inspect, custom labels are
+  supported through the `IO.inspect/2` `label` option.
+
+  ## Options
+    All options for IO.inspect/2 are supported.
+
+    * `:only` - A list of fields to inspect, will print the entire map by
+      default.
 
   ## Example
 
@@ -680,7 +686,13 @@ defmodule Ecto.Multi do
 
   defp apply_operation({name, {:peek, opts}}, _repo, _wrap_, _return, {acc, names}) do
     opts = Keyword.merge([label: Atom.to_string(name)], opts)
-    IO.inspect(acc, opts)
+
+    if opts[:only] do
+      acc |> Map.take(opts[:only]) |> IO.inspect(opts)
+    else
+      IO.inspect(acc, opts)
+    end
+
     {acc, names}
   end
 

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -656,7 +656,7 @@ defmodule Ecto.Multi do
       %{person_a: %Person{...}}
 
   """
-  @spec inspect(t, name, keyword()) :: t
+  @spec inspect(t, name, Keyword.t) :: t
   def inspect(multi, name, opts \\ []) do
     add_operation(multi, name, {:inspect, opts})
   end

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -126,6 +126,7 @@ defmodule Ecto.Multi do
   @typep operation :: {:changeset, Changeset.t, Keyword.t} |
                       {:run, run} |
                       {:put, any} |
+                      {:inspect, Keyword.t} |
                       {:merge, merge} |
                       {:update_all, Ecto.Query.t, Keyword.t} |
                       {:delete_all, Ecto.Query.t, Keyword.t} |

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -619,6 +619,25 @@ defmodule Ecto.Multi do
     add_operation(multi, name, {:put, value})
   end
 
+  @doc """
+  Peeks results from a Multi
+
+  The name is shown as a label to the inspect, options are passed directly
+  to `IO.inspect/2`. Custom labels are supported through the `label` option.
+
+  ## Example
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.insert(:person, changeset)
+      |> Ecto.Multi.peek()
+      |> MyApp.Repo.transaction()
+
+  """
+  @spec peek(t, name, keyword()) :: t
+  def peek(multi, name, opts \\ []) do
+    add_operation(multi, name, {:peek, opts})
+  end
+
   @doc false
   @spec __apply__(t, Ecto.Repo.t, fun, (term -> no_return)) :: {:ok, term} | {:error, term}
   def __apply__(%Multi{} = multi, repo, wrap, return) do
@@ -657,6 +676,12 @@ defmodule Ecto.Multi do
         {acc, _names} = merge_results(acc, nested_acc, names)
         return.({name, value, acc})
     end
+  end
+
+  defp apply_operation({name, {:peek, opts}}, _repo, _wrap_, _return, {acc, names}) do
+    opts = Keyword.merge([label: Atom.to_string(name)], opts)
+    IO.inspect(acc, opts)
+    {acc, names}
   end
 
   defp apply_operation({name, operation}, repo, wrap, return, {acc, names}) do

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -620,7 +620,7 @@ defmodule Ecto.Multi do
   end
 
   @doc """
-  Peeks results from a Multi
+  Inspects results from a Multi
 
   By default, the name is shown as a label to the inspect, custom labels are
   supported through the `IO.inspect/2` `label` option.
@@ -635,13 +635,13 @@ defmodule Ecto.Multi do
 
       Ecto.Multi.new()
       |> Ecto.Multi.insert(:person, changeset)
-      |> Ecto.Multi.peek()
+      |> Ecto.Multi.inspect()
       |> MyApp.Repo.transaction()
 
   """
-  @spec peek(t, name, keyword()) :: t
-  def peek(multi, name, opts \\ []) do
-    add_operation(multi, name, {:peek, opts})
+  @spec inspect(t, name, keyword()) :: t
+  def inspect(multi, name, opts \\ []) do
+    add_operation(multi, name, {:inspect, opts})
   end
 
   @doc false
@@ -684,7 +684,7 @@ defmodule Ecto.Multi do
     end
   end
 
-  defp apply_operation({name, {:peek, opts}}, _repo, _wrap_, _return, {acc, names}) do
+  defp apply_operation({name, {:inspect, opts}}, _repo, _wrap_, _return, {acc, names}) do
     opts = Keyword.merge([label: Atom.to_string(name)], opts)
 
     if opts[:only] do
@@ -703,7 +703,7 @@ defmodule Ecto.Multi do
       {:error, value} ->
         return.({name, value, acc})
       other ->
-        raise "expected Ecto.Multi callback named `#{inspect(name)}` to return either {:ok, value} or {:error, value}, got: #{inspect(other)}"
+        raise "expected Ecto.Multi callback named `#{inspect name}` to return either {:ok, value} or {:error, value}, got: #{inspect other}"
     end
   end
 

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -90,10 +90,10 @@ defmodule Ecto.MultiTest do
   test "inspect prints the multi state and return the base multi" do
     multi =
       Multi.new()
-      |> Multi.peek(:peek)
+      |> Multi.inspect(:inspect)
 
-    assert multi.names == MapSet.new([:peek])
-    assert multi.operations == [{:peek, {:peek, []}}]
+    assert multi.names == MapSet.new([:inspect])
+    assert multi.operations == [{:inspect, {:inspect, []}}]
   end
 
   test "insert_or_update changeset will update the changeset if it was loaded" do
@@ -490,15 +490,15 @@ defmodule Ecto.MultiTest do
       refute Map.has_key?(changes.run, :update)
     end
 
-    test "with peek" do
+    test "with inspect" do
       import ExUnit.CaptureIO
 
       multi =
         Multi.new()
-        |> Multi.peek(:before_put)
+        |> Multi.inspect(:before_put)
         |> Multi.put(:put, 1)
         |> Multi.put(:put2, 1)
-        |> Multi.peek(:after_put, only: [:put])
+        |> Multi.inspect(:after_put, only: [:put])
 
       assert capture_io(fn ->
         assert {:ok, result} = TestRepo.transaction(multi)

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -497,7 +497,8 @@ defmodule Ecto.MultiTest do
         Multi.new()
         |> Multi.peek(:before_put)
         |> Multi.put(:put, 1)
-        |> Multi.peek(:after_put)
+        |> Multi.put(:put2, 1)
+        |> Multi.peek(:after_put, only: [:put])
 
       assert capture_io(fn ->
         assert {:ok, result} = TestRepo.transaction(multi)

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -498,13 +498,14 @@ defmodule Ecto.MultiTest do
         |> Multi.inspect(:before_put)
         |> Multi.put(:put, 1)
         |> Multi.put(:put2, 1)
-        |> Multi.inspect(:after_put, only: [:put])
+        |> Multi.inspect(:inspect_put, only: [:put])
+        |> Multi.inspect(:inspect_put2, only: :put2)
 
       assert capture_io(fn ->
         assert {:ok, result} = TestRepo.transaction(multi)
         refute Map.has_key?(result, :before_put)
         refute Map.has_key?(result, :after_put)
-      end) == "before_put: %{}\nafter_put: %{put: 1}\n"
+      end) == "before_put: %{}\ninspect_put: %{put: 1}\ninspect_put2: %{put2: 1}\n"
     end
 
     test "with empty multi" do

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -90,9 +90,9 @@ defmodule Ecto.MultiTest do
   test "inspect prints the multi state and return the base multi" do
     multi =
       Multi.new()
-      |> Multi.inspect(:inspect)
+      |> Multi.inspect()
 
-    assert multi.names == MapSet.new([:inspect])
+    assert multi.names == MapSet.new([])
     assert multi.operations == [{:inspect, {:inspect, []}}]
   end
 
@@ -495,17 +495,17 @@ defmodule Ecto.MultiTest do
 
       multi =
         Multi.new()
-        |> Multi.inspect(:before_put)
+        |> Multi.inspect()
         |> Multi.put(:put, 1)
         |> Multi.put(:put2, 1)
-        |> Multi.inspect(:inspect_put, only: [:put])
-        |> Multi.inspect(:inspect_put2, only: :put2)
+        |> Multi.inspect(only: [:put])
+        |> Multi.inspect(only: :put2)
 
       assert capture_io(fn ->
         assert {:ok, result} = TestRepo.transaction(multi)
         refute Map.has_key?(result, :before_put)
         refute Map.has_key?(result, :after_put)
-      end) == "before_put: %{}\ninspect_put: %{put: 1}\ninspect_put2: %{put2: 1}\n"
+      end) == "%{}\n%{put: 1}\n%{put2: 1}\n"
     end
 
     test "with empty multi" do


### PR DESCRIPTION
Adds Multi.peek/2,3 as specified in the proposal:
https://groups.google.com/g/elixir-ecto/c/17MKpYXcEDU/m/zsR-BHpWAAAJ

Renamed from `inspect` to `peek` to avoid name-clashing with
`Kernel.inspect/2`