### PR TITLE
Use Decimal.equal? instead of matching

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -409,14 +409,20 @@ defmodule Ecto.Integration.TypeTest do
     decimal = Decimal.new("1.0")
     TestRepo.insert!(%Post{cost: decimal})
 
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^decimal, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1.0, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == ^1, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1.0, select: p.cost)
-    assert [^decimal] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
-
-    assert TestRepo.all(from p in Post, select: p.cost * 2) == [Decimal.new("2.0")]
-    assert TestRepo.all(from p in Post, select: p.cost - p.cost) == [Decimal.new("0.0")]
+    [cost] = TestRepo.all(from p in Post, where: p.cost == ^decimal, select: p.cost)
+    assert Decimal.equal?(decimal, cost)
+    [cost] = TestRepo.all(from p in Post, where: p.cost == ^1.0, select: p.cost)
+    assert Decimal.equal?(decimal, cost)
+    [cost] = TestRepo.all(from p in Post, where: p.cost == ^1, select: p.cost)
+    assert Decimal.equal?(decimal, cost)
+    [cost] = TestRepo.all(from p in Post, where: p.cost == 1.0, select: p.cost)
+    assert Decimal.equal?(decimal, cost)
+    [cost] = TestRepo.all(from p in Post, where: p.cost == 1, select: p.cost)
+    assert Decimal.equal?(decimal, cost)
+    [cost] = TestRepo.all(from p in Post, select: p.cost * 2)
+    assert Decimal.equal?(Decimal.new("2.0"), cost)
+    [cost] = TestRepo.all(from p in Post, select: p.cost - p.cost)
+    assert Decimal.equal?(Decimal.new("0.0"), cost)
   end
 
   @tag :decimal_type
@@ -427,7 +433,8 @@ defmodule Ecto.Integration.TypeTest do
 
     assert [1] = TestRepo.all(from p in Post, select: type(sum(p.cost), :integer))
     assert [1.0] = TestRepo.all(from p in Post, select: type(sum(p.cost), :float))
-    assert [^decimal] = TestRepo.all(from p in Post, select: type(sum(p.cost), :decimal))
+    [cost] = TestRepo.all(from p in Post, select: type(sum(p.cost), :decimal))
+    assert Decimal.equal?(decimal, cost)
   end
 
   @tag :decimal_type


### PR DESCRIPTION
While I am building exqlite I am running into issues with how sqlite3
handles decimals when summing.

```
sqlite> create table foo (id integer primary key, cost decimal(10, 2));
sqlite> insert into foo (id,cost) values (1, '1.00');
sqlite> select sum(foo.cost) + 0 from foo;
1
```

As you can see sqlite normalizes the decimal which results in
`Decimal.new(1)` which does not match

```
Decimal.new(1) != Decimal.new("1.00") #=> true
```

When there are values after the decimal it does what you expect.

```
sqlite> create table foo (id integer primary key, cost decimal);
sqlite> insert into foo (id,cost) values (1, '1.00'), (2, '1.2'), (3, '1.3');
sqlite> select sum(foo.cost) from foo;
3.5
```