### PR TITLE
Tag tests that use CONCAT fragments

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -884,6 +884,7 @@ defmodule Ecto.Integration.RepoTest do
   describe "insert_all with source query" do
     @tag :upsert
     @tag :with_conflict_target
+    @tag :concat
     test "insert_all with query and conflict target" do
       {:ok, %Post{id: id}} = TestRepo.insert(%Post{
         title: "A generic title"
@@ -903,6 +904,7 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     @tag :returning
+    @tag :concat
     test "insert_all with query and returning" do
       {:ok, %Post{id: id}} = TestRepo.insert(%Post{
         title: "A generic title"
@@ -922,6 +924,7 @@ defmodule Ecto.Integration.RepoTest do
 
     @tag :upsert
     @tag :without_conflict_target
+    @tag :concat
     test "insert_all with query and on_conflict" do
       {:ok, %Post{id: id}} = TestRepo.insert(%Post{
         title: "A generic title"
@@ -940,6 +943,7 @@ defmodule Ecto.Integration.RepoTest do
       assert %Post{title: ^expected_title} = TestRepo.get(Post, expected_id)
     end
 
+    @tag :concat
     test "insert_all with query" do
       {:ok, %Post{id: id}} = TestRepo.insert(%Post{
         title: "A generic title"


### PR DESCRIPTION
In SQLite3 we do not have access to a CONCAT function. Instead we have
to use `||` with an example like the following:

    SELECT p0.foo || ' thing ' || p0.bar from posts as p0

Not ideal, but it will allow us downstream to ignore these tests and
we'll make a test for the same functionality within the ecto_sqlite3
library itself.