### PR TITLE
Add guard for binary prefix in Ecto.Query.put_query_prefix/2

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -676,7 +676,7 @@ defmodule Ecto.Query do
     %{query | prefix: prefix}
   end
 
-  def put_query_prefix(other, prefix) do
+  def put_query_prefix(other, prefix) when is_binary(prefix) do
     other |> Ecto.Queryable.to_query() |> put_query_prefix(prefix)
   end
 


### PR DESCRIPTION
Currently passing a query and a non-binary prefix causes an infinite loop