### PR TITLE
Fixed database name

### DIFF
--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -60,7 +60,7 @@ This command will generate the configuration required to connect to a database. 
 
 ```elixir
 config :friends, Friends.Repo,
-  database: "friends_repo",
+  database: "friends",
   username: "user",
   password: "pass",
   hostname: "localhost"


### PR DESCRIPTION
The repo config had the database name as "friends_repo" but later in
the documentation, it was called out as "friends".