### PR TITLE
Clearer error message when an embedded struct is expected.

### DIFF
--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -57,24 +57,24 @@ defmodule Ecto.Embedded do
   def load(nil, _fun, %{cardinality: :one}), do: {:ok, nil}
 
   def load(value, fun, %{cardinality: :one, related: schema, field: field}) when is_map(value) do
-    {:ok, load(field, schema, value, fun)}
+    {:ok, load_field(field, schema, value, fun)}
   end
 
   def load(nil, _fun, %{cardinality: :many}), do: {:ok, []}
 
   def load(value, fun, %{cardinality: :many, related: schema, field: field}) when is_list(value) do
-    {:ok, Enum.map(value, &load(field, schema, &1, fun))}
+    {:ok, Enum.map(value, &load_field(field, schema, &1, fun))}
   end
 
   def load(_value, _fun, _embed) do
     :error
   end
 
-  def load(_field, schema, value, loader) when is_map(value) do
+  def load_field(_field, schema, value, loader) when is_map(value) do
     Ecto.Schema.Loader.unsafe_load(schema, value, loader)
   end
 
-  def load(field, _schema, value, _fun) do
+  def load_field(field, _schema, value, _fun) do
     raise ArgumentError, "cannot load embed `#{field}`, expected a map but got: #{inspect value}"
   end
 
@@ -82,23 +82,23 @@ defmodule Ecto.Embedded do
   def dump(nil, _, _), do: {:ok, nil}
 
   def dump(value, fun, %{cardinality: :one, related: schema, field: field}) when is_map(value) do
-    {:ok, dump(field, schema, value, schema.__schema__(:dump), fun)}
+    {:ok, dump_field(field, schema, value, schema.__schema__(:dump), fun)}
   end
 
   def dump(value, fun, %{cardinality: :many, related: schema, field: field}) when is_list(value) do
     types = schema.__schema__(:dump)
-    {:ok, Enum.map(value, &dump(field, schema, &1, types, fun))}
+    {:ok, Enum.map(value, &dump_field(field, schema, &1, types, fun))}
   end
 
   def dump(_value, _fun, _embed) do
     :error
   end
 
-  def dump(_field, schema, %{__struct__: schema} = struct, types, dumper) do
+  def dump_field(_field, schema, %{__struct__: schema} = struct, types, dumper) do
     Ecto.Schema.Loader.safe_dump(struct, types, dumper)
   end
 
-  def dump(field, schema, value, _types, _dumper) do
+  def dump_field(field, schema, value, _types, _dumper) do
     raise ArgumentError,
           "cannot dump embed `#{field}`, " <>
             "expected a struct #{inspect schema} value but got: #{inspect value}"

--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -75,7 +75,7 @@ defmodule Ecto.Embedded do
   end
 
   def load(field, _schema, value, _fun) do
-    raise ArgumentError, "cannot load embed `#{field}`, invalid value: #{inspect value}"
+    raise ArgumentError, "cannot load embed `#{field}`, expected a map but got: #{inspect value}"
   end
 
   @impl Ecto.ParameterizedType
@@ -98,8 +98,10 @@ defmodule Ecto.Embedded do
     Ecto.Schema.Loader.safe_dump(struct, types, dumper)
   end
 
-  def dump(field, _schema, value, _types, _fun) do
-    raise ArgumentError, "cannot dump embed `#{field}`, invalid value: #{inspect value}"
+  def dump(field, schema, value, _types, _dumper) do
+    raise ArgumentError,
+          "cannot dump embed `#{field}`, " <>
+            "expected a struct #{inspect schema} value but got: #{inspect value}"
   end
 
   @impl Ecto.ParameterizedType

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -528,6 +528,18 @@ defmodule Ecto.RepoTest do
         TestRepo.insert_all MySchema, [%{another: nil}]
       end
     end
+
+    test "with an embedded struct" do
+      TestRepo.insert_all(MySchemaWithEmbed, [%{embeds: [%MyEmbed{x: "x"}]}])
+      assert_received {:insert_all, %{source: "my_schema"}, [row]}
+      assert [embeds: [%{id: nil, x: "x"}]] = row
+    end
+
+    test "raises when an embedded struct is needed" do
+      assert_raise ArgumentError, ~r"expected a struct #{inspect(MyEmbed)} value", fn ->
+        TestRepo.insert_all(MySchemaWithEmbed, [%{embeds: [%{x: "x"}]}])
+      end
+    end
   end
 
   defmodule MySchemaWithBinaryId do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -115,12 +115,21 @@ defmodule Ecto.RepoTest do
     end
   end
 
-  defmodule MySchemaWithEmbed do
+  defmodule MySchemaEmbedsMany do
     use Ecto.Schema
 
     schema "my_schema" do
       field :x, :string
       embeds_many :embeds, MyEmbed
+    end
+  end
+
+  defmodule MySchemaEmbedsOne do
+    use Ecto.Schema
+
+    schema "my_schema" do
+      field :x, :string
+      embeds_one :embed, MyEmbed
     end
   end
 
@@ -529,15 +538,25 @@ defmodule Ecto.RepoTest do
       end
     end
 
-    test "with an embedded struct" do
-      TestRepo.insert_all(MySchemaWithEmbed, [%{embeds: [%MyEmbed{x: "x"}]}])
+    test "with an embeds_one field" do
+      TestRepo.insert_all(MySchemaEmbedsOne, [%{embed: %MyEmbed{x: "x"}}])
+      assert_received {:insert_all, %{source: "my_schema"}, [row]}
+      assert [embed: %{id: nil, x: "x"}] = row
+    end
+
+    test "with an embeds_many field" do
+      TestRepo.insert_all(MySchemaEmbedsMany, [%{embeds: [%MyEmbed{x: "x"}]}])
       assert_received {:insert_all, %{source: "my_schema"}, [row]}
       assert [embeds: [%{id: nil, x: "x"}]] = row
     end
 
     test "raises when an embedded struct is needed" do
       assert_raise ArgumentError, ~r"expected a struct #{inspect(MyEmbed)} value", fn ->
-        TestRepo.insert_all(MySchemaWithEmbed, [%{embeds: [%{x: "x"}]}])
+        TestRepo.insert_all(MySchemaEmbedsOne, [%{embed: %{x: "x"}}])
+      end
+
+      assert_raise ArgumentError, ~r"expected a struct #{inspect(MyEmbed)} value", fn ->
+        TestRepo.insert_all(MySchemaEmbedsMany, [%{embeds: [%{x: "x"}]}])
       end
     end
   end
@@ -1266,11 +1285,11 @@ defmodule Ecto.RepoTest do
         end)
 
       changeset =
-        %MySchemaWithEmbed{id: 1}
+        %MySchemaEmbedsMany{id: 1}
         |> Ecto.Changeset.cast(%{x: "one"}, [:x])
         |> Ecto.Changeset.put_embed(:embeds, [embed_changeset])
 
-      %MySchemaWithEmbed{embeds: [embed]} = TestRepo.insert!(changeset)
+      %MySchemaEmbedsMany{embeds: [embed]} = TestRepo.insert!(changeset)
       assert embed.x == "ONE"
       assert_received {:transaction, _}
       assert Process.get(:ecto_repo) == TestRepo
@@ -1341,7 +1360,7 @@ defmodule Ecto.RepoTest do
 
     test "passes all fields+embeds on replace_all" do
       fields = [:id, :x, :embeds]
-      TestRepo.insert(%MySchemaWithEmbed{id: 1}, on_conflict: :replace_all)
+      TestRepo.insert(%MySchemaEmbedsMany{id: 1}, on_conflict: :replace_all)
       assert_received {:insert, %{source: "my_schema", on_conflict: {^fields, [], []}}}
     end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -555,7 +555,7 @@ defmodule Ecto.RepoTest do
         TestRepo.insert_all(MySchemaEmbedsOne, [%{embed: %{x: "x"}}])
       end
 
-      assert_raise ArgumentError, ~r"expected a struct #{inspect(MyEmbed)} value", fn ->
+      assert_raise ArgumentError, ~r"expected a list of #{inspect(MyEmbed)} struct values", fn ->
         TestRepo.insert_all(MySchemaEmbedsMany, [%{embeds: [%{x: "x"}]}])
       end
     end


### PR DESCRIPTION
I tripped over this issue a while ago and only found the solution in the Elixir forum. Just want to make sure others aren't puzzled by the error message. :)

I have two questions though:
* In the first test the returned row contains a plain map and not the embedded struct. Is this correct?
* It doesn't make sense to implicitly cast a map value to the embedded struct, or would it?