### PR TITLE
Added apply_query() + other specs; fixed build_cte() spec.

### DIFF
--- a/lib/ecto/query/builder/cte.ex
+++ b/lib/ecto/query/builder/cte.ex
@@ -33,7 +33,7 @@ defmodule Ecto.Query.Builder.CTE do
     Builder.apply_query(query, __MODULE__, [escape(name), build_cte(name, cte, env)], env)
   end
 
-  @spec build_cte(Macro.t, Macro.t, Macro.t) :: Macro.t
+  @spec build_cte(Macro.t, Macro.t, Macro.Env.t) :: Macro.t
   def build_cte(_name, {:^, _, [expr]}, _env) do
     quote do: Ecto.Queryable.to_query(unquote(expr))
   end


### PR DESCRIPTION
Also refactored apply_query() a little. The escape_query() function will always receive a Query struct afaics so I removed the second clause.