### PR TITLE
add 2 error messages to catch invalid parameters being passed to joins

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1071,7 +1071,7 @@ defmodule Ecto.Query do
                            "list of variables, got: #{Macro.to_string(binding)}"
   end
 
-  defmacro join(_query, _qual, binding, _expr, opts) when is_list(binding) do
+  defmacro join(_query, _qual, binding, _expr, opts) do
     raise ArgumentError, "invalid opts passed to Ecto.Query.join/5, should be " <>
                            "list, got: #{Macro.to_string(opts)}"
   end

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1071,6 +1071,11 @@ defmodule Ecto.Query do
                            "list of variables, got: #{Macro.to_string(binding)}"
   end
 
+  defmacro join(_query, _qual, binding, _expr, opts) when is_list(binding) do
+    raise ArgumentError, "invalid opts passed to Ecto.Query.join/5, should be " <>
+                           "list, got: #{Macro.to_string(opts)}"
+  end
+
   @doc ~S'''
   A common table expression (CTE) also known as WITH expression.
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1071,7 +1071,7 @@ defmodule Ecto.Query do
                            "list of variables, got: #{Macro.to_string(binding)}"
   end
 
-  defmacro join(_query, _qual, binding, _expr, opts) do
+  defmacro join(_query, _qual, _binding, _expr, opts) do
     raise ArgumentError, "invalid opts passed to Ecto.Query.join/5, should be " <>
                            "list, got: #{Macro.to_string(opts)}"
   end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -572,12 +572,12 @@ defmodule Ecto.Query.Planner do
     with {:ok, source} <- Enum.reverse(sources) |> Enum.fetch(ix) do
       source
     else _ ->
-      raise ArgumentError, message: "could not find a source with index `#{ix}` in `#{inspect sources}"
+      raise ArgumentError, "could not find a source with index `#{ix}` in `#{inspect sources}"
     end
   end
 
   defp fetch_source!(_, ix) do
-    raise ArgumentError, message: "invalid binding index: `#{inspect ix}` (check if you're binding using a valid :as atom)"
+    raise ArgumentError, "invalid binding index: `#{inspect ix}` (check if you're binding using a valid :as atom)"
   end
 
   defp schema_for_association_join!(query, join, source) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -569,10 +569,9 @@ defmodule Ecto.Query.Planner do
   defp rewrite_param_ix(param, _, _, _, _), do: param
 
   defp fetch_source!(sources, ix) when is_integer(ix) do
-    with {:ok, source} <- Enum.reverse(sources) |> Enum.fetch(ix) do
-      source
-    else _ ->
-      raise ArgumentError, "could not find a source with index `#{ix}` in `#{inspect sources}"
+    case Enum.reverse(sources) |> Enum.fetch(ix) do
+      {:ok, source} -> source
+      :error -> raise ArgumentError, "could not find a source with index `#{ix}` in `#{inspect sources}"
     end
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -434,69 +434,61 @@ defmodule Ecto.Query.Planner do
 
   defp plan_joins([%JoinExpr{assoc: {ix, assoc}, qual: qual, on: on, prefix: prefix} = join|t],
                      query, joins, sources, tail_sources, counter, offset, adapter) do
+    source = fetch_source!(sources, ix)
+    schema = schema_for_association_join!(query, join, source)
+    refl = schema.__schema__(:association, assoc)
 
-    with r_sources = Enum.reverse(sources),
-         true <- is_integer(ix),
-         {:ok, source} <- Enum.fetch(r_sources, ix) do
-
-      schema = schema_for_association_join!(query, join, source)
-      refl = schema.__schema__(:association, assoc)
-
-      unless refl do
-        error! query, join, "could not find association `#{assoc}` on schema #{inspect schema}"
-      end
-
-      # If we have the following join:
-      #
-      #     from p in Post,
-      #       join: p in assoc(p, :comments)
-      #
-      # The callback below will return a query that contains only
-      # joins in a way it starts with the Post and ends in the
-      # Comment.
-      #
-      # This means we need to rewrite the joins below to properly
-      # shift the &... identifier in a way that:
-      #
-      #    &0         -> becomes assoc ix
-      #    &LAST_JOIN -> becomes counter
-      #
-      # All values in the middle should be shifted by offset,
-      # all values after join are already correct.
-      child = refl.__struct__.joins_query(refl)
-
-      # Rewrite prefixes:
-      # 1. the child query has the parent query prefix
-      #    (note the child query should NEVER have a prefix)
-      # 2. from and joins can have their prefixes explicitly
-      #    overwritten by the join prefix
-      child = rewrite_prefix(child, query.prefix)
-      child = update_in child.from, &rewrite_prefix(&1, prefix)
-      child = update_in child.joins, &Enum.map(&1, fn join -> rewrite_prefix(join, prefix) end)
-
-      last_ix = length(child.joins)
-      source_ix = counter
-
-      {_, child_from_source} = plan_source(child, child.from, adapter)
-
-      {child_joins, child_sources, child_tail} =
-        plan_joins(child, [child_from_source], offset + last_ix - 1, adapter)
-
-      # Rewrite joins indexes as mentioned above
-      child_joins = Enum.map(child_joins, &rewrite_join(&1, qual, ix, last_ix, source_ix, offset))
-
-      # Drop the last resource which is the association owner (it is reversed)
-      child_sources = Enum.drop(child_sources, -1)
-
-      [current_source|child_sources] = child_sources
-      child_sources = child_tail ++ child_sources
-
-      plan_joins(t, query, attach_on(child_joins, on) ++ joins, [current_source|sources],
-                    child_sources ++ tail_sources, counter + 1, offset + length(child_sources), adapter)
-
-    else _ ->
-      raise ArgumentError, message: "could not find an association binding with index `#{ix}`"
+    unless refl do
+      error! query, join, "could not find association `#{assoc}` on schema #{inspect schema}"
     end
+
+    # If we have the following join:
+    #
+    #     from p in Post,
+    #       join: p in assoc(p, :comments)
+    #
+    # The callback below will return a query that contains only
+    # joins in a way it starts with the Post and ends in the
+    # Comment.
+    #
+    # This means we need to rewrite the joins below to properly
+    # shift the &... identifier in a way that:
+    #
+    #    &0         -> becomes assoc ix
+    #    &LAST_JOIN -> becomes counter
+    #
+    # All values in the middle should be shifted by offset,
+    # all values after join are already correct.
+    child = refl.__struct__.joins_query(refl)
+
+    # Rewrite prefixes:
+    # 1. the child query has the parent query prefix
+    #    (note the child query should NEVER have a prefix)
+    # 2. from and joins can have their prefixes explicitly
+    #    overwritten by the join prefix
+    child = rewrite_prefix(child, query.prefix)
+    child = update_in child.from, &rewrite_prefix(&1, prefix)
+    child = update_in child.joins, &Enum.map(&1, fn join -> rewrite_prefix(join, prefix) end)
+
+    last_ix = length(child.joins)
+    source_ix = counter
+
+    {_, child_from_source} = plan_source(child, child.from, adapter)
+
+    {child_joins, child_sources, child_tail} =
+      plan_joins(child, [child_from_source], offset + last_ix - 1, adapter)
+
+    # Rewrite joins indexes as mentioned above
+    child_joins = Enum.map(child_joins, &rewrite_join(&1, qual, ix, last_ix, source_ix, offset))
+
+    # Drop the last resource which is the association owner (it is reversed)
+    child_sources = Enum.drop(child_sources, -1)
+
+    [current_source|child_sources] = child_sources
+    child_sources = child_tail ++ child_sources
+
+    plan_joins(t, query, attach_on(child_joins, on) ++ joins, [current_source|sources],
+                  child_sources ++ tail_sources, counter + 1, offset + length(child_sources), adapter)
   end
 
   defp plan_joins([%JoinExpr{source: %Ecto.Query{} = join_query, qual: qual, on: on, prefix: prefix} = join|t],
@@ -575,6 +567,18 @@ defmodule Ecto.Query.Planner do
   end
 
   defp rewrite_param_ix(param, _, _, _, _), do: param
+
+  defp fetch_source!(sources, ix) when is_integer(ix) do
+    with {:ok, source} <- Enum.reverse(sources) |> Enum.fetch(ix) do
+      source
+    else _ ->
+      raise ArgumentError, message: "could not find a source with index `#{ix}` in `#{inspect sources}"
+    end
+  end
+
+  defp fetch_source!(_, ix) do
+    raise ArgumentError, message: "invalid binding index: `#{inspect ix}` (check if you're binding using a valid :as atom)"
+  end
 
   defp schema_for_association_join!(query, join, source) do
     case source do

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -92,7 +92,7 @@ defmodule Ecto.Query.Builder.JoinTest do
     end
   end
 
-  test "raises on invalid expressions on :on" do 
+  test "raises on invalid expressions on :on" do
     assert_raise ArgumentError, ~r/invalid expression for join `:on`/, fn ->
       escape(quote do
         join("posts", :inner, [p], c in "comments", on: p.id in subquery("posts"))
@@ -117,6 +117,14 @@ defmodule Ecto.Query.Builder.JoinTest do
     assert_raise ArgumentError, ~r/invalid option `foo` passed/, fn ->
       escape(quote do
         join("posts", :left, [p], c in "comments", on: true, foo: :bar)
+      end, [], __ENV__)
+    end
+  end
+
+  test "raises on invalid opts passed to join/5" do
+    assert_raise ArgumentError, ~r/invalid opts passed/, fn ->
+      escape(quote do
+        join("posts", :left, [p], c in "comments", {:foo, :bar})
       end, [], __ENV__)
     end
   end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -341,8 +341,9 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "plan: raises on invalid binding index in join" do
-    query   = from(p in Post, as: :posts)
-    |> join(:left, [{p, :foo}], assoc(p, :comments))
+    query =
+      from(p in Post, as: :posts)
+      |> join(:left, [{p, :foo}], assoc(p, :comments))
 
     assert_raise ArgumentError, ~r/invalid binding index/, fn ->
       plan(query)

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -340,6 +340,15 @@ defmodule Ecto.Query.PlannerTest do
            "&5.id() == &3.special_long_comment_id() and fragment({:raw, \"LEN(\"}, {:expr, &5.text()}, {:raw, \") > 100\"})"
   end
 
+  test "plan: raises on invalid binding index in join" do
+    query   = from(p in Post, as: :posts)
+    |> join(:left, [{p, :foo}], assoc(p, :comments))
+
+    assert_raise ArgumentError, ~r/invalid binding index/, fn ->
+      plan(query)
+    end
+  end
+
   test "plan: cannot associate without schema" do
     query   = from(p in "posts", join: assoc(p, :comments))
     message = ~r"cannot perform association join on \"posts\" because it does not have a schema"


### PR DESCRIPTION
After spending longer than I wanted to debugging my code by adding inspects to Ecto, here are a couple error messages I added to make it easier next time. Happy to refactor if necessary...