### PR TITLE
prepare_changes of a many assoc

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -376,7 +376,7 @@ defmodule Ecto.Repo.Schema do
             error
         end
       else
-        {:error, changeset}
+        {:error, %{user_changeset | valid?: false}}
       end
     end)
   end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -458,7 +458,7 @@ defmodule Ecto.Repo.Schema do
               error
           end
         else
-          {:error, changeset}
+          {:error, %{user_changeset | valid?: false}}
         end
       end)
     else

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -61,7 +61,7 @@ defmodule Ecto.RepoTest do
       field :w, :string, virtual: true
       field :array, {:array, :string}
       field :map, {:map, :string}
-      has_many(:children, MySchemaChild)
+      has_many :children, MySchemaChild
     end
   end
 


### PR DESCRIPTION
returns the changeset with its associations.

Before the fix, the changeset returned was the one after the assoc was extracted (pop_assocs function). 

The problem is when the schema has a many assoc, and one of the many has an error in the prepare_changes function (when it is not in the prepare_changes, the changeset is directly return in do_insert function with the valid?: false match), and since the parent changeset is set to invalid the changeset (without the assocs) is returned and then the changeset does not contain the assoc..

PS: I added a test only for insert, should I add one also for update ?

