### PR TITLE
Clarify empty_values description

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -427,7 +427,7 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:empty_values` - a list of values to be considered as empty when casting.
-      All empty values are replaced with default values on cast if default values are specified. Defaults to `[""]`
+      Empty values are always replaced by the default value of the respective key. Defaults to `[""]`
 
   ## Examples
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -427,7 +427,7 @@ defmodule Ecto.Changeset do
   ## Options
 
     * `:empty_values` - a list of values to be considered as empty when casting.
-      All empty values are discarded on cast. Defaults to `[""]`
+      All empty values are replaced with default values on cast if default values are specified. Defaults to `[""]`
 
   ## Examples
 


### PR DESCRIPTION
Hi! Current description is a little bit misleading, and sounds like fields with empty values would be discarded at all if there is no default value for the field. I propose to clarify a description