### PR TITLE
Add @impl true to Repo callbacks in guide

### DIFF
--- a/guides/howtos/Multi tenancy with foreign keys.md
+++ b/guides/howtos/Multi tenancy with foreign keys.md
@@ -24,6 +24,7 @@ defmodule MyApp.Repo do
 
   require Ecto.Query
 
+  @impl true
   def prepare_query(_operation, query, opts) do
     cond do
       opts[:skip_org_id] || opts[:schema_migration] ->
@@ -79,6 +80,7 @@ The second change we need to do is to set the `org_id` as a default option on al
 defmodule MyApp.Repo do
   ...
 
+  @impl true
   def default_options(_operation) do
     [org_id: get_org_id()]
   end


### PR DESCRIPTION
It seems like it would be nice if we added `@impl true` to the Repo callbacks in the Multi Tenancy with Foreign Keys guide. This not only ensures the arity and spelling is correct, but also indicates this function is a callback.

Awesome guide, btw!