### PR TITLE
improvement: support a `skip_type_check` option on fields

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -670,6 +670,9 @@ defmodule Ecto.Schema do
       when inspected in changes inside a `Ecto.Changeset` and be excluded
       from inspect on the schema. Defaults to `false`.
 
+    * :skip_type_check - By default, types are checked at compile time to ensure
+    that they are defined. If using parameterized types, this will result in your 
+    parameterized types *not* using the `init` callback.
   """
   defmacro field(name, type \\ :string, opts \\ []) do
     quote do
@@ -2155,6 +2158,9 @@ defmodule Ecto.Schema do
 
   defp check_field_type!(mod, name, type, opts) do
     cond do
+      opts[:skip_type_check] ->
+        type
+
       composite?(type, name) ->
         {outer_type, inner_type} = type
         {outer_type, check_field_type!(mod, name, inner_type, opts)}


### PR DESCRIPTION
Hello! Due to an implementation detail in Ash (which I understand is not necessarily a concern of the ecto maintainers), I have types that can't necessarily be compiled when the ecto schema itself is compiled. This check supports a toggle called `skip_type_check` which allows this to be configured on a field-by-field basis. This could potentially be useful to anyone who is building ecto schemas and types behind macros as well.