### PR TITLE
Fix changeset inspection not redacting when embedded

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -3046,7 +3046,12 @@ defimpl Inspect, for: Ecto.Changeset do
     end
 
     redacted_fields = case data do
-      %type{__meta__: _} -> type.__schema__(:redact_fields)
+      %type{} -> 
+        if function_exported?(type, :__schema__, 1) do
+          type.__schema__(:redact_fields)
+        else
+          []
+        end
       _ -> []
     end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1905,6 +1905,17 @@ defmodule Ecto.ChangesetTest do
     end
   end
 
+  defmodule RedactedEmbeddedSchema do
+    use Ecto.Schema
+
+    embedded_schema do
+      field :password, :string, redact: true
+      field :username, :string
+      field :display_name, :string, redact: false
+      field :virtual_pass, :string, redact: true, virtual: true
+    end
+  end
+
   describe "inspect" do
     test "reveals relevant data" do
       assert inspect(%Ecto.Changeset{}) ==
@@ -1924,6 +1935,10 @@ defmodule Ecto.ChangesetTest do
 
     test "redacts fields marked redact: true" do
       changeset = Ecto.Changeset.cast(%RedactedSchema{}, %{password: "hunter2"}, [:password])
+      refute inspect(changeset) =~ "hunter2"
+      assert inspect(changeset) =~ "**redacted**"
+
+      changeset = Ecto.Changeset.cast(%RedactedEmbeddedSchema{}, %{password: "hunter2"}, [:password])
       refute inspect(changeset) =~ "hunter2"
       assert inspect(changeset) =~ "**redacted**"
     end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -182,19 +182,28 @@ defmodule Ecto.SchemaTest do
 
     embedded_schema do
       field :name,  :string, default: "eric"
+      field :password, :string, redact: true
     end
   end
 
   test "embedded schema" do
     assert EmbeddedSchema.__schema__(:source)          == nil
     assert EmbeddedSchema.__schema__(:prefix)          == nil
-    assert EmbeddedSchema.__schema__(:fields)          == [:id, :name]
+    assert EmbeddedSchema.__schema__(:fields)          == [:id, :name, :password]
     assert EmbeddedSchema.__schema__(:primary_key)     == [:id]
     assert EmbeddedSchema.__schema__(:autogenerate_id) == {:id, :id, :binary_id}
   end
 
   test "embedded schema does not have metadata" do
     refute match?(%{__meta__: _}, %EmbeddedSchema{})
+  end
+
+  test "embedded redacted_fields" do
+    assert EmbeddedSchema.__schema__(:redact_fields) == [:password]
+  end
+
+  test "embedded derives inspect" do
+    refute inspect(%EmbeddedSchema{password: "hunter2"}) =~ "hunter2"
   end
 
   defmodule CustomEmbeddedSchema do


### PR DESCRIPTION
The protocol implementation was matching the `__meta__` key in the
struct. This key isn't available on embedded structs.

Closes #3674