### PR TITLE
fix: insert_all on_conflict with conditional query using placeholders

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1070,6 +1070,7 @@ defmodule Ecto.Integration.RepoTest do
       assert [100] == TestRepo.all(query)
     end
 
+    @tag :upsert_all
     @tag :with_conflict_target
     test "Repo.insert_all upserts and fills in placeholders with conditioned on_conflict query" do
       do_not_update_title = "don't touch me"

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1073,16 +1073,38 @@ defmodule Ecto.Integration.RepoTest do
     @tag :with_conflict_target
     test "Repo.insert_all upserts and fills in placeholders with conditioned on_conflict query" do
       do_not_update_title = "don't touch me"
-      on_conflict = from p in Post, update: [set: [title: "updated"]], where: p.title != ^do_not_update_title
+
+      on_conflict =
+        from p in Post, update: [set: [title: "updated"]], where: p.title != ^do_not_update_title
+
       placeholders = %{posted: Date.utc_today(), title: "title"}
-      post1 = [title: {:placeholder, :title}, uuid: Ecto.UUID.generate(), posted: {:placeholder, :posted}]
-      post2 = [title: do_not_update_title, uuid: Ecto.UUID.generate(), posted: {:placeholder, :posted}]
-      assert TestRepo.insert_all(Post, [post1, post2], placeholders: placeholders, on_conflict: on_conflict, conflict_target: [:uuid]) ==
-             {2, nil}
+
+      post1 = [
+        title: {:placeholder, :title},
+        uuid: Ecto.UUID.generate(),
+        posted: {:placeholder, :posted}
+      ]
+
+      post2 = [
+        title: do_not_update_title,
+        uuid: Ecto.UUID.generate(),
+        posted: {:placeholder, :posted}
+      ]
+
+      assert TestRepo.insert_all(Post, [post1, post2],
+               placeholders: placeholders,
+               on_conflict: on_conflict,
+               conflict_target: [:uuid]
+             ) ==
+               {2, nil}
 
       # only update first post
-      assert TestRepo.insert_all(Post, [post1, post2], placeholders: placeholders, on_conflict: on_conflict, conflict_target: [:uuid]) ==
-             {1, nil}
+      assert TestRepo.insert_all(Post, [post1, post2],
+               placeholders: placeholders,
+               on_conflict: on_conflict,
+               conflict_target: [:uuid]
+             ) ==
+               {1, nil}
 
       assert TestRepo.aggregate(where(Post, title: "updated"), :count) == 1
     end

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1069,6 +1069,23 @@ defmodule Ecto.Integration.RepoTest do
       query = from(b in Barebone, select: b.num)
       assert [100] == TestRepo.all(query)
     end
+
+    @tag :with_conflict_target
+    test "Repo.insert_all upserts and fills in placeholders with conditioned on_conflict query" do
+      do_not_update_title = "don't touch me"
+      on_conflict = from p in Post, update: [set: [title: "updated"]], where: p.title != ^do_not_update_title
+      placeholders = %{posted: Date.utc_today(), title: "title"}
+      post1 = [title: {:placeholder, :title}, uuid: Ecto.UUID.generate(), posted: {:placeholder, :posted}]
+      post2 = [title: do_not_update_title, uuid: Ecto.UUID.generate(), posted: {:placeholder, :posted}]
+      assert TestRepo.insert_all(Post, [post1, post2], placeholders: placeholders, on_conflict: on_conflict, conflict_target: [:uuid]) ==
+             {2, nil}
+
+      # only update first post
+      assert TestRepo.insert_all(Post, [post1, post2], placeholders: placeholders, on_conflict: on_conflict, conflict_target: [:uuid]) ==
+             {1, nil}
+
+      assert TestRepo.aggregate(where(Post, title: "updated"), :count) == 1
+    end
   end
 
   test "update all" do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -89,7 +89,15 @@ defmodule Ecto.Repo.Schema do
 
     header = Map.keys(header)
 
-    counter = fn -> Enum.reduce(rows, 0, &length(&1) + &2) end
+    placeholder_size = map_size(placeholder_dump)
+
+    counter = fn ->
+      Enum.reduce(
+        rows,
+        placeholder_size,
+        &(Enum.count(&1, fn {_, val} -> !match?({:placeholder, _}, val) end) + &2)
+      )
+    end
 
     placeholder_vals_list =
       placeholder_dump

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -95,7 +95,7 @@ defmodule Ecto.Repo.Schema do
       Enum.reduce(
         rows,
         placeholder_size,
-        &(Enum.count(&1, fn {_, val} -> !match?({:placeholder, _}, val) end) + &2)
+        &(Enum.count(&1, fn {_, val} -> not match?({:placeholder, _}, val) end) + &2)
       )
     end
 


### PR DESCRIPTION
The parameter index was off for `insert_all` when using placeholders (#3515) and a conditional `on_conflict` query with a parameter. This fixes the counter function by not counting placeholder values since their parameters are reused.

Before this it would generate errors like the following:

```
** (Postgrex.Error) ERROR 42P18 (indeterminate_datatype) could not determine data type of parameter $6

query: INSERT INTO "posts" AS p0 ("posted","title","uuid") VALUES ($1,$2,$3),($1,$4,$5) ON CONFLICT ("uuid") DO UPDATE SET "title" = 'updated' WHERE (p0."title" != $7)
````