### PR TITLE
Update docs for Ecto.Enum module

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -37,7 +37,7 @@ defmodule Ecto.Enum do
   by an atom in the list will be invalid.
 
   The helper function `mappings/2` returns the mappings for a given schema and
-  field, which can be used in places like form drop-downs. For example, given 
+  field, which can be used in places like form drop-downs. For example, given
   the following schema:
 
       defmodule EnumSchema do
@@ -50,7 +50,7 @@ defmodule Ecto.Enum do
 
   you can call `mappings/2` like this:
 
-      Ecto.Enum.values(EnumSchema, :my_enum)
+      Ecto.Enum.mappings(EnumSchema, :my_enum)
       #=> [foo: "foo", bar: "bar", baz: "baz"]
 
   If you want the values only, you can use `Ecto.Enum.values/2`, and if you want
@@ -185,7 +185,8 @@ defmodule Ecto.Enum do
     try do
       schema.__changeset__()
     rescue
-      _ in UndefinedFunctionError -> raise ArgumentError, "#{inspect schema} is not an Ecto schema"
+      _ in UndefinedFunctionError ->
+        raise ArgumentError, "#{inspect(schema)} is not an Ecto schema"
     else
       %{^field => {:parameterized, Ecto.Enum, %{mappings: mappings}}} -> mappings
       %{^field => {_, {:parameterized, Ecto.Enum, %{mappings: mappings}}}} -> mappings


### PR DESCRIPTION
## What?
Updates docs for `Ecto.Enum` module

## Why?
In the recent release, `mappings/2` and `dump_values/2` were introduced as well as the return type of `values/2` was changed from `Keyword.t` to `[atom()]` (**which is breaking change**) . The PR corrects an example of mappings function inside docs of the module.
