### PR TITLE
bugfix(Ecto.Changeset#validate_number/3): Raise an exception when we …

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2212,11 +2212,15 @@ defmodule Ecto.Changeset do
     end
   end
 
-  defp validate_number(field, value, message, spec_key, spec_function, target_value) do
+  defp validate_number(field, value, message, spec_key, spec_function, target_value) when is_number(value) do
     case apply(spec_function, [value, target_value]) do
       true  -> nil
       false -> [{field, {message, validation: :number, kind: spec_key, number: target_value}}]
     end
+  end
+
+  defp validate_number(_field, value, _message, _spec_key, _spec_function, _target_value) do
+    raise ArgumentError, "expected value to be of type Decimal, Integer or Float, got: #{inspect value}"
   end
 
   # TODO: Remove me once we support Decimal 2.0 only

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1259,6 +1259,7 @@ defmodule Ecto.ChangesetTest do
     changeset = changeset(%{"decimal" => Decimal.new("4.9")})
                 |> validate_number(:decimal, greater_than_or_equal_to: 4.9)
     assert changeset.valid?
+
     changeset = changeset(%{"decimal" => Decimal.new(5)})
                 |> validate_number(:decimal, less_than: 4)
     refute changeset.valid?
@@ -1267,6 +1268,12 @@ defmodule Ecto.ChangesetTest do
   test "validate_number/3 with bad options" do
     assert_raise ArgumentError, ~r"unknown option :min given to validate_number/3", fn  ->
       validate_number(changeset(%{"upvotes" => 1}), :upvotes, min: Decimal.new("1.5"))
+    end
+  end
+
+  test "validate_number/3 with bad value" do 
+    assert_raise ArgumentError, "expected value to be of type Decimal, Integer or Float, got: \"Oops\"", fn -> 
+      validate_number(changeset(%{"virtual" => "Oops"}), :virtual, greater_than: 0)
     end
   end
 


### PR DESCRIPTION
…try to validate against a value that is not a number.

Handles issue #3695 