### PR TITLE
Ability to run integration tests in both GitHub Actions and locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,45 +1,60 @@
 name: CI
-
 on:
-  pull_request:
   push:
-    branches:
-      - master
-      - v3.*
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
-  test:
-    runs-on: ubuntu-16.04
+  integration-test:
+    name: integration test
+    runs-on: ubuntu-latest
     env:
-      MIX_ENV: test
+      FORCE_COLOR: 1
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - pair:
-              elixir: 1.8.2
-              otp: 20.3.8.26
-          - pair:
-              elixir: 1.11.3
-              otp: 23.2.5
-            lint: lint
+        elixirbase:
+          - "1.11.0-erlang-23.1.1-alpine-3.13.1"
+          - "1.11.0-erlang-21.3.8.21-alpine-3.13.1"
+          - "1.8.2-erlang-20.3.8.26-alpine-3.11.6"
     steps:
       - uses: actions/checkout@v2
-
-      - uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{matrix.pair.otp}}
-          elixir-version: ${{matrix.pair.elixir}}
-
-      - name: Install Dependencies
-        run: mix deps.get --only test
-
-      - run: mix deps.get && mix deps.unlock --check-unused
-        if: ${{ matrix.lint }}
-
-      - run: mix deps.compile
-
-      - run: mix compile --warnings-as-errors
-        if: ${{ matrix.lint }}
-
-      - run: mix test
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.8/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: ecto integration-test under ${{matrix.elixirbase}}
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +integration-test
+  unit-test:
+    name: unit test
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        elixirbase:
+          - "1.11.0-erlang-23.1.1-alpine-3.13.1"
+          - "1.11.0-erlang-21.3.8.21-alpine-3.13.1"
+          - "1.8.2-erlang-20.3.8.26-alpine-3.11.6"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.8/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: ecto test under ${{matrix.elixirbase}}
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +test
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        elixirbase:
+          - "1.11.0-erlang-23.1.1-alpine-3.13.1"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.8/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: ecto lint under ${{matrix.elixirbase}}
+        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +lint

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,115 @@
+all:
+    BUILD +all-test
+    BUILD +all-integration-test
+    BUILD +lint
+
+
+all-test:
+    BUILD \
+        --build-arg ELIXIR_BASE=1.11.0-erlang-23.1.1-alpine-3.13.1 \
+        --build-arg ELIXIR_BASE=1.11.0-erlang-21.3.8.21-alpine-3.13.1 \
+        --build-arg ELIXIR_BASE=1.8.2-erlang-20.3.8.26-alpine-3.11.6 \
+        +test
+
+
+test:
+    FROM +setup-base
+    COPY mix.exs mix.lock .formatter.exs ./
+    RUN mix deps.get
+
+    RUN MIX_ENV=test mix deps.compile
+    COPY --dir lib integration_test examples test ./
+
+    RUN mix deps.get --only test
+    RUN mix deps.compile
+    RUN mix test
+
+
+lint:
+    FROM +test
+    RUN mix deps.get
+    RUN mix deps.unlock --check-unused
+    RUN mix compile --warnings-as-errors
+
+
+all-integration-test:
+    BUILD \
+        --build-arg ELIXIR_BASE=1.11.0-erlang-23.1.1-alpine-3.13.1 \
+        --build-arg ELIXIR_BASE=1.11.0-erlang-21.3.8.21-alpine-3.13.1 \
+        +integration-test
+
+
+setup-base:
+    ARG ELIXIR_BASE=1.11.0-erlang-23.1.1-alpine-3.13.1
+    FROM hexpm/elixir:$ELIXIR_BASE
+    RUN apk add --no-progress --update git build-base
+    RUN mix local.rebar --force
+    RUN mix local.hex --force
+    ENV ELIXIR_ASSERT_TIMEOUT=10000
+    WORKDIR /src/ecto
+
+
+integration-test-base:
+    FROM +setup-base
+    RUN apk add --no-progress --update docker docker-compose git postgresql-client mysql-client
+
+    RUN apk add --no-cache curl gnupg --virtual .build-dependencies -- && \
+        curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.5.2.1-1_amd64.apk && \
+        curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.5.2.1-1_amd64.apk && \
+        echo y | apk add --allow-untrusted msodbcsql17_17.5.2.1-1_amd64.apk mssql-tools_17.5.2.1-1_amd64.apk && \
+        apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
+    ENV PATH="/opt/mssql-tools/bin:${PATH}"
+
+    GIT CLONE https://github.com/elixir-ecto/ecto_sql.git /src/ecto_sql
+    WORKDIR /src/ecto_sql
+    RUN mix deps.get
+
+
+integration-test:
+    FROM +integration-test-base
+    WORKDIR /src/ecto
+    COPY mix.exs mix.lock .formatter.exs ./
+    RUN mix deps.get
+
+    COPY --dir lib integration_test examples test ./
+    RUN mix test
+
+    WORKDIR /src/ecto_sql
+
+    # then run the tests
+    WITH DOCKER \
+        --pull "postgres:11.11" \
+        --pull "mcr.microsoft.com/mssql/server:2017-latest" \
+        --pull "mysql:5.7"
+        RUN set -e; \
+            timeout=$(expr $(date +%s) + 60); \
+
+            # start databases
+            docker run --name mssql --network=host -d -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=some!Password' mcr.microsoft.com/mssql/server:2017-latest; \
+            docker run --name pg --network=host -d -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres "postgres:11.11"; \
+            docker run --name mysql --network=host -d -e MYSQL_ROOT_PASSWORD=root "mysql:5.7"; \
+
+            # wait for mssql to start
+            while ! sqlcmd -S tcp:127.0.0.1,1433 -U sa -P 'some!Password' -Q "SELECT 1" >/dev/null 2>&1; do \
+                test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for mysql"; exit 1); \
+                echo "waiting for mssql"; \
+                sleep 1; \
+            done; \
+
+            # wait for postgres to start
+            while ! pg_isready --host=127.0.0.1 --port=5432 --quiet; do \
+                test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for postgres"; exit 1); \
+                echo "waiting for postgres"; \
+                sleep 1; \
+            done; \
+
+            # wait for mysql to start
+            while ! mysqladmin ping --host=127.0.0.1 --port=3306 --protocol=TCP --silent; do \
+                test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for mysql"; exit 1); \
+                echo "waiting for mysql"; \
+                sleep 1; \
+            done; \
+
+            # run test
+            MSSQL_URL='sa:some!Password@127.0.0.1' MYSQL_URL='root:root@127.0.0.1' PG_URL='postgres:postgres@127.0.0.1' ECTO_PATH='/src/ecto' mix test.all;
+    END

--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ Note that `mix test` does not run the tests in the `integration_test` folder. To
     $ mix deps.get
     $ ECTO_PATH=../ecto mix test.all
 
+#### Running containerized tests
+
+It is also possible to run the integration tests under a containerized environment using [earthly](https://earthly.dev/get-earthly):
+
+    $ earthly -P +all
+
+You can also use this to interactively debug any failing integration tests using:
+
+    $ earthly -P -i --build-arg ELIXIR_BASE=1.8.2-erlang-20.3.8.26-alpine-3.11.6 +integration-test
+
+Then once you enter the containerized shell, you can inspect the underlying databases with the respective commands:
+
+    PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres -d postgres ecto_test
+    MYSQL_PASSWORD=root mysql -h 127.0.0.1 -uroot -proot ecto_test
+    sqlcmd -U sa -P 'some!Password'
+
 ## Logo
 
 "Ecto" and the Ecto logo are Copyright (c) 2020 Dashbit.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ With the version 3.0, Ecto has become API stable. This means our main focus is o
   * [Mailing list](https://groups.google.com/forum/#!forum/elixir-ecto)
   * [Examples](https://github.com/elixir-ecto/ecto/tree/master/examples)
 
-### Running tests
+## Running tests
 
 Clone the repo and fetch its dependencies:
 
@@ -148,7 +148,7 @@ Note that `mix test` does not run the tests in the `integration_test` folder. To
     $ mix deps.get
     $ ECTO_PATH=../ecto mix test.all
 
-#### Running containerized tests
+### Running containerized tests
 
 It is also possible to run the integration tests under a containerized environment using [earthly](https://earthly.dev/get-earthly):
 


### PR DESCRIPTION
This PR adds integration testing to github actions CI, as well as the ability to run them locally via earthly.

## Github actions CI

integration testing is performed via ecto_sql against postgres, mysql, and mssql under
 - 1.11.0-erlang-23.1.1-alpine-3.13.1
 - 1.11.0-erlang-21.3.8.21-alpine-3.13.1
 - 1.8.2-erlang-20.3.8.26-alpine-3.11.6

the existing unit tests should continue to run under the same elixir+OTP versions above, as well as linting for 1.11.0-erlang-23.1.1-alpine-3.13.1;


## Running the CI steps locally
In addition to having the integrating tests run in CI, you can run them locally using earthly (run `brew install earthly` or visit https://earthly.dev/get-earthly for linux versions); once installed you can run the same workflows locally using:

    > earthly -P +all
    ...
    =========================== SUCCESS ===========================

You can run individual sections like this:

    # all unit tests on all specified elixir and otp versions
    > earthly +all-test

    # all integration tests on all specified elixir and otp versions
    > earthly -P all-integration-test
    
You can also run the tests on specific version like this:

    > earthly -P --build-arg --build-arg ELIXIR_BASE=1.11.0-erlang-21.3.8.21-alpine-3.13.1 +test

## Interactive debugging
If an integration test is failing and you want to view the contents of the database, you can use the `--interactive` or `-i` flag to get access to shell:

    > earthly -P -i --build-arg ELIXIR_BASE=1.8.2-erlang-20.3.8.26-alpine-3.11.6 +integration-test
    
This will drop you on to a shell inside an alpine container which has an instance of docker running on it which contains the test databases; you can then interact with docker:

    /src/ecto_sql # docker ps -a
    CONTAINER ID        IMAGE                                        COMMAND                  CREATED              STATUS              PORTS               NAMES
    336e612ecb93        mysql:5.7                                    "docker-entrypoint.s…"   About a minute ago   Up About a minute                       mysql
    ecd3174f31ae        postgres:11.11                               "docker-entrypoint.s…"   About a minute ago   Up About a minute                       pg
    d193c7452bf5        mcr.microsoft.com/mssql/server:2017-latest   "/opt/mssql/bin/nonr…"   About a minute ago   Up About a minute                       mssql

then you can access the databases;

for example with postgres:
```
/src/ecto_sql # PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres -d postgres
psql (12.6, server 11.11 (Debian 11.11-1.pgdg90+1))
Type "help" for help.

postgres=# \l
                                 List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    |   Access privileges   
-----------+----------+----------+------------+------------+-----------------------
 ecto_test | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
 postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
 template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
           |          |          |            |            | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
           |          |          |            |            | postgres=CTc/postgres
(4 rows)

postgres=# \c ecto_test
psql (12.6, server 11.11 (Debian 11.11-1.pgdg90+1))
You are now connected to database "ecto_test" as user "postgres".
ecto_test=# \dt
                  List of relations
 Schema |           Name           | Type  |  Owner   
--------+--------------------------+-------+----------
 public | barebones                | table | postgres
 public | bits                     | table | postgres
 public | comments                 | table | postgres
 public | composite_pk             | table | postgres
 public | constraints_test         | table | postgres
 public | corrupted_pk             | table | postgres
 public | customs                  | table | postgres
 public | customs_customs          | table | postgres
 public | duplicate_table          | table | postgres
 public | lock_counters            | table | postgres
 public | orders                   | table | postgres
 public | permalinks               | table | postgres
 public | posts                    | table | postgres
 public | posts_users              | table | postgres
 public | posts_users_composite_pk | table | postgres
 public | posts_users_pk           | table | postgres
 public | schema_migrations        | table | postgres
 public | tags                     | table | postgres
 public | transactions             | table | postgres
 public | usecs                    | table | postgres
 public | users                    | table | postgres
...
```

similarly with mysql
```
/src/ecto_sql # MYSQL_PASSWORD=root mysql -h 127.0.0.1 -uroot -proot ecto_test
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MySQL connection id is 113
Server version: 5.7.33 MySQL Community Server (GPL)

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MySQL [ecto_test]> show tables;
+--------------------------+
| Tables_in_ecto_test      |
+--------------------------+
| barebones                |
| bits                     |
| comments                 |
| composite_pk             |
| corrupted_pk             |
| customs                  |
| customs_customs          |
| lock_counters            |
| orders                   |
| permalinks               |
| posts                    |
| posts_users              |
| posts_users_composite_pk |
| posts_users_pk           |
| schema_migrations        |
| transactions             |
| usecs                    |
| users                    |
+--------------------------+
...
```

and mssql

```
/src/ecto_sql # sqlcmd -U sa -P 'some!Password'
1> select name from sys.databases;
2> go
name                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------
master                                                                                                                          
tempdb                                                                                                                          
model                                                                                                                           
msdb                                                                                                                            
ecto_test
1> use ecto_test
2> go
Changed database context to 'ecto_test'.
1> select name from SYSOBJECTS WHERE xtype = 'U'
2> go
name                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------
schema_migrations                                                                                                               
users                                                                                                                           
posts                                                                                                                           
posts_users                                                                                                                     
posts_users_pk                                                                                                                  
permalinks                                                                                                                      
comments                                                                                                                        
customs                                                                                                                         
customs_customs                                                                                                                 
barebones                                                                                                                       
transactions                                                                                                                    
lock_counters                                                                                                                   
orders                                                                                                                          
composite_pk                                                                                                                    
corrupted_pk                                                                                                                    
posts_users_composite_pk                                                                                                        
usecs                                                                                                                           
bits                                                                                                                            
constraints_test    
...
```

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>