### PR TITLE
Accept binary representation of atom on Ecto.Enum.cast/3

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -93,8 +93,10 @@ defmodule Ecto.Enum do
       end
 
     on_load = Map.new(mappings, fn {key, val} -> {val, key} end)
-    on_dump = Enum.into(mappings, %{})
-    %{on_load: on_load, on_dump: on_dump, mappings: mappings, type: type}
+    on_dump = Map.new(mappings)
+    on_cast = Map.new(mappings, fn {key, _} -> {Atom.to_string(key), key} end)
+
+    %{on_load: on_load, on_dump: on_dump, on_cast: on_cast, mappings: mappings, type: type}
   end
 
   defp validate_unique!(values) do
@@ -130,6 +132,7 @@ defmodule Ecto.Enum do
     case params do
       %{on_load: %{^data => as_atom}} -> {:ok, as_atom}
       %{on_dump: %{^data => _}} -> {:ok, data}
+      %{on_cast: %{^data => as_atom}} -> {:ok, as_atom}
       _ -> :error
     end
   end

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -24,8 +24,9 @@ defmodule Ecto.EnumTest do
       assert EnumSchema.__schema__(:type, :my_enum) ==
                {:parameterized, Ecto.Enum,
                 %{
-                  on_load: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                   on_dump: %{bar: "bar", baz: "baz", foo: "foo"},
+                  on_load: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
+                  on_cast: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                   mappings: [foo: "foo", bar: "bar", baz: "baz"],
                   type: :string
                 }}
@@ -37,6 +38,7 @@ defmodule Ecto.EnumTest do
                   %{
                     on_dump: %{bar: "bar", baz: "baz", foo: "foo"},
                     on_load: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
+                    on_cast: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                     mappings: [foo: "foo", bar: "bar", baz: "baz"],
                     type: :string
                   }}
@@ -47,6 +49,7 @@ defmodule Ecto.EnumTest do
                 %{
                   on_dump: %{bar: 2, baz: 5, foo: 1},
                   on_load: %{2 => :bar, 5 => :baz, 1 => :foo},
+                  on_cast: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                   mappings: [foo: 1, bar: 2, baz: 5],
                   type: :integer
                 }}
@@ -58,6 +61,7 @@ defmodule Ecto.EnumTest do
                   %{
                     on_dump: %{bar: 2, baz: 5, foo: 1},
                     on_load: %{2 => :bar, 5 => :baz, 1 => :foo},
+                    on_cast: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                     mappings: [foo: 1, bar: 2, baz: 5],
                     type: :integer
                   }}
@@ -68,6 +72,7 @@ defmodule Ecto.EnumTest do
                 %{
                   on_dump: %{bar: "baar", baz: "baaz", foo: "fooo"},
                   on_load: %{"baar" => :bar, "baaz" => :baz, "fooo" => :foo},
+                  on_cast: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                   mappings: [foo: "fooo", bar: "baar", baz: "baaz"],
                   type: :string
                 }}
@@ -79,6 +84,7 @@ defmodule Ecto.EnumTest do
                   %{
                     on_dump: %{bar: "baar", baz: "baaz", foo: "fooo"},
                     on_load: %{"baar" => :bar, "baaz" => :baz, "fooo" => :foo},
+                    on_cast: %{"bar" => :bar, "baz" => :baz, "foo" => :foo},
                     mappings: [foo: "fooo", bar: "baar", baz: "baaz"],
                     type: :string
                   }}
@@ -196,6 +202,20 @@ defmodule Ecto.EnumTest do
 
       assert %Changeset{valid?: true, changes: %{my_enums: [:bar]}} =
                Changeset.cast(%EnumSchema{}, %{my_enums: [:bar]}, [:my_enums])
+    end
+
+    test "cast string representation of atoms" do
+      assert %Changeset{valid?: true, changes: %{my_string_enum: :foo}} =
+               Changeset.cast(%EnumSchema{}, %{my_string_enum: "foo"}, [:my_string_enum])
+
+      assert %Changeset{valid?: true, changes: %{my_string_enums: [:foo]}} =
+               Changeset.cast(%EnumSchema{}, %{my_string_enums: ["foo"]}, [:my_string_enums])
+
+      assert %Changeset{valid?: true, changes: %{my_integer_enum: :foo}} =
+               Changeset.cast(%EnumSchema{}, %{my_integer_enum: "foo"}, [:my_integer_enum])
+
+      assert %Changeset{valid?: true, changes: %{my_integer_enums: [:foo]}} =
+               Changeset.cast(%EnumSchema{}, %{my_integer_enums: ["foo"]}, [:my_integer_enums])
     end
 
     test "rejects bad strings" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -384,7 +384,7 @@ defmodule Ecto.Query.PlannerTest do
 
   test "plan: generates a cache key" do
     {_query, _params, key} = plan(from(Post, []))
-    assert key == [:all, {"posts", Post, 30078239, "my_prefix"}]
+    assert key == [:all, {"posts", Post, 69355382, "my_prefix"}]
 
     query =
       from(
@@ -405,7 +405,7 @@ defmodule Ecto.Query.PlannerTest do
                    {:prefix, "foo"},
                    {:where, [{:and, {:is_nil, [], [nil]}}, {:or, {:is_nil, [], [nil]}}]},
                    {:join, [{:inner, {"comments", Comment, 38292156, "world"}, true}]},
-                   {"posts", Post, 30078239, "hello"},
+                   {"posts", Post, 69355382, "hello"},
                    {:select, 1}]
   end
 


### PR DESCRIPTION
We currently rely on the database representation for casting. This means
that, if :foo translates to 1 in the database, we only accept 1  and
:foo as input when casting. This PR changes it so "foo" is also
accepted.

Closes #3691 