### PR TITLE
initial stab at creating dynamic aliases

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -594,10 +594,15 @@ defmodule Ecto.Query.Builder do
     {:{}, [], [dot, [], []]}
   end
 
-  defp escape_field!({kind, _, [atom]}, field, _vars)
+  defp escape_field!({kind, _, [value]}, field, _vars)
        when kind in [:as, :parent_as] do
-    atom  = quoted_atom!(atom, "#{kind}/1")
-    as    = {:{}, [], [kind, [], [atom]]}
+    value =
+      case value do
+        {:^, _, [value]} ->
+          value
+        other -> other
+      end
+    as    = {:{}, [], [kind, [], [value]]}
     field = quoted_atom!(field, "field/2")
     dot   = {:{}, [], [:., [], [as, field]]}
     {:{}, [], [dot, [], []]}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -600,7 +600,9 @@ defmodule Ecto.Query.Builder do
       case value do
         {:^, _, [value]} ->
           value
-        other -> other
+
+        other ->
+          quoted_atom!(other, "#{kind}/1")
       end
     as    = {:{}, [], [kind, [], [value]]}
     field = quoted_atom!(field, "field/2")

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -66,6 +66,12 @@ defmodule Ecto.Query.Builder.From do
       {:ok, prefix} when is_binary(prefix) or is_nil(prefix) -> :ok
       _ -> Builder.error!("`prefix` must be a compile time string, got: `#{Macro.to_string(prefix)}`")
     end
+    
+    as = case as do
+      {:^, _, [as]} -> as
+      as when is_atom(as) -> as
+      as -> Builder.error!("`as` must be an atom or a variable using ^, got: #{Macro.to_string(as)}")
+    end
 
     {query, binds} = escape(query, env)
 

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -61,10 +61,6 @@ defmodule Ecto.Query.Builder.From do
       )
     end
 
-    unless is_atom(as) do
-      Builder.error!("`as` must be a compile time atom, got: `#{Macro.to_string(as)}`")
-    end
-
     case prefix do
       nil -> :ok
       {:ok, prefix} when is_binary(prefix) or is_nil(prefix) -> :ok

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -70,7 +70,7 @@ defmodule Ecto.Query.Builder.From do
     as = case as do
       {:^, _, [as]} -> as
       as when is_atom(as) -> as
-      as -> Builder.error!("`as` must be an atom or a variable using ^, got: #{Macro.to_string(as)}")
+      as -> Builder.error!("`as` must be a compile time atom or an interpolated value using ^, got: #{Macro.to_string(as)}")
     end
 
     {query, binds} = escape(query, env)

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -133,10 +133,6 @@ defmodule Ecto.Query.Builder.Join do
       )
     end
 
-    unless is_atom(as) do
-      Builder.error! "`as` must be a compile time atom, got: `#{Macro.to_string(as)}`"
-    end
-
     unless is_binary(prefix) or is_nil(prefix) do
       Builder.error! "`prefix` must be a compile time string, got: `#{Macro.to_string(prefix)}`"
     end

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -247,7 +247,7 @@ defmodule Ecto.Query.Builder.Join do
   """
   def runtime_aliases(aliases, nil, _), do: aliases
 
-  def runtime_aliases(aliases, name, join_count) when is_atom(name) and is_integer(join_count) do
+  def runtime_aliases(aliases, name, join_count) when is_integer(join_count) do
     if Map.has_key?(aliases, name) do
       Builder.error! "alias `#{inspect name}` already exists"
     else

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -137,13 +137,6 @@ defmodule Ecto.Query.Builder.JoinTest do
     end
   end
 
-  test "allows non-atom as" do
-    escape(quote do
-      as = "comments"
-      join("posts", :left, [p], c in "comments", on: true, as: ^as)
-    end, [], __ENV__)
-  end
-
   test "raises on non-string prefix" do
     assert_raise Ecto.Query.CompileError, ~r/`prefix` must be a compile time string/, fn ->
       escape(quote do

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -137,18 +137,11 @@ defmodule Ecto.Query.Builder.JoinTest do
     end
   end
 
-  test "raises on non-atom as" do
-    assert_raise Ecto.Query.CompileError, ~r/`as` must be a compile time atom/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, as: "string")
-      end, [], __ENV__)
-    end
-
-    assert_raise Ecto.Query.CompileError, ~r/`as` must be a compile time atom/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, as: atom)
-      end, [], __ENV__)
-    end
+  test "allows non-atom as" do
+    escape(quote do
+      as = "comments"
+      join("posts", :left, [p], c in "comments", on: true, as: ^as)
+    end, [], __ENV__)
   end
 
   test "raises on non-string prefix" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -851,19 +851,19 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "normalize: creating dynamic bindings with as" do
-    as = [:posts]
+    as = {:posts}
 
-    query = from(Post, as: as, where: as(^as).code == ^123) |> normalize()
+    query = from(Post, as: ^as, where: as(^as).code == ^123) |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
 
-    query = from(Post, as: as, where: field(as(^as), :code) == ^123) |> normalize()
+    query = from(Post, as: ^as, where: field(as(^as), :code) == ^123) |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
 
-    assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\[:posts\]\)`/, fn ->
+    assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\{:posts\}\)`/, fn ->
       from(Post, where: as(^as).code == ^123) |> normalize()
     end
 
-    query = from(Post, as: as, where: as(^as).code == ^123) |> normalize()
+    query = from(Post, as: ^as, where: as(^as).code == ^123) |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
   end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -855,6 +855,20 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
+  test "normalize: creating dynamic bindings with as" do
+    as = [:posts]
+
+    query = from(Post, as: as, where: as(^as).code == ^123) |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+
+    query = from(Post, as: as, where: field(as(^as), :code) == ^123) |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+
+    assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\[:posts\]\)`/, fn ->
+      from(Post, where: as(^as).code == ^123) |> normalize()
+    end
+  end
+
   test "normalize: late parent bindings with as" do
     child = from(c in Comment, where: parent_as(:posts).posted == c.posted)
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -848,11 +848,6 @@ defmodule Ecto.Query.PlannerTest do
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(:posts\)`/, fn ->
       from(Post, where: as(^as).code == ^123) |> normalize()
     end
-
-    assert_raise Ecto.Query.CompileError, ~r/expected atom in as\/1/, fn ->
-      as = "posts"
-      from(Post, where: as(^as).code == ^123) |> normalize()
-    end
   end
 
   test "normalize: creating dynamic bindings with as" do
@@ -867,6 +862,9 @@ defmodule Ecto.Query.PlannerTest do
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\[:posts\]\)`/, fn ->
       from(Post, where: as(^as).code == ^123) |> normalize()
     end
+
+    query = from(Post, as: as, where: as(^as).code == ^123) |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
   end
 
   test "normalize: late parent bindings with as" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -335,9 +335,10 @@ defmodule Ecto.QueryTest do
     end
 
     test "assign to source fails when non-atom name passed" do
-      query = from(p in "posts", as: "post")
-
-      assert %{aliases: %{"post" => 0}} = query
+      message = ~r/`as` must be a compile time atom or an interpolated value using \^, got: "post"/
+      assert_raise Ecto.Query.CompileError, message, fn -> 
+        quote_and_eval(from(p in "posts", as: "post"))
+      end
     end
 
     test "is not type checked but emits typed params" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -335,10 +335,9 @@ defmodule Ecto.QueryTest do
     end
 
     test "assign to source fails when non-atom name passed" do
-      message = ~r"`as` must be a compile time atom, got: `\"post\"`"
-      assert_raise Ecto.Query.CompileError, message, fn ->
-        quote_and_eval(from(p in "posts", as: "post"))
-      end
+      query = from(p in "posts", as: "post")
+
+      assert %{aliases: %{"post" => 0}} = query
     end
 
     test "is not type checked but emits typed params" do
@@ -824,74 +823,74 @@ defmodule Ecto.QueryTest do
     test "can be used to merge two dynamics" do
       left = dynamic([posts], posts.is_public == true)
       right = dynamic([posts], posts.is_draft == false)
-      
-      assert inspect(dynamic(^left and ^right)) == 
+
+      assert inspect(dynamic(^left and ^right)) ==
         inspect(dynamic([posts], posts.is_public == true and posts.is_draft == false))
-      
-      assert inspect(dynamic(^left or ^right)) == 
+
+      assert inspect(dynamic(^left or ^right)) ==
         inspect(dynamic([posts], posts.is_public == true or posts.is_draft == false))
     end
-      
+
     test "can be used to merge dynamics with subquery" do
-      subquery = 
-        from c in "comments", 
-          where: c.commented_by == ^Ecto.UUID.generate(), 
+      subquery =
+        from c in "comments",
+          where: c.commented_by == ^Ecto.UUID.generate(),
           select: c.post_id
-      
+
       dynamic = dynamic([posts], posts.is_public == true)
       dynamic_with_subquery = dynamic([posts], posts.id in subquery(subquery))
-      
-      assert inspect(dynamic(^dynamic and ^dynamic_with_subquery)) == 
+
+      assert inspect(dynamic(^dynamic and ^dynamic_with_subquery)) ==
         inspect(dynamic([posts], posts.is_public == true and posts.id in subquery(subquery)))
-      
-      assert inspect(dynamic(^dynamic_with_subquery or ^dynamic)) == 
+
+      assert inspect(dynamic(^dynamic_with_subquery or ^dynamic)) ==
         inspect(dynamic([posts], posts.id in subquery(subquery) or posts.is_public == true))
     end
-    
+
     test "can be used to merge two dynamics with named bindings" do
       left = dynamic([post: post], post.is_public == true)
       right = dynamic([post: post], post.is_draft == false)
-      
+
       query = from p in "post", as: :post
-      
+
       assert inspect(where(query, ^dynamic(^left and ^right))) ==
         inspect(where(query, [post: post], post.is_public == true and post.is_draft == false))
     end
-    
+
     test "can be used to merge two dynamics with subquery that reuse named binding" do
-      subquery = 
-        from c in "comments", 
-          where: c.commented_by == ^Ecto.UUID.generate(), 
+      subquery =
+        from c in "comments",
+          where: c.commented_by == ^Ecto.UUID.generate(),
           select: c.post_id
 
       dynamic = dynamic([post: post], post.is_public == ^true)
       dynamic_with_subquery = dynamic([post: post], post.id in subquery(subquery))
       dynamic_not_in = dynamic([post: post], post.foo not in ^[1, 2, 3])
-      
+
       query = from p in "post", as: :post
-      
+
       assert inspect(where(query, ^dynamic(^dynamic and ^dynamic_with_subquery))) ==
         inspect(where(query, [post: post], post.is_public == ^true and post.id in subquery(subquery)))
-      
+
       assert inspect(where(query, ^dynamic(^dynamic_with_subquery or ^dynamic))) ==
         inspect(where(query, [post: post], post.id in subquery(subquery) or post.is_public == ^true))
-      
+
       assert inspect(where(query, ^dynamic(^dynamic_with_subquery and ^dynamic and ^dynamic_not_in))) ==
         inspect(where(query, [post: post], post.id in subquery(subquery) and post.is_public == ^true and post.foo not in ^[1, 2, 3]))
     end
-    
+
     test "merges with precedence" do
       left = dynamic([posts], posts.is_public == true)
       right = dynamic([posts], posts.is_draft == false)
-      
-      assert inspect(dynamic(^left or ^left and ^right)) == 
+
+      assert inspect(dynamic(^left or ^left and ^right)) ==
         inspect(dynamic([posts], posts.is_public == true or (posts.is_public == true and posts.is_draft == false)))
-      
-      assert inspect(dynamic(^left and ^left or ^right)) == 
+
+      assert inspect(dynamic(^left and ^left or ^right)) ==
         inspect(dynamic([posts], (posts.is_public == true and posts.is_public == true) or posts.is_draft == false))
     end
   end
-  
+
   describe "fragment/1" do
     test "raises at runtime when interpolation is not a keyword list" do
       assert_raise ArgumentError, ~r/fragment\(...\) does not allow strings to be interpolated/s, fn ->


### PR DESCRIPTION
I did some exploration on what would be required for this, and this is what I have so far. When I try to apply this in practice, I'm getting an error in ecto_sql on the following query (not a real query I used, just a sample to test the functionality):

```elixir
from post in "posts", 
  as: [:post], 
  select: post.title, 
  inner_lateral_join: comment in subquery(
    from comment in "comments", 
    where: comment.post_id == parent_as([:post]).id) 

** (RuntimeError) {:&, [], [0]} not found in parent sources: %{[:post] => 0}
```

I added the error message you see there as a fallback clause to this function:
https://github.com/elixir-ecto/ecto_sql/blob/e5663b8ce28717a68ff073bd645570a57075a314/lib/ecto/adapters/myxql/connection.ex#L1005

I don't fully understand the reason that its getting translated to `{:&, [], [0]}` here: https://github.com/elixir-ecto/ecto/commit/ce90e4eb1#diff-c4841538fead8249c07e55c917f52f1dd7bc64229e86ea281a81a22234c1313fR1615, but that seems to have something to do with it? I've confirmed that I don't get that error message using the master branches of ecto and ecto_sql, so it must have something to do with the contents of this PR as well.


For some more context, see the initial discussion: https://groups.google.com/g/elixir-ecto/c/yJrs2LHCFfA/m/gppCqkWkBQAJ?utm_medium=email&utm_source=footer
