### PR TITLE
Recursively search for parent_as binding

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1631,11 +1631,11 @@ defmodule Ecto.Query.Planner do
           {ix, {:parent_as, [], [{:&, meta, [ix]}]}, query}
         end
 
-      %{} ->
-        error!(query, "could not find named binding `parent_as(#{inspect(as)})`")
+      %{} = parent ->
+        get_ix!({:parent_as, meta, [as]}, kind, parent)
 
       nil ->
-        error!(query, "`parent_as(#{inspect(as)})` can only be used in subqueries")
+        error!(query, "could not find named binding `parent_as(#{inspect(as)})`")
     end
   end
 


### PR DESCRIPTION
Work in progress attempt to fix #3619.