### PR TITLE
Add Ecto.Changeset.traverse_validations/2

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2931,7 +2931,7 @@ defmodule Ecto.Changeset do
   validations rules from `changeset.validations` to build detailed error
   description.
   """
-  @spec traverse_errors(t, (error -> String.t) | (Changeset.t, atom, error -> String.t)) :: %{atom => [String.t | map]}
+  @spec traverse_errors(t, (error -> String.t) | (Changeset.t, atom, error -> String.t)) :: %{atom => [term]}
   def traverse_errors(%Changeset{errors: errors, changes: changes, types: types} = changeset, msg_func)
       when is_function(msg_func, 1) or is_function(msg_func, 3) do
     errors
@@ -3020,7 +3020,7 @@ defmodule Ecto.Changeset do
       ...> end)
       %{title: [format: "/pattern/", length: "1-20"]}
   """
-  @spec traverse_validations(t, (error -> String.t) | (Changeset.t, atom, error -> String.t)) :: %{atom => [String.t | map]}
+  @spec traverse_validations(t, (error -> String.t) | (Changeset.t, atom, error -> String.t)) :: %{atom => [term]}
   def traverse_validations(%Changeset{validations: validations, changes: changes, types: types} = changeset, msg_func)
       when is_function(msg_func, 1) or is_function(msg_func, 3) do
     validations

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -997,4 +997,16 @@ defmodule Ecto.Changeset.EmbeddedTest do
     assert changeset.errors == []
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [%{title: [{"can't be blank", [validation: :required]}]}]}
   end
+
+  ## traverse_validations
+
+  test "traverses changeset validations with embeds_one" do
+    changeset = cast(%Author{}, %{profile: %{}}, :profile)
+    assert Changeset.traverse_validations(changeset, &(&1)) == %{profile: %{name: [length: [min: 3]]}}
+  end
+
+  test "traverses changeset validations with embeds_many" do
+    changeset = cast(%Author{}, %{posts: [%{}]}, :posts)
+    assert Changeset.traverse_validations(changeset, &(&1)) == %{posts: [%{title: [length: [min: 3]]}]}
+  end
 end

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -20,6 +20,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     def changeset(schema, params) do
       Changeset.cast(schema, params, ~w(title author_id)a)
       |> Changeset.validate_required(:title)
+      |> Changeset.validate_length(:title, min: 3)
     end
 
     def set_action(schema, params) do
@@ -66,6 +67,7 @@ defmodule Ecto.Changeset.HasAssocTest do
     def changeset(schema, params) do
       Changeset.cast(schema, params, ~w(name id)a)
       |> Changeset.validate_required(:name)
+      |> Changeset.validate_length(:name, min: 3)
     end
 
     def optional_changeset(schema, params) do
@@ -1199,5 +1201,17 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{posts: []}, :posts, required: true)
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
     assert Changeset.traverse_errors(changeset, &(&1)) == %{posts: [{"can't be blank", [validation: :required]}]}
+  end
+
+  ## traverse_validations
+
+  test "traverses changeset validations with has_one" do
+    changeset = cast(%Author{}, %{profile: %{}}, :profile)
+    assert Changeset.traverse_validations(changeset, &(&1)) == %{profile: %{name: [length: [min: 3]]}}
+  end
+
+  test "traverses changeset validations with has_many" do
+    changeset = cast(%Author{}, %{posts: [%{}]}, :posts)
+    assert Changeset.traverse_validations(changeset, &(&1)) == %{posts: [%{title: [length: [min: 3]]}]}
   end
 end


### PR DESCRIPTION
This allows for changeset validations to be traversed in the same way that errors are (reusing nearly all of the implementation of `traverse_errors`)

A potential use (and the reason I personally want it) is to easily expose the validations of a heavily-nested changeset to the web form that populates it, so the validations defined on the backend can be checked live on the client side as well.

Proposed in https://groups.google.com/g/elixir-ecto/c/yY9WP26ZJzc