### PR TITLE
Fix CTE subqueries not finding parent bindings (#3619)

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1632,7 +1632,7 @@ defmodule Ecto.Query.Planner do
         if kind == :select and not (ix < tuple_size(sources)) do
           error!(query, "the parent_as in a subquery select used as a join can only access the `from` binding")
         else
-          {ix, {:parent_as, [], [{:&, meta, [ix]}]}, query}
+          {ix, {:parent_as, [], [as]}, query}
         end
 
       %{} = parent ->

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -993,19 +993,23 @@ defmodule Ecto.Query.Planner do
 
     {queries, counter} =
       Enum.reduce with_expr.queries, {[], counter}, fn
-        {name, %Ecto.Query{} = query}, {queries, counter} ->
+        {name, %Ecto.Query{} = inner_query}, {queries, counter} ->
+          inner_query = put_in(inner_query.aliases[@parent_as], query)
+
           # We don't want to use normalize_subquery_select because we are
           # going to prepare the whole query ourselves next.
-          {_, query} = rewrite_subquery_select_expr(query, true)
-          {query, counter} = traverse_exprs(query, :all, counter, fun)
+          {_, inner_query} = rewrite_subquery_select_expr(inner_query, true)
+          {inner_query, counter} = traverse_exprs(inner_query, :all, counter, fun)
 
           # Now compute the fields as keyword lists so we emit AS in Ecto query.
-          %{select: %{expr: expr, take: take}} = query
-          {source, fields, _from} = collect_fields(expr, [], :never, query, take, true)
+          %{select: %{expr: expr, take: take}} = inner_query
+          {source, fields, _from} = collect_fields(expr, [], :never, inner_query, take, true)
           {_, keys} = subquery_struct_and_fields(source)
-          query = put_in(query.select.fields, Enum.zip(keys, Enum.reverse(fields)))
+          inner_query = put_in(inner_query.select.fields, Enum.zip(keys, Enum.reverse(fields)))
 
-          {[{name, query} | queries], counter}
+          {_, inner_query} = pop_in(inner_query.aliases[@parent_as])
+
+          {[{name, inner_query} | queries], counter}
 
         {name, %QueryExpr{expr: {:fragment, _, _} = fragment} = query_expr}, {queries, counter} ->
           {fragment, counter} = prewalk_source(fragment, :with_cte, query, with_expr, counter, adapter)

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -856,11 +856,11 @@ defmodule Ecto.Query.PlannerTest do
   test "normalize: late parent bindings with as" do
     child = from(c in Comment, where: parent_as(:posts).posted == c.posted)
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(&0).posted() == &0.posted()"
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).posted() == &0.posted()"
 
     child = from(c in Comment, select: %{map: parent_as(:posts).posted})
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(&0).posted()}"
+    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
 
     assert_raise Ecto.SubQueryError, ~r/the parent_as in a subquery select used as a join can only access the `from` binding in query/, fn ->
       child = from(c in Comment, select: %{map: parent_as(:itself).posted})
@@ -881,11 +881,11 @@ defmodule Ecto.Query.PlannerTest do
 
     child = from(c in Comment, where: parent_as(^as).posted == c.posted)
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(&0).posted() == &0.posted()"
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).posted() == &0.posted()"
 
     child = from(c in Comment, select: %{map: field(parent_as(^as), :posted)})
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(&0).posted()}"
+    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
   end
 
   test "normalize: nested parent_as" do
@@ -894,7 +894,7 @@ defmodule Ecto.Query.PlannerTest do
     child = from(c in Comment, where: parent_as(:posts).posted == c.posted and c.id in subquery(child2))
 
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "parent_as(&0).posted() == &0.posted()"
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "parent_as(:posts).posted() == &0.posted()"
     assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "in %Ecto.SubQuery{"
   end
 
@@ -905,7 +905,7 @@ defmodule Ecto.Query.PlannerTest do
     child = from(c in Comment, where: field(parent_as(^as), :posted) == c.posted and c.id in subquery(child2))
 
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "parent_as(&0).posted() == &0.posted()"
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "parent_as(:posts).posted() == &0.posted()"
     assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "in %Ecto.SubQuery{"
   end
 


### PR DESCRIPTION
This is a work in progress since there are still changes to be made in ecto_sql because If you run the query ([I provided a repo for testing here](https://github.com/joaopaulobdac/parenting)) with this PR, you'll get an error coming from ecto_sql caused by the binding source not being found.
I'll also ping @v0idpwn here because maybe he can shred some light on this since he provided the PR that closed the issue (#3624), although CTEs still remain a problem. Thank you!