### PR TITLE
Repo.aggregate: wrap query into a subquery if it has combinations

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -750,7 +750,7 @@ defmodule Ecto.Repo do
   @doc """
   Calculate the given `aggregate`.
 
-  If the query has a limit, offset or distinct set, it will be
+  If the query has a limit, offset, distinct or combination set, it will be
   automatically wrapped in a subquery in order to return the
   proper result.
 

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -473,7 +473,7 @@ defmodule Ecto.Repo.Queryable do
   defp query_for_aggregate(queryable, aggregate) do
     query =
       case prepare_for_aggregate(queryable) do
-        %{distinct: nil, limit: nil, offset: nil} = query ->
+        %{distinct: nil, limit: nil, offset: nil, combinations: []} = query ->
           %{query | order_bys: []}
 
         query ->
@@ -491,7 +491,7 @@ defmodule Ecto.Repo.Queryable do
 
     query =
       case prepare_for_aggregate(queryable) do
-        %{distinct: nil, limit: nil, offset: nil} = query ->
+        %{distinct: nil, limit: nil, offset: nil, combinations: []} = query ->
           %{query | order_bys: []}
 
         query ->


### PR DESCRIPTION
### Environment

* Elixir version (elixir -v): 1.12.2
* Database and version (PostgreSQL 9.4, MongoDB 3.2, etc.): 13.3
* Ecto version (mix deps): master
* Database adapter and version (mix deps): postgrex 0.15.10
* Operating system: mac

### Current behavior

`Repo.aggregate/3` may throw an exception if query has combinations.

```elixir
  supplier_query = Supplier |> select([s], s.city)
  query = Customer |> select([c], c.city) |> union(^supplier_query)

  Repo.aggregate(query, :count, :city)

  # The query will be something like 
  # Ecto.Query<from c in Customer, union: (from s in Supplier, select: s.city), select: count(c.city)>
```

The code above will count the Customer first , then union the count with citys in `supplier_query`, not count the union result.

### Expected behavior

Aggregate the union result. 

I wrap the query into a subquery if it has combinations .

