### PR TITLE
Add Ecto.Changeset.state/1

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -103,7 +103,7 @@ defmodule Ecto.Integration.RepoTest do
     assert %Post{__meta__: ^loaded_meta} = TestRepo.insert!(post)
 
     post = TestRepo.one(Post)
-    assert post.__meta__.state == :loaded
+    assert Ecto.Changeset.state(post) == :loaded
     assert post.inserted_at
   end
 
@@ -360,7 +360,7 @@ defmodule Ecto.Integration.RepoTest do
       |> Ecto.Changeset.unique_constraint(:uuid)
       |> TestRepo.insert()
     assert changeset.errors == [uuid: {"has already been taken", [constraint: :unique, constraint_name: "posts_uuid_index"]}]
-    assert changeset.data.__meta__.state == :built
+    assert Ecto.Changeset.state(changeset) == :built
   end
 
   @tag :unique_constraint
@@ -390,7 +390,7 @@ defmodule Ecto.Integration.RepoTest do
       |> Ecto.Changeset.unique_constraint(:uuid)
       |> TestRepo.insert()
     assert changeset.errors == [uuid: {"has already been taken", [constraint: :unique, constraint_name: "customs_uuid_index"]}]
-    assert changeset.data.__meta__.state == :built
+    assert Ecto.Changeset.state(changeset) == :built
   end
 
   test "unique pseudo-constraint violation error message with join table at the repository" do
@@ -1532,11 +1532,11 @@ defmodule Ecto.Integration.RepoTest do
       post = %Post{title: "first", uuid: Ecto.UUID.generate()}
       {:ok, inserted} = TestRepo.insert(post, on_conflict: :nothing)
       assert inserted.id
-      assert inserted.__meta__.state == :loaded
+      assert Ecto.Changeset.state(inserted) == :loaded
 
       {:ok, not_inserted} = TestRepo.insert(post, on_conflict: :nothing)
       assert not_inserted.id == nil
-      assert not_inserted.__meta__.state == :loaded
+      assert Ecto.Changeset.state(not_inserted) == :loaded
     end
 
     @tag :with_conflict_target

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2882,6 +2882,13 @@ defmodule Ecto.Changeset do
     do: field
 
   @doc ~S"""
+  Returns the state of the changeset as it relates to the data store; for
+  example, whether it has been persisted or deleted.
+  """
+  @spec state(changeset :: t()) :: Ecto.Schema.Metadata.state()
+  def state(%{data: %{__meta__: %{state: state}}}), do: state
+
+  @doc ~S"""
   Traverses changeset errors and applies the given function to error messages.
 
   This function is particularly useful when associations and embeds


### PR DESCRIPTION
Provides a public API for determining a changeset's state in data
storage.

I suspect there is a reason this function doesn't already exist, but in
case it was an oversight, here it is. 😄 

Context: when a record has a field that should not change, I have
used `changeset.data.__meta__.state` in a validation function
to ensure that it doesn't. For example:

```
  defp ensure_hostname_is_permanent(changeset) do
    state = changeset.data.__meta__.state

    if get_change(changeset, :hostname) && state != :built do
      add_error(changeset, :hostname, "Cannot change hostname after persisting")
    else
      changeset
    end
  end
```

Using `changeset.data.__meta__.state` seems hacky, since the `__meta__`
seems to imply "this is a private implementation detail".

If there is a better way to approach this problem, I'd be interested to
hear it.