### PR TITLE
Overridable get_dynamic_repo/0

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -247,6 +247,7 @@ defmodule Ecto.Repo do
       def get_dynamic_repo() do
         Process.get({__MODULE__, :dynamic_repo}, @default_dynamic_repo)
       end
+      defoverridable get_dynamic_repo: 0
 
       def put_dynamic_repo(dynamic) when is_atom(dynamic) or is_pid(dynamic) do
         Process.put({__MODULE__, :dynamic_repo}, dynamic) || @default_dynamic_repo
@@ -549,6 +550,15 @@ defmodule Ecto.Repo do
   Returns the atom name or pid of the current repository.
 
   See `c:put_dynamic_repo/1` for more information.
+
+  This is overridable in case you want to hand off dynamic repo
+  management to another library. For example:
+
+      def get_dynamic_repo do
+        MyMultiTenancyLibrary.get_current_tenant()
+        |> tenant_to_dynamic_repo()
+      end
+
   """
   @callback get_dynamic_repo() :: atom() | pid()
 


### PR DESCRIPTION
Dynamic repos don't work well with libraries that take a repo and make queries on your behalf in async tasks, which is the case with Absinthe and Dataloader.

I think the easiest workaround is to make `get_dynamic_repo/0` overridable and let the user figure out how to track the current repo across child processes. Here's an example implementation that works with `put_dynamic_repo/1`:

```elixir
def get_dynamic_repo do
  [self() | Process.get(:"$callers", [])]
  |> Enum.find_value(fn pid ->
    {:dictionary, dictionary} = Process.info(pid, :dictionary)
    Enum.find_value(dictionary, fn
      {{__MODULE__, :dynamic_repo}, repo} -> repo
      _ -> nil
    end)
  end)
  |> case do
    nil -> super()
    repo -> repo
  end
end
```

But one could also just completely hand off dynamic repo management to an external multi tenancy library (which is my team's use case):
```elixir
def get_dynamic_repo do
  MyMultiTenancyLibrary.get_current_tenant()
  |> tenant_to_dynamic_repo()
end
```

Then you don't have to worry about the implementation of `put_dynamic_repo/1`.

Thanks!