### PR TITLE
Raise on duplicate values in Ecto.Enum

### DIFF
--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -116,6 +116,40 @@ defmodule Ecto.EnumTest do
         end
       end
     end
+
+    test "repeated values" do
+      message = ~r"Ecto.Enum type values must be unique"
+
+      assert_raise ArgumentError, message, fn ->
+        defmodule SchemaDuplicateEnumValues do
+          use Ecto.Schema
+
+          schema "duplicate_values" do
+            field :name, Ecto.Enum, values: [:foo, :foo]
+          end
+        end
+      end
+
+      assert_raise ArgumentError, message, fn ->
+        defmodule SchemaDuplicateEnumKeys do
+          use Ecto.Schema
+
+          schema "duplicate_values" do
+            field :name, Ecto.Enum, values: [foo: 1, foo: 2]
+          end
+        end
+      end
+
+      assert_raise ArgumentError, message, fn ->
+        defmodule SchemaDuplicateEnumMappings do
+          use Ecto.Schema
+
+          schema "duplicate_values" do
+            field :name, Ecto.Enum, values: [foo: 1, bar: 1]
+          end
+        end
+      end
+    end
   end
 
   describe "cast" do


### PR DESCRIPTION
Duplicate values make so that only the last of the duplicates is taken
into account, due to the fact that the keyword list is cast into a map
for the `on_load` and `on_dump` values. With this commit we can avoid
this scenario in compile time.

Pointed out by @wojtekmach on #3676