### PR TITLE
fix: Consistent definition of `schema_or_source`

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -123,7 +123,7 @@ defmodule Ecto.Multi do
   @type run :: ((Ecto.Repo.t, changes) -> {:ok | :error, any}) | {module, atom, [any]}
   @type fun(result) :: (changes -> result)
   @type merge :: (changes -> t) | {module, atom, [any]}
-  @typep schema_or_source :: binary | {binary | nil, binary} | atom
+  @typep schema_or_source :: binary | {binary, module} | module
   @typep operation :: {:changeset, Changeset.t, Keyword.t} |
                       {:run, run} |
                       {:put, any} |


### PR DESCRIPTION
`Ecto.Multi` was using an inconsistent definition of `schema_or_source` from `c:Ecto.Repo.insert_all/3`.

https://github.com/elixir-ecto/ecto/blob/cc75abde90dbeea29e51611f530e2de768d48c69/lib/ecto/repo.ex#L1307

This PR would fix that inconsistency.