### PR TITLE
Add stale struct in Ecto.StaleEntryError fields

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -258,13 +258,12 @@ defmodule Ecto.StaleEntryError do
 
   def exception(opts) do
     action = Keyword.fetch!(opts, :action)
-    struct = Keyword.fetch!(opts, :struct)
     changeset = Keyword.fetch!(opts, :changeset)
 
     msg = """
     attempted to #{action} a stale struct:
 
-    #{inspect struct}
+    #{inspect changeset.data}
     """
 
     %__MODULE__{message: msg, changeset: changeset}

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -254,11 +254,12 @@ defmodule Ecto.MigrationError do
 end
 
 defmodule Ecto.StaleEntryError do
-  defexception [:message, :struct]
+  defexception [:message, :changeset]
 
   def exception(opts) do
     action = Keyword.fetch!(opts, :action)
     struct = Keyword.fetch!(opts, :struct)
+    changeset = Keyword.fetch!(opts, :changeset)
 
     msg = """
     attempted to #{action} a stale struct:
@@ -266,7 +267,7 @@ defmodule Ecto.StaleEntryError do
     #{inspect struct}
     """
 
-    %__MODULE__{message: msg, struct: struct}
+    %__MODULE__{message: msg, changeset: changeset}
   end
 end
 

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -254,7 +254,7 @@ defmodule Ecto.MigrationError do
 end
 
 defmodule Ecto.StaleEntryError do
-  defexception [:message]
+  defexception [:message, :struct]
 
   def exception(opts) do
     action = Keyword.fetch!(opts, :action)
@@ -266,7 +266,7 @@ defmodule Ecto.StaleEntryError do
     #{inspect struct}
     """
 
-    %__MODULE__{message: msg}
+    %__MODULE__{message: msg, struct: struct}
   end
 end
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -756,7 +756,7 @@ defmodule Ecto.Repo.Schema do
             {:error, user_changeset}
 
           _other ->
-            raise Ecto.StaleEntryError, struct: user_changeset.data, changeset: user_changeset, action: action
+            raise Ecto.StaleEntryError, changeset: user_changeset, action: action
         end
     end
   end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -756,7 +756,7 @@ defmodule Ecto.Repo.Schema do
             {:error, user_changeset}
 
           _other ->
-            raise Ecto.StaleEntryError, struct: user_changeset.data, action: action
+            raise Ecto.StaleEntryError, struct: user_changeset.data, changeset: user_changeset, action: action
         end
     end
   end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -751,6 +751,13 @@ defmodule Ecto.RepoTest do
       assert_raise Ecto.StaleEntryError, fn -> TestRepo.insert(stale) end
       assert_raise Ecto.StaleEntryError, fn -> TestRepo.update(stale) end
       assert_raise Ecto.StaleEntryError, fn -> TestRepo.delete(stale) end
+
+      try do
+        TestRepo.update(stale)
+      rescue
+        e in Ecto.StaleEntryError ->
+          assert %Ecto.Changeset{} = e.changeset
+      end
     end
 
     test "insert, update, and delete adds error to stale error field" do


### PR DESCRIPTION
If a stale entry error is raised, it is not possible to know which struct/schema is stale if you're working with associations.

Use case: say I want to update an appointment with its guests, if I get a stale entry, I would like to display an error message such as "The appointment no longer exists." or "A guest cannot be found" according to which struct is stale, as an example.

Note that I'm a little surprised about how stale entries are handled by default (https://groups.google.com/g/elixir-ecto/c/hdBMC0g8WgE), i.e. throwing errors while stale entries in a concurrent environment are mostly not errors, and maybe I am doing something wrong, so review carefully this PR. However it seems like a basic need for me to know which struct is stale in order to handle the error correctly for the user (appropriate error message).