### PR TITLE
Allows *_many relations to be considered empty if they are nil.

### DIFF
--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -32,9 +32,9 @@ defmodule Ecto.Changeset.Relation do
   Checks if the container can be considered empty.
   """
   def empty?(%{cardinality: _}, %NotLoaded{}), do: true
+  def empty?(%{cardinality: _}, nil), do: true
   def empty?(%{cardinality: :many}, []), do: true
   def empty?(%{cardinality: :many}, changes), do: filter_empty(changes) == []
-  def empty?(%{cardinality: :one}, nil), do: true
   def empty?(%{}, _), do: false
 
   @doc """


### PR DESCRIPTION
Right now you can set a changeset to have an `nil` for a has_many / embeds_many relation, but if you do that `Ecto.Changeset.Relation.empty?/2` errors. I think it should instead return true.

I don't know if this is a good idea so I thought I'd open a PR to see.