### PR TITLE
Link Shared options internally in doc

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -88,7 +88,7 @@ defmodule Ecto.Repo do
   options:
 
     * `:timeout` - The time in milliseconds (as an integer) to wait for the query call to
-      finish. `:infinity` will wait indefinitely (default: 15000)
+      finish. `:infinity` will wait indefinitely (default: `15_000`)
     * `:log` - When false, does not log the query
     * `:telemetry_event` - The telemetry event name to dispatch the event under.
       See the next section for more information
@@ -471,7 +471,8 @@ defmodule Ecto.Repo do
 
   ## Options
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
   """
   @callback checkout((() -> result), opts :: Keyword.t()) :: result when result: var
 
@@ -608,7 +609,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -632,7 +634,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -658,7 +661,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -688,7 +692,8 @@ defmodule Ecto.Repo do
       `Ecto.Query` documentation.
 
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -763,7 +768,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Examples
 
@@ -820,7 +826,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Examples
 
@@ -851,7 +858,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Examples
 
@@ -877,7 +885,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
   """
   @callback one!(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) ::
               Ecto.Schema.t()
@@ -904,7 +913,8 @@ defmodule Ecto.Repo do
       will use the same prefix as the one in the given collection. This
       option allows the prefix to be changed.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Examples
 
@@ -1001,7 +1011,8 @@ defmodule Ecto.Repo do
       in the schema. For more information see the "Query Prefix" section of the
       `Ecto.Query` documentation.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -1033,7 +1044,8 @@ defmodule Ecto.Repo do
     * `:max_rows` - The number of rows to load from the database as we stream.
       It is supported at least by Postgres and MySQL and defaults to 500.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -1067,8 +1079,8 @@ defmodule Ecto.Repo do
       in Postgres or the database in MySQL). This overrides the prefix set
       in the query and any `@schema_prefix` set in the schema.
 
-  See the "Shared options" section at the module documentation for
-  remaining options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for remaining options.
 
   ## Examples
 
@@ -1109,8 +1121,8 @@ defmodule Ecto.Repo do
       in Postgres or the database in MySQL). This overrides the prefix set
       in the query and any `@schema_prefix` set in the schema.
 
-  See the "Shared options" section at the module documentation for
-  remaining options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for remaining options.
 
   ## Examples
 
@@ -1188,8 +1200,8 @@ defmodule Ecto.Repo do
     * `:placeholders` - A map with placeholders. This feature is not supported
       by all databases. See the "Placeholders" section for more information.
 
-  See the "Shared options" section at the module documentation for
-  remaining options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for remaining options.
 
   ## Source query
 
@@ -1342,7 +1354,8 @@ defmodule Ecto.Repo do
     * `:stale_error_message` - The message to add to the configured
       `:stale_error_field` when stale errors happen, defaults to "is stale".
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Examples
 
@@ -1492,7 +1505,8 @@ defmodule Ecto.Repo do
     * `:stale_error_message` - The message to add to the configured
       `:stale_error_field` when stale errors happen, defaults to "is stale".
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -1535,7 +1549,8 @@ defmodule Ecto.Repo do
       `:stale_error_field` when stale errors happen, defaults to "is stale".
       Only applies to updates.
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -1577,7 +1592,8 @@ defmodule Ecto.Repo do
     * `:stale_error_message` - The message to add to the configured
       `:stale_error_field` when stale errors happen, defaults to "is stale".
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Example
 
@@ -1666,7 +1682,8 @@ defmodule Ecto.Repo do
 
   ## Options
 
-  See the "Shared options" section at the module documentation for more options.
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
 
   ## Examples
 


### PR DESCRIPTION
Instead of searching for the "Shared options" section, link to it
internally within the `Ecto.Repo` generated doc.