### PR TITLE
Add types Schema.embeds_one/embeds_many and MetaData.t(schema).

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -452,6 +452,8 @@ defmodule Ecto.Schema do
   @type has_one(t) :: t | Ecto.Association.NotLoaded.t()
   @type has_many(t) :: [t] | Ecto.Association.NotLoaded.t()
   @type many_to_many(t) :: [t] | Ecto.Association.NotLoaded.t()
+  @type embeds_one(t) :: t
+  @type embeds_many(t) :: [t]
 
   @doc false
   defmacro __using__(_) do

--- a/lib/ecto/schema/metadata.ex
+++ b/lib/ecto/schema/metadata.ex
@@ -39,13 +39,15 @@ defmodule Ecto.Schema.Metadata do
 
   @type context :: any
 
-  @type t :: %__MODULE__{
+  @type t(schema) :: %__MODULE__{
           context: context,
           prefix: Ecto.Schema.prefix(),
-          schema: module,
+          schema: schema,
           source: Ecto.Schema.source(),
           state: state
         }
+
+  @type t :: t(module)
 
   defimpl Inspect do
     import Inspect.Algebra


### PR DESCRIPTION
I'd like to add these types for completeness sake and to be able to use them in my own type specs.