### PR TITLE
Adds Multi.inspect/2

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -95,7 +95,7 @@ defmodule Ecto.Multi do
         # is as expected, for example:
         assert account_changeset.valid?
         assert log_changeset.valid?
-        assert inspect(query) == "#Ecto.Query<from a in Session>"
+        assert Kernel.inspect(query) == "#Ecto.Query<from a in Session>"
       end
 
   The name of each operation does not have to be an atom. This can be particularly
@@ -196,11 +196,11 @@ defmodule Ecto.Multi do
         raise ArgumentError, """
         error when merging the following Ecto.Multi structs:
 
-        #{inspect lhs}
+        #{Kernel.inspect lhs}
 
-        #{inspect rhs}
+        #{Kernel.inspect rhs}
 
-        both declared operations: #{inspect common}
+        both declared operations: #{Kernel.inspect common}
         """
     end
   end
@@ -409,7 +409,7 @@ defmodule Ecto.Multi do
 
   defp put_action(%{action: original}, action) do
     raise ArgumentError, "you provided a changeset with an action already set " <>
-      "to #{inspect original} when trying to #{action} it"
+      "to #{Kernel.inspect original} when trying to #{action} it"
   end
 
   @doc """
@@ -577,7 +577,7 @@ defmodule Ecto.Multi do
   defp add_operation(%Multi{} = multi, name, operation) do
     %{operations: operations, names: names} = multi
     if MapSet.member?(names, name) do
-      raise "#{inspect name} is already a member of the Ecto.Multi: \n#{inspect multi}"
+      raise "#{Kernel.inspect name} is already a member of the Ecto.Multi: \n#{Kernel.inspect multi}"
     else
       %{multi | operations: [{name, operation} | operations],
                 names: MapSet.put(names, name)}
@@ -602,6 +602,31 @@ defmodule Ecto.Multi do
     do: {name, {changeset.action, changeset, opts}}
   defp format_operation(other),
     do: other
+
+
+  @doc """
+  IO.inspects the state of the multi so far. You can optionally provide any of the options
+  available to IO.inspect.
+
+  This is useful for debugging.
+
+  ### Examples
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.put(:params, params)
+      |> Ecto.Multi.inspect(label: "Before Insert")
+      |> Ecto.Multi.insert(:user, fn changes -> &User.changeset(changes.params) end)
+      |> Ecto.Multi.inspect(label: "After Tnsert", limit: :infinity)
+      |> MyApp.Repo.transaction()
+  """
+  def inspect(%__MODULE__{} = multi, opts \\ []) do
+    io = Keyword.get(opts, :io, IO)
+
+    Ecto.Multi.run(multi, :erlang.unique_integer([:positive]), fn _, state ->
+      io.inspect(state, opts)
+      {:ok, :ok}
+    end)
+  end
 
   @doc """
   Adds a value to the changes so far under the given name.
@@ -666,7 +691,7 @@ defmodule Ecto.Multi do
       {:error, value} ->
         return.({name, value, acc})
       other ->
-        raise "expected Ecto.Multi callback named `#{inspect(name)}` to return either {:ok, value} or {:error, value}, got: #{inspect(other)}"
+        raise "expected Ecto.Multi callback named `#{Kernel.inspect(name)}` to return either {:ok, value} or {:error, value}, got: #{Kernel.inspect(other)}"
     end
   end
 
@@ -698,7 +723,7 @@ defmodule Ecto.Multi do
         {Map.merge(changes, new_changes), MapSet.union(names, new_names)}
       common ->
         raise "cannot merge multi, the following operations were found in " <>
-          "both Ecto.Multi: #{inspect common}"
+          "both Ecto.Multi: #{Kernel.inspect common}"
     end
   end
 

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -327,6 +327,29 @@ defmodule Ecto.MultiTest do
     ] = Ecto.Multi.to_list(multi)
   end
 
+  test "inspect/1" do
+    name = :halo
+    value = "statue"
+
+    defmodule TestIO do
+      def inspect(%{halo: "statue"} = state, opts) do
+        assert %{:halo => "statue"} = state
+        assert opts == [label: "after", io: Ecto.MultiTest.TestIO]
+      end
+
+      def inspect(%{} = state, opts) do
+        assert state == %{}
+        assert opts == [label: "before", io: Ecto.MultiTest.TestIO]
+      end
+    end
+
+    Multi.new()
+    |> Multi.inspect(label: "before", io: TestIO)
+    |> Multi.put(name, value)
+    |> Multi.inspect(label: "after", io: TestIO)
+    |> TestRepo.transaction()
+  end
+
   test "put" do
     name = :halo
     value = "statue"


### PR DESCRIPTION
When debugging a multi it is somtimes desireable to inspect the state of
the multi so far. This helper lets us do that easily.

email thread here:

https://groups.google.com/u/2/g/elixir-ecto/c/17MKpYXcEDU