### PR TITLE
use Decimal.equal? for coalesce on mixed type

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -141,6 +141,7 @@ defmodule Ecto.Integration.TypeTest do
     assert [^bid] = TestRepo.all(from c in Custom, select: type(^bid, :binary_id))
   end
 
+  @tag :like_match_blob
   test "text type as blob" do
     assert %Post{} = post = TestRepo.insert!(%Post{blob: <<0, 1, 2>>})
     id = post.id
@@ -148,6 +149,7 @@ defmodule Ecto.Integration.TypeTest do
     assert [^id] = TestRepo.all(from p in Post, where: like(p.blob, ^<<0, 1, 2>>), select: p.id)
   end
 
+  @tag :like_match_blob
   @tag :text_type_as_string
   test "text type as string" do
     assert %Post{} = post = TestRepo.insert!(%Post{blob: "hello"})
@@ -441,7 +443,8 @@ defmodule Ecto.Integration.TypeTest do
   test "on coalesce with mixed types" do
     decimal = Decimal.new("1.0")
     TestRepo.insert!(%Post{cost: decimal})
-    assert [^decimal] = TestRepo.all(from p in Post, select: coalesce(p.cost, 0))
+    [cost] = TestRepo.all(from p in Post, select: coalesce(p.cost, 0))
+    assert Decimal.equal?(decimal, cost)
   end
 
   @tag :union_with_literals


### PR DESCRIPTION
Followup to #3582 . I also added two tags we needed locally, if you don't mind.