### PR TITLE
Add note about index usage when using JSON access API

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -571,6 +571,15 @@ defmodule Ecto.Query.API do
   may return incorrect results or fail as the underlying database
   tries to compare incompatible types. You can, however, use `type/2`
   to force the types on the database level.
+
+  ## Warning: index usage
+
+  Some DBs offer indices types that allow faster querying of the JSON
+  fields, however this way of extracting **may not** create query that
+  will be able to utilise such index. Notable example of such behaviour
+  is PostgreSQL with GIN indices on JSON fields. This function will use
+  access operator (`#>`) that is not covered by the GIN index. For better
+  performance user is forced to use other operators via `fragment/1`.
   """
   def json_extract_path(json_field, path), do: doc! [json_field, path]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -578,8 +578,9 @@ defmodule Ecto.Query.API do
   fields, however this way of extracting **may not** create query that
   will be able to utilise such index. Notable example of such behaviour
   is PostgreSQL with GIN indices on JSON fields. This function will use
-  access operator (`#>`) that is not covered by the GIN index. For better
-  performance user is forced to use other operators via `fragment/1`.
+  access operator (`#>`) that is not covered by the GIN index. In such cases,
+  consider using `fragment/1` alongside PostgreSQL built-in operators for
+  better performance.
   """
   def json_extract_path(json_field, path), do: doc! [json_field, path]
 


### PR DESCRIPTION
Index may not always be used when querying the JSON fields using Ecto idiomatic queries. It is quite important to let users know about it to not induce performance degradation in ill-written queries.

Close elixir-ecto/ecto_sql#330