### PR TITLE
Add `doc false` to parameterised types functions

### DIFF
--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -182,8 +182,13 @@ defmodule Ecto.ParameterizedType do
   defmacro __using__(_) do
     quote location: :keep do
       @behaviour Ecto.ParameterizedType
+
+      @doc false
       def embed_as(_, _), do: :self
+
+      @doc false
       def equal?(term1, term2, _params), do: term1 == term2
+
       defoverridable embed_as: 2, equal?: 3
     end
   end


### PR DESCRIPTION
Otherwise, they show up in docs: https://hexdocs.pm/ecto_map_set/EctoMapSet.html#functions