### PR TITLE
Remove unreachable case branch in reload

### DIFF
--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -105,12 +105,7 @@ defmodule Ecto.Repo.Queryable do
 
   def reload!(name, struct, opts) do
     query = query_for_reload([struct])
-    case one!(name, query, opts) do
-      nil ->
-        raise Ecto.NoResultsError, queryable: query
-      res ->
-        res
-    end
+    one!(name, query, opts)
   end
 
   def aggregate(name, queryable, aggregate, opts) do


### PR DESCRIPTION
I believe `one!` will make sure to raise on no result.