### PR TITLE
Apply formatting and add a check to GitHub CI

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -30,6 +30,7 @@ lint:
     RUN mix deps.get
     RUN mix deps.unlock --check-unused
     RUN mix compile --warnings-as-errors
+    RUN mix format mix.exs "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}" --check-formatted
 
 
 all-integration-test:

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -396,11 +396,11 @@ defmodule Ecto do
   @doc """
   Returns the schema primary keys as a keyword list.
   """
-  @spec primary_key(Ecto.Schema.t) :: Keyword.t
+  @spec primary_key(Ecto.Schema.t()) :: Keyword.t()
   def primary_key(%{__struct__: schema} = struct) do
-    Enum.map schema.__schema__(:primary_key), fn(field) ->
+    Enum.map(schema.__schema__(:primary_key), fn field ->
       {field, Map.fetch!(struct, field)}
-    end
+    end)
   end
 
   @doc """
@@ -409,7 +409,7 @@ defmodule Ecto do
   Raises `Ecto.NoPrimaryKeyFieldError` if the schema has no
   primary key field.
   """
-  @spec primary_key!(Ecto.Schema.t) :: Keyword.t
+  @spec primary_key!(Ecto.Schema.t()) :: Keyword.t()
   def primary_key!(%{__struct__: schema} = struct) do
     case primary_key(struct) do
       [] -> raise Ecto.NoPrimaryKeyFieldError, schema: schema
@@ -469,7 +469,7 @@ defmodule Ecto do
   end
 
   defp drop_meta(%{} = attrs), do: Map.drop(attrs, [:__struct__, :__meta__])
-  defp drop_meta([_|_] = attrs), do: Keyword.drop(attrs, [:__struct__, :__meta__])
+  defp drop_meta([_ | _] = attrs), do: Keyword.drop(attrs, [:__struct__, :__meta__])
 
   @doc """
   Builds a query for the association in the given struct or structs.
@@ -510,10 +510,14 @@ defmodule Ecto do
     refl = %{owner_key: owner_key} = Ecto.Association.association_from_schema!(schema, assoc)
 
     values =
-      Enum.uniq for(struct <- structs,
-        assert_struct!(schema, struct),
-        key = Map.fetch!(struct, owner_key),
-        do: key)
+      Enum.uniq(
+        for(
+          struct <- structs,
+          assert_struct!(schema, struct),
+          key = Map.fetch!(struct, owner_key),
+          do: key
+        )
+      )
 
     case assocs do
       [] ->
@@ -548,10 +552,13 @@ defmodule Ecto do
   """
   def get_meta(struct, :context),
     do: struct.__meta__.context
+
   def get_meta(struct, :state),
     do: struct.__meta__.state
+
   def get_meta(struct, :source),
     do: struct.__meta__.source
+
   def get_meta(struct, :prefix),
     do: struct.__meta__.prefix
 
@@ -567,9 +574,13 @@ defmodule Ecto do
 
   Please refer to the `Ecto.Schema.Metadata` module for more information.
   """
-  @spec put_meta(Ecto.Schema.schema, meta) :: Ecto.Schema.schema
-        when meta: [source: Ecto.Schema.source, prefix: Ecto.Schema.prefix,
-                    context: Ecto.Schema.Metadata.context, state: Ecto.Schema.Metadata.state]
+  @spec put_meta(Ecto.Schema.schema(), meta) :: Ecto.Schema.schema()
+        when meta: [
+               source: Ecto.Schema.source(),
+               prefix: Ecto.Schema.prefix(),
+               context: Ecto.Schema.Metadata.context(),
+               state: Ecto.Schema.Metadata.state()
+             ]
   def put_meta(%{__meta__: meta} = struct, opts) do
     case put_or_noop_meta(opts, meta, false) do
       :noop -> struct
@@ -577,7 +588,7 @@ defmodule Ecto do
     end
   end
 
-  defp put_or_noop_meta([{key, value}|t], meta, updated?) do
+  defp put_or_noop_meta([{key, value} | t], meta, updated?) do
     case meta do
       %{^key => ^value} -> put_or_noop_meta(t, meta, updated?)
       _ -> put_or_noop_meta(t, put_meta(meta, key, value), true)
@@ -591,7 +602,7 @@ defmodule Ecto do
     if state in [:built, :loaded, :deleted] do
       %{meta | state: state}
     else
-      raise ArgumentError, "invalid state #{inspect state}"
+      raise ArgumentError, "invalid state #{inspect(state)}"
     end
   end
 
@@ -608,13 +619,14 @@ defmodule Ecto do
   end
 
   defp put_meta(_meta, key, _value) do
-    raise ArgumentError, "unknown meta key #{inspect key}"
+    raise ArgumentError, "unknown meta key #{inspect(key)}"
   end
 
   defp assert_struct!(module, %{__struct__: struct}) do
     if struct != module do
-      raise ArgumentError, "expected a homogeneous list containing the same struct, " <>
-                           "got: #{inspect module} and #{inspect struct}"
+      raise ArgumentError,
+            "expected a homogeneous list containing the same struct, " <>
+              "got: #{inspect(module)} and #{inspect(struct)}"
     else
       true
     end
@@ -647,12 +659,16 @@ defmodule Ecto do
       [%Setting{...}, ...]
   """
   @spec embedded_load(
-              module_or_map :: module | map(),
-              data :: map(),
-              format :: atom()
-            ) :: Ecto.Schema.t() | map()
+          module_or_map :: module | map(),
+          data :: map(),
+          format :: atom()
+        ) :: Ecto.Schema.t() | map()
   def embedded_load(schema_or_types, data, format) do
-    Ecto.Schema.Loader.unsafe_load(schema_or_types, data, &Ecto.Type.embedded_load(&1, &2, format))
+    Ecto.Schema.Loader.unsafe_load(
+      schema_or_types,
+      data,
+      &Ecto.Type.embedded_load(&1, &2, format)
+    )
   end
 
   @doc """
@@ -667,6 +683,10 @@ defmodule Ecto do
   """
   @spec embedded_dump(Ecto.Schema.t(), format :: atom()) :: map()
   def embedded_dump(%schema{} = data, format) do
-    Ecto.Schema.Loader.safe_dump(data, schema.__schema__(:dump), &Ecto.Type.embedded_dump(&1, &2, format))
+    Ecto.Schema.Loader.safe_dump(
+      data,
+      schema.__schema__(:dump),
+      &Ecto.Type.embedded_dump(&1, &2, format)
+    )
   end
 end

--- a/lib/ecto/adapter.ex
+++ b/lib/ecto/adapter.ex
@@ -25,7 +25,10 @@ defmodule Ecto.Adapter do
   @doc """
   Ensure all applications necessary to run the adapter are started.
   """
-  @callback ensure_all_started(config :: Keyword.t(), type :: :permanent | :transient | :temporary) ::
+  @callback ensure_all_started(
+              config :: Keyword.t(),
+              type :: :permanent | :transient | :temporary
+            ) ::
               {:ok, [atom]} | {:error, atom}
 
   @doc """
@@ -58,7 +61,8 @@ defmodule Ecto.Adapter do
   connection is then used in the other callbacks implementations, such as
   `Ecto.Adapter.Queryable` and `Ecto.Adapter.Schema`.
   """
-  @callback checkout(adapter_meta, config :: Keyword.t(), (() -> result)) :: result when result: var
+  @callback checkout(adapter_meta, config :: Keyword.t(), (() -> result)) :: result
+            when result: var
 
   @doc """
   Returns true if a connection has been checked out.

--- a/lib/ecto/adapter/queryable.ex
+++ b/lib/ecto/adapter/queryable.ex
@@ -37,9 +37,11 @@ defmodule Ecto.Adapter.Queryable do
   is called, the next time the same query is given to
   `c:execute/5`, it will receive the `:cache` tuple.
   """
-  @type query_cache :: {:nocache, prepared}
-                       | {:cache, cache_function :: (cached -> :ok), prepared}
-                       | {:cached, update_function :: (cached -> :ok), reset_function :: (prepared -> :ok), cached}
+  @type query_cache ::
+          {:nocache, prepared}
+          | {:cache, cache_function :: (cached -> :ok), prepared}
+          | {:cached, update_function :: (cached -> :ok), reset_function :: (prepared -> :ok),
+             cached}
 
   @type prepared :: term
   @type cached :: term
@@ -93,7 +95,7 @@ defmodule Ecto.Adapter.Queryable do
   It returns a stream of values.
   """
   @callback stream(adapter_meta, query_meta, query_cache, params :: list(), options) ::
-              Enumerable.t
+              Enumerable.t()
 
   @doc """
   Plans and prepares a query for the given repo, leveraging its query cache.

--- a/lib/ecto/adapter/storage.ex
+++ b/lib/ecto/adapter/storage.ex
@@ -18,7 +18,7 @@ defmodule Ecto.Adapter.Storage do
                  hostname: "localhost")
 
   """
-  @callback storage_up(options :: Keyword.t) :: :ok | {:error, :already_up} | {:error, term}
+  @callback storage_up(options :: Keyword.t()) :: :ok | {:error, :already_up} | {:error, term}
 
   @doc """
   Drops the storage given by options.
@@ -35,8 +35,8 @@ defmodule Ecto.Adapter.Storage do
                    hostname: "localhost")
 
   """
-  @callback storage_down(options :: Keyword.t) :: :ok | {:error, :already_down} | {:error, term}
-  
+  @callback storage_down(options :: Keyword.t()) :: :ok | {:error, :already_down} | {:error, term}
+
   @doc """
   Returns the status of a storage given by options.
 

--- a/lib/ecto/application.ex
+++ b/lib/ecto/application.ex
@@ -4,7 +4,7 @@ defmodule Ecto.Application do
 
   def start(_type, _args) do
     children = [
-      Ecto.Repo.Registry,
+      Ecto.Repo.Registry
     ]
 
     opts = [strategy: :one_for_one, name: Ecto.Supervisor]

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -12,16 +12,16 @@ defmodule Ecto.Association.NotLoaded do
   """
 
   @type t :: %__MODULE__{
-    __field__: atom(),
-    __owner__: any(),
-    __cardinality__: atom()
-  }
+          __field__: atom(),
+          __owner__: any(),
+          __cardinality__: atom()
+        }
 
   defstruct [:__field__, :__owner__, :__cardinality__]
 
   defimpl Inspect do
     def inspect(not_loaded, _opts) do
-      msg = "association #{inspect not_loaded.__field__} is not loaded"
+      msg = "association #{inspect(not_loaded.__field__)} is not loaded"
       ~s(#Ecto.Association.NotLoaded<#{msg}>)
     end
   end
@@ -30,15 +30,17 @@ end
 defmodule Ecto.Association do
   @moduledoc false
 
-  @type t :: %{required(:__struct__) => atom,
-               required(:on_cast) => nil | fun,
-               required(:cardinality) => :one | :many,
-               required(:relationship) => :parent | :child,
-               required(:owner) => atom,
-               required(:owner_key) => atom,
-               required(:field) => atom,
-               required(:unique) => boolean,
-               optional(atom) => any}
+  @type t :: %{
+          required(:__struct__) => atom,
+          required(:on_cast) => nil | fun,
+          required(:cardinality) => :one | :many,
+          required(:relationship) => :parent | :child,
+          required(:owner) => atom,
+          required(:owner_key) => atom,
+          required(:field) => atom,
+          required(:unique) => boolean,
+          optional(atom) => any
+        }
 
   alias Ecto.Query.Builder.OrderBy
 
@@ -77,7 +79,7 @@ defmodule Ecto.Association do
       of a `:child` or a `:parent`
 
   """
-  @callback struct(module, field :: atom, opts :: Keyword.t) :: t
+  @callback struct(module, field :: atom, opts :: Keyword.t()) :: t
 
   @doc """
   Invoked after the schema is compiled to validate associations.
@@ -85,7 +87,7 @@ defmodule Ecto.Association do
   Useful for checking if associated modules exist without running
   into deadlocks.
   """
-  @callback after_compile_validation(t, Macro.Env.t) :: :ok | {:error, String.t}
+  @callback after_compile_validation(t, Macro.Env.t()) :: :ok | {:error, String.t()}
 
   @doc """
   Builds a struct for the given association.
@@ -95,7 +97,7 @@ defmodule Ecto.Association do
 
   Invoked by `Ecto.build_assoc/3`.
   """
-  @callback build(t, owner :: Ecto.Schema.t, %{atom => term} | [Keyword.t]) :: Ecto.Schema.t
+  @callback build(t, owner :: Ecto.Schema.t(), %{atom => term} | [Keyword.t()]) :: Ecto.Schema.t()
 
   @doc """
   Returns an association join query.
@@ -115,7 +117,7 @@ defmodule Ecto.Association do
   This callback is invoked when `join: assoc(p, :comments)` is used
   inside queries.
   """
-  @callback joins_query(t) :: Ecto.Query.t
+  @callback joins_query(t) :: Ecto.Query.t()
 
   @doc """
   Returns the association query on top of the given query.
@@ -128,13 +130,14 @@ defmodule Ecto.Association do
 
   This callback is used by `Ecto.assoc/2` and when preloading.
   """
-  @callback assoc_query(t, Ecto.Query.t | nil, values :: [term]) :: Ecto.Query.t
+  @callback assoc_query(t, Ecto.Query.t() | nil, values :: [term]) :: Ecto.Query.t()
 
   @doc """
   Returns information used by the preloader.
   """
   @callback preload_info(t) ::
-              {:assoc, t, {integer, atom} | {integer, atom, Ecto.Type.t()}} | {:through, t, [atom]}
+              {:assoc, t, {integer, atom} | {integer, atom, Ecto.Type.t()}}
+              | {:through, t, [atom]}
 
   @doc """
   Performs the repository change on the association.
@@ -143,15 +146,21 @@ defmodule Ecto.Association do
   and the repository action options. Must return the
   persisted struct (or nil) or the changeset error.
   """
-  @callback on_repo_change(t, parent :: Ecto.Changeset.t, changeset :: Ecto.Changeset.t, Ecto.Adapter.t, Keyword.t) ::
-            {:ok, Ecto.Schema.t | nil} | {:error, Ecto.Changeset.t}
+  @callback on_repo_change(
+              t,
+              parent :: Ecto.Changeset.t(),
+              changeset :: Ecto.Changeset.t(),
+              Ecto.Adapter.t(),
+              Keyword.t()
+            ) ::
+              {:ok, Ecto.Schema.t() | nil} | {:error, Ecto.Changeset.t()}
 
   @doc """
   Retrieves the association from the given schema.
   """
   def association_from_schema!(schema, assoc) do
     schema.__schema__(:association, assoc) ||
-      raise ArgumentError, "schema #{inspect schema} does not have association #{inspect assoc}"
+      raise ArgumentError, "schema #{inspect(schema)} does not have association #{inspect(assoc)}"
   end
 
   @doc """
@@ -170,7 +179,7 @@ defmodule Ecto.Association do
 
   """
   def association_key(module, suffix) do
-    prefix = module |> Module.split |> List.last |> Macro.underscore
+    prefix = module |> Module.split() |> List.last() |> Macro.underscore()
     :"#{prefix}_#{suffix}"
   end
 
@@ -209,17 +218,19 @@ defmodule Ecto.Association do
     relation_list = resolve_through_tables(owner, through, chain_direction)
 
     # Filter out the joins which are redundant
-    filtered_list = Enum.with_index(relation_list)
-    |> Enum.filter(fn
-      # We always keep the first table in the chain since it's our source table for the query
-      {_, 0} -> true
+    filtered_list =
+      Enum.with_index(relation_list)
+      |> Enum.filter(fn
+        # We always keep the first table in the chain since it's our source table for the query
+        {_, 0} ->
+          true
 
-      {rel, _} ->
-        # If the condition is not empty we need to join to the table. Otherwise if the in_key and out_key is the same
-        # then this join is redundant since we can just join to the next table in the chain.
-        rel.in_key != rel.out_key or rel.where != []
-    end)
-    |> Enum.map(&elem(&1, 0))
+        {rel, _} ->
+          # If the condition is not empty we need to join to the table. Otherwise if the in_key and out_key is the same
+          # then this join is redundant since we can just join to the next table in the chain.
+          rel.in_key != rel.out_key or rel.where != []
+      end)
+      |> Enum.map(&elem(&1, 0))
 
     # If we're preloading we don't need the last table since it is the owner table.
     filtered_list = if(join_to == nil, do: Enum.slice(filtered_list, 0..-2), else: filtered_list)
@@ -233,37 +244,47 @@ defmodule Ecto.Association do
 
     # We need to create the query by joining all the tables, and also we need the out_key of the final table to use
     # for the final WHERE clause with values.
-    {_, query, _, dest_out_key} = Enum.reduce(joins, {source, query, counter, source.out_key}, fn curr_rel, {prev_rel, query, counter, _} ->
-      related_queryable = curr_rel.schema
+    {_, query, _, dest_out_key} =
+      Enum.reduce(joins, {source, query, counter, source.out_key}, fn curr_rel,
+                                                                      {prev_rel, query, counter,
+                                                                       _} ->
+        related_queryable = curr_rel.schema
 
-      next = join(query, :inner, [{src, counter}], dest in ^related_queryable, on: field(src, ^prev_rel.out_key) == field(dest, ^curr_rel.in_key))
-        |> combine_joins_query(curr_rel.where, counter + 1)
+        next =
+          join(query, :inner, [{src, counter}], dest in ^related_queryable,
+            on: field(src, ^prev_rel.out_key) == field(dest, ^curr_rel.in_key)
+          )
+          |> combine_joins_query(curr_rel.where, counter + 1)
 
-      {curr_rel, next, counter + 1, curr_rel.out_key}
-    end)
+        {curr_rel, next, counter + 1, curr_rel.out_key}
+      end)
 
     final_bind = Ecto.Query.Builder.count_binds(query) - 1
 
     values = List.wrap(values)
-    query = case {join_to, values} do
-      {nil, [single_value]} ->
-        query
-        |> where([{dest, final_bind}], field(dest, ^dest_out_key) == ^single_value)
 
-      {nil, values} ->
-        query
-        |> where([{dest, final_bind}], field(dest, ^dest_out_key) in ^values)
+    query =
+      case {join_to, values} do
+        {nil, [single_value]} ->
+          query
+          |> where([{dest, final_bind}], field(dest, ^dest_out_key) == ^single_value)
 
-      {_, _} ->
-        query
-    end
+        {nil, values} ->
+          query
+          |> where([{dest, final_bind}], field(dest, ^dest_out_key) in ^values)
+
+        {_, _} ->
+          query
+      end
 
     combine_assoc_query(query, source.where || [])
   end
 
   defp flatten_through_chain(owner, [], acc), do: {owner, acc}
+
   defp flatten_through_chain(owner, [assoc | tl], acc) do
     refl = association_from_schema!(owner, assoc)
+
     case refl do
       %{through: nested_throughs} ->
         {owner, acc} = flatten_through_chain(owner, nested_throughs, acc)
@@ -288,22 +309,41 @@ defmodule Ecto.Association do
       refl = association_from_schema!(owner, assoc)
       [owner_map | table_list] = table_list
 
-      table_list = case refl do
-        %{join_through: join_through, join_keys: join_keys, join_where: join_where, where: where} ->
-          [{owner_join_key, owner_key}, {related_join_key, related_key}] = join_keys
+      table_list =
+        case refl do
+          %{
+            join_through: join_through,
+            join_keys: join_keys,
+            join_where: join_where,
+            where: where
+          } ->
+            [{owner_join_key, owner_key}, {related_join_key, related_key}] = join_keys
 
-          owner_map = %{owner_map | in_key: owner_key}
-          join_map = %{schema: join_through, out_key: owner_join_key, in_key: related_join_key, where: join_where}
-          related_map = %{schema: refl.related, out_key: related_key, in_key: nil, where: where}
+            owner_map = %{owner_map | in_key: owner_key}
 
-          [related_map, join_map, owner_map | table_list]
+            join_map = %{
+              schema: join_through,
+              out_key: owner_join_key,
+              in_key: related_join_key,
+              where: join_where
+            }
 
-        _ ->
-          owner_map = %{owner_map | in_key: refl.owner_key}
-          related_map = %{schema: refl.related, out_key: refl.related_key, in_key: nil, where: refl.where}
+            related_map = %{schema: refl.related, out_key: related_key, in_key: nil, where: where}
 
-          [related_map, owner_map | table_list]
-      end
+            [related_map, join_map, owner_map | table_list]
+
+          _ ->
+            owner_map = %{owner_map | in_key: refl.owner_key}
+
+            related_map = %{
+              schema: refl.related,
+              out_key: refl.related_key,
+              in_key: nil,
+              where: refl.where
+            }
+
+            [related_map, owner_map | table_list]
+        end
 
       {refl.related, table_list}
     end)
@@ -339,10 +379,24 @@ defmodule Ecto.Association do
   Add the default assoc query where clauses a provided query.
   """
   def combine_assoc_query(query, []), do: query
+
   def combine_assoc_query(%{wheres: []} = query, conditions) do
     {expr, params} = expand_where(conditions, true, [], 0, 0)
-    %{query | wheres: [%Ecto.Query.BooleanExpr{op: :and, expr: expr, params: params, line: __ENV__.line, file: __ENV__.file}]}
+
+    %{
+      query
+      | wheres: [
+          %Ecto.Query.BooleanExpr{
+            op: :and,
+            expr: expr,
+            params: params,
+            line: __ENV__.line,
+            file: __ENV__.file
+          }
+        ]
+    }
   end
+
   def combine_assoc_query(%{wheres: wheres} = query, conditions) do
     {wheres, [where_expr]} = Enum.split(wheres, -1)
     %{params: params, expr: expr} = where_expr
@@ -353,7 +407,7 @@ defmodule Ecto.Association do
   defp expand_where(conditions, expr, params, counter, binding) do
     conjoin_exprs = fn
       true, r -> r
-      l, r-> {:and, [], [l, r]}
+      l, r -> {:and, [], [l, r]}
     end
 
     {expr, params, _counter} =
@@ -393,7 +447,8 @@ defmodule Ecto.Association do
     Enum.reduce(through, {query, counter}, fn current, {acc, counter} ->
       query = join(acc, :inner, [{x, counter}], assoc(x, ^current))
       {query, counter + 1}
-    end) |> elem(0)
+    end)
+    |> elem(0)
   end
 
   @doc """
@@ -411,10 +466,14 @@ defmodule Ecto.Association do
       ** (ArgumentError) association :comments_v1 queryable must be a schema or a {source, schema}. got: "wrong"
   """
   def related_from_query(atom, _name) when is_atom(atom), do: atom
-  def related_from_query({source, schema}, _name) when is_binary(source) and is_atom(schema), do: schema
+
+  def related_from_query({source, schema}, _name) when is_binary(source) and is_atom(schema),
+    do: schema
+
   def related_from_query(queryable, name) do
-    raise ArgumentError, "association #{inspect name} queryable must be a schema or " <>
-      "a {source, schema}. got: #{inspect queryable}"
+    raise ArgumentError,
+          "association #{inspect(name)} queryable must be a schema or " <>
+            "a {source, schema}. got: #{inspect(queryable)}"
   end
 
   @doc """
@@ -442,9 +501,12 @@ defmodule Ecto.Association do
     do: defaults
 
   def validate_defaults!(_module, name, defaults),
-    do: raise ArgumentError,
-              "expected defaults for #{inspect name} to be a keyword list " <>
-                "or a {module, fun, args} tuple, got: `#{inspect defaults}`"
+    do:
+      raise(
+        ArgumentError,
+        "expected defaults for #{inspect(name)} to be a keyword list " <>
+          "or a {module, fun, args} tuple, got: `#{inspect(defaults)}`"
+      )
 
   @doc """
   Validates `preload_order` for association named `name`.
@@ -457,25 +519,25 @@ defmodule Ecto.Association do
       {direction, field} when is_atom(direction) and is_atom(field) ->
         unless OrderBy.valid_direction?(direction) do
           raise ArgumentError,
-          "expected `:preload_order` for #{inspect name} to be a keyword list or a list of atoms/fields, " <>
-            "got: `#{inspect preload_order}`, " <>
-            "`#{inspect direction}` is not a valid direction"
+                "expected `:preload_order` for #{inspect(name)} to be a keyword list or a list of atoms/fields, " <>
+                  "got: `#{inspect(preload_order)}`, " <>
+                  "`#{inspect(direction)}` is not a valid direction"
         end
 
         {direction, field}
 
       item ->
         raise ArgumentError,
-          "expected `:preload_order` for #{inspect name} to be a keyword list or a list of atoms/fields, " <>
-            "got: `#{inspect preload_order}`, " <>
-            "`#{inspect item}` is not valid"
+              "expected `:preload_order` for #{inspect(name)} to be a keyword list or a list of atoms/fields, " <>
+                "got: `#{inspect(preload_order)}`, " <>
+                "`#{inspect(item)}` is not valid"
     end)
   end
 
   def validate_preload_order!(name, preload_order) do
     raise ArgumentError,
-      "expected `:preload_order` for #{inspect name} to be a keyword list or a list of atoms/fields, " <>
-        "got: `#{inspect preload_order}`"
+          "expected `:preload_order` for #{inspect(name)} to be a keyword list or a list of atoms/fields, " <>
+            "got: `#{inspect(preload_order)}`"
   end
 
   @doc """
@@ -513,7 +575,6 @@ defmodule Ecto.Association do
       ),
       do: update_in(changeset.data, &Ecto.put_meta(&1, prefix: prefix))
 
-
   def update_parent_prefix(changeset, _),
     do: changeset
 
@@ -534,20 +595,33 @@ defmodule Ecto.Association do
       end)
 
     case valid? do
-      true  -> {:ok, struct}
+      true -> {:ok, struct}
       false -> {:error, changes}
     end
   end
 
-  defp on_repo_change(%{cardinality: :one, field: field} = meta, nil, parent_changeset,
-                      _repo_action, adapter, opts, {parent, changes, halt, valid?}) do
+  defp on_repo_change(
+         %{cardinality: :one, field: field} = meta,
+         nil,
+         parent_changeset,
+         _repo_action,
+         adapter,
+         opts,
+         {parent, changes, halt, valid?}
+       ) do
     if not halt, do: maybe_replace_one!(meta, nil, parent, parent_changeset, adapter, opts)
     {Map.put(parent, field, nil), Map.put(changes, field, nil), halt, valid?}
   end
 
-  defp on_repo_change(%{cardinality: :one, field: field, __struct__: mod} = meta,
-                      %{action: action, data: current} = changeset, parent_changeset,
-                      repo_action, adapter, opts, {parent, changes, halt, valid?}) do
+  defp on_repo_change(
+         %{cardinality: :one, field: field, __struct__: mod} = meta,
+         %{action: action, data: current} = changeset,
+         parent_changeset,
+         repo_action,
+         adapter,
+         opts,
+         {parent, changes, halt, valid?}
+       ) do
     check_action!(meta, action, repo_action)
     if not halt, do: maybe_replace_one!(meta, current, parent, parent_changeset, adapter, opts)
 
@@ -561,15 +635,29 @@ defmodule Ecto.Association do
     end
   end
 
-  defp on_repo_change(%{cardinality: :many, field: field, __struct__: mod} = meta,
-                      changesets, parent_changeset, repo_action, adapter, opts,
-                      {parent, changes, halt, all_valid?}) do
+  defp on_repo_change(
+         %{cardinality: :many, field: field, __struct__: mod} = meta,
+         changesets,
+         parent_changeset,
+         repo_action,
+         adapter,
+         opts,
+         {parent, changes, halt, all_valid?}
+       ) do
     {changesets, structs, halt, valid?} =
       Enum.reduce(changesets, {[], [], halt, true}, fn
         %{action: action} = changeset, {changesets, structs, halt, valid?} ->
           check_action!(meta, action, repo_action)
 
-          case on_repo_change_unless_halted(halt, mod, meta, parent_changeset, changeset, adapter, opts) do
+          case on_repo_change_unless_halted(
+                 halt,
+                 mod,
+                 meta,
+                 parent_changeset,
+                 changeset,
+                 adapter,
+                 opts
+               ) do
             {:ok, nil} ->
               {[changeset | changesets], structs, halt, valid?}
 
@@ -577,23 +665,26 @@ defmodule Ecto.Association do
               {[changeset | changesets], [struct | structs], halt, valid?}
 
             {:error, error_changeset} ->
-              {[error_changeset | changesets], structs, halted?(halt, changeset, error_changeset), false}
+              {[error_changeset | changesets], structs, halted?(halt, changeset, error_changeset),
+               false}
           end
       end)
 
     if valid? do
       {Map.put(parent, field, Enum.reverse(structs)),
-       Map.put(changes, field, Enum.reverse(changesets)),
-       halt, all_valid?}
+       Map.put(changes, field, Enum.reverse(changesets)), halt, all_valid?}
     else
-      {parent,
-       Map.put(changes, field, Enum.reverse(changesets)),
-       halt, false}
+      {parent, Map.put(changes, field, Enum.reverse(changesets)), halt, false}
     end
   end
 
   defp check_action!(%{related: schema}, :delete, :insert),
-    do: raise(ArgumentError, "got action :delete in changeset for associated #{inspect schema} while inserting")
+    do:
+      raise(
+        ArgumentError,
+        "got action :delete in changeset for associated #{inspect(schema)} while inserting"
+      )
+
   defp check_action!(_, _, _), do: :ok
 
   defp halted?(true, _, _), do: true
@@ -603,22 +694,30 @@ defmodule Ecto.Association do
   defp on_repo_change_unless_halted(true, _mod, _meta, _parent, changeset, _adapter, _opts) do
     {:error, changeset}
   end
+
   defp on_repo_change_unless_halted(false, mod, meta, parent, changeset, adapter, opts) do
     mod.on_repo_change(meta, parent, changeset, adapter, opts)
   end
 
-  defp maybe_replace_one!(%{field: field, __struct__: mod} = meta, current, parent,
-                          parent_changeset, adapter, opts) do
+  defp maybe_replace_one!(
+         %{field: field, __struct__: mod} = meta,
+         current,
+         parent,
+         parent_changeset,
+         adapter,
+         opts
+       ) do
     previous = Map.get(parent, field)
+
     if replaceable?(previous) and primary_key!(previous) != primary_key!(current) do
       changeset = %{Ecto.Changeset.change(previous) | action: :replace}
 
       case mod.on_repo_change(meta, parent_changeset, changeset, adapter, opts) do
         {:ok, _} ->
           :ok
+
         {:error, changeset} ->
-          raise Ecto.InvalidChangesetError,
-            action: changeset.action, changeset: changeset
+          raise Ecto.InvalidChangesetError, action: changeset.action, changeset: changeset
       end
     end
   end
@@ -658,9 +757,24 @@ defmodule Ecto.Association.Has do
   @on_delete_opts [:nothing, :nilify_all, :delete_all]
   @on_replace_opts [:raise, :mark_as_invalid, :delete, :delete_if_exists, :nilify]
   @has_one_on_replace_opts @on_replace_opts ++ [:update]
-  defstruct [:cardinality, :field, :owner, :related, :owner_key, :related_key, :on_cast,
-             :queryable, :on_delete, :on_replace, where: [], unique: true, defaults: [],
-             relationship: :child, ordered: false, preload_order: []]
+  defstruct [
+    :cardinality,
+    :field,
+    :owner,
+    :related,
+    :owner_key,
+    :related_key,
+    :on_cast,
+    :queryable,
+    :on_delete,
+    :on_replace,
+    where: [],
+    unique: true,
+    defaults: [],
+    relationship: :child,
+    ordered: false,
+    preload_order: []
+  ]
 
   @impl true
   def after_compile_validation(%{queryable: queryable, related_key: related_key}, env) do
@@ -669,12 +783,16 @@ defmodule Ecto.Association.Has do
     cond do
       compiled == :skip ->
         :ok
+
       compiled == :not_found ->
-        {:error, "associated schema #{inspect queryable} does not exist"}
+        {:error, "associated schema #{inspect(queryable)} does not exist"}
+
       not function_exported?(queryable, :__schema__, 2) ->
-        {:error, "associated module #{inspect queryable} is not an Ecto schema"}
-      is_nil queryable.__schema__(:type, related_key) ->
-        {:error, "associated schema #{inspect queryable} does not have field `#{related_key}`"}
+        {:error, "associated module #{inspect(queryable)} is not an Ecto schema"}
+
+      is_nil(queryable.__schema__(:type, related_key)) ->
+        {:error, "associated schema #{inspect(queryable)} does not have field `#{related_key}`"}
+
       true ->
         :ok
     end
@@ -692,29 +810,34 @@ defmodule Ecto.Association.Has do
       |> get_ref(opts[:references], name)
 
     unless Module.get_attribute(module, :ecto_fields)[ref] do
-      raise ArgumentError, "schema does not have the field #{inspect ref} used by " <>
-        "association #{inspect name}, please set the :references option accordingly"
+      raise ArgumentError,
+            "schema does not have the field #{inspect(ref)} used by " <>
+              "association #{inspect(name)}, please set the :references option accordingly"
     end
 
     if opts[:through] do
-      raise ArgumentError, "invalid association #{inspect name}. When using the :through " <>
-                           "option, the schema should not be passed as second argument"
+      raise ArgumentError,
+            "invalid association #{inspect(name)}. When using the :through " <>
+              "option, the schema should not be passed as second argument"
     end
 
-    on_delete  = Keyword.get(opts, :on_delete, :nothing)
+    on_delete = Keyword.get(opts, :on_delete, :nothing)
+
     unless on_delete in @on_delete_opts do
-      raise ArgumentError, "invalid :on_delete option for #{inspect name}. " <>
-        "The only valid options are: " <>
-        Enum.map_join(@on_delete_opts, ", ", &"`#{inspect &1}`")
+      raise ArgumentError,
+            "invalid :on_delete option for #{inspect(name)}. " <>
+              "The only valid options are: " <>
+              Enum.map_join(@on_delete_opts, ", ", &"`#{inspect(&1)}`")
     end
 
     on_replace = Keyword.get(opts, :on_replace, :raise)
     on_replace_opts = if cardinality == :one, do: @has_one_on_replace_opts, else: @on_replace_opts
 
     unless on_replace in on_replace_opts do
-      raise ArgumentError, "invalid `:on_replace` option for #{inspect name}. " <>
-        "The only valid options are: " <>
-        Enum.map_join(@on_replace_opts, ", ", &"`#{inspect &1}`")
+      raise ArgumentError,
+            "invalid `:on_replace` option for #{inspect(name)}. " <>
+              "The only valid options are: " <>
+              Enum.map_join(@on_replace_opts, ", ", &"`#{inspect(&1)}`")
     end
 
     defaults = Ecto.Association.validate_defaults!(module, name, opts[:defaults] || [])
@@ -722,7 +845,8 @@ defmodule Ecto.Association.Has do
     where = opts[:where] || []
 
     unless is_list(where) do
-      raise ArgumentError, "expected `:where` for #{inspect name} to be a keyword list, got: `#{inspect where}`"
+      raise ArgumentError,
+            "expected `:where` for #{inspect(name)} to be a keyword list, got: `#{inspect(where)}`"
     end
 
     %__MODULE__{
@@ -742,9 +866,11 @@ defmodule Ecto.Association.Has do
   end
 
   defp get_ref(primary_key, nil, name) when primary_key in [nil, false] do
-    raise ArgumentError, "need to set :references option for " <>
-      "association #{inspect name} when schema has no primary key"
+    raise ArgumentError,
+          "need to set :references option for " <>
+            "association #{inspect(name)} when schema has no primary key"
   end
+
   defp get_ref(primary_key, nil, _name), do: elem(primary_key, 0)
   defp get_ref(_primary_key, references, _name), do: references
 
@@ -755,7 +881,10 @@ defmodule Ecto.Association.Has do
   end
 
   @impl true
-  def joins_query(%{related_key: related_key, owner: owner, owner_key: owner_key, queryable: queryable} = assoc) do
+  def joins_query(
+        %{related_key: related_key, owner: owner, owner_key: owner_key, queryable: queryable} =
+          assoc
+      ) do
     from(o in owner, join: q in ^queryable, on: field(q, ^related_key) == field(o, ^owner_key))
     |> Ecto.Association.combine_joins_query(assoc.where, 1)
   end
@@ -778,8 +907,13 @@ defmodule Ecto.Association.Has do
   end
 
   @impl true
-  def on_repo_change(%{on_replace: :delete_if_exists} = refl, parent_changeset,
-                     %{action: :replace} = changeset, adapter, opts) do
+  def on_repo_change(
+        %{on_replace: :delete_if_exists} = refl,
+        parent_changeset,
+        %{action: :replace} = changeset,
+        adapter,
+        opts
+      ) do
     try do
       on_repo_change(%{refl | on_replace: :delete}, parent_changeset, changeset, adapter, opts)
     rescue
@@ -787,13 +921,19 @@ defmodule Ecto.Association.Has do
     end
   end
 
-  def on_repo_change(%{on_replace: on_replace} = refl, %{data: parent} = parent_changeset,
-                     %{action: :replace} = changeset, adapter, opts) do
-    changeset = case on_replace do
-      :nilify -> %{changeset | action: :update}
-      :update -> %{changeset | action: :update}
-      :delete -> %{changeset | action: :delete}
-    end
+  def on_repo_change(
+        %{on_replace: on_replace} = refl,
+        %{data: parent} = parent_changeset,
+        %{action: :replace} = changeset,
+        adapter,
+        opts
+      ) do
+    changeset =
+      case on_replace do
+        :nilify -> %{changeset | action: :update}
+        :update -> %{changeset | action: :update}
+        :delete -> %{changeset | action: :delete}
+      end
 
     changeset = Ecto.Association.update_parent_prefix(changeset, parent)
 
@@ -814,6 +954,7 @@ defmodule Ecto.Association.Has do
     case apply(repo, action, [changeset, opts]) do
       {:ok, _} = ok ->
         if action == :delete, do: {:ok, nil}, else: ok
+
       {:error, changeset} ->
         original = Map.get(changes, key)
         {:error, put_in(changeset.changes[key], original)}
@@ -822,12 +963,14 @@ defmodule Ecto.Association.Has do
 
   defp update_parent_key(changeset, :delete, _key, _value),
     do: changeset
+
   defp update_parent_key(changeset, _action, key, value),
     do: Ecto.Changeset.put_change(changeset, key, value)
 
   defp parent_key(%{related_key: related_key}, nil) do
     {related_key, nil}
   end
+
   defp parent_key(%{owner_key: owner_key, related_key: related_key}, owner) do
     {related_key, Map.get(owner, owner_key)}
   end
@@ -847,19 +990,21 @@ defmodule Ecto.Association.Has do
   @doc false
   def delete_all(refl, parent, repo_name, opts) do
     if query = on_delete_query(refl, parent) do
-      Ecto.Repo.Queryable.delete_all repo_name, query, opts
+      Ecto.Repo.Queryable.delete_all(repo_name, query, opts)
     end
   end
 
   @doc false
   def nilify_all(%{related_key: related_key} = refl, parent, repo_name, opts) do
     if query = on_delete_query(refl, parent) do
-      Ecto.Repo.Queryable.update_all repo_name, query, [set: [{related_key, nil}]], opts
+      Ecto.Repo.Queryable.update_all(repo_name, query, [set: [{related_key, nil}]], opts)
     end
   end
 
-  defp on_delete_query(%{owner_key: owner_key, related_key: related_key,
-                         queryable: queryable}, parent) do
+  defp on_delete_query(
+         %{owner_key: owner_key, related_key: related_key, queryable: queryable},
+         parent
+       ) do
     if value = Map.get(parent, owner_key) do
       from x in queryable, where: field(x, ^related_key) == ^value
     end
@@ -881,8 +1026,17 @@ defmodule Ecto.Association.HasThrough do
   """
 
   @behaviour Ecto.Association
-  defstruct [:cardinality, :field, :owner, :owner_key, :through, :on_cast,
-             relationship: :child, unique: true, ordered: false]
+  defstruct [
+    :cardinality,
+    :field,
+    :owner,
+    :owner_key,
+    :through,
+    :on_cast,
+    relationship: :child,
+    unique: true,
+    ordered: false
+  ]
 
   @impl true
   def after_compile_validation(_, _) do
@@ -895,17 +1049,20 @@ defmodule Ecto.Association.HasThrough do
 
     refl =
       case through do
-        [h,_|_] ->
+        [h, _ | _] ->
           Module.get_attribute(module, :ecto_assocs)[h]
+
         _ ->
-          raise ArgumentError, ":through expects a list with at least two entries: " <>
-            "the association in the current module and one step through, got: #{inspect through}"
+          raise ArgumentError,
+                ":through expects a list with at least two entries: " <>
+                  "the association in the current module and one step through, got: #{inspect(through)}"
       end
 
     unless refl do
-      raise ArgumentError, "schema does not have the association #{inspect hd(through)} " <>
-        "used by association #{inspect name}, please ensure the association exists and " <>
-        "is defined before the :through one"
+      raise ArgumentError,
+            "schema does not have the association #{inspect(hd(through))} " <>
+              "used by association #{inspect(name)}, please ensure the association exists and " <>
+              "is defined before the :through one"
     end
 
     %__MODULE__{
@@ -913,15 +1070,15 @@ defmodule Ecto.Association.HasThrough do
       cardinality: Keyword.fetch!(opts, :cardinality),
       through: through,
       owner: module,
-      owner_key: refl.owner_key,
+      owner_key: refl.owner_key
     }
   end
 
   @impl true
   def build(%{field: name}, %{__struct__: owner}, _attributes) do
     raise ArgumentError,
-      "cannot build through association `#{inspect name}` for #{inspect owner}. " <>
-      "Instead build the intermediate steps explicitly."
+          "cannot build through association `#{inspect(name)}` for #{inspect(owner)}. " <>
+            "Instead build the intermediate steps explicitly."
   end
 
   @impl true
@@ -932,8 +1089,8 @@ defmodule Ecto.Association.HasThrough do
   @impl true
   def on_repo_change(%{field: name}, _, _, _, _) do
     raise ArgumentError,
-      "cannot insert/update/delete through associations `#{inspect name}` via the repository. " <>
-      "Instead build the intermediate steps explicitly."
+          "cannot insert/update/delete through associations `#{inspect(name)}` via the repository. " <>
+            "Instead build the intermediate steps explicitly."
   end
 
   @impl true
@@ -967,9 +1124,22 @@ defmodule Ecto.Association.BelongsTo do
 
   @behaviour Ecto.Association
   @on_replace_opts [:raise, :mark_as_invalid, :delete, :delete_if_exists, :nilify, :update]
-  defstruct [:field, :owner, :related, :owner_key, :related_key, :queryable, :on_cast,
-             :on_replace, where: [], defaults: [], cardinality: :one, relationship: :parent,
-             unique: true, ordered: false]
+  defstruct [
+    :field,
+    :owner,
+    :related,
+    :owner_key,
+    :related_key,
+    :queryable,
+    :on_cast,
+    :on_replace,
+    where: [],
+    defaults: [],
+    cardinality: :one,
+    relationship: :parent,
+    unique: true,
+    ordered: false
+  ]
 
   @impl true
   def after_compile_validation(%{queryable: queryable, related_key: related_key}, env) do
@@ -978,12 +1148,16 @@ defmodule Ecto.Association.BelongsTo do
     cond do
       compiled == :skip ->
         :ok
+
       compiled == :not_found ->
-        {:error, "associated schema #{inspect queryable} does not exist"}
+        {:error, "associated schema #{inspect(queryable)} does not exist"}
+
       not function_exported?(queryable, :__schema__, 2) ->
-        {:error, "associated module #{inspect queryable} is not an Ecto schema"}
-      is_nil queryable.__schema__(:type, related_key) ->
-        {:error, "associated schema #{inspect queryable} does not have field `#{related_key}`"}
+        {:error, "associated module #{inspect(queryable)} is not an Ecto schema"}
+
+      is_nil(queryable.__schema__(:type, related_key)) ->
+        {:error, "associated schema #{inspect(queryable)} does not have field `#{related_key}`"}
+
       true ->
         :ok
     end
@@ -997,16 +1171,18 @@ defmodule Ecto.Association.BelongsTo do
     on_replace = Keyword.get(opts, :on_replace, :raise)
 
     unless on_replace in @on_replace_opts do
-      raise ArgumentError, "invalid `:on_replace` option for #{inspect name}. " <>
-        "The only valid options are: " <>
-        Enum.map_join(@on_replace_opts, ", ", &"`#{inspect &1}`")
+      raise ArgumentError,
+            "invalid `:on_replace` option for #{inspect(name)}. " <>
+              "The only valid options are: " <>
+              Enum.map_join(@on_replace_opts, ", ", &"`#{inspect(&1)}`")
     end
 
     defaults = Ecto.Association.validate_defaults!(module, name, opts[:defaults] || [])
     where = opts[:where] || []
 
     unless is_list(where) do
-      raise ArgumentError, "expected `:where` for #{inspect name} to be a keyword list, got: `#{inspect where}`"
+      raise ArgumentError,
+            "expected `:where` for #{inspect(name)} to be a keyword list, got: `#{inspect(where)}`"
     end
 
     %__MODULE__{
@@ -1030,7 +1206,10 @@ defmodule Ecto.Association.BelongsTo do
   end
 
   @impl true
-  def joins_query(%{related_key: related_key, owner: owner, owner_key: owner_key, queryable: queryable} = assoc) do
+  def joins_query(
+        %{related_key: related_key, owner: owner, owner_key: owner_key, queryable: queryable} =
+          assoc
+      ) do
     from(o in owner, join: q in ^queryable, on: field(q, ^related_key) == field(o, ^owner_key))
     |> Ecto.Association.combine_joins_query(assoc.where, 1)
   end
@@ -1057,8 +1236,13 @@ defmodule Ecto.Association.BelongsTo do
     {:ok, nil}
   end
 
-  def on_repo_change(%{on_replace: :delete_if_exists} = refl, parent_changeset,
-                     %{action: :replace} = changeset, adapter, opts) do
+  def on_repo_change(
+        %{on_replace: :delete_if_exists} = refl,
+        parent_changeset,
+        %{action: :replace} = changeset,
+        adapter,
+        opts
+      ) do
     try do
       on_repo_change(%{refl | on_replace: :delete}, parent_changeset, changeset, adapter, opts)
     rescue
@@ -1066,8 +1250,13 @@ defmodule Ecto.Association.BelongsTo do
     end
   end
 
-  def on_repo_change(%{on_replace: on_replace} = refl, parent_changeset,
-                     %{action: :replace} = changeset, adapter, opts) do
+  def on_repo_change(
+        %{on_replace: on_replace} = refl,
+        parent_changeset,
+        %{action: :replace} = changeset,
+        adapter,
+        opts
+      ) do
     changeset =
       case on_replace do
         :delete -> %{changeset | action: :delete}
@@ -1077,12 +1266,19 @@ defmodule Ecto.Association.BelongsTo do
     on_repo_change(refl, parent_changeset, changeset, adapter, opts)
   end
 
-  def on_repo_change(_refl, %{data: parent, repo: repo}, %{action: action} = changeset, _adapter, opts) do
+  def on_repo_change(
+        _refl,
+        %{data: parent, repo: repo},
+        %{action: action} = changeset,
+        _adapter,
+        opts
+      ) do
     changeset = Ecto.Association.update_parent_prefix(changeset, parent)
 
     case apply(repo, action, [changeset, opts]) do
       {:ok, _} = ok ->
         if action == :delete, do: {:ok, nil}, else: ok
+
       {:error, changeset} ->
         {:error, changeset}
     end
@@ -1125,10 +1321,27 @@ defmodule Ecto.Association.ManyToMany do
   @behaviour Ecto.Association
   @on_delete_opts [:nothing, :delete_all]
   @on_replace_opts [:raise, :mark_as_invalid, :delete]
-  defstruct [:field, :owner, :related, :owner_key, :queryable, :on_delete,
-             :on_replace, :join_keys, :join_through, :on_cast, where: [],
-             join_where: [], defaults: [], join_defaults: [], relationship: :child,
-             cardinality: :many, unique: false, ordered: false, preload_order: []]
+  defstruct [
+    :field,
+    :owner,
+    :related,
+    :owner_key,
+    :queryable,
+    :on_delete,
+    :on_replace,
+    :join_keys,
+    :join_through,
+    :on_cast,
+    where: [],
+    join_where: [],
+    defaults: [],
+    join_defaults: [],
+    relationship: :child,
+    cardinality: :many,
+    unique: false,
+    ordered: false,
+    preload_order: []
+  ]
 
   @impl true
   def after_compile_validation(%{queryable: queryable, join_through: join_through}, env) do
@@ -1138,16 +1351,22 @@ defmodule Ecto.Association.ManyToMany do
     cond do
       compiled == :skip ->
         :ok
+
       compiled == :not_found ->
-        {:error, "associated schema #{inspect queryable} does not exist"}
+        {:error, "associated schema #{inspect(queryable)} does not exist"}
+
       not function_exported?(queryable, :__schema__, 2) ->
-        {:error, "associated module #{inspect queryable} is not an Ecto schema"}
+        {:error, "associated module #{inspect(queryable)} is not an Ecto schema"}
+
       join_compiled == :skip ->
         :ok
+
       join_compiled == :not_found ->
-        {:error, ":join_through schema #{inspect join_through} does not exist"}
+        {:error, ":join_through schema #{inspect(join_through)} does not exist"}
+
       not function_exported?(join_through, :__schema__, 2) ->
-        {:error, ":join_through module #{inspect join_through} is not an Ecto schema"}
+        {:error, ":join_through module #{inspect(join_through)} is not an Ecto schema"}
+
       true ->
         :ok
     end
@@ -1165,37 +1384,42 @@ defmodule Ecto.Association.ManyToMany do
     {owner_key, join_keys} =
       case join_keys do
         [{join_owner_key, owner_key}, {join_related_key, related_key}]
-            when is_atom(join_owner_key) and is_atom(owner_key) and
-                 is_atom(join_related_key) and is_atom(related_key) ->
+        when is_atom(join_owner_key) and is_atom(owner_key) and
+               is_atom(join_related_key) and is_atom(related_key) ->
           {owner_key, join_keys}
+
         nil ->
           {:id, default_join_keys(module, related)}
+
         _ ->
           raise ArgumentError,
-            "many_to_many #{inspect name} expect :join_keys to be a keyword list " <>
-            "with two entries, the first being how the join table should reach " <>
-            "the current schema and the second how the join table should reach " <>
-            "the associated schema. For example: #{inspect default_join_keys(module, related)}"
+                "many_to_many #{inspect(name)} expect :join_keys to be a keyword list " <>
+                  "with two entries, the first being how the join table should reach " <>
+                  "the current schema and the second how the join table should reach " <>
+                  "the associated schema. For example: #{inspect(default_join_keys(module, related))}"
       end
 
     unless Module.get_attribute(module, :ecto_fields)[owner_key] do
-      raise ArgumentError, "schema does not have the field #{inspect owner_key} used by " <>
-        "association #{inspect name}, please set the :join_keys option accordingly"
+      raise ArgumentError,
+            "schema does not have the field #{inspect(owner_key)} used by " <>
+              "association #{inspect(name)}, please set the :join_keys option accordingly"
     end
 
-    on_delete  = Keyword.get(opts, :on_delete, :nothing)
+    on_delete = Keyword.get(opts, :on_delete, :nothing)
     on_replace = Keyword.get(opts, :on_replace, :raise)
 
     unless on_delete in @on_delete_opts do
-      raise ArgumentError, "invalid :on_delete option for #{inspect name}. " <>
-        "The only valid options are: " <>
-        Enum.map_join(@on_delete_opts, ", ", &"`#{inspect &1}`")
+      raise ArgumentError,
+            "invalid :on_delete option for #{inspect(name)}. " <>
+              "The only valid options are: " <>
+              Enum.map_join(@on_delete_opts, ", ", &"`#{inspect(&1)}`")
     end
 
     unless on_replace in @on_replace_opts do
-      raise ArgumentError, "invalid `:on_replace` option for #{inspect name}. " <>
-        "The only valid options are: " <>
-        Enum.map_join(@on_replace_opts, ", ", &"`#{inspect &1}`")
+      raise ArgumentError,
+            "invalid `:on_replace` option for #{inspect(name)}. " <>
+              "The only valid options are: " <>
+              Enum.map_join(@on_replace_opts, ", ", &"`#{inspect(&1)}`")
     end
 
     where = opts[:where] || []
@@ -1205,11 +1429,13 @@ defmodule Ecto.Association.ManyToMany do
     preload_order = Ecto.Association.validate_preload_order!(name, opts[:preload_order] || [])
 
     unless is_list(where) do
-      raise ArgumentError, "expected `:where` for #{inspect name} to be a keyword list, got: `#{inspect where}`"
+      raise ArgumentError,
+            "expected `:where` for #{inspect(name)} to be a keyword list, got: `#{inspect(where)}`"
     end
 
     unless is_list(join_where) do
-      raise ArgumentError, "expected `:join_where` for #{inspect name} to be a keyword list, got: `#{inspect join_where}`"
+      raise ArgumentError,
+            "expected `:join_where` for #{inspect(name)} to be a keyword list, got: `#{inspect(join_where)}`"
     end
 
     if opts[:join_defaults] && is_binary(join_through) do
@@ -1237,18 +1463,25 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   defp default_join_keys(module, related) do
-    [{Ecto.Association.association_key(module, :id), :id},
-     {Ecto.Association.association_key(related, :id), :id}]
+    [
+      {Ecto.Association.association_key(module, :id), :id},
+      {Ecto.Association.association_key(related, :id), :id}
+    ]
   end
 
   @impl true
-  def joins_query(%{owner: owner, queryable: queryable,
-                    join_through: join_through, join_keys: join_keys} = assoc) do
+  def joins_query(
+        %{owner: owner, queryable: queryable, join_through: join_through, join_keys: join_keys} =
+          assoc
+      ) do
     [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
 
     from(o in owner,
-      join: j in ^join_through, on: field(j, ^join_owner_key) == field(o, ^owner_key),
-      join: q in ^queryable, on: field(j, ^join_related_key) == field(q, ^related_key))
+      join: j in ^join_through,
+      on: field(j, ^join_owner_key) == field(o, ^owner_key),
+      join: q in ^queryable,
+      on: field(j, ^join_related_key) == field(q, ^related_key)
+    )
     |> Ecto.Association.combine_joins_query(assoc.where, 2)
     |> Ecto.Association.combine_joins_query(assoc.join_where, 1)
   end
@@ -1259,7 +1492,9 @@ defmodule Ecto.Association.ManyToMany do
 
   @impl true
   def assoc_query(assoc, query, values) do
-    %{queryable: queryable, join_through: join_through, join_keys: join_keys, owner: owner} = assoc
+    %{queryable: queryable, join_through: join_through, join_keys: join_keys, owner: owner} =
+      assoc
+
     [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
 
     owner_key_type = owner.__schema__(:type, owner_key)
@@ -1267,7 +1502,8 @@ defmodule Ecto.Association.ManyToMany do
     # We only need to join in the "join table". Preload and Ecto.assoc expressions can then filter
     # by &1.join_owner_key in ^... to filter down to the associated entries in the related table.
     from(q in (query || queryable),
-      join: j in ^join_through, on: field(q, ^related_key) == field(j, ^join_related_key),
+      join: j in ^join_through,
+      on: field(q, ^related_key) == field(j, ^join_related_key),
       where: field(j, ^join_owner_key) in type(^values, {:in, ^owner_key_type})
     )
     |> Ecto.Association.combine_assoc_query(assoc.where)
@@ -1291,30 +1527,45 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   @impl true
-  def on_repo_change(%{on_replace: :delete} = refl, parent_changeset,
-                     %{action: :replace}  = changeset, adapter, opts) do
+  def on_repo_change(
+        %{on_replace: :delete} = refl,
+        parent_changeset,
+        %{action: :replace} = changeset,
+        adapter,
+        opts
+      ) do
     on_repo_change(refl, parent_changeset, %{changeset | action: :delete}, adapter, opts)
   end
 
-  def on_repo_change(%{join_keys: join_keys, join_through: join_through},
-                     %{repo: repo, data: owner}, %{action: :delete, data: related}, adapter, opts) do
+  def on_repo_change(
+        %{join_keys: join_keys, join_through: join_through},
+        %{repo: repo, data: owner},
+        %{action: :delete, data: related},
+        adapter,
+        opts
+      ) do
     [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
-    owner_value = dump! :delete, join_through, owner, owner_key, adapter
-    related_value = dump! :delete, join_through, related, related_key, adapter
+    owner_value = dump!(:delete, join_through, owner, owner_key, adapter)
+    related_value = dump!(:delete, join_through, related, related_key, adapter)
 
     query =
       from j in join_through,
-        where: field(j, ^join_owner_key) == ^owner_value and
-               field(j, ^join_related_key) == ^related_value
+        where:
+          field(j, ^join_owner_key) == ^owner_value and
+            field(j, ^join_related_key) == ^related_value
 
     query = %{query | prefix: owner.__meta__.prefix}
     repo.delete_all(query, opts)
     {:ok, nil}
   end
 
-  def on_repo_change(%{field: field, join_through: join_through, join_keys: join_keys} = refl,
-                     %{repo: repo, data: owner} = parent_changeset,
-                     %{action: action} = changeset, adapter, opts) do
+  def on_repo_change(
+        %{field: field, join_through: join_through, join_keys: join_keys} = refl,
+        %{repo: repo, data: owner} = parent_changeset,
+        %{action: action} = changeset,
+        adapter,
+        opts
+      ) do
     changeset = Ecto.Association.update_parent_prefix(changeset, owner)
 
     case apply(repo, action, [changeset, opts]) do
@@ -1322,14 +1573,19 @@ defmodule Ecto.Association.ManyToMany do
         [{join_owner_key, owner_key}, {join_related_key, related_key}] = join_keys
 
         if insert_join?(parent_changeset, changeset, field, related_key) do
-          owner_value = dump! :insert, join_through, owner, owner_key, adapter
-          related_value = dump! :insert, join_through, related, related_key, adapter
+          owner_value = dump!(:insert, join_through, owner, owner_key, adapter)
+          related_value = dump!(:insert, join_through, related, related_key, adapter)
           data = %{join_owner_key => owner_value, join_related_key => related_value}
 
           case insert_join(join_through, refl, parent_changeset, data, opts) do
             {:error, join_changeset} ->
-              {:error, %{changeset | errors: join_changeset.errors ++ changeset.errors,
-                                     valid?: join_changeset.valid? and changeset.valid?}}
+              {:error,
+               %{
+                 changeset
+                 | errors: join_changeset.errors ++ changeset.errors,
+                   valid?: join_changeset.valid? and changeset.valid?
+               }}
+
             _ ->
               {:ok, related}
           end
@@ -1343,24 +1599,30 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   defp validate_join_through(name, nil) do
-    raise ArgumentError, "many_to_many #{inspect name} associations require the :join_through option to be given"
+    raise ArgumentError,
+          "many_to_many #{inspect(name)} associations require the :join_through option to be given"
   end
-  defp validate_join_through(_, join_through) when is_atom(join_through) or is_binary(join_through) do
+
+  defp validate_join_through(_, join_through)
+       when is_atom(join_through) or is_binary(join_through) do
     :ok
   end
+
   defp validate_join_through(name, _join_through) do
     raise ArgumentError,
-      "many_to_many #{inspect name} associations require the :join_through option to be " <>
-      "an atom (representing a schema) or a string (representing a table)"
+          "many_to_many #{inspect(name)} associations require the :join_through option to be " <>
+            "an atom (representing a schema) or a string (representing a table)"
   end
 
   defp insert_join?(%{action: :insert}, _, _field, _related_key), do: true
   defp insert_join?(_, %{action: :insert}, _field, _related_key), do: true
+
   defp insert_join?(%{data: owner}, %{data: related}, field, related_key) do
     current_key = Map.fetch!(related, related_key)
-    not Enum.any? Map.fetch!(owner, field), fn child ->
+
+    not Enum.any?(Map.fetch!(owner, field), fn child ->
       Map.get(child, related_key) == current_key
-    end
+    end)
   end
 
   defp insert_join(join_through, _refl, %{repo: repo}, data, opts) when is_binary(join_through) do
@@ -1381,20 +1643,22 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   defp field!(op, struct, field) do
-    Map.get(struct, field) || raise "could not #{op} join entry because `#{field}` is nil in #{inspect struct}"
+    Map.get(struct, field) ||
+      raise "could not #{op} join entry because `#{field}` is nil in #{inspect(struct)}"
   end
 
   defp dump!(action, join_through, struct, field, adapter) when is_binary(join_through) do
     value = field!(action, struct, field)
-    type  = struct.__struct__.__schema__(:type, field)
+    type = struct.__struct__.__schema__(:type, field)
 
     case Ecto.Type.adapter_dump(adapter, type, value) do
       {:ok, value} ->
         value
+
       :error ->
         raise Ecto.ChangeError,
-          "value `#{inspect value}` for `#{inspect struct.__struct__}.#{field}` " <>
-            "in `#{action}` does not match type #{inspect type}"
+              "value `#{inspect(value)}` for `#{inspect(struct.__struct__)}.#{field}` " <>
+                "in `#{action}` does not match type #{inspect(type)}"
     end
   end
 
@@ -1421,8 +1685,11 @@ defmodule Ecto.Association.ManyToMany do
 
     if value = Map.get(parent, owner_key) do
       owner_type = owner.__schema__(:type, owner_key)
-      query = from j in join_through, where: field(j, ^join_owner_key) == type(^value, ^owner_type)
-      Ecto.Repo.Queryable.delete_all repo_name, query, opts
+
+      query =
+        from j in join_through, where: field(j, ^join_owner_key) == type(^value, ^owner_type)
+
+      Ecto.Repo.Queryable.delete_all(repo_name, query, opts)
     end
   end
 end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -279,10 +279,21 @@ defmodule Ecto.Changeset do
   @empty_values [""]
 
   # If a new field is added here, def merge must be adapted
-  defstruct valid?: false, data: nil, params: nil, changes: %{},
-            errors: [], validations: [], required: [], prepare: [],
-            constraints: [], filters: %{}, action: nil, types: nil,
-            empty_values: @empty_values, repo: nil, repo_opts: []
+  defstruct valid?: false,
+            data: nil,
+            params: nil,
+            changes: %{},
+            errors: [],
+            validations: [],
+            required: [],
+            prepare: [],
+            constraints: [],
+            filters: %{},
+            action: nil,
+            types: nil,
+            empty_values: @empty_values,
+            repo: nil,
+            repo_opts: []
 
   @type t(data_type) :: %Changeset{
           valid?: boolean(),
@@ -301,22 +312,27 @@ defmodule Ecto.Changeset do
           types: nil | %{atom => Ecto.Type.t() | {:assoc, term()} | {:embed, term()}}
         }
 
-  @type t :: t(Ecto.Schema.t | map | nil)
-  @type error :: {String.t, Keyword.t}
+  @type t :: t(Ecto.Schema.t() | map | nil)
+  @type error :: {String.t(), Keyword.t()}
   @type action :: nil | :insert | :update | :delete | :replace | :ignore | atom
-  @type constraint :: %{type: :check | :exclusion | :foreign_key | :unique,
-                        constraint: String.t, match: :exact | :suffix | :prefix,
-                        field: atom, error_message: String.t, error_type: atom}
+  @type constraint :: %{
+          type: :check | :exclusion | :foreign_key | :unique,
+          constraint: String.t(),
+          match: :exact | :suffix | :prefix,
+          field: atom,
+          error_message: String.t(),
+          error_type: atom
+        }
   @type data :: map()
   @type types :: map()
 
   @number_validators %{
-    less_than:                {&</2,  "must be less than %{number}"},
-    greater_than:             {&>/2,  "must be greater than %{number}"},
-    less_than_or_equal_to:    {&<=/2, "must be less than or equal to %{number}"},
+    less_than: {&</2, "must be less than %{number}"},
+    greater_than: {&>/2, "must be greater than %{number}"},
+    less_than_or_equal_to: {&<=/2, "must be less than or equal to %{number}"},
     greater_than_or_equal_to: {&>=/2, "must be greater than or equal to %{number}"},
-    equal_to:                 {&==/2, "must be equal to %{number}"},
-    not_equal_to:             {&!=/2, "must be not equal to %{number}"},
+    equal_to: {&==/2, "must be equal to %{number}"},
+    not_equal_to: {&!=/2, "must be not equal to %{number}"}
   }
 
   @relations [:embed, :assoc]
@@ -376,7 +392,7 @@ defmodule Ecto.Changeset do
       "body"
 
   """
-  @spec change(Ecto.Schema.t | t | {data, types}, %{atom => term} | Keyword.t) :: t
+  @spec change(Ecto.Schema.t() | t | {data, types}, %{atom => term} | Keyword.t()) :: t
   def change(data, changes \\ %{})
 
   def change({data, types}, changes) when is_map(data) do
@@ -390,16 +406,15 @@ defmodule Ecto.Changeset do
   def change(%Changeset{changes: changes, types: types} = changeset, new_changes)
       when is_map(new_changes) or is_list(new_changes) do
     {changes, errors, valid?} =
-      get_changed(changeset.data, types, changes, new_changes,
-                  changeset.errors, changeset.valid?)
+      get_changed(changeset.data, types, changes, new_changes, changeset.errors, changeset.valid?)
+
     %{changeset | changes: changes, errors: errors, valid?: valid?}
   end
 
   def change(%{__struct__: struct} = data, changes) when is_map(changes) or is_list(changes) do
     types = struct.__changeset__()
     {changes, errors, valid?} = get_changed(data, types, %{}, changes, [], true)
-    %Changeset{valid?: valid?, data: data, changes: changes,
-               errors: errors, types: types}
+    %Changeset{valid?: valid?, data: data, changes: changes, errors: errors, types: types}
   end
 
   defp get_changed(data, types, old_changes, new_changes, errors, valid?) do
@@ -464,15 +479,19 @@ defmodule Ecto.Changeset do
   Parameters are merged (**not deep-merged**) and the ones passed to `cast/4`
   take precedence over the ones already in the changeset.
   """
-  @spec cast(Ecto.Schema.t | t | {data, types},
-             %{binary => term} | %{atom => term} | :invalid,
-             [atom],
-             Keyword.t) :: t
+  @spec cast(
+          Ecto.Schema.t() | t | {data, types},
+          %{binary => term} | %{atom => term} | :invalid,
+          [atom],
+          Keyword.t()
+        ) :: t
   def cast(data, params, permitted, opts \\ [])
 
   def cast(_data, %{__struct__: _} = params, _permitted, _opts) do
-    raise Ecto.CastError, type: :map, value: params,
-                          message: "expected params to be a :map, got: `#{inspect(params)}`"
+    raise Ecto.CastError,
+      type: :map,
+      value: params,
+      message: "expected params to be a :map, got: `#{inspect(params)}`"
   end
 
   def cast({data, types}, params, permitted, opts) when is_map(data) do
@@ -483,8 +502,13 @@ defmodule Ecto.Changeset do
     raise ArgumentError, "changeset does not have types information"
   end
 
-  def cast(%Changeset{changes: changes, data: data, types: types, empty_values: empty_values} = changeset,
-                      params, permitted, opts) do
+  def cast(
+        %Changeset{changes: changes, data: data, types: types, empty_values: empty_values} =
+          changeset,
+        params,
+        permitted,
+        opts
+      ) do
     opts = Keyword.put_new(opts, :empty_values, empty_values)
     new_changeset = cast(data, types, changes, params, permitted, opts)
     cast_merge(changeset, new_changeset)
@@ -494,32 +518,45 @@ defmodule Ecto.Changeset do
     cast(data, module.__changeset__(), %{}, params, permitted, opts)
   end
 
-  defp cast(%{} = data, %{} = types, %{} = changes, :invalid, permitted, _opts) when is_list(permitted) do
+  defp cast(%{} = data, %{} = types, %{} = changes, :invalid, permitted, _opts)
+       when is_list(permitted) do
     _ = Enum.each(permitted, &cast_key/1)
-    %Changeset{params: nil, data: data, valid?: false, errors: [],
-               changes: changes, types: types}
+    %Changeset{params: nil, data: data, valid?: false, errors: [], changes: changes, types: types}
   end
 
-  defp cast(%{} = data, %{} = types, %{} = changes, %{} = params, permitted, opts) when is_list(permitted) do
+  defp cast(%{} = data, %{} = types, %{} = changes, %{} = params, permitted, opts)
+       when is_list(permitted) do
     empty_values = Keyword.get(opts, :empty_values, @empty_values)
     params = convert_params(params)
 
-    defaults = case data do
-      %{__struct__: struct} -> struct.__struct__()
-      %{} -> %{}
-    end
+    defaults =
+      case data do
+        %{__struct__: struct} -> struct.__struct__()
+        %{} -> %{}
+      end
 
     {changes, errors, valid?} =
-      Enum.reduce(permitted, {changes, [], true},
-                  &process_param(&1, params, types, data, empty_values, defaults, &2))
+      Enum.reduce(
+        permitted,
+        {changes, [], true},
+        &process_param(&1, params, types, data, empty_values, defaults, &2)
+      )
 
-    %Changeset{params: params, data: data, valid?: valid?,
-               errors: Enum.reverse(errors), changes: changes, types: types}
+    %Changeset{
+      params: params,
+      data: data,
+      valid?: valid?,
+      errors: Enum.reverse(errors),
+      changes: changes,
+      types: types
+    }
   end
 
   defp cast(%{}, %{}, %{}, params, permitted, _opts) when is_list(permitted) do
-    raise Ecto.CastError, type: :map, value: params,
-                          message: "expected params to be a :map, got: `#{inspect params}`"
+    raise Ecto.CastError,
+      type: :map,
+      value: params,
+      message: "expected params to be a :map, got: `#{inspect(params)}`"
   end
 
   defp process_param(key, params, types, data, empty_values, defaults, {changes, errors, valid?}) do
@@ -535,14 +572,17 @@ defmodule Ecto.Changeset do
     case cast_field(key, param_key, type, params, current, empty_values, defaults, valid?) do
       {:ok, value, valid?} ->
         {Map.put(changes, key, value), errors, valid?}
+
       :missing ->
         {changes, errors, valid?}
+
       {:invalid, custom_errors} ->
         {message, new_errors} =
           custom_errors
           |> Keyword.put_new(:validation, :cast)
           |> Keyword.put(:type, type)
           |> Keyword.pop(:message, "is invalid")
+
         {changes, [{key, {message, new_errors}} | errors], false}
     end
   end
@@ -550,11 +590,14 @@ defmodule Ecto.Changeset do
   defp cast_type!(types, key) do
     case types do
       %{^key => {tag, _}} when tag in @relations ->
-        raise "casting #{tag}s with cast/4 for #{inspect key} field is not supported, use cast_#{tag}/3 instead"
+        raise "casting #{tag}s with cast/4 for #{inspect(key)} field is not supported, use cast_#{tag}/3 instead"
+
       %{^key => type} ->
         type
+
       _ ->
         known_fields = types |> Map.keys() |> Enum.map_join(", ", &inspect/1)
+
         raise ArgumentError,
               "unknown field `#{inspect(key)}` given to cast. Either the field does not exist or it is a " <>
                 ":through association (which are read-only). The known fields are: #{known_fields}"
@@ -565,12 +608,13 @@ defmodule Ecto.Changeset do
     do: {key, Atom.to_string(key)}
 
   defp cast_key(key),
-    do: raise ArgumentError, "cast/3 expects a list of atom keys, got: `#{inspect key}`"
+    do: raise(ArgumentError, "cast/3 expects a list of atom keys, got: `#{inspect(key)}`")
 
   defp cast_field(key, param_key, type, params, current, empty_values, defaults, valid?) do
     case params do
       %{^param_key => value} ->
         value = if value in empty_values, do: Map.get(defaults, key), else: value
+
         case Ecto.Type.cast(type, value) do
           {:ok, value} ->
             if Ecto.Type.equal?(type, current, value) do
@@ -604,9 +648,12 @@ defmodule Ecto.Changeset do
             if is_atom(key) do
               {Atom.to_string(key), value}
             else
-              raise Ecto.CastError, type: :map, value: params,
-                message: "expected params to be a map with atoms or string keys, " <>
-                           "got a map with mixed keys: #{inspect params}"
+              raise Ecto.CastError,
+                type: :map,
+                value: params,
+                message:
+                  "expected params to be a map with atoms or string keys, " <>
+                    "got a map with mixed keys: #{inspect(params)}"
             end
           end
 
@@ -622,9 +669,12 @@ defmodule Ecto.Changeset do
           nil
 
         {key, _value}, _ when is_binary(key) ->
-          raise Ecto.CastError, type: :map, value: params,
-                                message: "expected params to be a map with atoms or string keys, " <>
-                                         "got a map with mixed keys: #{inspect params}"
+          raise Ecto.CastError,
+            type: :map,
+            value: params,
+            message:
+              "expected params to be a map with atoms or string keys, " <>
+                "got a map with mixed keys: #{inspect(params)}"
 
         {key, value}, nil when is_atom(key) ->
           [{Atom.to_string(key), value}]
@@ -794,9 +844,10 @@ defmodule Ecto.Changeset do
   end
 
   defp cast_relation(type, %Changeset{data: data, types: types}, _name, _opts)
-      when data == nil or types == nil do
-    raise ArgumentError, "cast_#{type}/3 expects the changeset to be cast. " <>
-                         "Please call cast/4 before calling cast_#{type}/3"
+       when data == nil or types == nil do
+    raise ArgumentError,
+          "cast_#{type}/3 expects the changeset to be cast. " <>
+            "Please call cast/4 before calling cast_#{type}/3"
   end
 
   defp cast_relation(type, %Changeset{} = changeset, key, opts) do
@@ -807,18 +858,19 @@ defmodule Ecto.Changeset do
 
     {changeset, required?} =
       if opts[:required] do
-        {update_in(changeset.required, &[key|&1]), true}
+        {update_in(changeset.required, &[key | &1]), true}
       else
         {changeset, false}
       end
 
-    on_cast  = Keyword.get_lazy(opts, :with, fn -> on_cast_default(type, related) end)
+    on_cast = Keyword.get_lazy(opts, :with, fn -> on_cast_default(type, related) end)
     original = Map.get(data, key)
 
     changeset =
       case Map.fetch(params, param_key) do
         {:ok, value} ->
-          current  = Relation.load!(data, original)
+          current = Relation.load!(data, original)
+
           case Relation.cast(relation, data, value, current, on_cast) do
             {:ok, change, relation_valid?} when change != original ->
               valid? = changeset.valid? and relation_valid?
@@ -840,9 +892,9 @@ defmodule Ecto.Changeset do
           missing_relation(changeset, key, original, required?, relation, opts)
       end
 
-    update_in changeset.types[key], fn {type, relation} ->
+    update_in(changeset.types[key], fn {type, relation} ->
       {type, %{relation | on_cast: on_cast}}
-    end
+    end)
   end
 
   defp on_cast_default(type, module) do
@@ -852,10 +904,11 @@ defmodule Ecto.Changeset do
       rescue
         e in UndefinedFunctionError ->
           case __STACKTRACE__ do
-            [{^module, :changeset, args_or_arity, _}] when args_or_arity == 2
-                                                      when length(args_or_arity) == 2 ->
+            [{^module, :changeset, args_or_arity, _}]
+            when args_or_arity == 2
+            when length(args_or_arity) == 2 ->
               raise ArgumentError, """
-              the module #{inspect module} does not define a changeset/2 function,
+              the module #{inspect(module)} does not define a changeset/2 function,
               which is used by cast_#{type}/3. You need to either:
 
                 1. implement the #{type}.changeset/2 function
@@ -864,6 +917,7 @@ defmodule Ecto.Changeset do
 
               When using an inline embed, the :with option must be given
               """
+
             stacktrace ->
               reraise e, stacktrace
           end
@@ -871,11 +925,22 @@ defmodule Ecto.Changeset do
     end
   end
 
-  defp missing_relation(%{changes: changes, errors: errors} = changeset,
-                        name, current, required?, relation, opts) do
+  defp missing_relation(
+         %{changes: changes, errors: errors} = changeset,
+         name,
+         current,
+         required?,
+         relation,
+         opts
+       ) do
     current_changes = Map.get(changes, name, current)
+
     if required? and Relation.empty?(relation, current_changes) do
-      errors = [{name, {message(opts, :required_message, "can't be blank"), [validation: :required]}} | errors]
+      errors = [
+        {name, {message(opts, :required_message, "can't be blank"), [validation: :required]}}
+        | errors
+      ]
+
       %{changeset | errors: errors, valid?: false}
     else
       changeset
@@ -884,14 +949,34 @@ defmodule Ecto.Changeset do
 
   defp relation!(_op, type, _name, {type, relation}),
     do: relation
+
   defp relation!(op, :assoc, name, nil),
-    do: raise(ArgumentError, "cannot #{op} assoc `#{name}`, assoc `#{name}` not found. Make sure it is spelled correctly and that the association type is not read-only")
+    do:
+      raise(
+        ArgumentError,
+        "cannot #{op} assoc `#{name}`, assoc `#{name}` not found. Make sure it is spelled correctly and that the association type is not read-only"
+      )
+
   defp relation!(op, type, name, nil),
-    do: raise(ArgumentError, "cannot #{op} #{type} `#{name}`, #{type} `#{name}` not found. Make sure that it exists and is spelled correctly")
+    do:
+      raise(
+        ArgumentError,
+        "cannot #{op} #{type} `#{name}`, #{type} `#{name}` not found. Make sure that it exists and is spelled correctly"
+      )
+
   defp relation!(op, type, name, {other, _}) when other in @relations,
-    do: raise(ArgumentError, "expected `#{name}` to be an #{type} in `#{op}_#{type}`, got: `#{other}`")
+    do:
+      raise(
+        ArgumentError,
+        "expected `#{name}` to be an #{type} in `#{op}_#{type}`, got: `#{other}`"
+      )
+
   defp relation!(op, type, name, schema_type),
-    do: raise(ArgumentError, "expected `#{name}` to be an #{type} in `#{op}_#{type}`, got: `#{inspect schema_type}`")
+    do:
+      raise(
+        ArgumentError,
+        "expected `#{name}` to be an #{type} in `#{op}_#{type}`, got: `#{inspect(schema_type)}`"
+      )
 
   defp force_update(changeset, opts) do
     if Keyword.get(opts, :force_update_on_change, true) do
@@ -944,16 +1029,25 @@ defmodule Ecto.Changeset do
   def merge(changeset1, changeset2)
 
   def merge(%Changeset{data: data} = cs1, %Changeset{data: data} = cs2) do
-    new_repo        = merge_identical(cs1.repo, cs2.repo, "repos")
-    new_repo_opts   = Keyword.merge(cs1.repo_opts, cs2.repo_opts)
-    new_action      = merge_identical(cs1.action, cs2.action, "actions")
-    new_filters     = Map.merge(cs1.filters, cs2.filters)
+    new_repo = merge_identical(cs1.repo, cs2.repo, "repos")
+    new_repo_opts = Keyword.merge(cs1.repo_opts, cs2.repo_opts)
+    new_action = merge_identical(cs1.action, cs2.action, "actions")
+    new_filters = Map.merge(cs1.filters, cs2.filters)
     new_validations = cs1.validations ++ cs2.validations
     new_constraints = cs1.constraints ++ cs2.constraints
 
-    cast_merge %{cs1 | repo: new_repo, repo_opts: new_repo_opts, filters: new_filters,
-                       action: new_action, validations: new_validations,
-                       constraints: new_constraints}, cs2
+    cast_merge(
+      %{
+        cs1
+        | repo: new_repo,
+          repo_opts: new_repo_opts,
+          filters: new_filters,
+          action: new_action,
+          validations: new_validations,
+          constraints: new_constraints
+      },
+      cs2
+    )
   end
 
   def merge(%Changeset{}, %Changeset{}) do
@@ -961,23 +1055,32 @@ defmodule Ecto.Changeset do
   end
 
   defp cast_merge(cs1, cs2) do
-    new_params   = (cs1.params || cs2.params) && Map.merge(cs1.params || %{}, cs2.params || %{})
-    new_changes  = Map.merge(cs1.changes, cs2.changes)
-    new_errors   = Enum.uniq(cs1.errors ++ cs2.errors)
+    new_params = (cs1.params || cs2.params) && Map.merge(cs1.params || %{}, cs2.params || %{})
+    new_changes = Map.merge(cs1.changes, cs2.changes)
+    new_errors = Enum.uniq(cs1.errors ++ cs2.errors)
     new_required = Enum.uniq(cs1.required ++ cs2.required)
-    new_types    = cs1.types || cs2.types
-    new_valid?   = cs1.valid? and cs2.valid?
+    new_types = cs1.types || cs2.types
+    new_valid? = cs1.valid? and cs2.valid?
 
-    %{cs1 | params: new_params, valid?: new_valid?, errors: new_errors, types: new_types,
-            changes: new_changes, required: new_required}
+    %{
+      cs1
+      | params: new_params,
+        valid?: new_valid?,
+        errors: new_errors,
+        types: new_types,
+        changes: new_changes,
+        required: new_required
+    }
   end
 
   defp merge_identical(object, nil, _thing), do: object
   defp merge_identical(nil, object, _thing), do: object
   defp merge_identical(object, object, _thing), do: object
+
   defp merge_identical(lhs, rhs, thing) do
-    raise ArgumentError, "different #{thing} (`#{inspect lhs}` and " <>
-                         "`#{inspect rhs}`) when merging changesets"
+    raise ArgumentError,
+          "different #{thing} (`#{inspect(lhs)}` and " <>
+            "`#{inspect(rhs)}`) when merging changesets"
   end
 
   @doc """
@@ -1005,14 +1108,16 @@ defmodule Ecto.Changeset do
 
   """
   @spec fetch_field(t, atom) :: {:changes, term} | {:data, term} | :error
-  def fetch_field(%Changeset{changes: changes, data: data, types: types}, key) when is_atom(key) do
+  def fetch_field(%Changeset{changes: changes, data: data, types: types}, key)
+      when is_atom(key) do
     case Map.fetch(changes, key) do
       {:ok, value} ->
         {:changes, change_as_field(types, key, value)}
+
       :error ->
         case Map.fetch(data, key) do
           {:ok, value} -> {:data, data_as_field(data, types, key, value)}
-          :error       -> :error
+          :error -> :error
         end
     end
   end
@@ -1064,10 +1169,11 @@ defmodule Ecto.Changeset do
     case Map.fetch(changes, key) do
       {:ok, value} ->
         change_as_field(types, key, value)
+
       :error ->
         case Map.fetch(data, key) do
           {:ok, value} -> data_as_field(data, types, key, value)
-          :error       -> default
+          :error -> default
         end
     end
   end
@@ -1076,6 +1182,7 @@ defmodule Ecto.Changeset do
     case Map.get(types, key) do
       {tag, relation} when tag in @relations ->
         Relation.apply_changes(relation, value)
+
       _other ->
         value
     end
@@ -1085,6 +1192,7 @@ defmodule Ecto.Changeset do
     case Map.get(types, key) do
       {tag, _relation} when tag in @relations ->
         Relation.load!(data, value)
+
       _other ->
         value
     end
@@ -1145,7 +1253,8 @@ defmodule Ecto.Changeset do
 
   """
   @spec get_change(t, atom, term) :: term
-  def get_change(%Changeset{changes: changes} = _changeset, key, default \\ nil) when is_atom(key) do
+  def get_change(%Changeset{changes: changes} = _changeset, key, default \\ nil)
+      when is_atom(key) do
     Map.get(changes, key, default)
   end
 
@@ -1169,6 +1278,7 @@ defmodule Ecto.Changeset do
     case Map.fetch(changes, key) do
       {:ok, value} ->
         put_change(changeset, key, function.(value))
+
       :error ->
         changeset
     end
@@ -1209,8 +1319,10 @@ defmodule Ecto.Changeset do
 
   def put_change(%Changeset{data: data, types: types} = changeset, key, value) do
     type = Map.get(types, key)
+
     {changes, errors, valid?} =
       put_change(data, changeset.changes, changeset.errors, changeset.valid?, key, value, type)
+
     %{changeset | changes: changes, errors: errors, valid?: valid?}
   end
 
@@ -1222,8 +1334,10 @@ defmodule Ecto.Changeset do
     case Relation.change(relation, value, current) do
       {:ok, change, relation_valid?} when change != original ->
         {Map.put(changes, key, change), errors, valid? and relation_valid?}
+
       {:error, error} ->
         {changes, [{key, error} | errors], false}
+
       # ignore or ok with change == original
       _ ->
         {Map.delete(changes, key), errors, valid?}
@@ -1235,7 +1349,8 @@ defmodule Ecto.Changeset do
   end
 
   defp put_change(_data, _changes, _errors, _valid?, key, _value, nil) when not is_atom(key) do
-    raise ArgumentError, "field names given to change/put_change must be atoms, got: `#{inspect(key)}`"
+    raise ArgumentError,
+          "field names given to change/put_change must be atoms, got: `#{inspect(key)}`"
   end
 
   defp put_change(data, changes, errors, valid?, key, value, type) do
@@ -1428,8 +1543,10 @@ defmodule Ecto.Changeset do
   defp put_relation(tag, changeset, name, value, _opts) do
     %{data: data, types: types, changes: changes, errors: errors, valid?: valid?} = changeset
     relation = relation!(:put, tag, name, Map.get(types, name))
+
     {changes, errors, valid?} =
       put_change(data, changes, errors, valid?, name, value, {tag, relation})
+
     %{changeset | changes: changes, errors: errors, valid?: valid?}
   end
 
@@ -1460,11 +1577,13 @@ defmodule Ecto.Changeset do
     case Map.get(types, key) do
       {tag, _} when tag in @relations ->
         raise "changing #{tag}s with force_change/3 is not supported, " <>
-              "please use put_#{tag}/4 instead"
+                "please use put_#{tag}/4 instead"
+
       nil ->
         raise ArgumentError, "unknown field `#{inspect(key)}` in #{inspect(changeset.data)}"
+
       _ ->
-        put_in changeset.changes[key], value
+        put_in(changeset.changes[key], value)
     end
   end
 
@@ -1481,9 +1600,8 @@ defmodule Ecto.Changeset do
   """
   @spec delete_change(t, atom) :: t
   def delete_change(%Changeset{} = changeset, key) when is_atom(key) do
-    update_in changeset.changes, &Map.delete(&1, key)
+    update_in(changeset.changes, &Map.delete(&1, key))
   end
-
 
   @doc """
   Applies the changeset changes to the changeset data.
@@ -1498,7 +1616,7 @@ defmodule Ecto.Changeset do
       %Post{author: "bar", title: "foo"}
 
   """
-  @spec apply_changes(t) :: Ecto.Schema.t | data
+  @spec apply_changes(t) :: Ecto.Schema.t() | data
   def apply_changes(%Changeset{changes: changes, data: data}) when changes == %{} do
     data
   end
@@ -1511,6 +1629,7 @@ defmodule Ecto.Changeset do
 
         {:ok, _} ->
           Map.put(acc, key, value)
+
         :error ->
           acc
       end
@@ -1542,8 +1661,9 @@ defmodule Ecto.Changeset do
       {:error, %Changeset{changeset | action: action}}
     end
   end
+
   def apply_action(%Changeset{}, action) do
-    raise ArgumentError, "expected action to be an atom, got: #{inspect action}"
+    raise ArgumentError, "expected action to be an atom, got: #{inspect(action)}"
   end
 
   @doc """
@@ -1661,9 +1781,10 @@ defmodule Ecto.Changeset do
       iex> changeset.valid?
       false
   """
-  @spec add_error(t, atom, String.t, Keyword.t) :: t
-  def add_error(%Changeset{errors: errors} = changeset, key, message, keys \\ []) when is_binary(message) do
-    %{changeset | errors: [{key, {message, keys}}|errors], valid?: false}
+  @spec add_error(t, atom, String.t(), Keyword.t()) :: t
+  def add_error(%Changeset{errors: errors} = changeset, key, message, keys \\ [])
+      when is_binary(message) do
+    %{changeset | errors: [{key, {message, keys}} | errors], valid?: false}
   end
 
   @doc """
@@ -1693,24 +1814,30 @@ defmodule Ecto.Changeset do
       [title: {"cannot be foo", []}]
 
   """
-  @spec validate_change(t, atom, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}}])) :: t
+  @spec validate_change(
+          t,
+          atom,
+          (atom, term -> [{atom, String.t()} | {atom, {String.t(), Keyword.t()}}])
+        ) :: t
   def validate_change(%Changeset{} = changeset, field, validator) when is_atom(field) do
     %{changes: changes, errors: errors} = changeset
     ensure_field_exists!(changeset, field)
 
     value = Map.get(changes, field)
-    new   = if is_nil(value), do: [], else: validator.(field, value)
-    new   =
+    new = if is_nil(value), do: [], else: validator.(field, value)
+
+    new =
       Enum.map(new, fn
         {key, val} when is_atom(key) and is_binary(val) ->
           {key, {val, []}}
+
         {key, {val, opts}} when is_atom(key) and is_binary(val) and is_list(opts) ->
           {key, {val, opts}}
       end)
 
     case new do
-      []    -> changeset
-      [_|_] -> %{changeset | errors: new ++ errors, valid?: false}
+      [] -> changeset
+      [_ | _] -> %{changeset | errors: new ++ errors, valid?: false}
     end
   end
 
@@ -1732,10 +1859,19 @@ defmodule Ecto.Changeset do
       [title: :useless_validator]
 
   """
-  @spec validate_change(t, atom, term, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}}])) :: t
-  def validate_change(%Changeset{validations: validations} = changeset,
-                      field, metadata, validator) do
-    changeset = %{changeset | validations: [{field, metadata}|validations]}
+  @spec validate_change(
+          t,
+          atom,
+          term,
+          (atom, term -> [{atom, String.t()} | {atom, {String.t(), Keyword.t()}}])
+        ) :: t
+  def validate_change(
+        %Changeset{validations: validations} = changeset,
+        field,
+        metadata,
+        validator
+      ) do
+    changeset = %{changeset | validations: [{field, metadata} | validations]}
     validate_change(changeset, field, validator)
   end
 
@@ -1781,7 +1917,7 @@ defmodule Ecto.Changeset do
       validate_required(changeset, [:title, :body])
 
   """
-  @spec validate_required(t, list | atom, Keyword.t) :: t
+  @spec validate_required(t, list | atom, Keyword.t()) :: t
   def validate_required(%Changeset{} = changeset, fields, opts \\ []) when not is_nil(fields) do
     %{required: required, errors: errors, changes: changes} = changeset
     trim = Keyword.get(opts, :trim, true)
@@ -1798,11 +1934,18 @@ defmodule Ecto.Changeset do
       [] ->
         %{changeset | required: fields ++ required}
 
-      _  ->
+      _ ->
         message = message(opts, "can't be blank")
         new_errors = Enum.map(fields_with_errors, &{&1, {message, [validation: :required]}})
         changes = Map.drop(changes, fields_with_errors)
-        %{changeset | changes: changes, required: fields ++ required, errors: new_errors ++ errors, valid?: false}
+
+        %{
+          changeset
+          | changes: changes,
+            required: fields ++ required,
+            errors: new_errors ++ errors,
+            valid?: false
+        }
     end
   end
 
@@ -1856,28 +1999,32 @@ defmodule Ecto.Changeset do
       unsafe_validate_unique(changeset, [:city_name, :state_name], repo, query: from(c in City, where: is_nil(c.deleted_at)))
 
   """
-  @spec unsafe_validate_unique(t, atom | [atom, ...], Ecto.Repo.t, Keyword.t) :: t
+  @spec unsafe_validate_unique(t, atom | [atom, ...], Ecto.Repo.t(), Keyword.t()) :: t
   def unsafe_validate_unique(changeset, fields, repo, opts \\ []) when is_list(opts) do
     fields = List.wrap(fields)
     {repo_opts, opts} = Keyword.pop(opts, :repo_opts, [])
+
     {validations, schema} =
       case changeset do
         %Ecto.Changeset{validations: validations, data: %schema{}} ->
           {validations, schema}
+
         %Ecto.Changeset{} ->
           raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets"
       end
+
     changeset = %{changeset | validations: [{:unsafe_unique, fields} | validations]}
 
-    where_clause = for field <- fields do
-      {field, get_field(changeset, field)}
-    end
+    where_clause =
+      for field <- fields do
+        {field, get_field(changeset, field)}
+      end
 
     # No need to query if there is a prior error for the fields
     any_prior_errors_for_fields? = Enum.any?(changeset.errors, &(elem(&1, 0) in fields))
 
     # No need to query if we haven't changed any of the fields in question
-    unrelated_changes? = Enum.all?(fields, &not Map.has_key?(changeset.changes, &1))
+    unrelated_changes? = Enum.all?(fields, &(not Map.has_key?(changeset.changes, &1)))
 
     # If we don't have values for all fields, we can't query for uniqueness
     any_nil_values_for_fields? = Enum.any?(where_clause, &(&1 |> elem(1) |> is_nil()))
@@ -1903,7 +2050,9 @@ defmodule Ecto.Changeset do
         error_key = Keyword.get(opts, :error_key, hd(fields))
 
         add_error(changeset, error_key, message(opts, "has already been taken"),
-                  validation: :unsafe_unique, fields: fields)
+          validation: :unsafe_unique,
+          fields: fields
+        )
       else
         changeset
       end
@@ -1946,25 +2095,36 @@ defmodule Ecto.Changeset do
     unless Map.has_key?(types, field) do
       raise ArgumentError, "unknown field #{inspect(field)} in #{inspect(data)}"
     end
+
     true
   end
 
   defp missing?(changeset, field, trim) when is_atom(field) do
     case get_field(changeset, field) do
       %{__struct__: Ecto.Association.NotLoaded} ->
-        raise ArgumentError, "attempting to validate association `#{field}` " <>
-                             "that was not loaded. Please preload your associations " <>
-                             "before calling validate_required/3 or pass the :required " <>
-                             "option to Ecto.Changeset.cast_assoc/3"
-      value when is_binary(value) and trim -> String.trim_leading(value) == ""
-      value when is_binary(value) -> value == ""
-      nil -> true
-      _ -> false
+        raise ArgumentError,
+              "attempting to validate association `#{field}` " <>
+                "that was not loaded. Please preload your associations " <>
+                "before calling validate_required/3 or pass the :required " <>
+                "option to Ecto.Changeset.cast_assoc/3"
+
+      value when is_binary(value) and trim ->
+        String.trim_leading(value) == ""
+
+      value when is_binary(value) ->
+        value == ""
+
+      nil ->
+        true
+
+      _ ->
+        false
     end
   end
 
   defp missing?(_changeset, field, _trim) do
-    raise ArgumentError, "validate_required/3 expects field names to be atoms, got: `#{inspect field}`"
+    raise ArgumentError,
+          "validate_required/3 expects field names to be atoms, got: `#{inspect(field)}`"
   end
 
   @doc """
@@ -1981,11 +2141,13 @@ defmodule Ecto.Changeset do
       validate_format(changeset, :email, ~r/@/)
 
   """
-  @spec validate_format(t, atom, Regex.t, Keyword.t) :: t
+  @spec validate_format(t, atom, Regex.t(), Keyword.t()) :: t
   def validate_format(changeset, field, format, opts \\ []) do
-    validate_change changeset, field, {:format, format}, fn _, value ->
-      if value =~ format, do: [], else: [{field, {message(opts, "has invalid format"), [validation: :format]}}]
-    end
+    validate_change(changeset, field, {:format, format}, fn _, value ->
+      if value =~ format,
+        do: [],
+        else: [{field, {message(opts, "has invalid format"), [validation: :format]}}]
+    end)
   end
 
   @doc """
@@ -2001,15 +2163,15 @@ defmodule Ecto.Changeset do
       validate_inclusion(changeset, :age, 0..99)
 
   """
-  @spec validate_inclusion(t, atom, Enum.t, Keyword.t) :: t
+  @spec validate_inclusion(t, atom, Enum.t(), Keyword.t()) :: t
   def validate_inclusion(changeset, field, data, opts \\ []) do
-    validate_change changeset, field, {:inclusion, data}, fn _, value ->
+    validate_change(changeset, field, {:inclusion, data}, fn _, value ->
       type = Map.fetch!(changeset.types, field)
 
       if Ecto.Type.include?(type, value, data),
         do: [],
         else: [{field, {message(opts, "is invalid"), [validation: :inclusion, enum: data]}}]
-    end
+    end)
   end
 
   @doc ~S"""
@@ -2029,16 +2191,19 @@ defmodule Ecto.Changeset do
       validate_subset(changeset, :lottery_numbers, 0..99)
 
   """
-  @spec validate_subset(t, atom, Enum.t, Keyword.t) :: t
+  @spec validate_subset(t, atom, Enum.t(), Keyword.t()) :: t
   def validate_subset(changeset, field, data, opts \\ []) do
-    validate_change changeset, field, {:subset, data}, fn _, value ->
+    validate_change(changeset, field, {:subset, data}, fn _, value ->
       {:array, element_type} = Map.fetch!(changeset.types, field)
 
       case Enum.any?(value, fn element -> not Ecto.Type.include?(element_type, element, data) end) do
-        true -> [{field, {message(opts, "has an invalid entry"), [validation: :subset, enum: data]}}]
-        false -> []
+        true ->
+          [{field, {message(opts, "has an invalid entry"), [validation: :subset, enum: data]}}]
+
+        false ->
+          []
       end
-    end
+    end)
   end
 
   @doc """
@@ -2053,14 +2218,15 @@ defmodule Ecto.Changeset do
       validate_exclusion(changeset, :name, ~w(admin superadmin))
 
   """
-  @spec validate_exclusion(t, atom, Enum.t, Keyword.t) :: t
+  @spec validate_exclusion(t, atom, Enum.t(), Keyword.t()) :: t
   def validate_exclusion(changeset, field, data, opts \\ []) do
-    validate_change changeset, field, {:exclusion, data}, fn _, value ->
+    validate_change(changeset, field, {:exclusion, data}, fn _, value ->
       type = Map.fetch!(changeset.types, field)
 
-      if Ecto.Type.include?(type, value, data), do:
-        [{field, {message(opts, "is reserved"), [validation: :exclusion, enum: data]}}], else: []
-    end
+      if Ecto.Type.include?(type, value, data),
+        do: [{field, {message(opts, "is reserved"), [validation: :exclusion, enum: data]}}],
+        else: []
+    end)
   end
 
   @doc """
@@ -2102,28 +2268,34 @@ defmodule Ecto.Changeset do
       validate_length(changeset, :icon, count: :bytes, max: 1024 * 16)
 
   """
-  @spec validate_length(t, atom, Keyword.t) :: t
+  @spec validate_length(t, atom, Keyword.t()) :: t
   def validate_length(changeset, field, opts) when is_list(opts) do
-    validate_change changeset, field, {:length, opts}, fn
+    validate_change(changeset, field, {:length, opts}, fn
       _, value ->
         count_type = opts[:count] || :graphemes
-        {type, length} = case {value, count_type} do
-          {value, :codepoints} when is_binary(value) ->
-            {:string, codepoints_length(value, 0)}
-          {value, :graphemes} when is_binary(value) ->
-            {:string, String.length(value)}
-          {value, :bytes} when is_binary(value) ->
-            {:binary, byte_size(value)}
-          {value, _} when is_list(value) ->
-            {:list, list_length(changeset, field, value)}
-        end
 
-        error = ((is = opts[:is]) && wrong_length(type, length, is, opts)) ||
-                ((min = opts[:min]) && too_short(type, length, min, opts)) ||
-                ((max = opts[:max]) && too_long(type, length, max, opts))
+        {type, length} =
+          case {value, count_type} do
+            {value, :codepoints} when is_binary(value) ->
+              {:string, codepoints_length(value, 0)}
+
+            {value, :graphemes} when is_binary(value) ->
+              {:string, String.length(value)}
+
+            {value, :bytes} when is_binary(value) ->
+              {:binary, byte_size(value)}
+
+            {value, _} when is_list(value) ->
+              {:list, list_length(changeset, field, value)}
+          end
+
+        error =
+          ((is = opts[:is]) && wrong_length(type, length, is, opts)) ||
+            ((min = opts[:min]) && too_short(type, length, min, opts)) ||
+            ((max = opts[:max]) && too_long(type, length, max, opts))
 
         if error, do: [{field, error}], else: []
-    end
+    end)
   end
 
   defp codepoints_length(<<_::utf8, rest::binary>>, acc), do: codepoints_length(rest, acc + 1)
@@ -2134,34 +2306,62 @@ defmodule Ecto.Changeset do
     case Map.fetch(types, field) do
       {:ok, {tag, _association}} when tag in [:embed, :assoc] ->
         length(Relation.filter_empty(value))
+
       _ ->
         length(value)
     end
   end
 
   defp wrong_length(_type, value, value, _opts), do: nil
-  defp wrong_length(:string, _length, value, opts), do:
-    {message(opts, "should be %{count} character(s)"), count: value, validation: :length, kind: :is, type: :string}
-  defp wrong_length(:binary, _length, value, opts), do:
-    {message(opts, "should be %{count} byte(s)"), count: value, validation: :length, kind: :is, type: :binary}
-  defp wrong_length(:list, _length, value, opts), do:
-    {message(opts, "should have %{count} item(s)"), count: value, validation: :length, kind: :is, type: :list}
+
+  defp wrong_length(:string, _length, value, opts),
+    do:
+      {message(opts, "should be %{count} character(s)"),
+       count: value, validation: :length, kind: :is, type: :string}
+
+  defp wrong_length(:binary, _length, value, opts),
+    do:
+      {message(opts, "should be %{count} byte(s)"),
+       count: value, validation: :length, kind: :is, type: :binary}
+
+  defp wrong_length(:list, _length, value, opts),
+    do:
+      {message(opts, "should have %{count} item(s)"),
+       count: value, validation: :length, kind: :is, type: :list}
 
   defp too_short(_type, length, value, _opts) when length >= value, do: nil
-  defp too_short(:string, _length, value, opts), do:
-    {message(opts, "should be at least %{count} character(s)"), count: value, validation: :length, kind: :min, type: :string}
-  defp too_short(:binary, _length, value, opts), do:
-    {message(opts, "should be at least %{count} byte(s)"), count: value, validation: :length, kind: :min, type: :binary}
-  defp too_short(:list, _length, value, opts), do:
-    {message(opts, "should have at least %{count} item(s)"), count: value, validation: :length, kind: :min, type: :list}
+
+  defp too_short(:string, _length, value, opts),
+    do:
+      {message(opts, "should be at least %{count} character(s)"),
+       count: value, validation: :length, kind: :min, type: :string}
+
+  defp too_short(:binary, _length, value, opts),
+    do:
+      {message(opts, "should be at least %{count} byte(s)"),
+       count: value, validation: :length, kind: :min, type: :binary}
+
+  defp too_short(:list, _length, value, opts),
+    do:
+      {message(opts, "should have at least %{count} item(s)"),
+       count: value, validation: :length, kind: :min, type: :list}
 
   defp too_long(_type, length, value, _opts) when length <= value, do: nil
-  defp too_long(:string, _length, value, opts), do:
-    {message(opts, "should be at most %{count} character(s)"), count: value, validation: :length, kind: :max, type: :string}
-  defp too_long(:binary, _length, value, opts), do:
-    {message(opts, "should be at most %{count} byte(s)"), count: value, validation: :length, kind: :max, type: :binary}
-  defp too_long(:list, _length, value, opts), do:
-    {message(opts, "should have at most %{count} item(s)"), count: value, validation: :length, kind: :max, type: :list}
+
+  defp too_long(:string, _length, value, opts),
+    do:
+      {message(opts, "should be at most %{count} character(s)"),
+       count: value, validation: :length, kind: :max, type: :string}
+
+  defp too_long(:binary, _length, value, opts),
+    do:
+      {message(opts, "should be at most %{count} byte(s)"),
+       count: value, validation: :length, kind: :max, type: :binary}
+
+  defp too_long(:list, _length, value, opts),
+    do:
+      {message(opts, "should have at most %{count} item(s)"),
+       count: value, validation: :length, kind: :max, type: :list}
 
   @doc """
   Validates the properties of a number.
@@ -2189,48 +2389,60 @@ defmodule Ecto.Changeset do
       validate_number(changeset, :the_answer_to_life_the_universe_and_everything, equal_to: 42)
 
   """
-  @spec validate_number(t, atom, Keyword.t) :: t
+  @spec validate_number(t, atom, Keyword.t()) :: t
   def validate_number(changeset, field, opts) do
-    validate_change changeset, field, {:number, opts}, fn
+    validate_change(changeset, field, {:number, opts}, fn
       field, value ->
         {message, opts} = Keyword.pop(opts, :message)
-        Enum.find_value opts, [], fn {spec_key, target_value} ->
+
+        Enum.find_value(opts, [], fn {spec_key, target_value} ->
           case Map.fetch(@number_validators, spec_key) do
             {:ok, {spec_function, default_message}} ->
-              validate_number(field, value, message || default_message,
-                              spec_key, spec_function, target_value)
+              validate_number(
+                field,
+                value,
+                message || default_message,
+                spec_key,
+                spec_function,
+                target_value
+              )
+
             :error ->
-              supported_options = @number_validators |> Map.keys() |> Enum.map_join("\n", &"  * #{inspect(&1)}")
+              supported_options =
+                @number_validators |> Map.keys() |> Enum.map_join("\n", &"  * #{inspect(&1)}")
 
               raise ArgumentError, """
-              unknown option #{inspect spec_key} given to validate_number/3
+              unknown option #{inspect(spec_key)} given to validate_number/3
 
               The supported options are:
 
               #{supported_options}
               """
           end
-        end
-    end
+        end)
+    end)
   end
 
   defp validate_number(field, %Decimal{} = value, message, spec_key, _spec_function, target_value) do
     result = Decimal.compare(value, decimal_new(target_value)) |> normalize_compare()
+
     case decimal_compare(result, spec_key) do
-      true  -> nil
+      true -> nil
       false -> [{field, {message, validation: :number, kind: spec_key, number: target_value}}]
     end
   end
 
-  defp validate_number(field, value, message, spec_key, spec_function, target_value) when is_number(value) do
+  defp validate_number(field, value, message, spec_key, spec_function, target_value)
+       when is_number(value) do
     case apply(spec_function, [value, target_value]) do
-      true  -> nil
+      true -> nil
       false -> [{field, {message, validation: :number, kind: spec_key, number: target_value}}]
     end
   end
 
   defp validate_number(_field, value, _message, _spec_key, _spec_function, _target_value) do
-    raise ArgumentError, "expected value to be of type Decimal, Integer or Float, got: #{inspect value}"
+    raise ArgumentError,
+          "expected value to be of type Decimal, Integer or Float, got: #{inspect(value)}"
   end
 
   # TODO: Remove me once we support Decimal 2.0 only
@@ -2248,8 +2460,12 @@ defmodule Ecto.Changeset do
   defp decimal_new(term), do: Decimal.new(term)
 
   defp decimal_compare(:lt, spec), do: spec in [:less_than, :less_than_or_equal_to, :not_equal_to]
-  defp decimal_compare(:gt, spec), do: spec in [:greater_than, :greater_than_or_equal_to, :not_equal_to]
-  defp decimal_compare(:eq, spec), do: spec in [:equal_to, :less_than_or_equal_to, :greater_than_or_equal_to]
+
+  defp decimal_compare(:gt, spec),
+    do: spec in [:greater_than, :greater_than_or_equal_to, :not_equal_to]
+
+  defp decimal_compare(:eq, spec),
+    do: spec in [:equal_to, :less_than_or_equal_to, :greater_than_or_equal_to]
 
   @doc """
   Validates that the given parameter matches its confirmation.
@@ -2280,8 +2496,9 @@ defmodule Ecto.Changeset do
       |> validate_confirmation(:password, message: "does not match password")
 
   """
-  @spec validate_confirmation(t, atom, Keyword.t) :: t
+  @spec validate_confirmation(t, atom, Keyword.t()) :: t
   def validate_confirmation(changeset, field, opts \\ [])
+
   def validate_confirmation(%{params: params} = changeset, field, opts) when is_map(params) do
     param = Atom.to_string(field)
     error_param = "#{param}_confirmation"
@@ -2292,24 +2509,35 @@ defmodule Ecto.Changeset do
       case Map.fetch(params, error_param) do
         {:ok, ^value} ->
           []
+
         {:ok, _} ->
-          [{error_field,
-           {message(opts, "does not match confirmation"), [validation: :confirmation]}}]
+          [
+            {error_field,
+             {message(opts, "does not match confirmation"), [validation: :confirmation]}}
+          ]
+
         :error ->
           confirmation_missing(opts, error_field)
       end
 
-    %{changeset | validations: [{field, {:confirmation, opts}} | changeset.validations],
-                  errors: errors ++ changeset.errors,
-                  valid?: changeset.valid? and errors == []}
+    %{
+      changeset
+      | validations: [{field, {:confirmation, opts}} | changeset.validations],
+        errors: errors ++ changeset.errors,
+        valid?: changeset.valid? and errors == []
+    }
   end
+
   def validate_confirmation(%{params: nil} = changeset, _, _) do
     changeset
   end
 
   defp confirmation_missing(opts, error_field) do
     required = Keyword.get(opts, :required, false)
-    if required, do: [{error_field, {message(opts, "can't be blank"), [validation: :required]}}], else: []
+
+    if required,
+      do: [{error_field, {message(opts, "can't be blank"), [validation: :required]}}],
+      else: []
   end
 
   defp message(opts, key \\ :message, default) do
@@ -2333,14 +2561,18 @@ defmodule Ecto.Changeset do
       validate_acceptance(changeset, :rules, message: "please accept rules")
 
   """
-  @spec validate_acceptance(t, atom, Keyword.t) :: t
+  @spec validate_acceptance(t, atom, Keyword.t()) :: t
   def validate_acceptance(changeset, field, opts \\ [])
+
   def validate_acceptance(%{params: params} = changeset, field, opts) do
     errors = validate_acceptance_errors(params, field, opts)
 
-    %{changeset | validations: [{field, {:acceptance, opts}} | changeset.validations],
-                  errors: errors ++ changeset.errors,
-                  valid?: changeset.valid? and errors == []}
+    %{
+      changeset
+      | validations: [{field, {:acceptance, opts}} | changeset.validations],
+        errors: errors ++ changeset.errors,
+        valid?: changeset.valid? and errors == []
+    }
   end
 
   defp validate_acceptance_errors(nil, _field, _opts), do: []
@@ -2439,16 +2671,17 @@ defmodule Ecto.Changeset do
       iex> Ecto.Changeset.optimistic_lock(post, :lock_uuid, fn _ -> Ecto.UUID.generate end)
 
   """
-  @spec optimistic_lock(Ecto.Schema.t | t, atom, (term -> term)) :: t
+  @spec optimistic_lock(Ecto.Schema.t() | t, atom, (term -> term)) :: t
   def optimistic_lock(data_or_changeset, field, incrementer \\ &increment_with_rollover/1) do
     changeset = change(data_or_changeset, %{})
     current = get_field(changeset, field)
 
     # Apply these changes only inside the repo because we
     # don't want to permanently track the lock change.
-    changeset = prepare_changes(changeset, fn changeset ->
-      put_in(changeset.changes[field], incrementer.(current))
-    end)
+    changeset =
+      prepare_changes(changeset, fn changeset ->
+        put_in(changeset.changes[field], incrementer.(current))
+      end)
 
     changeset = put_in(changeset.filters[field], current)
     changeset
@@ -2500,7 +2733,8 @@ defmodule Ecto.Changeset do
   changeset must be returned.
   """
   @spec prepare_changes(t, (t -> t)) :: t
-  def prepare_changes(%Changeset{prepare: prepare} = changeset, function) when is_function(function, 1) do
+  def prepare_changes(%Changeset{prepare: prepare} = changeset, function)
+      when is_function(function, 1) do
     %{changeset | prepare: [function | prepare]}
   end
 
@@ -2566,7 +2800,7 @@ defmodule Ecto.Changeset do
   """
   def check_constraint(changeset, field, opts \\ []) do
     constraint = opts[:name] || raise ArgumentError, "must supply the name of the constraint"
-    message    = message(opts, "is invalid")
+    message = message(opts, "is invalid")
     match_type = Keyword.get(opts, :match, :exact)
     add_constraint(changeset, :check, to_string(constraint), match_type, field, message)
   end
@@ -2680,7 +2914,7 @@ defmodule Ecto.Changeset do
       |> unique_constraint(:email)
 
   """
-  @spec unique_constraint(t, atom | [atom, ...], Keyword.t) :: t
+  @spec unique_constraint(t, atom | [atom, ...], Keyword.t()) :: t
   def unique_constraint(changeset, field_or_fields, opts \\ [])
 
   def unique_constraint(changeset, field, opts) when is_atom(field) do
@@ -2689,7 +2923,7 @@ defmodule Ecto.Changeset do
 
   def unique_constraint(changeset, [first_field | _] = fields, opts) do
     constraint = opts[:name] || unique_index_name(changeset, fields)
-    message    = message(opts, "has already been taken")
+    message = message(opts, "has already been taken")
     match_type = Keyword.get(opts, :match, :exact)
     add_constraint(changeset, :unique, to_string(constraint), match_type, first_field, message)
   end
@@ -2739,11 +2973,22 @@ defmodule Ecto.Changeset do
       explicitly for complex cases
 
   """
-  @spec foreign_key_constraint(t, atom, Keyword.t) :: t
+  @spec foreign_key_constraint(t, atom, Keyword.t()) :: t
   def foreign_key_constraint(changeset, field, opts \\ []) do
-    constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_fkey"
-    message    = message(opts, "does not exist")
-    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, field, message, :foreign)
+    constraint =
+      opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_fkey"
+
+    message = message(opts, "does not exist")
+
+    add_constraint(
+      changeset,
+      :foreign_key,
+      to_string(constraint),
+      :exact,
+      field,
+      message,
+      :foreign
+    )
   end
 
   @doc """
@@ -2779,16 +3024,18 @@ defmodule Ecto.Changeset do
       name is inferred from the table + association field.
       May be required explicitly for complex cases
   """
-  @spec assoc_constraint(t, atom, Keyword.t) :: t
+  @spec assoc_constraint(t, atom, Keyword.t()) :: t
   def assoc_constraint(changeset, assoc, opts \\ []) do
-    constraint = opts[:name] ||
-      case get_assoc(changeset, assoc) do
-        %Ecto.Association.BelongsTo{owner_key: owner_key} ->
-          "#{get_source(changeset)}_#{owner_key}_fkey"
-        other ->
-          raise ArgumentError,
-            "assoc_constraint can only be added to belongs to associations, got: #{inspect other}"
-      end
+    constraint =
+      opts[:name] ||
+        case get_assoc(changeset, assoc) do
+          %Ecto.Association.BelongsTo{owner_key: owner_key} ->
+            "#{get_source(changeset)}_#{owner_key}_fkey"
+
+          other ->
+            raise ArgumentError,
+                  "assoc_constraint can only be added to belongs to associations, got: #{inspect(other)}"
+        end
 
     message = message(opts, "does not exist")
     add_constraint(changeset, :foreign_key, to_string(constraint), :exact, assoc, message, :assoc)
@@ -2829,20 +3076,32 @@ defmodule Ecto.Changeset do
       field. May be required explicitly for complex cases
 
   """
-  @spec no_assoc_constraint(t, atom, Keyword.t) :: t
+  @spec no_assoc_constraint(t, atom, Keyword.t()) :: t
   def no_assoc_constraint(changeset, assoc, opts \\ []) do
     {constraint, message} =
       case get_assoc(changeset, assoc) do
-        %Ecto.Association.Has{cardinality: cardinality,
-                              related_key: related_key, related: related} ->
+        %Ecto.Association.Has{
+          cardinality: cardinality,
+          related_key: related_key,
+          related: related
+        } ->
           {opts[:name] || "#{related.__schema__(:source)}_#{related_key}_fkey",
            message(opts, no_assoc_message(cardinality))}
+
         other ->
           raise ArgumentError,
-            "no_assoc_constraint can only be added to has one/many associations, got: #{inspect other}"
+                "no_assoc_constraint can only be added to has one/many associations, got: #{inspect(other)}"
       end
 
-    add_constraint(changeset, :foreign_key, to_string(constraint), :exact, assoc, message, :no_assoc)
+    add_constraint(
+      changeset,
+      :foreign_key,
+      to_string(constraint),
+      :exact,
+      assoc,
+      message,
+      :no_assoc
+    )
   end
 
   @doc """
@@ -2866,10 +3125,21 @@ defmodule Ecto.Changeset do
 
   """
   def exclusion_constraint(changeset, field, opts \\ []) do
-    constraint = opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_exclusion"
-    message    = message(opts, "violates an exclusion constraint")
+    constraint =
+      opts[:name] || "#{get_source(changeset)}_#{get_field_source(changeset, field)}_exclusion"
+
+    message = message(opts, "violates an exclusion constraint")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :exclusion, to_string(constraint), match_type, field, message, :exclusion)
+
+    add_constraint(
+      changeset,
+      :exclusion,
+      to_string(constraint),
+      match_type,
+      field,
+      message,
+      :exclusion
+    )
   end
 
   defp no_assoc_message(:one), do: "is still associated with this entry"
@@ -2879,11 +3149,19 @@ defmodule Ecto.Changeset do
     add_constraint(changeset, type, constraint, match, field, message, type)
   end
 
-  defp add_constraint(%Changeset{constraints: constraints} = changeset,
-                      type, constraint, match, field, error_message, error_type)
+  defp add_constraint(
+         %Changeset{constraints: constraints} = changeset,
+         type,
+         constraint,
+         match,
+         field,
+         error_message,
+         error_type
+       )
        when is_binary(constraint) and is_atom(field) and is_binary(error_message) do
     unless match in @match_types do
-      raise ArgumentError, "invalid match type: #{inspect match}. Allowed match types: #{inspect @match_types}"
+      raise ArgumentError,
+            "invalid match type: #{inspect(match)}. Allowed match types: #{inspect(@match_types)}"
     end
 
     constraint = %{
@@ -2900,15 +3178,26 @@ defmodule Ecto.Changeset do
 
   defp get_source(%{data: %{__meta__: %{source: source}}}) when is_binary(source),
     do: source
-  defp get_source(%{data: data}), do:
-    raise ArgumentError, "cannot add constraint to changeset because it does not have a source, got: #{inspect data}"
-  defp get_source(item), do:
-    raise ArgumentError, "cannot add constraint because a changeset was not supplied, got: #{inspect item}"
+
+  defp get_source(%{data: data}),
+    do:
+      raise(
+        ArgumentError,
+        "cannot add constraint to changeset because it does not have a source, got: #{inspect(data)}"
+      )
+
+  defp get_source(item),
+    do:
+      raise(
+        ArgumentError,
+        "cannot add constraint because a changeset was not supplied, got: #{inspect(item)}"
+      )
 
   defp get_assoc(%{types: types}, assoc) do
     case Map.fetch(types, assoc) do
       {:ok, {:assoc, association}} ->
         association
+
       _ ->
         raise_invalid_assoc(types, assoc)
     end
@@ -2916,12 +3205,15 @@ defmodule Ecto.Changeset do
 
   defp raise_invalid_assoc(types, assoc) do
     associations = for {_key, {:assoc, %{field: field}}} <- types, do: field
-    raise ArgumentError, "cannot add constraint to changeset because association `#{assoc}` does not exist. " <>
-                         "Did you mean one of `#{Enum.join(associations, "`, `")}`?"
+
+    raise ArgumentError,
+          "cannot add constraint to changeset because association `#{assoc}` does not exist. " <>
+            "Did you mean one of `#{Enum.join(associations, "`, `")}`?"
   end
 
   defp get_field_source(%{data: %{__struct__: schema}}, field) when is_atom(schema),
     do: schema.__schema__(:field_source, field) || field
+
   defp get_field_source(%{}, field),
     do: field
 
@@ -2952,8 +3244,12 @@ defmodule Ecto.Changeset do
   validations rules from `changeset.validations` to build detailed error
   description.
   """
-  @spec traverse_errors(t, (error -> String.t) | (Changeset.t, atom, error -> String.t)) :: %{atom => [term]}
-  def traverse_errors(%Changeset{errors: errors, changes: changes, types: types} = changeset, msg_func)
+  @spec traverse_errors(t, (error -> String.t()) | (Changeset.t(), atom, error -> String.t())) ::
+          %{atom => [term]}
+  def traverse_errors(
+        %Changeset{errors: errors, changes: changes, types: types} = changeset,
+        msg_func
+      )
       when is_function(msg_func, 1) or is_function(msg_func, 3) do
     errors
     |> Enum.reverse()
@@ -2961,17 +3257,17 @@ defmodule Ecto.Changeset do
     |> merge_related_keys(changes, types, msg_func, &traverse_errors/2)
   end
 
-  defp merge_keyword_keys(keyword_list, msg_func, _) when is_function(msg_func, 1)  do
-    Enum.reduce(keyword_list, %{}, fn({key, val}, acc) ->
+  defp merge_keyword_keys(keyword_list, msg_func, _) when is_function(msg_func, 1) do
+    Enum.reduce(keyword_list, %{}, fn {key, val}, acc ->
       val = msg_func.(val)
-      Map.update(acc, key, [val], &[val|&1])
+      Map.update(acc, key, [val], &[val | &1])
     end)
   end
 
-  defp merge_keyword_keys(keyword_list, msg_func, changeset) when is_function(msg_func, 3)  do
-    Enum.reduce(keyword_list, %{}, fn({key, val}, acc) ->
+  defp merge_keyword_keys(keyword_list, msg_func, changeset) when is_function(msg_func, 3) do
+    Enum.reduce(keyword_list, %{}, fn {key, val}, acc ->
       val = msg_func.(changeset, key, val)
-      Map.update(acc, key, [val], &[val|&1])
+      Map.update(acc, key, [val], &[val | &1])
     end)
   end
 
@@ -2980,7 +3276,7 @@ defmodule Ecto.Changeset do
   end
 
   defp merge_related_keys(map, changes, types, msg_func, traverse_function) do
-    Enum.reduce types, map, fn
+    Enum.reduce(types, map, fn
       {field, {tag, %{cardinality: :many}}}, acc when tag in @relations ->
         if changesets = Map.get(changes, field) do
           {child, all_empty?} =
@@ -2990,12 +3286,13 @@ defmodule Ecto.Changeset do
             end)
 
           case all_empty? do
-            true  -> acc
+            true -> acc
             false -> Map.put(acc, field, child)
           end
         else
           acc
         end
+
       {field, {tag, %{cardinality: :one}}}, acc when tag in @relations ->
         if changeset = Map.get(changes, field) do
           case traverse_function.(changeset, msg_func) do
@@ -3005,9 +3302,10 @@ defmodule Ecto.Changeset do
         else
           acc
         end
+
       {_, _}, acc ->
         acc
-    end
+    end)
   end
 
   defp apply_relation_changes(acc, key, relation, value) do
@@ -3041,8 +3339,14 @@ defmodule Ecto.Changeset do
       ...> end)
       %{title: [format: "/pattern/", length: "1-20"]}
   """
-  @spec traverse_validations(t, (error -> String.t) | (Changeset.t, atom, error -> String.t)) :: %{atom => [term]}
-  def traverse_validations(%Changeset{validations: validations, changes: changes, types: types} = changeset, msg_func)
+  @spec traverse_validations(
+          t,
+          (error -> String.t()) | (Changeset.t(), atom, error -> String.t())
+        ) :: %{atom => [term]}
+  def traverse_validations(
+        %Changeset{validations: validations, changes: changes, types: types} = changeset,
+        msg_func
+      )
       when is_function(msg_func, 1) or is_function(msg_func, 3) do
     validations
     |> Enum.reverse()
@@ -3055,26 +3359,39 @@ defimpl Inspect, for: Ecto.Changeset do
   import Inspect.Algebra
 
   def inspect(%Ecto.Changeset{data: data} = changeset, opts) do
-    list = for attr <- [:action, :changes, :errors, :data, :valid?] do
-      {attr, Map.get(changeset, attr)}
-    end
+    list =
+      for attr <- [:action, :changes, :errors, :data, :valid?] do
+        {attr, Map.get(changeset, attr)}
+      end
 
-    redacted_fields = case data do
-      %type{} -> 
-        if function_exported?(type, :__schema__, 1) do
-          type.__schema__(:redact_fields)
-        else
+    redacted_fields =
+      case data do
+        %type{} ->
+          if function_exported?(type, :__schema__, 1) do
+            type.__schema__(:redact_fields)
+          else
+            []
+          end
+
+        _ ->
           []
-        end
-      _ -> []
-    end
+      end
 
     container_doc("#Ecto.Changeset<", list, ">", opts, fn
-      {:action, action}, opts   -> concat("action: ", to_doc(action, opts))
-      {:changes, changes}, opts -> concat("changes: ", changes |> filter(redacted_fields) |> to_doc(opts))
-      {:data, data}, _opts      -> concat("data: ", to_struct(data, opts))
-      {:errors, errors}, opts   -> concat("errors: ", to_doc(errors, opts))
-      {:valid?, valid?}, opts   -> concat("valid?: ", to_doc(valid?, opts))
+      {:action, action}, opts ->
+        concat("action: ", to_doc(action, opts))
+
+      {:changes, changes}, opts ->
+        concat("changes: ", changes |> filter(redacted_fields) |> to_doc(opts))
+
+      {:data, data}, _opts ->
+        concat("data: ", to_struct(data, opts))
+
+      {:errors, errors}, opts ->
+        concat("errors: ", to_doc(errors, opts))
+
+      {:valid?, valid?}, opts ->
+        concat("valid?: ", to_doc(valid?, opts))
     end)
   end
 

--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -49,9 +49,10 @@ defmodule Ecto.Embedded do
       if cardinality == :one, do: @embeds_one_on_replace_opts, else: @on_replace_opts
 
     unless opts[:on_replace] in on_replace_opts do
-      raise ArgumentError, "invalid `:on_replace` option for #{inspect Keyword.fetch!(opts, :field)}. " <>
-        "The only valid options are: " <>
-        Enum.map_join(on_replace_opts, ", ", &"`#{inspect &1}`")
+      raise ArgumentError,
+            "invalid `:on_replace` option for #{inspect(Keyword.fetch!(opts, :field))}. " <>
+              "The only valid options are: " <>
+              Enum.map_join(on_replace_opts, ", ", &"`#{inspect(&1)}`")
     end
 
     struct(%Embedded{}, opts)
@@ -66,7 +67,8 @@ defmodule Ecto.Embedded do
 
   def load(nil, _fun, %{cardinality: :many}), do: {:ok, []}
 
-  def load(value, fun, %{cardinality: :many, related: schema, field: field}) when is_list(value) do
+  def load(value, fun, %{cardinality: :many, related: schema, field: field})
+      when is_list(value) do
     {:ok, Enum.map(value, &load_field(field, schema, &1, fun))}
   end
 
@@ -79,7 +81,7 @@ defmodule Ecto.Embedded do
   end
 
   defp load_field(field, _schema, value, _fun) do
-    raise ArgumentError, "cannot load embed `#{field}`, expected a map but got: #{inspect value}"
+    raise ArgumentError, "cannot load embed `#{field}`, expected a map but got: #{inspect(value)}"
   end
 
   @impl Ecto.ParameterizedType
@@ -89,7 +91,8 @@ defmodule Ecto.Embedded do
     {:ok, dump_field(field, schema, value, schema.__schema__(:dump), fun, _one_embed? = true)}
   end
 
-  def dump(value, fun, %{cardinality: :many, related: schema, field: field}) when is_list(value) do
+  def dump(value, fun, %{cardinality: :many, related: schema, field: field})
+      when is_list(value) do
     types = schema.__schema__(:dump)
     {:ok, Enum.map(value, &dump_field(field, schema, &1, types, fun, _one_embed? = false))}
   end
@@ -105,20 +108,22 @@ defmodule Ecto.Embedded do
   defp dump_field(field, schema, value, _types, _dumper, one_embed?) do
     one_or_many =
       if one_embed?,
-        do: "a struct #{inspect schema} value",
-        else: "a list of #{inspect schema} struct values"
+        do: "a struct #{inspect(schema)} value",
+        else: "a list of #{inspect(schema)} struct values"
 
     raise ArgumentError,
-          "cannot dump embed `#{field}`, expected #{one_or_many} but got: #{inspect value}"
+          "cannot dump embed `#{field}`, expected #{one_or_many} but got: #{inspect(value)}"
   end
 
   @impl Ecto.ParameterizedType
   def cast(nil, %{cardinality: :one}), do: {:ok, nil}
+
   def cast(%{__struct__: schema} = struct, %{cardinality: :one, related: schema}) do
     {:ok, struct}
   end
 
   def cast(nil, %{cardinality: :many}), do: {:ok, []}
+
   def cast(value, %{cardinality: :many, related: schema}) when is_list(value) do
     if Enum.all?(value, &Kernel.match?(%{__struct__: ^schema}, &1)) do
       {:ok, value}
@@ -152,10 +157,10 @@ defmodule Ecto.Embedded do
   end
 
   defp prepare(embeds, types, adapter, repo, repo_action) do
-    Enum.reduce embeds, embeds, fn {name, changeset_or_changesets}, acc ->
+    Enum.reduce(embeds, embeds, fn {name, changeset_or_changesets}, acc ->
       {:embed, embed} = Map.get(types, name)
       Map.put(acc, name, prepare_each(embed, changeset_or_changesets, adapter, repo, repo_action))
-    end
+    end)
   end
 
   defp prepare_each(%{cardinality: :one}, nil, _adapter, _repo, _repo_action) do
@@ -176,20 +181,21 @@ defmodule Ecto.Embedded do
         do: prepared
   end
 
-  defp to_struct(%Changeset{valid?: false}, _action,
-                 %{related: schema}, _adapter) do
-    raise ArgumentError, "changeset for embedded #{inspect schema} is invalid, " <>
-                         "but the parent changeset was not marked as invalid"
+  defp to_struct(%Changeset{valid?: false}, _action, %{related: schema}, _adapter) do
+    raise ArgumentError,
+          "changeset for embedded #{inspect(schema)} is invalid, " <>
+            "but the parent changeset was not marked as invalid"
   end
 
-  defp to_struct(%Changeset{data: %{__struct__: actual}}, _action,
-                 %{related: expected}, _adapter) when actual != expected do
-    raise ArgumentError, "expected changeset for embedded schema `#{inspect expected}`, " <>
-                         "got: #{inspect actual}"
+  defp to_struct(%Changeset{data: %{__struct__: actual}}, _action, %{related: expected}, _adapter)
+       when actual != expected do
+    raise ArgumentError,
+          "expected changeset for embedded schema `#{inspect(expected)}`, " <>
+            "got: #{inspect(actual)}"
   end
 
-  defp to_struct(%Changeset{changes: changes, data: schema}, :update,
-                 _embed, _adapter) when changes == %{} do
+  defp to_struct(%Changeset{changes: changes, data: schema}, :update, _embed, _adapter)
+       when changes == %{} do
     schema
   end
 
@@ -198,8 +204,8 @@ defmodule Ecto.Embedded do
   end
 
   defp to_struct(%Changeset{data: data} = changeset, action, %{related: schema}, adapter) do
-    %{data: struct, changes: changes} = changeset =
-      Relation.surface_changes(changeset, data, schema.__schema__(:fields))
+    %{data: struct, changes: changes} =
+      changeset = Relation.surface_changes(changeset, data, schema.__schema__(:fields))
 
     embeds = prepare(changeset, schema.__schema__(:embeds), adapter, action)
 
@@ -215,10 +221,12 @@ defmodule Ecto.Embedded do
 
     Enum.reduce(Enum.reverse(changeset.prepare), changeset, fn fun, acc ->
       case fun.(acc) do
-        %Ecto.Changeset{} = acc -> acc
+        %Ecto.Changeset{} = acc ->
+          acc
+
         other ->
-          raise "expected function #{inspect fun} given to Ecto.Changeset.prepare_changes/2 " <>
-                "to return an Ecto.Changeset, got: `#{inspect other}`"
+          raise "expected function #{inspect(fun)} given to Ecto.Changeset.prepare_changes/2 " <>
+                  "to return an Ecto.Changeset, got: `#{inspect(other)}`"
       end
     end)
   end
@@ -229,18 +237,27 @@ defmodule Ecto.Embedded do
 
   defp check_action!(:replace, action, %{on_replace: :delete} = embed),
     do: check_action!(:delete, action, embed)
+
   defp check_action!(:update, :insert, %{related: schema}),
-    do: raise(ArgumentError, "got action :update in changeset for embedded #{inspect schema} while inserting")
+    do:
+      raise(
+        ArgumentError,
+        "got action :update in changeset for embedded #{inspect(schema)} while inserting"
+      )
+
   defp check_action!(action, _, _), do: action
 
   defp autogenerate_id(changes, _struct, :insert, schema, adapter) do
     case schema.__schema__(:autogenerate_id) do
       {key, _source, :binary_id} ->
         Map.put_new_lazy(changes, key, fn -> adapter.autogenerate(:embed_id) end)
+
       {_key, :id} ->
-        raise ArgumentError, "embedded schema `#{inspect schema}` cannot autogenerate `:id` primary keys, " <>
-                             "those are typically used for auto-incrementing constraints. " <>
-                             "Maybe you meant to use `:binary_id` instead?"
+        raise ArgumentError,
+              "embedded schema `#{inspect(schema)}` cannot autogenerate `:id` primary keys, " <>
+                "those are typically used for auto-incrementing constraints. " <>
+                "Maybe you meant to use `:binary_id` instead?"
+
       nil ->
         changes
     end
@@ -250,6 +267,7 @@ defmodule Ecto.Embedded do
     for {_, nil} <- Ecto.primary_key(struct) do
       raise Ecto.NoPrimaryKeyValueError, struct: struct
     end
+
     changes
   end
 

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -185,7 +185,8 @@ defmodule Ecto.Enum do
     try do
       schema.__changeset__()
     rescue
-      _ in UndefinedFunctionError -> raise ArgumentError, "#{inspect schema} is not an Ecto schema"
+      _ in UndefinedFunctionError ->
+        raise ArgumentError, "#{inspect(schema)} is not an Ecto schema"
     else
       %{^field => {:parameterized, Ecto.Enum, %{mappings: mappings}}} -> mappings
       %{^field => {_, {:parameterized, Ecto.Enum, %{mappings: mappings}}}} -> mappings

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -13,8 +13,8 @@ defmodule Ecto.Query.CastError do
 
   def exception(opts) do
     value = Keyword.fetch!(opts, :value)
-    type  = Keyword.fetch!(opts, :type)
-    msg   = Keyword.fetch!(opts, :message)
+    type = Keyword.fetch!(opts, :type)
+    msg = Keyword.fetch!(opts, :message)
     %__MODULE__{value: value, type: type, message: msg}
   end
 end
@@ -27,8 +27,8 @@ defmodule Ecto.QueryError do
 
   def exception(opts) do
     message = Keyword.fetch!(opts, :message)
-    query   = Keyword.fetch!(opts, :query)
-    hint    = Keyword.fetch(opts, :hint)
+    query = Keyword.fetch!(opts, :query)
+    hint = Keyword.fetch(opts, :hint)
 
     message = """
     #{message} in query:
@@ -65,7 +65,7 @@ defmodule Ecto.SubQueryError do
 
   def exception(opts) do
     exception = Keyword.fetch!(opts, :exception)
-    query     = Keyword.fetch!(opts, :query)
+    query = Keyword.fetch!(opts, :query)
 
     message = """
     the following exception happened when compiling a subquery.
@@ -97,40 +97,43 @@ defmodule Ecto.InvalidChangesetError do
 
     Errors
 
-    #{pretty errors}
+    #{pretty(errors)}
 
     Applied changes
 
-    #{pretty changes}
+    #{pretty(changes)}
 
     Params
 
-    #{pretty changeset.params}
+    #{pretty(changeset.params)}
 
     Changeset
 
-    #{pretty changeset}
+    #{pretty(changeset)}
     """
   end
 
   defp pretty(term) do
     inspect(term, pretty: true)
     |> String.split("\n")
-    |> Enum.map_join("\n", &"    " <> &1)
+    |> Enum.map_join("\n", &("    " <> &1))
   end
 
   defp extract_changes(%Ecto.Changeset{changes: changes}) do
-    Enum.reduce(changes, %{}, fn({key, value}, acc) ->
+    Enum.reduce(changes, %{}, fn {key, value}, acc ->
       case value do
         %Ecto.Changeset{action: :delete} -> acc
         _ -> Map.put(acc, key, extract_changes(value))
       end
     end)
   end
+
   defp extract_changes([%Ecto.Changeset{action: :delete} | tail]),
     do: extract_changes(tail)
+
   defp extract_changes([%Ecto.Changeset{} = changeset | tail]),
     do: [extract_changes(changeset) | extract_changes(tail)]
+
   defp extract_changes(other),
     do: other
 end
@@ -142,9 +145,9 @@ defmodule Ecto.CastError do
   defexception [:message, :type, :value]
 
   def exception(opts) do
-    type  = Keyword.fetch!(opts, :type)
+    type = Keyword.fetch!(opts, :type)
     value = Keyword.fetch!(opts, :value)
-    msg   = opts[:message] || "cannot cast #{inspect value} to #{inspect type}"
+    msg = opts[:message] || "cannot cast #{inspect(value)} to #{inspect(type)}"
     %__MODULE__{message: msg, type: type, value: value}
   end
 end
@@ -168,8 +171,8 @@ defmodule Ecto.NoPrimaryKeyFieldError do
   defexception [:message, :schema]
 
   def exception(opts) do
-    schema  = Keyword.fetch!(opts, :schema)
-    message = "schema `#{inspect schema}` has no primary key"
+    schema = Keyword.fetch!(opts, :schema)
+    message = "schema `#{inspect(schema)}` has no primary key"
     %__MODULE__{message: message, schema: schema}
   end
 end
@@ -182,8 +185,8 @@ defmodule Ecto.NoPrimaryKeyValueError do
   defexception [:message, :struct]
 
   def exception(opts) do
-    struct  = Keyword.fetch!(opts, :struct)
-    message = "struct `#{inspect struct}` is missing primary key value"
+    struct = Keyword.fetch!(opts, :struct)
+    message = "struct `#{inspect(struct)}` is missing primary key value"
     %__MODULE__{message: message, struct: struct}
   end
 end
@@ -196,7 +199,7 @@ defmodule Ecto.NoResultsError do
   defexception [:message]
 
   def exception(opts) do
-    query = Keyword.fetch!(opts, :queryable) |> Ecto.Queryable.to_query
+    query = Keyword.fetch!(opts, :queryable) |> Ecto.Queryable.to_query()
 
     msg = """
     expected at least one result but got none in query:
@@ -212,7 +215,7 @@ defmodule Ecto.MultipleResultsError do
   defexception [:message]
 
   def exception(opts) do
-    query = Keyword.fetch!(opts, :queryable) |> Ecto.Queryable.to_query
+    query = Keyword.fetch!(opts, :queryable) |> Ecto.Queryable.to_query()
     count = Keyword.fetch!(opts, :count)
 
     msg = """
@@ -242,7 +245,7 @@ defmodule Ecto.MultiplePrimaryKeyError do
 
     Those are the parameters sent to the repository:
 
-    #{inspect params}
+    #{inspect(params)}
     """
 
     %__MODULE__{message: msg}
@@ -263,7 +266,7 @@ defmodule Ecto.StaleEntryError do
     msg = """
     attempted to #{action} a stale struct:
 
-    #{inspect changeset.data}
+    #{inspect(changeset.data)}
     """
 
     %__MODULE__{message: msg, changeset: changeset}
@@ -283,6 +286,7 @@ defmodule Ecto.ConstraintError do
       case changeset.constraints do
         [] ->
           "The changeset has not defined any constraint."
+
         constraints ->
           "The changeset defined the following constraints:\n\n" <>
             Enum.map_join(constraints, "\n", &"    * #{&1.constraint} (#{&1.type}_constraint)")

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -120,20 +120,21 @@ defmodule Ecto.Multi do
   defstruct operations: [], names: MapSet.new()
 
   @type changes :: map
-  @type run :: ((Ecto.Repo.t, changes) -> {:ok | :error, any}) | {module, atom, [any]}
+  @type run :: (Ecto.Repo.t(), changes -> {:ok | :error, any}) | {module, atom, [any]}
   @type fun(result) :: (changes -> result)
   @type merge :: (changes -> t) | {module, atom, [any]}
   @typep schema_or_source :: binary | {binary, module} | module
-  @typep operation :: {:changeset, Changeset.t, Keyword.t} |
-                      {:run, run} |
-                      {:put, any} |
-                      {:inspect, Keyword.t} |
-                      {:merge, merge} |
-                      {:update_all, Ecto.Query.t, Keyword.t} |
-                      {:delete_all, Ecto.Query.t, Keyword.t} |
-                      {:insert_all, schema_or_source, [map | Keyword.t], Keyword.t}
+  @typep operation ::
+           {:changeset, Changeset.t(), Keyword.t()}
+           | {:run, run}
+           | {:put, any}
+           | {:inspect, Keyword.t()}
+           | {:merge, merge}
+           | {:update_all, Ecto.Query.t(), Keyword.t()}
+           | {:delete_all, Ecto.Query.t(), Keyword.t()}
+           | {:insert_all, schema_or_source, [map | Keyword.t()], Keyword.t()}
   @typep operations :: [{name, operation}]
-  @typep names :: MapSet.t
+  @typep names :: MapSet.t()
   @type name :: any
   @type t :: %__MODULE__{operations: operations, names: names}
 
@@ -190,19 +191,20 @@ defmodule Ecto.Multi do
   defp merge_structs(%Multi{} = lhs, %Multi{} = rhs, joiner) do
     %{names: lhs_names, operations: lhs_ops} = lhs
     %{names: rhs_names, operations: rhs_ops} = rhs
-    case MapSet.intersection(lhs_names, rhs_names) |> MapSet.to_list do
+
+    case MapSet.intersection(lhs_names, rhs_names) |> MapSet.to_list() do
       [] ->
-        %Multi{names: MapSet.union(lhs_names, rhs_names),
-               operations: joiner.(lhs_ops, rhs_ops)}
+        %Multi{names: MapSet.union(lhs_names, rhs_names), operations: joiner.(lhs_ops, rhs_ops)}
+
       common ->
         raise ArgumentError, """
         error when merging the following Ecto.Multi structs:
 
-        #{Kernel.inspect lhs}
+        #{Kernel.inspect(lhs)}
 
-        #{Kernel.inspect rhs}
+        #{Kernel.inspect(rhs)}
 
-        both declared operations: #{Kernel.inspect common}
+        both declared operations: #{Kernel.inspect(common)}
         """
     end
   end
@@ -272,7 +274,12 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec insert(t, name, Changeset.t | Ecto.Schema.t | fun(Changeset.t | Ecto.Schema.t), Keyword.t) :: t
+  @spec insert(
+          t,
+          name,
+          Changeset.t() | Ecto.Schema.t() | fun(Changeset.t() | Ecto.Schema.t()),
+          Keyword.t()
+        ) :: t
   def insert(multi, name, changeset_or_struct_or_fun, opts \\ [])
 
   def insert(multi, name, %Changeset{} = changeset, opts) do
@@ -308,7 +315,7 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec update(t, name, Changeset.t | fun(Changeset.t), Keyword.t) :: t
+  @spec update(t, name, Changeset.t() | fun(Changeset.t()), Keyword.t()) :: t
   def update(multi, name, changeset_or_fun, opts \\ [])
 
   def update(multi, name, %Changeset{} = changeset, opts) do
@@ -341,10 +348,15 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec insert_or_update(t, name, Changeset.t | fun(Changeset.t), Keyword.t) :: t
+  @spec insert_or_update(t, name, Changeset.t() | fun(Changeset.t()), Keyword.t()) :: t
   def insert_or_update(multi, name, changeset_or_fun, opts \\ [])
 
-  def insert_or_update(multi, name, %Changeset{data: %{__meta__: %{state: :loaded}}} = changeset, opts) do
+  def insert_or_update(
+        multi,
+        name,
+        %Changeset{data: %{__meta__: %{state: :loaded}}} = changeset,
+        opts
+      ) do
     add_changeset(multi, :update, name, changeset, opts)
   end
 
@@ -382,7 +394,12 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec delete(t, name, Changeset.t | Ecto.Schema.t | fun(Changeset.t | Ecto.Schema.t), Keyword.t) :: t
+  @spec delete(
+          t,
+          name,
+          Changeset.t() | Ecto.Schema.t() | fun(Changeset.t() | Ecto.Schema.t()),
+          Keyword.t()
+        ) :: t
   def delete(multi, name, changeset_or_struct_fun, opts \\ [])
 
   def delete(multi, name, %Changeset{} = changeset, opts) do
@@ -410,8 +427,9 @@ defmodule Ecto.Multi do
   end
 
   defp put_action(%{action: original}, action) do
-    raise ArgumentError, "you provided a changeset with an action already set " <>
-      "to #{Kernel.inspect original} when trying to #{action} it"
+    raise ArgumentError,
+          "you provided a changeset with an action already set " <>
+            "to #{Kernel.inspect(original)} when trying to #{action} it"
   end
 
   @doc """
@@ -490,10 +508,17 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec insert_all(t, name, schema_or_source, [map | Keyword.t] | fun([map | Keyword.t]), Keyword.t) :: t
+  @spec insert_all(
+          t,
+          name,
+          schema_or_source,
+          [map | Keyword.t()] | fun([map | Keyword.t()]),
+          Keyword.t()
+        ) :: t
   def insert_all(multi, name, schema_or_source, entries_or_fun, opts \\ [])
 
-  def insert_all(multi, name, schema_or_source, entries_fun, opts) when is_function(entries_fun, 1) and is_list(opts) do
+  def insert_all(multi, name, schema_or_source, entries_fun, opts)
+      when is_function(entries_fun, 1) and is_list(opts) do
     run(multi, name, operation_fun({:insert_all, schema_or_source, entries_fun}, opts))
   end
 
@@ -526,10 +551,17 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec update_all(t, name, Ecto.Queryable.t | fun(Ecto.Queryable.t), Keyword.t, Keyword.t) :: t
+  @spec update_all(
+          t,
+          name,
+          Ecto.Queryable.t() | fun(Ecto.Queryable.t()),
+          Keyword.t(),
+          Keyword.t()
+        ) :: t
   def update_all(multi, name, queryable_or_fun, updates, opts \\ [])
 
-  def update_all(multi, name, queryable_fun, updates, opts) when is_function(queryable_fun, 1) and is_list(opts) do
+  def update_all(multi, name, queryable_fun, updates, opts)
+      when is_function(queryable_fun, 1) and is_list(opts) do
     run(multi, name, operation_fun({:update_all, queryable_fun, updates}, opts))
   end
 
@@ -564,7 +596,7 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec delete_all(t, name, Ecto.Queryable.t | fun(Ecto.Queryable.t), Keyword.t) :: t
+  @spec delete_all(t, name, Ecto.Queryable.t() | fun(Ecto.Queryable.t()), Keyword.t()) :: t
   def delete_all(multi, name, queryable_or_fun, opts \\ [])
 
   def delete_all(multi, name, fun, opts) when is_function(fun, 1) and is_list(opts) do
@@ -578,11 +610,11 @@ defmodule Ecto.Multi do
 
   defp add_operation(%Multi{} = multi, name, operation) do
     %{operations: operations, names: names} = multi
+
     if MapSet.member?(names, name) do
-      raise "#{Kernel.inspect name} is already a member of the Ecto.Multi: \n#{Kernel.inspect multi}"
+      raise "#{Kernel.inspect(name)} is already a member of the Ecto.Multi: \n#{Kernel.inspect(multi)}"
     else
-      %{multi | operations: [{name, operation} | operations],
-                names: MapSet.put(names, name)}
+      %{multi | operations: [{name, operation} | operations], names: MapSet.put(names, name)}
     end
   end
 
@@ -596,12 +628,13 @@ defmodule Ecto.Multi do
   @spec to_list(t) :: [{name, term}]
   def to_list(%Multi{operations: operations}) do
     operations
-    |> Enum.reverse
+    |> Enum.reverse()
     |> Enum.map(&format_operation/1)
   end
 
   defp format_operation({name, {:changeset, changeset, opts}}),
     do: {name, {changeset.action, changeset, opts}}
+
   defp format_operation(other),
     do: other
 
@@ -657,13 +690,13 @@ defmodule Ecto.Multi do
       %{person_a: %Person{...}}
 
   """
-  @spec inspect(t, Keyword.t) :: t
+  @spec inspect(t, Keyword.t()) :: t
   def inspect(multi, opts \\ []) do
     Map.update!(multi, :operations, &[{:inspect, {:inspect, opts}} | &1])
   end
 
   @doc false
-  @spec __apply__(t, Ecto.Repo.t, fun, (term -> no_return)) :: {:ok, term} | {:error, term}
+  @spec __apply__(t, Ecto.Repo.t(), fun, (term -> no_return)) :: {:ok, term} | {:error, term}
   def __apply__(%Multi{} = multi, repo, wrap, return) do
     operations = Enum.reverse(multi.operations)
 
@@ -678,12 +711,15 @@ defmodule Ecto.Multi do
 
   defp invalid_operation({name, {:changeset, %{valid?: false} = changeset, _}}),
     do: {:error, {name, changeset, %{}}}
+
   defp invalid_operation({name, {:error, value}}),
     do: {:error, {name, value, %{}}}
+
   defp invalid_operation(_operation),
     do: nil
 
   defp apply_operations([], _names, _repo, _wrap, _return), do: {:ok, %{}}
+
   defp apply_operations(operations, names, repo, wrap, return) do
     wrap.(fn ->
       operations
@@ -696,6 +732,7 @@ defmodule Ecto.Multi do
     case __apply__(apply_merge_fun(merge, acc), repo, wrap, return) do
       {:ok, value} ->
         merge_results(acc, value, names)
+
       {:error, {name, value, nested_acc}} ->
         {acc, _names} = merge_results(acc, nested_acc, names)
         return.({name, value, acc})
@@ -716,25 +753,33 @@ defmodule Ecto.Multi do
     case apply_operation(operation, acc, {wrap, return}, repo) do
       {:ok, value} ->
         {Map.put(acc, name, value), names}
+
       {:error, value} ->
         return.({name, value, acc})
+
       other ->
-        raise "expected Ecto.Multi callback named `#{Kernel.inspect name}` to return either {:ok, value} or {:error, value}, got: #{Kernel.inspect other}"
+        raise "expected Ecto.Multi callback named `#{Kernel.inspect(name)}` to return either {:ok, value} or {:error, value}, got: #{Kernel.inspect(other)}"
     end
   end
 
   defp apply_operation({:changeset, changeset, opts}, _acc, _apply_args, repo),
     do: apply(repo, changeset.action, [changeset, opts])
+
   defp apply_operation({:run, run}, acc, _apply_args, repo),
     do: apply_run_fun(run, repo, acc)
+
   defp apply_operation({:error, value}, _acc, _apply_args, _repo),
     do: {:error, value}
+
   defp apply_operation({:insert_all, source, entries, opts}, _acc, _apply_args, repo),
     do: {:ok, repo.insert_all(source, entries, opts)}
+
   defp apply_operation({:update_all, query, updates, opts}, _acc, _apply_args, repo),
     do: {:ok, repo.update_all(query, updates, opts)}
+
   defp apply_operation({:delete_all, query, opts}, _acc, _apply_args, repo),
     do: {:ok, repo.delete_all(query, opts)}
+
   defp apply_operation({:put, value}, _acc, _apply_args, _repo),
     do: {:ok, value}
 
@@ -745,13 +790,15 @@ defmodule Ecto.Multi do
   defp apply_run_fun(fun, repo, acc), do: apply(fun, [repo, acc])
 
   defp merge_results(changes, new_changes, names) do
-    new_names = new_changes |> Map.keys |> MapSet.new()
-    case MapSet.intersection(names, new_names) |> MapSet.to_list do
+    new_names = new_changes |> Map.keys() |> MapSet.new()
+
+    case MapSet.intersection(names, new_names) |> MapSet.to_list() do
       [] ->
         {Map.merge(changes, new_changes), MapSet.union(names, new_names)}
+
       common ->
         raise "cannot merge multi, the following operations were found in " <>
-          "both Ecto.Multi: #{Kernel.inspect common}"
+                "both Ecto.Multi: #{Kernel.inspect(common)}"
     end
   end
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -223,7 +223,7 @@ defmodule Ecto.Query do
 
   Only atoms are accepted for binding names. Named binding references
   must always be placed at the end of the bindings list:
-  
+
       [positional_binding_1, positional_binding_2, named_1: binding, named_2: binding]
 
   Named bindings can also be used for late binding with the `as/1`
@@ -376,10 +376,26 @@ defmodule Ecto.Query do
   The prefixes set in the query will be preserved when loading data.
   """
 
-  defstruct [prefix: nil, sources: nil, from: nil, joins: [], aliases: %{}, wheres: [], select: nil,
-             order_bys: [], limit: nil, offset: nil, group_bys: [], combinations: [], updates: [],
-             havings: [], preloads: [], assocs: [], distinct: nil, lock: nil, windows: [],
-             with_ctes: nil]
+  defstruct prefix: nil,
+            sources: nil,
+            from: nil,
+            joins: [],
+            aliases: %{},
+            wheres: [],
+            select: nil,
+            order_bys: [],
+            limit: nil,
+            offset: nil,
+            group_bys: [],
+            combinations: [],
+            updates: [],
+            havings: [],
+            preloads: [],
+            assocs: [],
+            distinct: nil,
+            lock: nil,
+            windows: [],
+            with_ctes: nil
 
   defmodule FromExpr do
     @moduledoc false
@@ -408,12 +424,24 @@ defmodule Ecto.Query do
 
   defmodule JoinExpr do
     @moduledoc false
-    defstruct [:qual, :source, :on, :file, :line, :assoc, :as, :ix, :prefix, params: [], hints: []]
+    defstruct [
+      :qual,
+      :source,
+      :on,
+      :file,
+      :line,
+      :assoc,
+      :as,
+      :ix,
+      :prefix,
+      params: [],
+      hints: []
+    ]
   end
 
   defmodule WithExpr do
     @moduledoc false
-    defstruct [recursive: false, queries: []]
+    defstruct recursive: false, queries: []
   end
 
   defmodule Tagged do
@@ -656,9 +684,13 @@ defmodule Ecto.Query do
   """
   def subquery(query, opts \\ []) do
     subquery = wrap_in_subquery(query)
+
     case Keyword.fetch(opts, :prefix) do
-      {:ok, prefix} when is_binary(prefix) or is_nil(prefix) -> put_in(subquery.query.prefix, prefix)
-      :error -> subquery
+      {:ok, prefix} when is_binary(prefix) or is_nil(prefix) ->
+        put_in(subquery.query.prefix, prefix)
+
+      :error ->
+        subquery
     end
   end
 
@@ -666,8 +698,16 @@ defmodule Ecto.Query do
   defp wrap_in_subquery(%Ecto.Query{} = query), do: %Ecto.SubQuery{query: query}
   defp wrap_in_subquery(queryable), do: %Ecto.SubQuery{query: Ecto.Queryable.to_query(queryable)}
 
-  @joins [:join, :inner_join, :cross_join, :left_join, :right_join, :full_join,
-          :inner_lateral_join, :left_lateral_join]
+  @joins [
+    :join,
+    :inner_join,
+    :cross_join,
+    :left_join,
+    :right_join,
+    :full_join,
+    :inner_lateral_join,
+    :left_lateral_join
+  ]
 
   @doc """
   Puts the given prefix in a query.
@@ -724,12 +764,14 @@ defmodule Ecto.Query do
   defp do_exclude(%Ecto.Query{} = query, :join) do
     %{query | joins: [], aliases: Map.take(query.aliases, [query.from.as])}
   end
+
   defp do_exclude(%Ecto.Query{} = query, join_keyword) when join_keyword in @joins do
     qual = join_qual(join_keyword)
     {excluded, remaining} = Enum.split_with(query.joins, &(&1.qual == qual))
-    aliases =  Map.drop(query.aliases, Enum.map(excluded, & &1.as))
+    aliases = Map.drop(query.aliases, Enum.map(excluded, & &1.as))
     %{query | joins: remaining, aliases: aliases}
   end
+
   defp do_exclude(%Ecto.Query{} = query, :where), do: %{query | wheres: []}
   defp do_exclude(%Ecto.Query{} = query, :order_by), do: %{query | order_bys: []}
   defp do_exclude(%Ecto.Query{} = query, :group_by), do: %{query | group_bys: []}
@@ -813,7 +855,7 @@ defmodule Ecto.Query do
   @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge, :with_ctes]
 
-  defp from([{type, expr}|t], env, count_bind, quoted, binds) when type in @binds do
+  defp from([{type, expr} | t], env, count_bind, quoted, binds) when type in @binds do
     # If all bindings are integer indexes keep AST Macro expandable to %Query{},
     # otherwise ensure that quoted code is evaluated before macro call
     quoted =
@@ -831,7 +873,7 @@ defmodule Ecto.Query do
     from(t, env, count_bind, quoted, binds)
   end
 
-  defp from([{type, expr}|t], env, count_bind, quoted, binds) when type in @no_binds do
+  defp from([{type, expr} | t], env, count_bind, quoted, binds) when type in @no_binds do
     quoted =
       quote do
         Ecto.Query.unquote(type)(unquote(quoted), unquote(expr))
@@ -840,7 +882,7 @@ defmodule Ecto.Query do
     from(t, env, count_bind, quoted, binds)
   end
 
-  defp from([{join, expr}|t], env, count_bind, quoted, binds) when join in @joins do
+  defp from([{join, expr} | t], env, count_bind, quoted, binds) when join in @joins do
     qual = join_qual(join)
     {t, on, as, prefix, hints} = collect_on(t, nil, nil, nil, nil)
 
@@ -850,16 +892,17 @@ defmodule Ecto.Query do
     from(t, env, count_bind, quoted, to_query_binds(binds))
   end
 
-  defp from([{:on, _value}|_], _env, _count_bind, _quoted, _binds) do
-    Builder.error! "`on` keyword must immediately follow a join"
+  defp from([{:on, _value} | _], _env, _count_bind, _quoted, _binds) do
+    Builder.error!("`on` keyword must immediately follow a join")
   end
 
-  defp from([{key, _value}|_], _env, _count_bind, _quoted, _binds) when key in @from_join_opts do
-    Builder.error! "`#{key}` keyword must immediately follow a from/join"
+  defp from([{key, _value} | _], _env, _count_bind, _quoted, _binds)
+       when key in @from_join_opts do
+    Builder.error!("`#{key}` keyword must immediately follow a from/join")
   end
 
-  defp from([{key, _value}|_], _env, _count_bind, _quoted, _binds) do
-    Builder.error! "unsupported #{inspect key} in keyword query expression"
+  defp from([{key, _value} | _], _env, _count_bind, _quoted, _binds) do
+    Builder.error!("unsupported #{inspect(key)} in keyword query expression")
   end
 
   defp from([], _env, _count_bind, quoted, _binds) do
@@ -886,23 +929,31 @@ defmodule Ecto.Query do
 
   defp collect_on([{:on, on} | t], nil, as, prefix, hints),
     do: collect_on(t, on, as, prefix, hints)
+
   defp collect_on([{:on, expr} | t], on, as, prefix, hints),
     do: collect_on(t, {:and, [], [on, expr]}, as, prefix, hints)
+
   defp collect_on(t, on, as, prefix, hints),
     do: {t, on, as, prefix, hints}
 
   defp collect_as_and_prefix_and_hints([{:as, as} | t], nil, prefix, hints),
     do: collect_as_and_prefix_and_hints(t, as, prefix, hints)
+
   defp collect_as_and_prefix_and_hints([{:as, _} | _], _, _, _),
-    do: Builder.error! "`as` keyword was given more than once to the same from/join"
+    do: Builder.error!("`as` keyword was given more than once to the same from/join")
+
   defp collect_as_and_prefix_and_hints([{:prefix, prefix} | t], as, nil, hints),
     do: collect_as_and_prefix_and_hints(t, as, {:ok, prefix}, hints)
+
   defp collect_as_and_prefix_and_hints([{:prefix, _} | _], _, _, _),
-    do: Builder.error! "`prefix` keyword was given more than once to the same from/join"
+    do: Builder.error!("`prefix` keyword was given more than once to the same from/join")
+
   defp collect_as_and_prefix_and_hints([{:hints, hints} | t], as, prefix, nil),
     do: collect_as_and_prefix_and_hints(t, as, prefix, hints)
+
   defp collect_as_and_prefix_and_hints([{:hints, _} | _], _, _, _),
-    do: Builder.error! "`hints` keyword was given more than once to the same from/join"
+    do: Builder.error!("`hints` keyword was given more than once to the same from/join")
+
   defp collect_as_and_prefix_and_hints(t, as, prefix, hints),
     do: {t, as, prefix, hints}
 
@@ -1053,13 +1104,15 @@ defmodule Ecto.Query do
   @join_opts [:on | @from_join_opts]
 
   defmacro join(query, qual, binding \\ [], expr, opts \\ [])
+
   defmacro join(query, qual, binding, expr, opts)
            when is_list(binding) and is_list(opts) do
     {t, on, as, prefix, hints} = collect_on(opts, nil, nil, nil, nil)
 
     with [{key, _} | _] <- t do
-      raise ArgumentError, "invalid option `#{key}` passed to Ecto.Query.join/5, " <>
-                             "valid options are: #{inspect(@join_opts)}"
+      raise ArgumentError,
+            "invalid option `#{key}` passed to Ecto.Query.join/5, " <>
+              "valid options are: #{inspect(@join_opts)}"
     end
 
     query
@@ -1068,13 +1121,15 @@ defmodule Ecto.Query do
   end
 
   defmacro join(_query, _qual, binding, _expr, opts) when is_list(opts) do
-    raise ArgumentError, "invalid binding passed to Ecto.Query.join/5, should be " <>
-                           "list of variables, got: #{Macro.to_string(binding)}"
+    raise ArgumentError,
+          "invalid binding passed to Ecto.Query.join/5, should be " <>
+            "list of variables, got: #{Macro.to_string(binding)}"
   end
 
   defmacro join(_query, _qual, _binding, _expr, opts) do
-    raise ArgumentError, "invalid opts passed to Ecto.Query.join/5, should be " <>
-                           "list, got: #{Macro.to_string(opts)}"
+    raise ArgumentError,
+          "invalid opts passed to Ecto.Query.join/5, should be " <>
+            "list, got: #{Macro.to_string(opts)}"
   end
 
   @doc ~S'''
@@ -2027,13 +2082,16 @@ defmodule Ecto.Query do
 
   def first(%Ecto.Query{} = query, nil) do
     query = %{query | limit: limit()}
+
     case query do
       %{order_bys: []} ->
         %{query | order_bys: [order_by_pk(query, :asc)]}
+
       %{} ->
         query
     end
   end
+
   def first(queryable, nil), do: first(Ecto.Queryable.to_query(queryable), nil)
   def first(queryable, key), do: first(order_by(queryable, ^key), nil)
 
@@ -2064,12 +2122,15 @@ defmodule Ecto.Query do
 
   defp order_by_pk(query, dir) do
     schema = assert_schema!(query)
-    pks    = schema.__schema__(:primary_key)
-    expr   = for pk <- pks, do: {dir, field(0, pk)}
+    pks = schema.__schema__(:primary_key)
+    expr = for pk <- pks, do: {dir, field(0, pk)}
     %QueryExpr{expr: expr, file: __ENV__.file, line: __ENV__.line}
   end
 
-  defp assert_schema!(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}}) when schema != nil, do: schema
+  defp assert_schema!(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}})
+       when schema != nil,
+       do: schema
+
   defp assert_schema!(query) do
     raise Ecto.QueryError, query: query, message: "expected a from expression with a schema"
   end

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -48,67 +48,67 @@ defmodule Ecto.Query.API do
   @doc """
   Binary `==` operation.
   """
-  def left == right, do: doc! [left, right]
+  def left == right, do: doc!([left, right])
 
   @doc """
   Binary `!=` operation.
   """
-  def left != right, do: doc! [left, right]
+  def left != right, do: doc!([left, right])
 
   @doc """
   Binary `<=` operation.
   """
-  def left <= right, do: doc! [left, right]
+  def left <= right, do: doc!([left, right])
 
   @doc """
   Binary `>=` operation.
   """
-  def left >= right, do: doc! [left, right]
+  def left >= right, do: doc!([left, right])
 
   @doc """
   Binary `<` operation.
   """
-  def left < right, do: doc! [left, right]
+  def left < right, do: doc!([left, right])
 
   @doc """
   Binary `>` operation.
   """
-  def left > right, do: doc! [left, right]
+  def left > right, do: doc!([left, right])
 
   @doc """
   Binary `+` operation.
   """
-  def left + right, do: doc! [left, right]
+  def left + right, do: doc!([left, right])
 
   @doc """
   Binary `-` operation.
   """
-  def left - right, do: doc! [left, right]
+  def left - right, do: doc!([left, right])
 
   @doc """
   Binary `*` operation.
   """
-  def left * right, do: doc! [left, right]
+  def left * right, do: doc!([left, right])
 
   @doc """
   Binary `/` operation.
   """
-  def left / right, do: doc! [left, right]
+  def left / right, do: doc!([left, right])
 
   @doc """
   Binary `and` operation.
   """
-  def left and right, do: doc! [left, right]
+  def left and right, do: doc!([left, right])
 
   @doc """
   Binary `or` operation.
   """
-  def left or right, do: doc! [left, right]
+  def left or right, do: doc!([left, right])
 
   @doc """
   Unary `not` operation.
   """
-  def not(value), do: doc! [value]
+  def not value, do: doc!([value])
 
   @doc """
   Checks if the left-value is included in the right one.
@@ -126,7 +126,7 @@ defmodule Ecto.Query.API do
         from(p in Post, where: p.created_at > ^since)
       )
   """
-  def left in right, do: doc! [left, right]
+  def left in right, do: doc!([left, right])
 
   @doc """
   Evaluates to true if the provided subquery returns 1 or more rows.
@@ -147,7 +147,7 @@ defmodule Ecto.Query.API do
   In the above example the query returns posts which have at least one comment that
   has more than 5 replies.
   """
-  def exists(subquery), do: doc! [subquery]
+  def exists(subquery), do: doc!([subquery])
 
   @doc """
   Tests whether one or more values returned from the provided subquery match in a comparison operation.
@@ -162,7 +162,7 @@ defmodule Ecto.Query.API do
   Both `any` and `all` must be given a subquery as an argument, and they must be used on the right hand side of a comparison.
   Both can be used with every comparison operator: `==`, `!=`, `>`, `>=`, `<`, `<=`.
   """
-  def any(subquery), do: doc! [subquery]
+  def any(subquery), do: doc!([subquery])
 
   @doc """
   Evaluates whether all values returned from the provided subquery match in a comparison operation.
@@ -182,7 +182,7 @@ defmodule Ecto.Query.API do
   Both `any` and `all` must be given a subquery as an argument, and they must be used on the right hand side of a comparison.
   Both can be used with every comparison operator: `==`, `!=`, `>`, `>=`, `<`, `<=`.
   """
-  def all(subquery), do: doc! [subquery]
+  def all(subquery), do: doc!([subquery])
 
   @doc """
   Searches for `search` in `string`.
@@ -199,7 +199,7 @@ defmodule Ecto.Query.API do
   as part of LIKE query, since they allow to perform
   [LIKE-injections](https://githubengineering.com/like-injection/).
   """
-  def like(string, search), do: doc! [string, search]
+  def like(string, search), do: doc!([string, search])
 
   @doc """
   Searches for `search` in `string` in a case insensitive fashion.
@@ -209,7 +209,7 @@ defmodule Ecto.Query.API do
   Translates to the underlying SQL ILIKE query. This operation is
   only available on PostgreSQL.
   """
-  def ilike(string, search), do: doc! [string, search]
+  def ilike(string, search), do: doc!([string, search])
 
   @doc """
   Checks if the given value is nil.
@@ -220,28 +220,28 @@ defmodule Ecto.Query.API do
 
       from p in Post, where: not is_nil(p.published_at)
   """
-  def is_nil(value), do: doc! [value]
+  def is_nil(value), do: doc!([value])
 
   @doc """
   Counts the entries in the table.
 
       from p in Post, select: count()
   """
-  def count, do: doc! []
+  def count, do: doc!([])
 
   @doc """
   Counts the given entry.
 
       from p in Post, select: count(p.id)
   """
-  def count(value), do: doc! [value]
+  def count(value), do: doc!([value])
 
   @doc """
   Counts the distinct values in given entry.
 
       from p in Post, select: count(p.id, :distinct)
   """
-  def count(value, :distinct), do: doc! [value, :distinct]
+  def count(value, :distinct), do: doc!([value, :distinct])
 
   @doc """
   Takes whichever value is not null, or null if they both are.
@@ -252,7 +252,7 @@ defmodule Ecto.Query.API do
 
       from p in Payment, select: p.value |> coalesce(p.backup_value) |> coalesce(0)
   """
-  def coalesce(value, expr), do: doc! [value, expr]
+  def coalesce(value, expr), do: doc!([value, expr])
 
   @doc """
   Applies the given expression as a FILTER clause against an
@@ -262,35 +262,35 @@ defmodule Ecto.Query.API do
 
       from p in Payment, select: avg(p.value) |> filter(p.value < 0)
   """
-  def filter(value, filter), do: doc! [value, filter]
+  def filter(value, filter), do: doc!([value, filter])
 
   @doc """
   Calculates the average for the given entry.
 
       from p in Payment, select: avg(p.value)
   """
-  def avg(value), do: doc! [value]
+  def avg(value), do: doc!([value])
 
   @doc """
   Calculates the sum for the given entry.
 
       from p in Payment, select: sum(p.value)
   """
-  def sum(value), do: doc! [value]
+  def sum(value), do: doc!([value])
 
   @doc """
   Calculates the minimum for the given entry.
 
       from p in Payment, select: min(p.value)
   """
-  def min(value), do: doc! [value]
+  def min(value), do: doc!([value])
 
   @doc """
   Calculates the maximum for the given entry.
 
       from p in Payment, select: max(p.value)
   """
-  def max(value), do: doc! [value]
+  def max(value), do: doc!([value])
 
   @doc """
   Adds a given interval to a datetime.
@@ -309,7 +309,7 @@ defmodule Ecto.Query.API do
 
   See [Intervals](#module-intervals) for supported `interval` values.
   """
-  def datetime_add(datetime, count, interval), do: doc! [datetime, count, interval]
+  def datetime_add(datetime, count, interval), do: doc!([datetime, count, interval])
 
   @doc """
   Adds a given interval to a date.
@@ -318,7 +318,7 @@ defmodule Ecto.Query.API do
 
   See [Intervals](#module-intervals) for supported `interval` values.
   """
-  def date_add(date, count, interval), do: doc! [date, count, interval]
+  def date_add(date, count, interval), do: doc!([date, count, interval])
 
   @doc """
   Adds the given interval to the current time in UTC.
@@ -333,7 +333,7 @@ defmodule Ecto.Query.API do
       from a in Account, where: a.expires_at < from_now(3, "month")
 
   """
-  def from_now(count, interval), do: doc! [count, interval]
+  def from_now(count, interval), do: doc!([count, interval])
 
   @doc """
   Subtracts the given interval from the current time in UTC.
@@ -347,7 +347,7 @@ defmodule Ecto.Query.API do
 
       from p in Post, where: p.published_at > ago(3, "month")
   """
-  def ago(count, interval), do: doc! [count, interval]
+  def ago(count, interval), do: doc!([count, interval])
 
   @doc """
   Send fragments directly to the database.
@@ -409,7 +409,7 @@ defmodule Ecto.Query.API do
   inspecting the Elixir query.  Other than that, it should be
   equivalent to a built-in Ecto query function.
   """
-  def fragment(fragments), do: doc! [fragments]
+  def fragment(fragments), do: doc!([fragments])
 
   @doc """
   Allows a field to be dynamically accessed.
@@ -422,7 +422,7 @@ defmodule Ecto.Query.API do
   In the example above, both `at_least_four(:doors)` and `at_least_four(:tires)`
   would be valid calls as the field is dynamically generated.
   """
-  def field(source, field), do: doc! [source, field]
+  def field(source, field), do: doc!([source, field])
 
   @doc """
   Used in `select` to specify which struct fields should be returned.
@@ -470,7 +470,7 @@ defmodule Ecto.Query.API do
   MUST include the foreign keys used in the relationship,
   otherwise Ecto will be unable to find associated records.
   """
-  def struct(source, fields), do: doc! [source, fields]
+  def struct(source, fields), do: doc!([source, fields])
 
   @doc """
   Used in `select` to specify which fields should be returned as a map.
@@ -513,7 +513,7 @@ defmodule Ecto.Query.API do
   MUST include the foreign keys used in the relationship,
   otherwise Ecto will be unable to find associated records.
   """
-  def map(source, fields), do: doc! [source, fields]
+  def map(source, fields), do: doc!([source, fields])
 
   @doc """
   Merges the map on the right over the map on the left.
@@ -527,7 +527,7 @@ defmodule Ecto.Query.API do
   This function is primarily used by `Ecto.Query.select_merge/3`
   to merge different select clauses.
   """
-  def merge(left_map, right_map), do: doc! [left_map, right_map]
+  def merge(left_map, right_map), do: doc!([left_map, right_map])
 
   @doc """
   Returns value from the `json_field` pointed to by `path`.
@@ -582,7 +582,7 @@ defmodule Ecto.Query.API do
   consider using `fragment/1` alongside PostgreSQL built-in operators for
   better performance.
   """
-  def json_extract_path(json_field, path), do: doc! [json_field, path]
+  def json_extract_path(json_field, path), do: doc!([json_field, path])
 
   @doc """
   Casts the given value to the given type at the database level.
@@ -622,14 +622,14 @@ defmodule Ecto.Query.API do
       from p in Post, select: type(filter(avg(p.cost), p.cost > 0), :integer)
 
   """
-  def type(interpolated_value, type), do: doc! [interpolated_value, type]
+  def type(interpolated_value, type), do: doc!([interpolated_value, type])
 
   @doc """
   Refer to a named atom binding.
 
   See the "Named binding" section in `Ecto.Query` for more information.
   """
-  def as(binding), do: doc! [binding]
+  def as(binding), do: doc!([binding])
 
   @doc """
   Refer to a named atom binding in the parent query.
@@ -638,10 +638,10 @@ defmodule Ecto.Query.API do
 
   See the "Named binding" section in `Ecto.Query` for more information.
   """
-  def parent_as(binding), do: doc! [binding]
+  def parent_as(binding), do: doc!([binding])
 
   defp doc!(_) do
     raise "the functions in Ecto.Query.API should not be invoked directly, " <>
-          "they serve for documentation purposes only"
+            "they serve for documentation purposes only"
   end
 end

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -50,7 +50,7 @@ defmodule Ecto.Query.Builder do
   which include all primitive types and custom user types. Also
   note custom user types do not show up during compilation time.
   """
-  @type quoted_type :: Ecto.Type.primitive | {non_neg_integer, atom | Macro.t}
+  @type quoted_type :: Ecto.Type.primitive() | {non_neg_integer, atom | Macro.t()}
 
   @doc """
   Smart escapes a query expression and extracts interpolated values in
@@ -61,12 +61,18 @@ defmodule Ecto.Query.Builder do
   with `^index` in the query where index is a number indexing into the
   map.
   """
-  @spec escape(Macro.t, quoted_type | {:in, quoted_type} | {:out, quoted_type}, {list, term},
-               Keyword.t, Macro.Env.t | {Macro.Env.t, fun}) :: {Macro.t, {list, term}}
+  @spec escape(
+          Macro.t(),
+          quoted_type | {:in, quoted_type} | {:out, quoted_type},
+          {list, term},
+          Keyword.t(),
+          Macro.Env.t() | {Macro.Env.t(), fun}
+        ) :: {Macro.t(), {list, term}}
   def escape(expr, type, params_acc, vars, env)
 
   # var.x - where var is bound
-  def escape({{:., _, [callee, field]}, _, []}, _type, params_acc, vars, _env) when is_atom(field) do
+  def escape({{:., _, [callee, field]}, _, []}, _type, params_acc, vars, _env)
+      when is_atom(field) do
     {escape_field!(callee, field, vars), params_acc}
   end
 
@@ -90,7 +96,13 @@ defmodule Ecto.Query.Builder do
     {expr, {params, acc}}
   end
 
-  def escape({:type, _, [{{:., _, [{var, _, context}, field]}, _, []} = expr, type]}, _type, params_acc, vars, env)
+  def escape(
+        {:type, _, [{{:., _, [{var, _, context}, field]}, _, []} = expr, type]},
+        _type,
+        params_acc,
+        vars,
+        env
+      )
       when is_atom(var) and is_atom(context) and is_atom(field) do
     escape_with_type(expr, type, params_acc, vars, env)
   end
@@ -109,18 +121,30 @@ defmodule Ecto.Query.Builder do
     escape_with_type(expr, type, params_acc, vars, env)
   end
 
-  def escape({:type, _, [{:json_extract_path, _, [_ | _]} = expr, type]}, _type, params_acc, vars, env) do
+  def escape(
+        {:type, _, [{:json_extract_path, _, [_ | _]} = expr, type]},
+        _type,
+        params_acc,
+        vars,
+        env
+      ) do
     escape_with_type(expr, type, params_acc, vars, env)
   end
 
-  def escape({:type, _, [{{:., _, [Access, :get]}, _, _} = access_expr, type]}, _type, params_acc, vars, env) do
+  def escape(
+        {:type, _, [{{:., _, [Access, :get]}, _, _} = access_expr, type]},
+        _type,
+        params_acc,
+        vars,
+        env
+      ) do
     escape_with_type(access_expr, type, params_acc, vars, env)
   end
 
   def escape({:type, meta, [expr, type]}, given_type, params_acc, vars, env) do
     case Macro.expand_once(expr, get_env(env)) do
       ^expr ->
-        error! """
+        error!("""
         the first argument of type/2 must be one of:
 
           * interpolations, such as ^value
@@ -131,7 +155,7 @@ defmodule Ecto.Query.Builder do
           * access/json paths (p.column[0].field)
 
         Got: #{Macro.to_string(expr)}
-        """
+        """)
 
       expanded ->
         escape({:type, meta, [expanded, type]}, given_type, params_acc, vars, env)
@@ -142,13 +166,16 @@ defmodule Ecto.Query.Builder do
   def escape({:fragment, _, [query]}, _type, params_acc, vars, env) when is_list(query) do
     {escaped, params_acc} =
       Enum.map_reduce(query, params_acc, &escape_fragment(&1, :any, &2, vars, env))
+
     {{:{}, [], [:fragment, [], [escaped]]}, params_acc}
   end
 
   def escape({:fragment, _, [{:^, _, [var]} = _expr]}, _type, params_acc, _vars, _env) do
-    expr = quote do
-      Ecto.Query.Builder.fragment!(unquote(var))
-    end
+    expr =
+      quote do
+        Ecto.Query.Builder.fragment!(unquote(var))
+      end
+
     {{:{}, [], [:fragment, [], [expr]]}, params_acc}
   end
 
@@ -156,8 +183,10 @@ defmodule Ecto.Query.Builder do
     pieces = expand_and_split_fragment(query, env)
 
     if length(pieces) != length(frags) + 1 do
-      error! "fragment(...) expects extra arguments in the same amount of question marks in string. " <>
-               "It received #{length(frags)} extra argument(s) but expected #{length(pieces) - 1}"
+      error!(
+        "fragment(...) expects extra arguments in the same amount of question marks in string. " <>
+          "It received #{length(frags)} extra argument(s) but expected #{length(pieces) - 1}"
+      )
     end
 
     {frags, params_acc} = Enum.map_reduce(frags, params_acc, &escape(&1, :any, &2, vars, env))
@@ -173,14 +202,17 @@ defmodule Ecto.Query.Builder do
 
   def escape({:ago, meta, [count, interval]}, type, params_acc, vars, env) do
     utc = quote do: ^DateTime.utc_now()
+
     count =
       case count do
         {:^, meta, [value]} ->
           negate = quote do: Ecto.Query.Builder.negate!(unquote(value))
           {:^, meta, [negate]}
+
         value ->
           {:-, [], [value]}
       end
+
     escape({:datetime_add, meta, [utc, count, interval]}, type, params_acc, vars, env)
   end
 
@@ -230,7 +262,7 @@ defmodule Ecto.Query.Builder do
 
   # lists
   def escape(list, type, params_acc, vars, env) when is_list(list) do
-    if Enum.all?(list, &is_binary(&1) or is_number(&1) or is_boolean(&1)) do
+    if Enum.all?(list, &(is_binary(&1) or is_number(&1) or is_boolean(&1))) do
       {literal(list, type, vars), params_acc}
     else
       fun =
@@ -251,15 +283,18 @@ defmodule Ecto.Query.Builder do
 
   # literals
   def escape({:<<>>, _, args} = expr, type, params_acc, vars, _env) do
-    valid? = Enum.all?(args, fn
-      {:::, _, [left, _]} -> is_integer(left) or is_binary(left)
-      left -> is_integer(left) or is_binary(left)
-    end)
+    valid? =
+      Enum.all?(args, fn
+        {:"::", _, [left, _]} -> is_integer(left) or is_binary(left)
+        left -> is_integer(left) or is_binary(left)
+      end)
 
     unless valid? do
-      error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
-             "Only literal binaries and strings are allowed, " <>
-             "dynamic values need to be explicitly interpolated in queries with ^"
+      error!(
+        "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
+          "Only literal binaries and strings are allowed, " <>
+          "dynamic values need to be explicitly interpolated in queries with ^"
+      )
     end
 
     {literal(expr, type, vars), params_acc}
@@ -267,12 +302,16 @@ defmodule Ecto.Query.Builder do
 
   def escape({:-, _, [number]}, type, params_acc, vars, _env) when is_number(number),
     do: {literal(-number, type, vars), params_acc}
+
   def escape(number, type, params_acc, vars, _env) when is_number(number),
     do: {literal(number, type, vars), params_acc}
+
   def escape(binary, type, params_acc, vars, _env) when is_binary(binary),
     do: {literal(binary, type, vars), params_acc}
+
   def escape(nil, _type, params_acc, _vars, _env),
     do: {nil, params_acc}
+
   def escape(atom, type, params_acc, vars, _env) when is_atom(atom),
     do: {literal(atom, type, vars), params_acc}
 
@@ -289,25 +328,26 @@ defmodule Ecto.Query.Builder do
     assert_type!(expr, type, :boolean)
 
     if is_nil(left) or is_nil(right) do
-      error! "comparison with nil is forbidden as it is unsafe. " <>
-             "If you want to check if a value is nil, use is_nil/1 instead"
+      error!(
+        "comparison with nil is forbidden as it is unsafe. " <>
+          "If you want to check if a value is nil, use is_nil/1 instead"
+      )
     end
 
     ltype = quoted_type(right, vars)
     rtype = quoted_type(left, vars)
 
-    {left,  params_acc} = escape(left, ltype, params_acc, vars, env)
+    {left, params_acc} = escape(left, ltype, params_acc, vars, env)
     {right, params_acc} = escape(right, rtype, params_acc, vars, env)
 
     {params, acc} = params_acc
-    {{:{}, [], [comp_op, [], [left, right]]},
-     {params |> wrap_nil(left) |> wrap_nil(right), acc}}
+    {{:{}, [], [comp_op, [], [left, right]]}, {params |> wrap_nil(left) |> wrap_nil(right), acc}}
   end
 
   # mathematical operators
   def escape({math_op, _, [left, right]}, type, params_acc, vars, env)
       when math_op in ~w(+ - * /)a do
-    {left,  params_acc} = escape(left, type, params_acc, vars, env)
+    {left, params_acc} = escape(left, type, params_acc, vars, env)
     {right, params_acc} = escape(right, type, params_acc, vars, env)
 
     {{:{}, [], [math_op, [], [left, right]]}, params_acc}
@@ -375,20 +415,27 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:over, [], [aggregate, window]]}, params_acc}
   end
 
-  def escape({quantifier, meta, [subquery]}, type, params_acc, vars, env) when quantifier in [:all, :any, :exists] do
-    {subquery, params_acc} = escape_subquery({:subquery, meta, [subquery]}, type, params_acc, vars, env)
+  def escape({quantifier, meta, [subquery]}, type, params_acc, vars, env)
+      when quantifier in [:all, :any, :exists] do
+    {subquery, params_acc} =
+      escape_subquery({:subquery, meta, [subquery]}, type, params_acc, vars, env)
+
     {{:{}, [], [quantifier, [], [subquery]]}, params_acc}
   end
 
   def escape({:=, _, _} = expr, _type, _params_acc, _vars, _env) do
-    error! "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
-            "The match operator is not supported: `=`. " <>
-            "Did you mean to use `==` instead?"
+    error!(
+      "`#{Macro.to_string(expr)}` is not a valid query expression. " <>
+        "The match operator is not supported: `=`. " <>
+        "Did you mean to use `==` instead?"
+    )
   end
 
   def escape({op, _, _}, _type, _params_acc, _vars, _env) when op in ~w(|| && !)a do
-    error! "short-circuit operators are not supported: `#{op}`. " <>
-           "Instead use boolean operators: `and`, `or`, and `not`"
+    error!(
+      "short-circuit operators are not supported: `#{op}`. " <>
+        "Instead use boolean operators: `and`, `or`, and `not`"
+    )
   end
 
   # Tuple
@@ -403,8 +450,9 @@ defmodule Ecto.Query.Builder do
         list
         |> Enum.zip(types)
         |> Enum.map_reduce(params_acc, fn {expr, type}, params_acc ->
-             escape(expr, type, params_acc, vars, env)
-           end)
+          escape(expr, type, params_acc, vars, env)
+        end)
+
       expr = {:{}, [], [:{}, [], list]}
       {expr, params_acc}
     else
@@ -414,29 +462,32 @@ defmodule Ecto.Query.Builder do
 
   # Tuple
   def escape({:{}, _, _}, _, _, _, _) do
-    error! "Tuples can only be used in comparisons with literal tuples of the same size"
+    error!("Tuples can only be used in comparisons with literal tuples of the same size")
   end
 
   # Other functions - no type casting
-  def escape({name, _, args} = expr, type, params_acc, vars, env) when is_atom(name) and is_list(args) do
+  def escape({name, _, args} = expr, type, params_acc, vars, env)
+      when is_atom(name) and is_list(args) do
     case call_type(name, length(args)) do
       {in_type, out_type} ->
         assert_type!(expr, type, out_type)
         escape_call(expr, in_type, params_acc, vars, env)
+
       nil ->
         try_expansion(expr, type, params_acc, vars, env)
     end
   end
 
   # Finally handle vars
-  def escape({var, _, context}, _type, params_acc, vars, _env) when is_atom(var) and is_atom(context) do
+  def escape({var, _, context}, _type, params_acc, vars, _env)
+      when is_atom(var) and is_atom(context) do
     {escape_var!(var, vars), params_acc}
   end
 
   # Raise nice error messages for fun calls.
   def escape({fun, _, args} = other, _type, _params_acc, _vars, _env)
       when is_atom(fun) and is_list(args) do
-    error! """
+    error!("""
     `#{Macro.to_string(other)}` is not a valid query expression. \
     If you are trying to invoke a function that is not supported by Ecto, \
     you can use fragments:
@@ -445,7 +496,7 @@ defmodule Ecto.Query.Builder do
 
     See Ecto.Query.API to learn more about the supported functions and \
     Ecto.Query.API.fragment/1 to learn more about fragments.
-    """
+    """)
   end
 
   # Raise nice error message for remote calls
@@ -453,17 +504,17 @@ defmodule Ecto.Query.Builder do
       when is_atom(fun) do
     fun_arity = "#{fun}/#{length(args)}"
 
-    error! """
+    error!("""
     `#{Macro.to_string(other)}` is not a valid query expression. \
     If you want to invoke #{Macro.to_string(mod)}.#{fun_arity} in \
     a query, make sure that the module #{Macro.to_string(mod)} \
     is required and that #{fun_arity} is a macro
-    """
+    """)
   end
 
   # For everything else we raise
   def escape(other, _type, _params_acc, _vars, _env) do
-    error! "`#{Macro.to_string(other)}` is not a valid query expression"
+    error!("`#{Macro.to_string(other)}` is not a valid query expression")
   end
 
   defp escape_with_type(expr, {:^, _, [type]}, params_acc, vars, env) do
@@ -480,14 +531,18 @@ defmodule Ecto.Query.Builder do
   defp escape_subquery({:subquery, _, [expr]}, _, {params, subqueries}, _vars, _env) do
     subquery = quote(do: Ecto.Query.subquery(unquote(expr)))
     index = length(subqueries)
-    expr = {:subquery, index} # used both in ast and in parameters, as a placeholder.
+    # used both in ast and in parameters, as a placeholder.
+    expr = {:subquery, index}
     {expr, {[expr | params], [subquery | subqueries]}}
   end
+
   defp escape_subquery(expr, type, params, vars, env) do
     escape(expr, type, params, vars, env)
   end
 
-  defp wrap_nil(params, {:{}, _, [:^, _, [ix]]}), do: wrap_nil(params, length(params) - ix - 1, [])
+  defp wrap_nil(params, {:{}, _, [:^, _, [ix]]}),
+    do: wrap_nil(params, length(params) - ix - 1, [])
+
   defp wrap_nil(params, _other), do: params
 
   defp wrap_nil([{val, type} | params], 0, acc) do
@@ -503,8 +558,9 @@ defmodule Ecto.Query.Builder do
     case Macro.expand(query, get_env(env)) do
       binary when is_binary(binary) ->
         split_fragment(binary, "")
+
       _ ->
-        error! bad_fragment_message(Macro.to_string(query))
+        error!(bad_fragment_message(Macro.to_string(query)))
     end
   end
 
@@ -515,12 +571,15 @@ defmodule Ecto.Query.Builder do
 
   defp split_fragment(<<>>, consumed),
     do: [consumed]
-  defp split_fragment(<<??, rest :: binary>>, consumed),
+
+  defp split_fragment(<<??, rest::binary>>, consumed),
     do: [consumed | split_fragment(rest, "")]
-  defp split_fragment(<<?\\, ??, rest :: binary>>, consumed),
+
+  defp split_fragment(<<?\\, ??, rest::binary>>, consumed),
     do: split_fragment(rest, consumed <> <<??>>)
-  defp split_fragment(<<first :: utf8, rest :: binary>>, consumed),
-    do: split_fragment(rest, consumed <> <<first :: utf8>>)
+
+  defp split_fragment(<<first::utf8, rest::binary>>, consumed),
+    do: split_fragment(rest, consumed <> <<first::utf8>>)
 
   @doc "Returns fragment pieces, given a fragment string and arguments."
   def fragment_pieces(frag, args) do
@@ -531,16 +590,21 @@ defmodule Ecto.Query.Builder do
 
   defp escape_window_description([], params_acc, _vars, _env),
     do: {[], params_acc}
-  defp escape_window_description([window_name], params_acc, _vars, _env) when is_atom(window_name),
-    do: {window_name, params_acc}
+
+  defp escape_window_description([window_name], params_acc, _vars, _env)
+       when is_atom(window_name),
+       do: {window_name, params_acc}
+
   defp escape_window_description([kw], params_acc, vars, env) do
     case Ecto.Query.Builder.Windows.escape(kw, params_acc, vars, env) do
       {runtime, [], params_acc} ->
         {runtime, params_acc}
 
       {_, [{key, _} | _], _} ->
-        error! "windows definitions given to over/2 do not allow interpolations at the root of " <>
-                 "`#{key}`. Please use Ecto.Query.windows/3 to explicitly define a window instead"
+        error!(
+          "windows definitions given to over/2 do not allow interpolations at the root of " <>
+            "`#{key}`. Please use Ecto.Query.windows/3 to explicitly define a window instead"
+        )
     end
   end
 
@@ -560,8 +624,11 @@ defmodule Ecto.Query.Builder do
     else
       case Macro.expand_once(expr, get_env(env)) do
         ^expr ->
-          error! "unknown window function #{agg}/#{length(args)}. " <>
-                   "See Ecto.Query.WindowAPI for all available functions"
+          error!(
+            "unknown window function #{agg}/#{length(args)}. " <>
+              "See Ecto.Query.WindowAPI for all available functions"
+          )
+
         expr ->
           validate_window_function!(expr, env)
       end
@@ -578,18 +645,18 @@ defmodule Ecto.Query.Builder do
 
   defp escape_field!({var, _, context}, field, vars)
        when is_atom(var) and is_atom(context) do
-    var   = escape_var!(var, vars)
+    var = escape_var!(var, vars)
     field = quoted_atom!(field, "field/2")
-    dot   = {:{}, [], [:., [], [var, field]]}
+    dot = {:{}, [], [:., [], [var, field]]}
     {:{}, [], [dot, [], []]}
   end
 
   defp escape_field!({kind, _, [atom]}, field, _vars)
        when kind in [:as, :parent_as] do
-    atom  = quoted_atom!(atom, "#{kind}/1")
-    as    = {:{}, [], [kind, [], [atom]]}
+    atom = quoted_atom!(atom, "#{kind}/1")
+    as = {:{}, [], [kind, [], [atom]]}
     field = quoted_atom!(field, "field/2")
-    dot   = {:{}, [], [:., [], [as, field]]}
+    dot = {:{}, [], [:., [], [as, field]]}
     {:{}, [], [dot, [], []]}
   end
 
@@ -606,17 +673,20 @@ defmodule Ecto.Query.Builder do
   defp escape_interval(count, interval, params_acc, vars, env) do
     type =
       cond do
-        is_float(count)   -> :float
+        is_float(count) -> :float
         is_integer(count) -> :integer
-        true              -> :decimal
+        true -> :decimal
       end
 
     {count, params_acc} = escape(count, type, params_acc, vars, env)
     {count, quoted_interval!(interval), params_acc}
   end
 
-  defp escape_fragment({key, [{_, _}|_] = exprs}, type, params_acc, vars, env) when is_atom(key) do
-    {escaped, params_acc} = Enum.map_reduce(exprs, params_acc, &escape_fragment(&1, type, &2, vars, env))
+  defp escape_fragment({key, [{_, _} | _] = exprs}, type, params_acc, vars, env)
+       when is_atom(key) do
+    {escaped, params_acc} =
+      Enum.map_reduce(exprs, params_acc, &escape_fragment(&1, type, &2, vars, env))
+
     {{key, escaped}, params_acc}
   end
 
@@ -626,11 +696,14 @@ defmodule Ecto.Query.Builder do
   end
 
   defp escape_fragment({key, _expr}, _type, _params_acc, _vars, _env) do
-    error! "fragment(...) with keywords accepts only atoms as keys, got `#{Macro.to_string(key)}`"
+    error!(
+      "fragment(...) with keywords accepts only atoms as keys, got `#{Macro.to_string(key)}`"
+    )
   end
 
-  defp merge_fragments([h1|t1], [h2|t2]),
-    do: [{:raw, h1}, {:expr, h2}|merge_fragments(t1, t2)]
+  defp merge_fragments([h1 | t1], [h2 | t2]),
+    do: [{:raw, h1}, {:expr, h2} | merge_fragments(t1, t2)]
+
   defp merge_fragments([h1], []),
     do: [{:raw, h1}]
 
@@ -662,9 +735,11 @@ defmodule Ecto.Query.Builder do
         :ok
 
       true ->
-        error! "expression `#{Macro.to_string(expr)}` does not type check. " <>
-               "It returns a value of type #{inspect actual} but a value of " <>
-               "type #{inspect type} is expected"
+        error!(
+          "expression `#{Macro.to_string(expr)}` does not type check. " <>
+            "It returns a value of type #{inspect(actual)} but a value of " <>
+            "type #{inspect(type)} is expected"
+        )
     end
   end
 
@@ -673,21 +748,28 @@ defmodule Ecto.Query.Builder do
   """
   def validate_type!({composite, type}, vars, env),
     do: {composite, validate_type!(type, vars, env)}
+
   def validate_type!({:^, _, [type]}, _vars, _env),
     do: type
+
   def validate_type!({:__aliases__, _, _} = type, _vars, env),
     do: Macro.expand(type, get_env(env))
+
   def validate_type!(type, _vars, _env) when is_atom(type),
     do: type
+
   def validate_type!({{:., _, [{var, _, context}, field]}, _, []}, vars, _env)
-    when is_atom(var) and is_atom(context) and is_atom(field),
-    do: {find_var!(var, vars), field}
+      when is_atom(var) and is_atom(context) and is_atom(field),
+      do: {find_var!(var, vars), field}
+
   def validate_type!({:field, _, [{var, _, context}, field]}, vars, _env)
-    when is_atom(var) and is_atom(context) and is_atom(field),
-    do: {find_var!(var, vars), field}
+      when is_atom(var) and is_atom(context) and is_atom(field),
+      do: {find_var!(var, vars), field}
 
   def validate_type!(type, _vars, _env) do
-    error! "type/2 expects an alias, atom or source.field as second argument, got: `#{Macro.to_string(type)}`"
+    error!(
+      "type/2 expects an alias, atom or source.field as second argument, got: `#{Macro.to_string(type)}`"
+    )
   end
 
   @always_tagged [:binary]
@@ -697,10 +779,13 @@ defmodule Ecto.Query.Builder do
 
   defp do_literal(value, _, current) when current in @always_tagged,
     do: {:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: value, type: current]}]}
+
   defp do_literal(value, :any, _current),
     do: value
+
   defp do_literal(value, expected, expected),
     do: value
+
   defp do_literal(value, expected, _current),
     do: {:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: value, type: expected]}]}
 
@@ -716,7 +801,7 @@ defmodule Ecto.Query.Builder do
   A escaped variable is represented internally as
   `&0`, `&1` and so on.
   """
-  @spec escape_var!(atom, Keyword.t) :: Macro.t
+  @spec escape_var!(atom, Keyword.t()) :: Macro.t()
   def escape_var!(var, vars) do
     {:{}, [], [:&, [], [find_var!(var, vars)]]}
   end
@@ -742,21 +827,24 @@ defmodule Ecto.Query.Builder do
       ** (Ecto.Query.CompileError) binding list should contain only variables or `{as, var}` tuples, got: :foo
 
   """
-  @spec escape_binding(Macro.t, list, Macro.Env.t) :: {Macro.t, Keyword.t}
+  @spec escape_binding(Macro.t(), list, Macro.Env.t()) :: {Macro.t(), Keyword.t()}
   def escape_binding(query, binding, _env) when is_list(binding) do
-    vars = binding |> Enum.with_index |> Enum.map(&escape_bind/1)
+    vars = binding |> Enum.with_index() |> Enum.map(&escape_bind/1)
     assert_no_duplicate_binding!(vars)
 
-    {positional_vars, named_vars} = Enum.split_while(vars, &not named_bind?(&1))
+    {positional_vars, named_vars} = Enum.split_while(vars, &(not named_bind?(&1)))
     assert_named_binds_in_tail!(named_vars, binding)
 
     {query, positional_binds} = calculate_positional_binds(query, positional_vars)
     {query, named_binds} = calculate_named_binds(query, named_vars)
     {query, positional_binds ++ named_binds}
   end
+
   def escape_binding(_query, bind, _env) do
-    error! "binding should be list of variables and `{as, var}` tuples " <>
-             "at the end, got: #{Macro.to_string(bind)}"
+    error!(
+      "binding should be list of variables and `{as, var}` tuples " <>
+        "at the end, got: #{Macro.to_string(bind)}"
+    )
   end
 
   defp named_bind?({kind, _, _}), do: kind == :named
@@ -765,8 +853,10 @@ defmodule Ecto.Query.Builder do
     if Enum.all?(named_vars, &named_bind?/1) do
       :ok
     else
-      error! "named binds in the form of `{as, var}` tuples must be at the end " <>
-               "of the binding list, got: #{Macro.to_string(binding)}"
+      error!(
+        "named binds in the form of `{as, var}` tuples must be at the end " <>
+          "of the binding list, got: #{Macro.to_string(binding)}"
+      )
     end
   end
 
@@ -774,16 +864,17 @@ defmodule Ecto.Query.Builder do
     bound_vars = for {_, var, _} <- vars, var != :_, do: var
 
     case bound_vars -- Enum.uniq(bound_vars) do
-      []  -> :ok
-      [var | _] -> error! "variable `#{var}` is bound twice"
+      [] -> :ok
+      [var | _] -> error!("variable `#{var}` is bound twice")
     end
   end
 
   defp calculate_positional_binds(query, vars) do
-    case Enum.split_while(vars, &elem(&1, 1) != :...) do
+    case Enum.split_while(vars, &(elem(&1, 1) != :...)) do
       {vars, []} ->
         vars = for {:pos, var, count} <- vars, do: {var, count}
         {query, vars}
+
       {vars, [_ | tail]} ->
         query =
           quote do
@@ -795,7 +886,9 @@ defmodule Ecto.Query.Builder do
         tail =
           tail
           |> Enum.with_index(-length(tail))
-          |> Enum.map(fn {{:pos, k, _}, count} -> {k, quote(do: escape_count + unquote(count))} end)
+          |> Enum.map(fn {{:pos, k, _}, count} ->
+            {k, quote(do: escape_count + unquote(count))}
+          end)
 
         vars = for {:pos, var, count} <- vars, do: {var, count}
         {query, vars ++ tail}
@@ -803,6 +896,7 @@ defmodule Ecto.Query.Builder do
   end
 
   def calculate_named_binds(query, []), do: {query, []}
+
   def calculate_named_binds(query, vars) do
     query =
       quote do
@@ -829,21 +923,30 @@ defmodule Ecto.Query.Builder do
         ix
 
       %{} ->
-        raise Ecto.QueryError, message: "unknown bind name `#{inspect name}`", query: query
+        raise Ecto.QueryError, message: "unknown bind name `#{inspect(name)}`", query: query
     end
   end
 
   defp escape_bind({{{var, _, context}, ix}, _}) when is_atom(var) and is_atom(context),
     do: {:pos, var, ix}
+
   defp escape_bind({{var, _, context}, ix}) when is_atom(var) and is_atom(context),
     do: {:pos, var, ix}
-  defp escape_bind({{name, {var, _, context}}, _ix}) when is_atom(name) and is_atom(var) and is_atom(context),
-    do: {:named, var, name}
-  defp escape_bind({{{:^, _, [expr]}, {var, _, context}}, _ix}) when is_atom(var) and is_atom(context),
-    do: {:named, var, expr}
+
+  defp escape_bind({{name, {var, _, context}}, _ix})
+       when is_atom(name) and is_atom(var) and is_atom(context),
+       do: {:named, var, name}
+
+  defp escape_bind({{{:^, _, [expr]}, {var, _, context}}, _ix})
+       when is_atom(var) and is_atom(context),
+       do: {:named, var, expr}
+
   defp escape_bind({bind, _ix}),
-    do: error!("binding list should contain only variables or " <>
-          "`{as, var}` tuples, got: #{Macro.to_string(bind)}")
+    do:
+      error!(
+        "binding list should contain only variables or " <>
+          "`{as, var}` tuples, got: #{Macro.to_string(bind)}"
+      )
 
   defp try_expansion(expr, type, params, vars, %Macro.Env{} = env) do
     try_expansion(expr, type, params, vars, {env, &escape/5})
@@ -852,7 +955,7 @@ defmodule Ecto.Query.Builder do
   defp try_expansion(expr, type, params, vars, {env, fun}) do
     case Macro.expand_once(expr, env) do
       ^expr ->
-        error! """
+        error!("""
         `#{Macro.to_string(expr)}` is not a valid query expression.
 
         * If you intended to call an Elixir function or introduce a value,
@@ -864,7 +967,7 @@ defmodule Ecto.Query.Builder do
         * If you intended to extend Ecto's query DSL, make sure that you have required
           the module or imported the relevant function. Note that you need macros to
           extend Ecto's querying capabilities
-        """
+        """)
 
       expanded ->
         fun.(expanded, type, params, vars, env)
@@ -875,7 +978,10 @@ defmodule Ecto.Query.Builder do
   Finds the index value for the given var in vars or raises.
   """
   def find_var!(var, vars) do
-    vars[var] || error! "unbound variable `#{var}` in query. If you are attempting to interpolate a value, use ^var"
+    vars[var] ||
+      error!(
+        "unbound variable `#{var}` in query. If you are attempting to interpolate a value, use ^var"
+      )
   end
 
   @doc """
@@ -892,7 +998,7 @@ defmodule Ecto.Query.Builder do
     do:
       error!(
         "expected literal atom or interpolated value in #{used_ref}, got: " <>
-        "`#{Macro.to_string(other)}`"
+          "`#{Macro.to_string(other)}`"
       )
 
   @doc """
@@ -902,7 +1008,7 @@ defmodule Ecto.Query.Builder do
     do: atom
 
   def atom!(other, used_ref),
-    do: error!("expected atom in #{used_ref}, got: `#{inspect other}`")
+    do: error!("expected atom in #{used_ref}, got: `#{inspect(other)}`")
 
   defp escape_json_path(path) when is_list(path) do
     Enum.map(path, &quoted_json_path_element!/1)
@@ -925,7 +1031,7 @@ defmodule Ecto.Query.Builder do
     do:
       error!(
         "expected JSON path to contain literal strings, literal integers, or interpolated values, got: " <>
-        "`#{Macro.to_string(other)}`"
+          "`#{Macro.to_string(other)}`"
       )
 
   @doc """
@@ -933,18 +1039,22 @@ defmodule Ecto.Query.Builder do
   """
   def json_path_element!(binary) when is_binary(binary),
     do: binary
+
   def json_path_element!(integer) when is_integer(integer),
     do: integer
+
   def json_path_element!(other),
-    do: error!("expected string or integer in json_extract_path/2, got: `#{inspect other}`")
+    do: error!("expected string or integer in json_extract_path/2, got: `#{inspect(other)}`")
 
   @doc """
   Called by escaper at runtime to verify that a value is not nil.
   """
   def not_nil!(nil) do
-    raise ArgumentError, "comparison with nil is forbidden as it is unsafe. " <>
-                         "If you want to check if a value is nil, use is_nil/1 instead"
+    raise ArgumentError,
+          "comparison with nil is forbidden as it is unsafe. " <>
+            "If you want to check if a value is nil, use is_nil/1 instead"
   end
+
   def not_nil!(not_nil) do
     not_nil
   end
@@ -955,6 +1065,7 @@ defmodule Ecto.Query.Builder do
   """
   def quoted_interval!({:^, _, [expr]}),
     do: quote(do: Ecto.Query.Builder.interval!(unquote(expr)))
+
   def quoted_interval!(other),
     do: interval!(other)
 
@@ -975,10 +1086,15 @@ defmodule Ecto.Query.Builder do
   @interval ~w(year month week day hour minute second millisecond microsecond)
   def interval!(interval) when interval in @interval,
     do: interval
+
   def interval!(other_string) when is_binary(other_string),
-    do: error!("invalid interval: `#{inspect other_string}` (expected one of #{Enum.join(@interval, ", ")})")
+    do:
+      error!(
+        "invalid interval: `#{inspect(other_string)}` (expected one of #{Enum.join(@interval, ", ")})"
+      )
+
   def interval!(not_string),
-    do: error!("invalid interval: `#{inspect not_string}` (expected a string)")
+    do: error!("invalid interval: `#{inspect(not_string)}` (expected a string)")
 
   @doc """
   Negates the given number.
@@ -995,24 +1111,24 @@ defmodule Ecto.Query.Builder do
   @doc """
   Returns the type of an expression at build time.
   """
-  @spec quoted_type(Macro.t, Keyword.t) :: quoted_type
+  @spec quoted_type(Macro.t(), Keyword.t()) :: quoted_type
 
   # Fields
   def quoted_type({{:., _, [{var, _, context}, field]}, _, []}, vars)
-    when is_atom(var) and is_atom(context) and is_atom(field),
-    do: {find_var!(var, vars), field}
+      when is_atom(var) and is_atom(context) and is_atom(field),
+      do: {find_var!(var, vars), field}
 
   def quoted_type({:field, _, [{var, _, context}, field]}, vars)
-    when is_atom(var) and is_atom(context) and is_atom(field),
-    do: {find_var!(var, vars), field}
+      when is_atom(var) and is_atom(context) and is_atom(field),
+      do: {find_var!(var, vars), field}
 
   # Unquoting code here means the second argument of field will
   # always be unquoted twice, one by the type checking and another
   # in the query itself. We are assuming this is not an issue
   # as the solution is somewhat complicated.
   def quoted_type({:field, _, [{var, _, context}, {:^, _, [code]}]}, vars)
-    when is_atom(var) and is_atom(context),
-    do: {find_var!(var, vars), code}
+      when is_atom(var) and is_atom(context),
+      do: {find_var!(var, vars), code}
 
   # Interval
   def quoted_type({:datetime_add, _, [_, _, _]}, _vars), do: :naive_datetime
@@ -1024,7 +1140,9 @@ defmodule Ecto.Query.Builder do
 
   # Sigils
   def quoted_type({sigil, _, [_, []]}, _vars) when sigil in ~w(sigil_s sigil_S)a, do: :string
-  def quoted_type({sigil, _, [_, []]}, _vars) when sigil in ~w(sigil_w sigil_W)a, do: {:array, :string}
+
+  def quoted_type({sigil, _, [_, []]}, _vars) when sigil in ~w(sigil_w sigil_W)a,
+    do: {:array, :string}
 
   # Lists
   def quoted_type(list, vars) when is_list(list) do
@@ -1048,8 +1166,8 @@ defmodule Ecto.Query.Builder do
   end
 
   # Literals
-  def quoted_type(literal, _vars) when is_float(literal),   do: :float
-  def quoted_type(literal, _vars) when is_binary(literal),  do: :string
+  def quoted_type(literal, _vars) when is_float(literal), do: :float
+  def quoted_type(literal, _vars) when is_binary(literal), do: :string
   def quoted_type(literal, _vars) when is_boolean(literal), do: :boolean
   def quoted_type(literal, _vars) when is_atom(literal) and not is_nil(literal), do: :atom
   def quoted_type(literal, _vars) when is_integer(literal), do: :integer
@@ -1061,7 +1179,7 @@ defmodule Ecto.Query.Builder do
   def quoted_type({name, _, args}, _vars) when is_atom(name) and is_list(args) do
     case call_type(name, length(args)) do
       {_in, out} -> out
-      nil        -> :any
+      nil -> :any
     end
   end
 
@@ -1074,14 +1192,16 @@ defmodule Ecto.Query.Builder do
   Raises a query building error.
   """
   def error!(message) when is_binary(message) do
-    {:current_stacktrace, [_|t]} = Process.info(self(), :current_stacktrace)
+    {:current_stacktrace, [_ | t]} = Process.info(self(), :current_stacktrace)
 
-    t = Enum.drop_while t, fn
-      {mod, _, _, _} ->
-        String.starts_with?(Atom.to_string(mod), ["Elixir.Ecto.Query.", "Elixir.Enum"])
-      _ ->
-        false
-    end
+    t =
+      Enum.drop_while(t, fn
+        {mod, _, _, _} ->
+          String.starts_with?(Atom.to_string(mod), ["Elixir.Ecto.Query.", "Elixir.Enum"])
+
+        _ ->
+          false
+      end)
 
     reraise Ecto.Query.CompileError, [message: message], t
   end
@@ -1095,7 +1215,7 @@ defmodule Ecto.Query.Builder do
       4
 
   """
-  @spec count_binds(Ecto.Query.t) :: non_neg_integer
+  @spec count_binds(Ecto.Query.t()) :: non_neg_integer
   def count_binds(%Query{joins: joins}) do
     1 + length(joins)
   end
@@ -1155,7 +1275,7 @@ defmodule Ecto.Query.Builder do
   the query properly, but they will be in their runtime form
   when invoked at runtime.
   """
-  @spec apply_query(Macro.t, Macro.t, Macro.t, Macro.Env.t) :: Macro.t
+  @spec apply_query(Macro.t(), Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
   def apply_query(query, module, args, env) do
     case Macro.expand(query, env) |> unescape_query() do
       %Query{} = compiletime_query ->
@@ -1172,10 +1292,11 @@ defmodule Ecto.Query.Builder do
   end
 
   # Unescapes an `Ecto.Query` struct.
-  @spec unescape_query(Macro.t) :: Query.t | Macro.t
+  @spec unescape_query(Macro.t()) :: Query.t() | Macro.t()
   defp unescape_query({:%, _, [Query, {:%{}, _, list}]}) do
     struct(Query, list)
   end
+
   defp unescape_query({:%{}, _, list} = ast) do
     if List.keyfind(list, :__struct__, 0) == {:__struct__, Query} do
       Map.new(list)
@@ -1183,12 +1304,13 @@ defmodule Ecto.Query.Builder do
       ast
     end
   end
+
   defp unescape_query(other) do
     other
   end
 
   # Escapes an `Ecto.Query` and associated structs.
-  @spec escape_query(Query.t) :: Macro.t
+  @spec escape_query(Query.t()) :: Macro.t()
   defp escape_query(%Query{} = query), do: {:%{}, [], Map.to_list(query)}
 
   defp parse_access_get({{:., _, [Access, :get]}, _, [left, right]}, acc) do

--- a/lib/ecto/query/builder/combination.ex
+++ b/lib/ecto/query/builder/combination.ex
@@ -12,24 +12,27 @@ defmodule Ecto.Query.Builder.Combination do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(atom, Macro.t, Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(atom, Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(kind, query, {:^, _, [expr]}, env) do
     expr = quote do: Ecto.Queryable.to_query(unquote(expr))
     Builder.apply_query(query, __MODULE__, [[{kind, expr}]], env)
   end
 
   def build(kind, _query, other, _env) do
-    Builder.error! "`#{Macro.to_string(other)}` is not a valid #{kind}. " <>
-                   "#{kind} must always be an interpolated query, such as ^existing_query"
+    Builder.error!(
+      "`#{Macro.to_string(other)}` is not a valid #{kind}. " <>
+        "#{kind} must always be an interpolated query, such as ^existing_query"
+    )
   end
 
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
   def apply(%Ecto.Query{combinations: combinations} = query, value) do
     %{query | combinations: combinations ++ value}
   end
+
   def apply(query, value) do
     apply(Ecto.Queryable.to_query(query), value)
   end

--- a/lib/ecto/query/builder/cte.ex
+++ b/lib/ecto/query/builder/cte.ex
@@ -12,7 +12,7 @@ defmodule Ecto.Query.Builder.CTE do
       "FOO"
 
   """
-  @spec escape(Macro.t, Macro.Env.t) :: Macro.t
+  @spec escape(Macro.t(), Macro.Env.t()) :: Macro.t()
   def escape(name, _env) when is_bitstring(name), do: name
 
   def escape({:^, _, [expr]}, _env), do: expr
@@ -20,8 +20,10 @@ defmodule Ecto.Query.Builder.CTE do
   def escape(expr, env) do
     case Macro.expand_once(expr, env) do
       ^expr ->
-        Builder.error! "`#{Macro.to_string(expr)}` is not a valid CTE name. " <>
-                       "It must be a literal string or an interpolated variable."
+        Builder.error!(
+          "`#{Macro.to_string(expr)}` is not a valid CTE name. " <>
+            "It must be a literal string or an interpolated variable."
+        )
 
       expr ->
         escape(expr, env)
@@ -35,12 +37,12 @@ defmodule Ecto.Query.Builder.CTE do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, Macro.t, Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(Macro.t(), Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(query, name, cte, env) do
     Builder.apply_query(query, __MODULE__, [escape(name, env), build_cte(name, cte, env)], env)
   end
 
-  @spec build_cte(Macro.t, Macro.t, Macro.Env.t) :: Macro.t
+  @spec build_cte(Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
   def build_cte(_name, {:^, _, [expr]}, _env) do
     quote do: Ecto.Queryable.to_query(unquote(expr))
   end
@@ -62,8 +64,10 @@ defmodule Ecto.Query.Builder.CTE do
   def build_cte(name, cte, env) do
     case Macro.expand_once(cte, env) do
       ^cte ->
-        Builder.error! "`#{Macro.to_string(cte)}` is not a valid CTE (named: #{Macro.to_string(name)}). " <>
-                       "The CTE must be an interpolated query, such as ^existing_query or a fragment."
+        Builder.error!(
+          "`#{Macro.to_string(cte)}` is not a valid CTE (named: #{Macro.to_string(name)}). " <>
+            "The CTE must be an interpolated query, such as ^existing_query or a fragment."
+        )
 
       cte ->
         build_cte(name, cte, env)
@@ -73,7 +77,7 @@ defmodule Ecto.Query.Builder.CTE do
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, bitstring, Ecto.Queryable.t) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), bitstring, Ecto.Queryable.t()) :: Ecto.Query.t()
   def apply(%Ecto.Query{with_ctes: with_expr} = query, name, with_query) do
     with_expr = with_expr || %Ecto.Query.WithExpr{}
     queries = List.keystore(with_expr.queries, name, 0, {name, with_query})

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -15,11 +15,11 @@ defmodule Ecto.Query.Builder.GroupBy do
         13],
        {[], :acc}}
   """
-  @spec escape(:group_by | :partition_by, Macro.t, {list, term}, Keyword.t, Macro.Env.t) ::
-          {Macro.t, {list, term}}
+  @spec escape(:group_by | :partition_by, Macro.t(), {list, term}, Keyword.t(), Macro.Env.t()) ::
+          {Macro.t(), {list, term}}
   def escape(kind, expr, params_acc, vars, env) do
     expr
-    |> List.wrap
+    |> List.wrap()
     |> Enum.map_reduce(params_acc, &do_escape(&1, &2, kind, vars, env))
   end
 
@@ -40,9 +40,10 @@ defmodule Ecto.Query.Builder.GroupBy do
   """
   def field!(_kind, field) when is_atom(field),
     do: to_field(field)
+
   def field!(kind, other) do
     raise ArgumentError,
-      "expected a field as an atom in `#{kind}`, got: `#{inspect other}`"
+          "expected a field as an atom in `#{kind}`, got: `#{inspect(other)}`"
   end
 
   @doc """
@@ -55,12 +56,14 @@ defmodule Ecto.Query.Builder.GroupBy do
           {to_field(field), params_count}
 
         %Ecto.Query.DynamicExpr{} = dynamic, {params, count} ->
-          {expr, params, count} = Builder.Dynamic.partially_expand(kind, query, dynamic, params, count)
+          {expr, params, count} =
+            Builder.Dynamic.partially_expand(kind, query, dynamic, params, count)
+
           {expr, {params, count}}
 
         other, _params_count ->
           raise ArgumentError,
-                "expected a list of fields and dynamics in `#{kind}`, got: `#{inspect other}`"
+                "expected a list of fields and dynamics in `#{kind}`, got: `#{inspect(other)}`"
       end)
 
     {expr, params}
@@ -84,10 +87,15 @@ defmodule Ecto.Query.Builder.GroupBy do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(query, _binding, {:^, _, [var]}, env) do
     quote do
-      Ecto.Query.Builder.GroupBy.group_by!(unquote(query), unquote(var), unquote(env.file), unquote(env.line))
+      Ecto.Query.Builder.GroupBy.group_by!(
+        unquote(query),
+        unquote(var),
+        unquote(env.file),
+        unquote(env.line)
+      )
     end
   end
 
@@ -96,21 +104,25 @@ defmodule Ecto.Query.Builder.GroupBy do
     {expr, {params, _}} = escape(:group_by, expr, {[], :acc}, binding, env)
     params = Builder.escape_params(params)
 
-    group_by = quote do: %Ecto.Query.QueryExpr{
-                           expr: unquote(expr),
-                           params: unquote(params),
-                           file: unquote(env.file),
-                           line: unquote(env.line)}
+    group_by =
+      quote do: %Ecto.Query.QueryExpr{
+              expr: unquote(expr),
+              params: unquote(params),
+              file: unquote(env.file),
+              line: unquote(env.line)
+            }
+
     Builder.apply_query(query, __MODULE__, [group_by], env)
   end
 
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
   def apply(%Ecto.Query{group_bys: group_bys} = query, expr) do
     %{query | group_bys: group_bys ++ [expr]}
   end
+
   def apply(query, expr) do
     apply(Ecto.Queryable.to_query(query), expr)
   end

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -12,21 +12,23 @@ defmodule Ecto.Query.Builder.LimitOffset do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(:limit | :offset, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(:limit | :offset, Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(type, query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, :acc}} = Builder.escape(expr, :integer, {[], :acc}, binding, env)
     params = Builder.escape_params(params)
 
     if contains_variable?(expr) do
-      Builder.error! "query variables are not allowed in #{type} expression"
+      Builder.error!("query variables are not allowed in #{type} expression")
     end
 
-    limoff = quote do: %Ecto.Query.QueryExpr{
-                        expr: unquote(expr),
-                        params: unquote(params),
-                        file: unquote(env.file),
-                        line: unquote(env.line)}
+    limoff =
+      quote do: %Ecto.Query.QueryExpr{
+              expr: unquote(expr),
+              params: unquote(params),
+              file: unquote(env.file),
+              line: unquote(env.line)
+            }
 
     Builder.apply_query(query, __MODULE__, [type, limoff], env)
   end
@@ -34,22 +36,24 @@ defmodule Ecto.Query.Builder.LimitOffset do
   defp contains_variable?(ast) do
     ast
     |> Macro.prewalk(false, fn
-         {:&, _, [_]} = expr, _ -> {expr, true}
-         expr, acc -> {expr, acc}
-       end)
+      {:&, _, [_]} = expr, _ -> {expr, true}
+      expr, acc -> {expr, acc}
+    end)
     |> elem(1)
   end
 
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, :limit | :offset, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), :limit | :offset, term) :: Ecto.Query.t()
   def apply(%Ecto.Query{} = query, :limit, expr) do
     %{query | limit: expr}
   end
+
   def apply(%Ecto.Query{} = query, :offset, expr) do
     %{query | offset: expr}
   end
+
   def apply(query, kind, expr) do
     apply(Ecto.Queryable.to_query(query), kind, expr)
   end

--- a/lib/ecto/query/builder/lock.ex
+++ b/lib/ecto/query/builder/lock.ex
@@ -12,7 +12,7 @@ defmodule Ecto.Query.Builder.Lock do
       "FOO"
 
   """
-  @spec escape(Macro.t(), Keyword.t, Macro.Env.t) :: Macro.t()
+  @spec escape(Macro.t(), Keyword.t(), Macro.Env.t()) :: Macro.t()
   def escape(lock, _vars, _env) when is_binary(lock), do: lock
 
   def escape({:fragment, _, [_ | _]} = expr, vars, env) do

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -47,20 +47,22 @@ defmodule Ecto.Query.Builder.OrderBy do
        {[], :acc}}
 
   """
-  @spec escape(:order_by | :distinct, Macro.t, {list, term}, Keyword.t, Macro.Env.t) ::
-          {Macro.t, {list, term}}
+  @spec escape(:order_by | :distinct, Macro.t(), {list, term}, Keyword.t(), Macro.Env.t()) ::
+          {Macro.t(), {list, term}}
   def escape(kind, expr, params_acc, vars, env) do
     expr
-    |> List.wrap
+    |> List.wrap()
     |> Enum.map_reduce(params_acc, &do_escape(&1, &2, kind, vars, env))
   end
 
   defp do_escape({dir, {:^, _, [expr]}}, params_acc, kind, _vars, _env) do
-    {{quoted_dir!(kind, dir), quote(do: Ecto.Query.Builder.OrderBy.field!(unquote(kind), unquote(expr)))}, params_acc}
+    {{quoted_dir!(kind, dir),
+      quote(do: Ecto.Query.Builder.OrderBy.field!(unquote(kind), unquote(expr)))}, params_acc}
   end
 
   defp do_escape({:^, _, [expr]}, params_acc, kind, _vars, _env) do
-    {{:asc, quote(do: Ecto.Query.Builder.OrderBy.field!(unquote(kind), unquote(expr)))}, params_acc}
+    {{:asc, quote(do: Ecto.Query.Builder.OrderBy.field!(unquote(kind), unquote(expr)))},
+     params_acc}
   end
 
   defp do_escape({dir, field}, params_acc, kind, _vars, _env) when is_atom(field) do
@@ -87,12 +89,14 @@ defmodule Ecto.Query.Builder.OrderBy do
   """
   def quoted_dir!(kind, {:^, _, [expr]}),
     do: quote(do: Ecto.Query.Builder.OrderBy.dir!(unquote(kind), unquote(expr)))
+
   def quoted_dir!(_kind, dir) when dir in @directions,
     do: dir
+
   def quoted_dir!(kind, other) do
     Builder.error!(
       "expected #{Enum.map_join(@directions, ", ", &inspect/1)} or interpolated value " <>
-        "in `#{kind}`, got: `#{inspect other}`"
+        "in `#{kind}`, got: `#{inspect(other)}`"
     )
   end
 
@@ -104,8 +108,8 @@ defmodule Ecto.Query.Builder.OrderBy do
 
   def dir!(kind, other) do
     raise ArgumentError,
-      "expected one of #{Enum.map_join(@directions, ", ", &inspect/1)} " <>
-        "in `#{kind}`, got: `#{inspect other}`"
+          "expected one of #{Enum.map_join(@directions, ", ", &inspect/1)} " <>
+            "in `#{kind}`, got: `#{inspect(other)}`"
   end
 
   @doc """
@@ -114,8 +118,9 @@ defmodule Ecto.Query.Builder.OrderBy do
   def field!(_kind, field) when is_atom(field) do
     to_field(field)
   end
+
   def field!(kind, other) do
-    raise ArgumentError, "expected a field as an atom in `#{kind}`, got: `#{inspect other}`"
+    raise ArgumentError, "expected a field as an atom in `#{kind}`, got: `#{inspect(other)}`"
   end
 
   defp to_field(field), do: {{:., [], [{:&, [], [0]}, field]}, [], []}
@@ -129,6 +134,7 @@ defmodule Ecto.Query.Builder.OrderBy do
         {dir, expr}, params_count when dir in @directions ->
           {expr, params} = dynamic_or_field!(kind, expr, query, params_count)
           {{dir, expr}, params}
+
         expr, params_count ->
           {expr, params} = dynamic_or_field!(kind, expr, query, params_count)
           {{:asc, expr}, params}
@@ -158,7 +164,7 @@ defmodule Ecto.Query.Builder.OrderBy do
   defp dynamic_or_field!(kind, other, _query, _params_count) do
     raise ArgumentError,
           "`#{kind}` interpolated on root expects a field or a keyword list " <>
-            "with the direction as keys and fields or dynamics as values, got: `#{inspect other}`"
+            "with the direction as keys and fields or dynamics as values, got: `#{inspect(other)}`"
   end
 
   @doc """
@@ -168,10 +174,15 @@ defmodule Ecto.Query.Builder.OrderBy do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(query, _binding, {:^, _, [var]}, env) do
     quote do
-      Ecto.Query.Builder.OrderBy.order_by!(unquote(query), unquote(var), unquote(env.file), unquote(env.line))
+      Ecto.Query.Builder.OrderBy.order_by!(
+        unquote(query),
+        unquote(var),
+        unquote(env.file),
+        unquote(env.line)
+      )
     end
   end
 
@@ -180,21 +191,25 @@ defmodule Ecto.Query.Builder.OrderBy do
     {expr, {params, _}} = escape(:order_by, expr, {[], :acc}, binding, env)
     params = Builder.escape_params(params)
 
-    order_by = quote do: %Ecto.Query.QueryExpr{
-                           expr: unquote(expr),
-                           params: unquote(params),
-                           file: unquote(env.file),
-                           line: unquote(env.line)}
+    order_by =
+      quote do: %Ecto.Query.QueryExpr{
+              expr: unquote(expr),
+              params: unquote(params),
+              file: unquote(env.file),
+              line: unquote(env.line)
+            }
+
     Builder.apply_query(query, __MODULE__, [order_by], env)
   end
 
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
   def apply(%Ecto.Query{order_bys: order_bys} = query, expr) do
     %{query | order_bys: order_bys ++ [expr]}
   end
+
   def apply(query, expr) do
     apply(Ecto.Queryable.to_query(query), expr)
   end

--- a/lib/ecto/query/builder/preload.ex
+++ b/lib/ecto/query/builder/preload.ex
@@ -44,60 +44,65 @@ defmodule Ecto.Query.Builder.Preload do
       ** (Ecto.Query.CompileError) cannot preload join association `:bar` with binding `c` because parent preload is not a join association
 
   """
-  @spec escape(Macro.t, Keyword.t) :: {[Macro.t], [Macro.t]}
+  @spec escape(Macro.t(), Keyword.t()) :: {[Macro.t()], [Macro.t()]}
   def escape(preloads, vars) do
     {preloads, assocs} = escape(preloads, :both, [], [], vars)
     {Enum.reverse(preloads), Enum.reverse(assocs)}
   end
 
   defp escape(atom, _mode, preloads, assocs, _vars) when is_atom(atom) do
-    {[atom|preloads], assocs}
+    {[atom | preloads], assocs}
   end
 
   defp escape(list, mode, preloads, assocs, vars) when is_list(list) do
-    Enum.reduce list, {preloads, assocs}, fn item, acc ->
+    Enum.reduce(list, {preloads, assocs}, fn item, acc ->
       escape_each(item, mode, acc, vars)
-    end
+    end)
   end
 
   defp escape({:^, _, [inner]}, _mode, preloads, assocs, _vars) do
-    {[inner|preloads], assocs}
+    {[inner | preloads], assocs}
   end
 
   defp escape(other, _mode, _preloads, _assocs, _vars) do
-    Builder.error! "`#{Macro.to_string other}` is not a valid preload expression. " <>
-                   "preload expects an atom, a list of atoms or a keyword list with " <>
-                   "more preloads as values. Use ^ on the outermost preload to interpolate a value"
+    Builder.error!(
+      "`#{Macro.to_string(other)}` is not a valid preload expression. " <>
+        "preload expects an atom, a list of atoms or a keyword list with " <>
+        "more preloads as values. Use ^ on the outermost preload to interpolate a value"
+    )
   end
 
   defp escape_each({key, {:^, _, [inner]}}, _mode, {preloads, assocs}, _vars) do
     key = escape_key(key)
-    {[{key, inner}|preloads], assocs}
+    {[{key, inner} | preloads], assocs}
   end
 
-  defp escape_each({key, {var, _, context}}, mode, {preloads, assocs}, vars) when is_atom(context) do
+  defp escape_each({key, {var, _, context}}, mode, {preloads, assocs}, vars)
+       when is_atom(context) do
     assert_assoc!(mode, key, var)
     key = escape_key(key)
     idx = Builder.find_var!(var, vars)
-    {preloads, [{key, {idx, []}}|assocs]}
+    {preloads, [{key, {idx, []}} | assocs]}
   end
 
-  defp escape_each({key, {{var, _, context}, list}}, mode, {preloads, assocs}, vars) when is_atom(context) do
+  defp escape_each({key, {{var, _, context}, list}}, mode, {preloads, assocs}, vars)
+       when is_atom(context) do
     assert_assoc!(mode, key, var)
     key = escape_key(key)
     idx = Builder.find_var!(var, vars)
     {inner_preloads, inner_assocs} = escape(list, :assoc, [], [], vars)
-    assocs = [{key, {idx, Enum.reverse(inner_assocs)}}|assocs]
+    assocs = [{key, {idx, Enum.reverse(inner_assocs)}} | assocs]
+
     case inner_preloads do
       [] -> {preloads, assocs}
-      _  -> {[{key, Enum.reverse(inner_preloads)}|preloads], assocs}
+      _ -> {[{key, Enum.reverse(inner_preloads)} | preloads], assocs}
     end
   end
 
   defp escape_each({key, list}, _mode, {preloads, assocs}, vars) do
     key = escape_key(key)
     {inner_preloads, []} = escape(list, :preload, [], [], vars)
-    {[{key, Enum.reverse(inner_preloads)}|preloads], assocs}
+    {[{key, Enum.reverse(inner_preloads)} | preloads], assocs}
   end
 
   defp escape_each(other, mode, {preloads, assocs}, vars) do
@@ -113,13 +118,16 @@ defmodule Ecto.Query.Builder.Preload do
   end
 
   defp escape_key(other) do
-    Builder.error! "malformed key in preload `#{Macro.to_string(other)}` in query expression"
+    Builder.error!("malformed key in preload `#{Macro.to_string(other)}` in query expression")
   end
 
   defp assert_assoc!(mode, _atom, _var) when mode in [:both, :assoc], do: :ok
+
   defp assert_assoc!(_mode, atom, var) do
-    Builder.error! "cannot preload join association `#{Macro.to_string atom}` with binding `#{var}` " <>
-                   "because parent preload is not a join association"
+    Builder.error!(
+      "cannot preload join association `#{Macro.to_string(atom)}` with binding `#{var}` " <>
+        "because parent preload is not a join association"
+    )
   end
 
   @doc """
@@ -127,9 +135,10 @@ defmodule Ecto.Query.Builder.Preload do
   """
   def key!(key) when is_atom(key),
     do: key
+
   def key!(key) do
     raise ArgumentError,
-      "expected key in preload to be an atom, got: `#{inspect key}`"
+          "expected key in preload to be an atom, got: `#{inspect(key)}`"
   end
 
   @doc """
@@ -139,7 +148,7 @@ defmodule Ecto.Query.Builder.Preload do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {preloads, assocs} = escape(expr, binding)
@@ -149,10 +158,11 @@ defmodule Ecto.Query.Builder.Preload do
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term, term) :: Ecto.Query.t()
   def apply(%Ecto.Query{preloads: p, assocs: a} = query, preloads, assocs) do
     %{query | preloads: p ++ preloads, assocs: a ++ assocs}
   end
+
   def apply(query, preloads, assocs) do
     apply(Ecto.Queryable.to_query(query), preloads, assocs)
   end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -23,12 +23,12 @@ defmodule Ecto.Query.Builder.Select do
       {{:{}, [], [:&, [], [0]]}, {[], %{}}}
 
   """
-  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{}}}
+  @spec escape(Macro.t(), Keyword.t(), Macro.Env.t()) :: {Macro.t(), {list, %{}}}
   def escape(atom, _vars, _env)
       when is_atom(atom) and not is_boolean(atom) and atom != nil do
-    Builder.error! """
+    Builder.error!("""
     #{inspect(atom)} is not a valid query expression, :select expects a query expression or a list of fields
-    """
+    """)
   end
 
   def escape(other, vars, env) do
@@ -37,12 +37,12 @@ defmodule Ecto.Query.Builder.Select do
         {{:{}, [], [:&, [], [0]]}, {[], %{0 => {:any, other}}}}
 
       maybe_take?(other) ->
-        Builder.error! """
+        Builder.error!("""
         Cannot mix fields with interpolations, such as: `select: [:foo, ^:bar, :baz]`. \
         Instead interpolate all fields at once, such as: `select: ^[:foo, :bar, :baz]`. \
         Got: #{Macro.to_string(other)}.
-        """
-    
+        """)
+
       true ->
         escape(other, {[], %{}}, vars, env)
     end
@@ -83,7 +83,9 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   defp escape({:merge, _, [_left, right]}, _params_take, _vars, _env) do
-    Builder.error! "expected the second argument of merge/2 in select to be a map, got: `#{Macro.to_string(right)}`"
+    Builder.error!(
+      "expected the second argument of merge/2 in select to be a map, got: `#{Macro.to_string(right)}`"
+    )
   end
 
   # Map
@@ -115,16 +117,17 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   defp escape_pairs(pairs, params_take, vars, env) do
-    Enum.map_reduce pairs, params_take, fn({k, v}, acc) ->
+    Enum.map_reduce(pairs, params_take, fn {k, v}, acc ->
       {k, acc} = escape_key(k, acc, vars, env)
       {v, acc} = escape(v, acc, vars, env)
       {{k, v}, acc}
-    end
+    end)
   end
 
   defp escape_key(k, params_take, _vars, _env) when is_atom(k) do
     {k, params_take}
   end
+
   defp escape_key(k, params_take, vars, env) do
     escape(k, params_take, vars, env)
   end
@@ -134,13 +137,17 @@ defmodule Ecto.Query.Builder.Select do
       Ecto.Query.Builder.Select.fields!(unquote(tag), unquote(interpolated))
     end
   end
+
   defp escape_fields(expr, tag, env) do
     case Macro.expand(expr, env) do
       fields when is_list(fields) ->
         fields
+
       _ ->
-        Builder.error! "`#{tag}/2` in `select` expects either a literal or " <>
-          "an interpolated list of atom fields"
+        Builder.error!(
+          "`#{tag}/2` in `select` expects either a literal or " <>
+            "an interpolated list of atom fields"
+        )
     end
   end
 
@@ -152,24 +159,26 @@ defmodule Ecto.Query.Builder.Select do
       fields
     else
       raise ArgumentError,
-        "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect fields}`"
+            "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect(fields)}`"
     end
   end
 
   defp take?(fields) do
-    is_list(fields) and Enum.all?(fields, fn
-      {k, v} when is_atom(k) -> take?(List.wrap(v))
-      k when is_atom(k) -> true
-      _ -> false
-    end)
+    is_list(fields) and
+      Enum.all?(fields, fn
+        {k, v} when is_atom(k) -> take?(List.wrap(v))
+        k when is_atom(k) -> true
+        _ -> false
+      end)
   end
 
   defp maybe_take?(fields) do
-    is_list(fields) and Enum.any?(fields, fn
-      {k, v} when is_atom(k) -> maybe_take?(List.wrap(v))
-      k when is_atom(k) -> true
-      _ -> false
-    end)
+    is_list(fields) and
+      Enum.any?(fields, fn
+        {k, v} when is_atom(k) -> maybe_take?(List.wrap(v))
+        k when is_atom(k) -> true
+        _ -> false
+      end)
   end
 
   @doc """
@@ -178,6 +187,7 @@ defmodule Ecto.Query.Builder.Select do
   def select!(kind, query, fields, file, line) do
     take = %{0 => {:any, fields!(:select, fields)}}
     expr = %Ecto.Query.SelectExpr{expr: {:&, [], [0]}, take: take, file: file, line: line}
+
     if kind == :select do
       apply(query, expr)
     else
@@ -192,12 +202,17 @@ defmodule Ecto.Query.Builder.Select do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(:select | :merge, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(:select | :merge, Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
 
   def build(kind, query, _binding, {:^, _, [var]}, env) do
     quote do
-      Ecto.Query.Builder.Select.select!(unquote(kind), unquote(query), unquote(var),
-                                        unquote(env.file), unquote(env.line))
+      Ecto.Query.Builder.Select.select!(
+        unquote(kind),
+        unquote(query),
+        unquote(var),
+        unquote(env.file),
+        unquote(env.line)
+      )
     end
   end
 
@@ -205,14 +220,16 @@ defmodule Ecto.Query.Builder.Select do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, take}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
-    take   = {:%{}, [], Map.to_list(take)}
+    take = {:%{}, [], Map.to_list(take)}
 
-    select = quote do: %Ecto.Query.SelectExpr{
-                         expr: unquote(expr),
-                         params: unquote(params),
-                         file: unquote(env.file),
-                         line: unquote(env.line),
-                         take: unquote(take)}
+    select =
+      quote do: %Ecto.Query.SelectExpr{
+              expr: unquote(expr),
+              params: unquote(params),
+              file: unquote(env.file),
+              line: unquote(env.line),
+              take: unquote(take)
+            }
 
     if kind == :select do
       Builder.apply_query(query, __MODULE__, [select], env)
@@ -227,13 +244,15 @@ defmodule Ecto.Query.Builder.Select do
   @doc """
   The callback applied by `build/5` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
   def apply(%Ecto.Query{select: nil} = query, expr) do
     %{query | select: expr}
   end
+
   def apply(%Ecto.Query{}, _expr) do
-    Builder.error! "only one select expression is allowed in query"
+    Builder.error!("only one select expression is allowed in query")
   end
+
   def apply(query, expr) do
     apply(Ecto.Queryable.to_query(query), expr)
   end
@@ -244,10 +263,12 @@ defmodule Ecto.Query.Builder.Select do
   def merge(%Ecto.Query{select: nil} = query, new_select) do
     merge(query, new_select, {:&, [], [0]}, [], %{}, new_select)
   end
+
   def merge(%Ecto.Query{select: old_select} = query, new_select) do
     %{expr: old_expr, params: old_params, take: old_take} = old_select
     merge(query, old_select, old_expr, old_params, old_take, new_select)
   end
+
   def merge(query, expr) do
     merge(Ecto.Queryable.to_query(query), expr)
   end
@@ -312,9 +333,10 @@ defmodule Ecto.Query.Builder.Select do
       end
 
     select = %{
-      select | expr: expr,
-               params: old_params ++ new_params,
-               take: merge_take(old_expr, old_take, new_take)
+      select
+      | expr: expr,
+        params: old_params ++ new_params,
+        take: merge_take(old_expr, old_take, new_take)
     }
 
     %{query | select: select}
@@ -384,8 +406,11 @@ defmodule Ecto.Query.Builder.Select do
   defp merge_take_kind(_, kind, kind), do: kind
   defp merge_take_kind(_, :any, kind), do: kind
   defp merge_take_kind(_, kind, :any), do: kind
+
   defp merge_take_kind(binding, old, new) do
-    Builder.error! "cannot select_merge because the binding at position #{binding} " <>
-                   "was previously specified as a `#{old}` and later as `#{new}`"
+    Builder.error!(
+      "cannot select_merge because the binding at position #{binding} " <>
+        "was previously specified as a `#{old}` and later as `#{new}`"
+    )
   end
 end

--- a/lib/ecto/query/builder/update.ex
+++ b/lib/ecto/query/builder/update.ex
@@ -25,7 +25,7 @@ defmodule Ecto.Query.Builder.Update do
       {[], [set: [foo: 1]], []}
 
   """
-  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, Macro.t, list}
+  @spec escape(Macro.t(), Keyword.t(), Macro.Env.t()) :: {Macro.t(), Macro.t(), list}
   def escape(expr, vars, env) when is_list(expr) do
     escape_op(expr, [], [], [], vars, env)
   end
@@ -38,19 +38,23 @@ defmodule Ecto.Query.Builder.Update do
     compile_error!(expr)
   end
 
-  defp escape_op([{k, v}|t], compile, runtime, params, vars, env) when is_atom(k) and is_list(v) do
+  defp escape_op([{k, v} | t], compile, runtime, params, vars, env)
+       when is_atom(k) and is_list(v) do
     validate_op!(k)
     {compile_values, runtime_values, params} = escape_kw(k, v, params, vars, env)
+
     compile =
       if compile_values == [], do: compile, else: [{k, Enum.reverse(compile_values)} | compile]
+
     runtime =
       if runtime_values == [], do: runtime, else: [{k, Enum.reverse(runtime_values)} | runtime]
+
     escape_op(t, compile, runtime, params, vars, env)
   end
 
-  defp escape_op([{k, {:^, _, [v]}}|t], compile, runtime, params, vars, env) when is_atom(k) do
+  defp escape_op([{k, {:^, _, [v]}} | t], compile, runtime, params, vars, env) when is_atom(k) do
     validate_op!(k)
-    escape_op(t, compile, [{k, v}|runtime], params, vars, env)
+    escape_op(t, compile, [{k, v} | runtime], params, vars, env)
   end
 
   defp escape_op([], compile, runtime, params, _vars, _env) do
@@ -62,17 +66,24 @@ defmodule Ecto.Query.Builder.Update do
   end
 
   defp escape_kw(op, kw, params, vars, env) do
-    Enum.reduce kw, {[], [], params}, fn
+    Enum.reduce(kw, {[], [], params}, fn
       {k, {:^, _, [v]}}, {compile, runtime, params} when is_atom(k) ->
         {compile, [{k, v} | runtime], params}
+
       {k, v}, {compile, runtime, params} ->
         k = escape_field!(k)
-        {v, {params, :acc}} = Builder.escape(v, type_for_key(op, {0, k}), {params, :acc}, vars, env)
+
+        {v, {params, :acc}} =
+          Builder.escape(v, type_for_key(op, {0, k}), {params, :acc}, vars, env)
+
         {[{k, v} | compile], runtime, params}
+
       _, _acc ->
-        Builder.error! "malformed #{inspect op} in update `#{Macro.to_string(kw)}`, " <>
-                       "expected a keyword list"
-    end
+        Builder.error!(
+          "malformed #{inspect(op)} in update `#{Macro.to_string(kw)}`, " <>
+            "expected a keyword list"
+        )
+    end)
   end
 
   defp escape_field!({:^, _, [k]}), do: quote(do: Ecto.Query.Builder.Update.field!(unquote(k)))
@@ -87,13 +98,15 @@ defmodule Ecto.Query.Builder.Update do
   def field!(field) when is_atom(field), do: field
 
   def field!(other) do
-    raise ArgumentError, "expected a field as an atom in `update`, got: `#{inspect other}`"
+    raise ArgumentError, "expected a field as an atom in `update`, got: `#{inspect(other)}`"
   end
 
   defp compile_error!(expr) do
-    Builder.error! "malformed update `#{Macro.to_string(expr)}` in query expression, " <>
-                   "expected a keyword list with set/push/pop as keys with field-value " <>
-                   "pairs as values"
+    Builder.error!(
+      "malformed update `#{Macro.to_string(expr)}` in query expression, " <>
+        "expected a keyword list with set/push/pop as keys with field-value " <>
+        "pairs as values"
+    )
   end
 
   @doc """
@@ -103,7 +116,7 @@ defmodule Ecto.Query.Builder.Update do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {compile, runtime, params} = escape(expr, binding, env)
@@ -114,10 +127,15 @@ defmodule Ecto.Query.Builder.Update do
       else
         params = Builder.escape_params(params)
 
-        update = quote do
-          %Ecto.Query.QueryExpr{expr: unquote(compile), params: unquote(params),
-                                file: unquote(env.file), line: unquote(env.line)}
-        end
+        update =
+          quote do
+            %Ecto.Query.QueryExpr{
+              expr: unquote(compile),
+              params: unquote(params),
+              file: unquote(env.file),
+              line: unquote(env.line)
+            }
+          end
 
         Builder.apply_query(query, __MODULE__, [update], env)
       end
@@ -126,8 +144,12 @@ defmodule Ecto.Query.Builder.Update do
       query
     else
       quote do
-        Ecto.Query.Builder.Update.update!(unquote(query), unquote(runtime),
-                                          unquote(env.file), unquote(env.line))
+        Ecto.Query.Builder.Update.update!(
+          unquote(query),
+          unquote(runtime),
+          unquote(env.file),
+          unquote(env.line)
+        )
       end
     end
   end
@@ -135,10 +157,11 @@ defmodule Ecto.Query.Builder.Update do
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), term) :: Ecto.Query.t()
   def apply(%Ecto.Query{updates: updates} = query, expr) do
     %{query | updates: updates ++ [expr]}
   end
+
   def apply(query, expr) do
     apply(Ecto.Queryable.to_query(query), expr)
   end
@@ -150,17 +173,22 @@ defmodule Ecto.Query.Builder.Update do
   """
   def update!(query, runtime, file, line) when is_list(runtime) do
     {runtime, {params, _count}} =
-      Enum.map_reduce runtime, {[], 0}, fn
+      Enum.map_reduce(runtime, {[], 0}, fn
         {k, v}, acc when is_atom(k) and is_list(v) ->
           validate_op!(k)
           {v, params} = runtime_field!(query, k, v, acc)
           {{k, v}, params}
+
         _, _ ->
           runtime_error!(runtime)
-      end
+      end)
 
-    expr = %Ecto.Query.QueryExpr{expr: runtime, params: Enum.reverse(params),
-                                 file: file, line: line}
+    expr = %Ecto.Query.QueryExpr{
+      expr: runtime,
+      params: Enum.reverse(params),
+      file: file,
+      line: line
+    }
 
     apply(query, expr)
   end
@@ -170,31 +198,36 @@ defmodule Ecto.Query.Builder.Update do
   end
 
   defp runtime_field!(query, key, kw, acc) do
-    Enum.map_reduce kw, acc, fn
+    Enum.map_reduce(kw, acc, fn
       {k, %Ecto.Query.DynamicExpr{} = v}, {params, count} when is_atom(k) ->
-        {v, params, count} = Ecto.Query.Builder.Dynamic.partially_expand(:update, query, v, params, count)
+        {v, params, count} =
+          Ecto.Query.Builder.Dynamic.partially_expand(:update, query, v, params, count)
+
         {{k, v}, {params, count}}
+
       {k, v}, {params, count} when is_atom(k) ->
         params = [{v, type_for_key(key, {0, k})} | params]
         {{k, {:^, [], [count]}}, {params, count + 1}}
+
       _, _acc ->
-        raise ArgumentError, "malformed #{inspect key} in update `#{inspect(kw)}`, " <>
-                             "expected a keyword list"
-    end
+        raise ArgumentError,
+              "malformed #{inspect(key)} in update `#{inspect(kw)}`, " <>
+                "expected a keyword list"
+    end)
   end
 
   defp runtime_error!(value) do
     raise ArgumentError,
           "malformed update `#{inspect(value)}` in query expression, " <>
-          "expected a keyword list with set/push/pop as keys with field-value pairs as values"
+            "expected a keyword list with set/push/pop as keys with field-value pairs as values"
   end
 
   defp validate_op!(key) when key in @keys, do: :ok
-  defp validate_op!(key), do: Builder.error! "unknown key `#{inspect(key)}` in update"
+  defp validate_op!(key), do: Builder.error!("unknown key `#{inspect(key)}` in update")
 
   # Out means the given type must be taken out of an array
   # It is the opposite of "left in right" in the query API.
   defp type_for_key(:push, type), do: {:out, type}
   defp type_for_key(:pull, type), do: {:out, type}
-  defp type_for_key(_, type),     do: type
+  defp type_for_key(_, type), do: type
 end

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -16,11 +16,14 @@ defmodule Ecto.Query.Builder.Windows do
       {[order_by: [desc: 13]], [], {[], :acc}}
 
   """
-  @spec escape([Macro.t], {list, term}, Keyword.t, Macro.Env.t | {Macro.Env.t, fun})
-          :: {Macro.t, [{atom, term}], {list, term}}
+  @spec escape([Macro.t()], {list, term}, Keyword.t(), Macro.Env.t() | {Macro.Env.t(), fun}) ::
+          {Macro.t(), [{atom, term}], {list, term}}
   def escape(kw, params_acc, vars, env) when is_list(kw) do
     {compile, runtime} = sort(@sort_order, kw, :compile, [], [])
-    {compile, params_acc} = Enum.map_reduce(compile, params_acc, &escape_compile(&1, &2, vars, env))
+
+    {compile, params_acc} =
+      Enum.map_reduce(compile, params_acc, &escape_compile(&1, &2, vars, env))
+
     {compile, runtime, params_acc}
   end
 
@@ -38,8 +41,10 @@ defmodule Ecto.Query.Builder.Windows do
 
       {_, _} when mode == :runtime ->
         [{runtime_key, _} | _] = runtime
-        raise ArgumentError, "window has an interpolated value under `#{runtime_key}` " <>
-                             "and therefore `#{key}` must also be interpolated"
+
+        raise ArgumentError,
+              "window has an interpolated value under `#{runtime_key}` " <>
+                "and therefore `#{key}` must also be interpolated"
 
       {expr, kw} ->
         sort(keys, kw, mode, [{key, expr} | compile], runtime)
@@ -72,14 +77,15 @@ defmodule Ecto.Query.Builder.Windows do
   defp escape_frame({:fragment, _, _} = fragment, params_acc, vars, env) do
     Builder.escape(fragment, :any, params_acc, vars, env)
   end
+
   defp escape_frame(other, _, _, _) do
-    Builder.error!("expected a dynamic or fragment in `:frame`, got: `#{inspect other}`")
+    Builder.error!("expected a dynamic or fragment in `:frame`, got: `#{inspect(other)}`")
   end
 
   defp error!(other) do
     Builder.error!(
       "expected window definition to be a keyword list " <>
-        "with partition_by, order_by or frame as keys, got: `#{inspect other}`"
+        "with partition_by, order_by or frame as keys, got: `#{inspect(other)}`"
     )
   end
 
@@ -90,14 +96,14 @@ defmodule Ecto.Query.Builder.Windows do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, [Macro.t], Keyword.t, Macro.Env.t) :: Macro.t
+  @spec build(Macro.t(), [Macro.t()], Keyword.t(), Macro.Env.t()) :: Macro.t()
   def build(query, binding, windows, env) when is_list(windows) do
     {query, binding} = Builder.escape_binding(query, binding, env)
 
     {compile, runtime} =
       windows
       |> Enum.map(&escape_window(binding, &1, env))
-      |> Enum.split_with(&elem(&1, 2) == [])
+      |> Enum.split_with(&(elem(&1, 2) == []))
 
     compile = Enum.map(compile, &build_compile_window(&1, env))
     runtime = Enum.map(runtime, &build_runtime_window(&1, env))
@@ -120,7 +126,7 @@ defmodule Ecto.Query.Builder.Windows do
   def build(_, _, windows, _) do
     Builder.error!(
       "expected window definitions to be a keyword list with window names as keys and " <>
-        "a keyword list with the window definition as value, got: `#{inspect windows}`"
+        "a keyword list with the window definition as value, got: `#{inspect(windows)}`"
     )
   end
 
@@ -152,7 +158,14 @@ defmodule Ecto.Query.Builder.Windows do
     windows =
       Enum.map(runtime, fn {name, compile_acc, runtime_acc, params} ->
         {acc, params} = do_runtime_window!(runtime_acc, query, compile_acc, params)
-        expr = %Ecto.Query.QueryExpr{expr: Enum.reverse(acc), params: Enum.reverse(params), file: file, line: line}
+
+        expr = %Ecto.Query.QueryExpr{
+          expr: Enum.reverse(acc),
+          params: Enum.reverse(params),
+          file: file,
+          line: line
+        }
+
         {name, expr}
       end)
 
@@ -165,19 +178,23 @@ defmodule Ecto.Query.Builder.Windows do
   end
 
   defp do_runtime_window!([{:partition_by, partition_by} | kw], query, acc, params) do
-    {partition_by, params} = GroupBy.group_or_partition_by!(:partition_by, query, partition_by, params)
+    {partition_by, params} =
+      GroupBy.group_or_partition_by!(:partition_by, query, partition_by, params)
+
     do_runtime_window!(kw, query, [{:partition_by, partition_by} | acc], params)
   end
 
   defp do_runtime_window!([{:frame, frame} | kw], query, acc, params) do
     case frame do
       %Ecto.Query.DynamicExpr{} ->
-        {frame, params, _count} = Builder.Dynamic.partially_expand(:windows, query, frame, params, length(params))
+        {frame, params, _count} =
+          Builder.Dynamic.partially_expand(:windows, query, frame, params, length(params))
+
         do_runtime_window!(kw, query, [{:frame, frame} | acc], params)
 
       _ ->
         raise ArgumentError,
-                "expected a dynamic or fragment in `:frame`, got: `#{inspect frame}`"
+              "expected a dynamic or fragment in `:frame`, got: `#{inspect(frame)}`"
     end
   end
 
@@ -186,11 +203,12 @@ defmodule Ecto.Query.Builder.Windows do
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, Keyword.t) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), Keyword.t()) :: Ecto.Query.t()
   def apply(%Ecto.Query{windows: windows} = query, definitions) do
-    merged = Keyword.merge(windows, definitions, fn name, _, _ ->
-      Builder.error! "window with name #{name} is already defined"
-    end)
+    merged =
+      Keyword.merge(windows, definitions, fn name, _, _ ->
+        Builder.error!("window with name #{name} is already defined")
+      end)
 
     %{query | windows: merged}
   end

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -14,7 +14,7 @@ defimpl Inspect, for: Ecto.Query.DynamicExpr do
     aliases =
       for({as, _} when is_atom(as) <- binding, do: as)
       |> Enum.with_index()
-      |> Map.new
+      |> Map.new()
 
     query = %Ecto.Query{joins: joins, aliases: aliases}
 
@@ -54,10 +54,11 @@ defimpl Inspect, for: Ecto.Query do
       %WithExpr{recursive: recursive, queries: [_ | _] = queries} ->
         with_ctes =
           Enum.map(queries, fn {name, query} ->
-            cte = case query do
-              %Ecto.Query{} -> __MODULE__.inspect(query, opts)
-              %Ecto.Query.QueryExpr{} -> expr(query, {})
-            end
+            cte =
+              case query do
+                %Ecto.Query{} -> __MODULE__.inspect(query, opts)
+                %Ecto.Query.QueryExpr{} -> expr(query, {})
+              end
 
             concat(["|> with_cte(\"" <> name <> "\", as: ", cte, ")"])
           end)

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -28,7 +28,7 @@ defmodule Ecto.Query.Planner do
     last = length(joins) + position
 
     mapping = fn
-      0  -> last
+      0 -> last
       ix -> ix + position - 1
     end
 
@@ -37,8 +37,12 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp merge_expr_and_params(op, %QueryExpr{expr: left_expr, params: left_params} = struct,
-                             right_expr, right_params) do
+  defp merge_expr_and_params(
+         op,
+         %QueryExpr{expr: left_expr, params: left_params} = struct,
+         right_expr,
+         right_params
+       ) do
     right_expr = Ecto.Query.Builder.bump_interpolations(right_expr, left_params)
     %{struct | expr: merge_expr(op, left_expr, right_expr), params: left_params ++ right_params}
   end
@@ -52,22 +56,25 @@ defmodule Ecto.Query.Planner do
   """
   def rewrite_sources(%{expr: expr, params: params} = part, mapping) do
     expr =
-      Macro.prewalk expr, fn
+      Macro.prewalk(expr, fn
         %Ecto.Query.Tagged{type: type, tag: tag} = tagged ->
           %{tagged | type: rewrite_type(type, mapping), tag: rewrite_type(tag, mapping)}
+
         {:&, meta, [ix]} ->
           {:&, meta, [mapping.(ix)]}
+
         other ->
           other
-      end
+      end)
 
     params =
-      Enum.map params, fn
+      Enum.map(params, fn
         {val, type} ->
           {val, rewrite_type(type, mapping)}
+
         val ->
           val
-      end
+      end)
 
     %{part | expr: expr, params: params}
   end
@@ -125,10 +132,12 @@ defmodule Ecto.Query.Planner do
     case query_lookup(key, query, operation, cache, adapter, counter) do
       {_, select, prepared} ->
         {build_meta(query, select), {:nocache, prepared}, params}
+
       {_key, :cached, select, cached} ->
         update = &cache_update(cache, key, &1)
         reset = &cache_reset(cache, key, &1)
         {build_meta(query, select), {:cached, update, reset, cached}, params}
+
       {_key, :cache, select, prepared} ->
         update = &cache_update(cache, key, &1)
         {build_meta(query, select), {:cache, update, prepared}, params}
@@ -150,6 +159,7 @@ defmodule Ecto.Query.Planner do
     case query_without_cache(query, operation, adapter, counter) do
       {:cache, select, prepared} ->
         cache_insert(cache, key, {key, :cache, select, prepared})
+
       {:nocache, _, _} = nocache ->
         nocache
     end
@@ -159,6 +169,7 @@ defmodule Ecto.Query.Planner do
     case :ets.insert_new(cache, elem) do
       true ->
         elem
+
       false ->
         [elem] = :ets.lookup(cache, key)
         elem
@@ -195,7 +206,8 @@ defmodule Ecto.Query.Planner do
   This function is called by the backend before invoking
   any cache mechanism.
   """
-  @spec plan(Ecto.Query.t, atom, module) :: {planned_query :: Ecto.Query.t, parameters :: list, cache_key :: any}
+  @spec plan(Ecto.Query.t(), atom, module) ::
+          {planned_query :: Ecto.Query.t(), parameters :: list, cache_key :: any}
   def plan(query, operation, adapter) do
     query
     |> plan_sources(adapter)
@@ -207,7 +219,7 @@ defmodule Ecto.Query.Planner do
   rescue
     e ->
       # Reraise errors so we ignore the planner inner stacktrace
-      filter_and_reraise e, __STACKTRACE__
+      filter_and_reraise(e, __STACKTRACE__)
   end
 
   @doc """
@@ -222,9 +234,12 @@ defmodule Ecto.Query.Planner do
 
     {joins, sources, tail_sources} = plan_joins(query, [source], length(query.joins), adapter)
 
-    %{query | from: from,
-              joins: joins |> Enum.reverse,
-              sources: (tail_sources ++ sources) |> Enum.reverse |> List.to_tuple()}
+    %{
+      query
+      | from: from,
+        joins: joins |> Enum.reverse(),
+        sources: (tail_sources ++ sources) |> Enum.reverse() |> List.to_tuple()
+    }
   end
 
   defp plan_from(%{from: nil} = query, _adapter) do
@@ -252,10 +267,10 @@ defmodule Ecto.Query.Planner do
        do: {expr, {source, schema, prefix || query.prefix}}
 
   defp plan_source(_query, %{source: {:fragment, _, _} = source, prefix: nil} = expr, _adapter),
-       do: {expr, source}
+    do: {expr, source}
 
   defp plan_source(query, %{source: {:fragment, _, _}, prefix: prefix} = expr, _adapter),
-       do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for fragment joins")
+    do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for fragment joins")
 
   defp plan_subquery(subquery, query, prefix, adapter, source?) do
     %{query: inner_query} = subquery
@@ -322,7 +337,10 @@ defmodule Ecto.Query.Planner do
           {:%, [], [struct, {:%{}, [], fields}]}
 
         :error when source? ->
-          error!(query, "subquery/cte must select a source (t), a field (t.field) or a map, got: `#{Macro.to_string(expr)}`")
+          error!(
+            query,
+            "subquery/cte must select a source (t), a field (t.field) or a map, got: `#{Macro.to_string(expr)}`"
+          )
 
         :error ->
           expr
@@ -336,15 +354,20 @@ defmodule Ecto.Query.Planner do
     {right_struct, right_fields} = subquery_select(right, take, query)
 
     unless is_nil(left_struct) or is_nil(right_struct) or left_struct == right_struct do
-      error!(query, "cannot merge #{inspect(left_struct)} and #{inspect(right_struct)} because they are different structs")
+      error!(
+        query,
+        "cannot merge #{inspect(left_struct)} and #{inspect(right_struct)} because they are different structs"
+      )
     end
 
     {left_struct || right_struct, Keyword.merge(left_fields, right_fields)}
   end
+
   defp subquery_select({:%, _, [name, map]}, take, query) do
     {_, fields} = subquery_select(map, take, query)
     {name, fields}
   end
+
   defp subquery_select({:%{}, _, [{:|, _, [{:&, [], [ix]}, pairs]}]} = expr, take, query) do
     assert_subquery_fields!(query, expr, pairs)
     {source, _} = source_take!(:select, query, take, ix, ix)
@@ -355,8 +378,14 @@ defmodule Ecto.Query.Planner do
     update_keys = Keyword.keys(pairs)
 
     case update_keys -- valid_keys do
-      [] -> :ok
-      [key | _] -> error!(query, "invalid key `#{inspect key}` for `#{inspect struct}` on map update in subquery/cte")
+      [] ->
+        :ok
+
+      [key | _] ->
+        error!(
+          query,
+          "invalid key `#{inspect(key)}` for `#{inspect(struct)}` on map update in subquery/cte"
+        )
     end
 
     # In case of map updates, we need to remove duplicated fields
@@ -365,18 +394,22 @@ defmodule Ecto.Query.Planner do
     kept_keys = fields -- update_keys
     {struct, subquery_fields(kept_keys, ix) ++ pairs}
   end
+
   defp subquery_select({:%{}, _, pairs} = expr, _take, query) do
     assert_subquery_fields!(query, expr, pairs)
     {nil, pairs}
   end
+
   defp subquery_select({:&, _, [ix]}, take, query) do
     {source, _} = source_take!(:select, query, take, ix, ix)
     {struct, fields} = subquery_struct_and_fields(source)
     {struct, subquery_fields(fields, ix)}
   end
+
   defp subquery_select({{:., _, [{:&, _, [ix]}, field]}, _, []}, _take, _query) do
     {nil, subquery_fields([field], ix)}
   end
+
   defp subquery_select(_expr, _take, _query) do
     :error
   end
@@ -384,9 +417,11 @@ defmodule Ecto.Query.Planner do
   defp subquery_struct_and_fields({:source, {_, schema}, _, types}) do
     {schema, Keyword.keys(types)}
   end
+
   defp subquery_struct_and_fields({:struct, name, types}) do
     {name, Keyword.keys(types)}
   end
+
   defp subquery_struct_and_fields({:map, types}) do
     {nil, Keyword.keys(types)}
   end
@@ -398,7 +433,10 @@ defmodule Ecto.Query.Planner do
   end
 
   defp subquery_type_for({:source, _, _, fields}, field), do: Keyword.fetch(fields, field)
-  defp subquery_type_for({:struct, _name, types}, field), do: subquery_type_for_value(types, field)
+
+  defp subquery_type_for({:struct, _name, types}, field),
+    do: subquery_type_for_value(types, field)
+
   defp subquery_type_for({:map, types}, field), do: subquery_type_for_value(types, field)
 
   defp subquery_type_for_value(types, field) do
@@ -412,34 +450,52 @@ defmodule Ecto.Query.Planner do
   defp assert_subquery_fields!(query, expr, pairs) do
     Enum.each(pairs, fn
       {key, _} when not is_atom(key) ->
-        error!(query, "only atom keys are allowed when selecting a map in subquery, got: `#{Macro.to_string(expr)}`")
+        error!(
+          query,
+          "only atom keys are allowed when selecting a map in subquery, got: `#{Macro.to_string(expr)}`"
+        )
+
       {key, value} ->
         if valid_subquery_value?(value) do
           {key, value}
         else
-          error!(query, "maps, lists, tuples and sources are not allowed as map values in subquery, got: `#{Macro.to_string(expr)}`")
+          error!(
+            query,
+            "maps, lists, tuples and sources are not allowed as map values in subquery, got: `#{Macro.to_string(expr)}`"
+          )
         end
     end)
   end
 
   defp valid_subquery_value?({_, _}), do: false
   defp valid_subquery_value?(args) when is_list(args), do: false
+
   defp valid_subquery_value?({container, _, args})
-       when container in [:{}, :%{}, :&] and is_list(args), do: false
+       when container in [:{}, :%{}, :&] and is_list(args),
+       do: false
+
   defp valid_subquery_value?(_), do: true
 
   defp plan_joins(query, sources, offset, adapter) do
     plan_joins(query.joins, query, [], sources, [], 1, offset, adapter)
   end
 
-  defp plan_joins([%JoinExpr{assoc: {ix, assoc}, qual: qual, on: on, prefix: prefix} = join|t],
-                     query, joins, sources, tail_sources, counter, offset, adapter) do
+  defp plan_joins(
+         [%JoinExpr{assoc: {ix, assoc}, qual: qual, on: on, prefix: prefix} = join | t],
+         query,
+         joins,
+         sources,
+         tail_sources,
+         counter,
+         offset,
+         adapter
+       ) do
     source = fetch_source!(sources, ix)
     schema = schema_for_association_join!(query, join, source)
     refl = schema.__schema__(:association, assoc)
 
     unless refl do
-      error! query, join, "could not find association `#{assoc}` on schema #{inspect schema}"
+      error!(query, join, "could not find association `#{assoc}` on schema #{inspect(schema)}")
     end
 
     # If we have the following join:
@@ -467,8 +523,8 @@ defmodule Ecto.Query.Planner do
     # 2. from and joins can have their prefixes explicitly
     #    overwritten by the join prefix
     child = rewrite_prefix(child, query.prefix)
-    child = update_in child.from, &rewrite_prefix(&1, prefix)
-    child = update_in child.joins, &Enum.map(&1, fn join -> rewrite_prefix(join, prefix) end)
+    child = update_in(child.from, &rewrite_prefix(&1, prefix))
+    child = update_in(child.joins, &Enum.map(&1, fn join -> rewrite_prefix(join, prefix) end))
 
     last_ix = length(child.joins)
     source_ix = counter
@@ -484,38 +540,97 @@ defmodule Ecto.Query.Planner do
     # Drop the last resource which is the association owner (it is reversed)
     child_sources = Enum.drop(child_sources, -1)
 
-    [current_source|child_sources] = child_sources
+    [current_source | child_sources] = child_sources
     child_sources = child_tail ++ child_sources
 
-    plan_joins(t, query, attach_on(child_joins, on) ++ joins, [current_source|sources],
-                  child_sources ++ tail_sources, counter + 1, offset + length(child_sources), adapter)
+    plan_joins(
+      t,
+      query,
+      attach_on(child_joins, on) ++ joins,
+      [current_source | sources],
+      child_sources ++ tail_sources,
+      counter + 1,
+      offset + length(child_sources),
+      adapter
+    )
   end
 
-  defp plan_joins([%JoinExpr{source: %Ecto.Query{} = join_query, qual: qual, on: on, prefix: prefix} = join|t],
-                      query, joins, sources, tail_sources, counter, offset, adapter) do
+  defp plan_joins(
+         [
+           %JoinExpr{source: %Ecto.Query{} = join_query, qual: qual, on: on, prefix: prefix} =
+             join
+           | t
+         ],
+         query,
+         joins,
+         sources,
+         tail_sources,
+         counter,
+         offset,
+         adapter
+       ) do
     case join_query do
-      %{order_bys: [], limit: nil, offset: nil, group_bys: [], joins: [],
-        havings: [], preloads: [], assocs: [], distinct: nil, lock: nil} ->
+      %{
+        order_bys: [],
+        limit: nil,
+        offset: nil,
+        group_bys: [],
+        joins: [],
+        havings: [],
+        preloads: [],
+        assocs: [],
+        distinct: nil,
+        lock: nil
+      } ->
         join_query = rewrite_prefix(join_query, query.prefix)
         from = rewrite_prefix(join_query.from, prefix)
         {from, source} = plan_source(join_query, from, adapter)
         [join] = attach_on(query_to_joins(qual, from.source, join_query, counter), on)
-        plan_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter)
+
+        plan_joins(
+          t,
+          query,
+          [join | joins],
+          [source | sources],
+          tail_sources,
+          counter + 1,
+          offset,
+          adapter
+        )
+
       _ ->
-        error! query, join, """
+        error!(query, join, """
         invalid query was interpolated in a join.
         If you want to pass a query to a join, you must either:
 
           1. Make sure the query only has `where` conditions (which will be converted to ON clauses)
           2. Or wrap the query in a subquery by calling subquery(query)
-        """
+        """)
     end
   end
 
-  defp plan_joins([%JoinExpr{} = join|t],
-                      query, joins, sources, tail_sources, counter, offset, adapter) do
+  defp plan_joins(
+         [%JoinExpr{} = join | t],
+         query,
+         joins,
+         sources,
+         tail_sources,
+         counter,
+         offset,
+         adapter
+       ) do
     {join, source} = plan_source(query, %{join | ix: counter}, adapter)
-    plan_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter)
+
+    plan_joins(
+      t,
+      query,
+      [join | joins],
+      [source | sources],
+      tail_sources,
+      counter + 1,
+      offset,
+      adapter
+    )
   end
 
   defp plan_joins([], _query, joins, sources, tail_sources, _counter, _offset, _adapter) do
@@ -531,19 +646,26 @@ defmodule Ecto.Query.Planner do
   defp rewrite_prefix(expr, _prefix), do: expr
 
   defp rewrite_join(%{on: on, ix: join_ix} = join, qual, ix, last_ix, source_ix, inc_ix) do
-    expr = Macro.prewalk on.expr, fn
+    expr =
+      Macro.prewalk(on.expr, fn
         {:&, meta, [join_ix]} ->
           {:&, meta, [rewrite_ix(join_ix, ix, last_ix, source_ix, inc_ix)]}
+
         expr = %Ecto.Query.Tagged{type: {type_ix, type}} when is_integer(type_ix) ->
           %{expr | type: {rewrite_ix(type_ix, ix, last_ix, source_ix, inc_ix), type}}
+
         other ->
           other
-      end
+      end)
 
     params = Enum.map(on.params, &rewrite_param_ix(&1, ix, last_ix, source_ix, inc_ix))
 
-    %{join | on: %{on | expr: expr, params: params}, qual: qual,
-             ix: rewrite_ix(join_ix, ix, last_ix, source_ix, inc_ix)}
+    %{
+      join
+      | on: %{on | expr: expr, params: params},
+        qual: qual,
+        ix: rewrite_ix(join_ix, ix, last_ix, source_ix, inc_ix)
+    }
   end
 
   # We need to replace the source by the one from the assoc
@@ -558,11 +680,13 @@ defmodule Ecto.Query.Planner do
   # All others need to be incremented by the offset sources
   defp rewrite_ix(join_ix, _ix, _last_ix, _source_ix, inc_ix), do: join_ix + inc_ix
 
-  defp rewrite_param_ix({value, {upper, {type_ix, field}}}, ix, last_ix, source_ix, inc_ix) when is_integer(type_ix) do
+  defp rewrite_param_ix({value, {upper, {type_ix, field}}}, ix, last_ix, source_ix, inc_ix)
+       when is_integer(type_ix) do
     {value, {upper, {rewrite_ix(type_ix, ix, last_ix, source_ix, inc_ix), field}}}
   end
 
-  defp rewrite_param_ix({value, {type_ix, field}}, ix, last_ix, source_ix, inc_ix) when is_integer(type_ix) do
+  defp rewrite_param_ix({value, {type_ix, field}}, ix, last_ix, source_ix, inc_ix)
+       when is_integer(type_ix) do
     {value, {rewrite_ix(type_ix, ix, last_ix, source_ix, inc_ix), field}}
   end
 
@@ -570,23 +694,31 @@ defmodule Ecto.Query.Planner do
 
   defp fetch_source!(sources, ix) when is_integer(ix) do
     case Enum.reverse(sources) |> Enum.fetch(ix) do
-      {:ok, source} -> source
-      :error -> raise ArgumentError, "could not find a source with index `#{ix}` in `#{inspect sources}"
+      {:ok, source} ->
+        source
+
+      :error ->
+        raise ArgumentError, "could not find a source with index `#{ix}` in `#{inspect(sources)}"
     end
   end
 
   defp fetch_source!(_, ix) do
-    raise ArgumentError, "invalid binding index: `#{inspect ix}` (check if you're binding using a valid :as atom)"
+    raise ArgumentError,
+          "invalid binding index: `#{inspect(ix)}` (check if you're binding using a valid :as atom)"
   end
 
   defp schema_for_association_join!(query, join, source) do
     case source do
       {:fragment, _, _} ->
-        error! query, join, "cannot perform association joins on fragment sources"
+        error!(query, join, "cannot perform association joins on fragment sources")
 
       {source, nil, _} ->
-          error! query, join, "cannot perform association join on #{inspect source} " <>
-                              "because it does not have a schema"
+        error!(
+          query,
+          join,
+          "cannot perform association join on #{inspect(source)} " <>
+            "because it does not have a schema"
+        )
 
       {_, schema, _} ->
         schema
@@ -598,15 +730,19 @@ defmodule Ecto.Query.Planner do
         schema
 
       %Ecto.SubQuery{} ->
-        error! query, join, "can only perform association joins on subqueries " <>
-                            "that return a source with schema in select"
+        error!(
+          query,
+          join,
+          "can only perform association joins on subqueries " <>
+            "that return a source with schema in select"
+        )
 
       _ ->
-        error! query, join, "can only perform association joins on sources with a schema"
+        error!(query, join, "can only perform association joins on sources with a schema")
     end
   end
 
-  @spec plan_wheres(Ecto.Query.t, module) :: Ecto.Query.t
+  @spec plan_wheres(Ecto.Query.t(), module) :: Ecto.Query.t()
   defp plan_wheres(query, adapter) do
     wheres =
       Enum.map(query.wheres, fn
@@ -614,7 +750,10 @@ defmodule Ecto.Query.Planner do
           where
 
         %{subqueries: subqueries} = where ->
-          %{where | subqueries: Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false))}
+          %{
+            where
+            | subqueries: Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false))
+          }
       end)
 
     %{query | wheres: wheres}
@@ -640,7 +779,7 @@ defmodule Ecto.Query.Planner do
   end
 
   defp merge_cache(kind, query, expr, {cache, params}, _operation, adapter)
-      when kind in ~w(select distinct limit offset)a do
+       when kind in ~w(select distinct limit offset)a do
     if expr do
       {params, cacheable?} = cast_and_merge_params(kind, query, expr, params, adapter)
       {merge_cache({kind, expr_to_cache(expr)}, cache, cacheable?), params}
@@ -650,56 +789,59 @@ defmodule Ecto.Query.Planner do
   end
 
   defp merge_cache(kind, query, exprs, {cache, params}, _operation, adapter)
-      when kind in ~w(where update group_by having order_by)a do
+       when kind in ~w(where update group_by having order_by)a do
     {expr_cache, {params, cacheable?}} =
-      Enum.map_reduce exprs, {params, true}, fn expr, {params, cacheable?} ->
+      Enum.map_reduce(exprs, {params, true}, fn expr, {params, cacheable?} ->
         {params, current_cacheable?} = cast_and_merge_params(kind, query, expr, params, adapter)
         {expr_to_cache(expr), {params, cacheable? and current_cacheable?}}
-      end
+      end)
 
     case expr_cache do
       [] -> {cache, params}
-      _  -> {merge_cache({kind, expr_cache}, cache, cacheable?), params}
+      _ -> {merge_cache({kind, expr_cache}, cache, cacheable?), params}
     end
   end
 
   defp merge_cache(:join, query, exprs, {cache, params}, _operation, adapter) do
     {expr_cache, {params, cacheable?}} =
-      Enum.map_reduce exprs, {params, true}, fn
+      Enum.map_reduce(exprs, {params, true}, fn
         %JoinExpr{on: on, qual: qual, hints: hints} = join, {params, cacheable?} ->
           {key, params} = source_cache(join, params)
           {params, join_cacheable?} = cast_and_merge_params(:join, query, join, params, adapter)
           {params, on_cacheable?} = cast_and_merge_params(:join, query, on, params, adapter)
+
           {{qual, key, on.expr, hints},
            {params, cacheable? and join_cacheable? and on_cacheable? and key != :nocache}}
-      end
+      end)
 
     case expr_cache do
       [] -> {cache, params}
-      _  -> {merge_cache({:join, expr_cache}, cache, cacheable?), params}
+      _ -> {merge_cache({:join, expr_cache}, cache, cacheable?), params}
     end
   end
 
   defp merge_cache(:windows, query, exprs, {cache, params}, _operation, adapter) do
     {expr_cache, {params, cacheable?}} =
-      Enum.map_reduce exprs, {params, true}, fn {key, expr}, {params, cacheable?} ->
-        {params, current_cacheable?} = cast_and_merge_params(:windows, query, expr, params, adapter)
+      Enum.map_reduce(exprs, {params, true}, fn {key, expr}, {params, cacheable?} ->
+        {params, current_cacheable?} =
+          cast_and_merge_params(:windows, query, expr, params, adapter)
+
         {{key, expr_to_cache(expr)}, {params, cacheable? and current_cacheable?}}
-      end
+      end)
 
     case expr_cache do
       [] -> {cache, params}
-      _  -> {merge_cache({:windows, expr_cache}, cache, cacheable?), params}
+      _ -> {merge_cache({:windows, expr_cache}, cache, cacheable?), params}
     end
   end
 
   defp merge_cache(:combination, _query, combinations, cache_and_params, operation, adapter) do
     # In here we add each combination as its own entry in the cache key.
     # We could group them to avoid multiple keys, but since they are uncommon, we keep it simple.
-    Enum.reduce combinations, cache_and_params, fn {modifier, query}, {cache, params} ->
+    Enum.reduce(combinations, cache_and_params, fn {modifier, query}, {cache, params} ->
       {_, params, inner_cache} = traverse_cache(query, operation, {[], params}, adapter)
       {merge_cache({modifier, inner_cache}, cache, inner_cache != :nocache), params}
-    end
+    end)
   end
 
   defp merge_cache(:with_cte, _query, nil, cache_and_params, _operation, _adapter) do
@@ -712,29 +854,33 @@ defmodule Ecto.Query.Planner do
 
     # In here we add each cte as its own entry in the cache key.
     # We could group them to avoid multiple keys, but since they are uncommon, we keep it simple.
-    Enum.reduce queries, cache_and_params, fn
+    Enum.reduce(queries, cache_and_params, fn
       {name, %Ecto.Query{} = query}, {cache, params} ->
         {_, params, inner_cache} = traverse_cache(query, :all, {[], params}, adapter)
         {merge_cache({key, name, inner_cache}, cache, inner_cache != :nocache), params}
 
       {name, %Ecto.Query.QueryExpr{} = query_expr}, {cache, params} ->
-        {params, cacheable?} = cast_and_merge_params(:with_cte, query, query_expr, params, adapter)
+        {params, cacheable?} =
+          cast_and_merge_params(:with_cte, query, query_expr, params, adapter)
+
         {merge_cache({key, name, expr_to_cache(query_expr)}, cache, cacheable?), params}
-    end
+    end)
   end
 
   defp expr_to_cache(%QueryExpr{expr: expr}), do: expr
   defp expr_to_cache(%SelectExpr{expr: expr}), do: expr
   defp expr_to_cache(%BooleanExpr{op: op, expr: expr, subqueries: []}), do: {op, expr}
+
   defp expr_to_cache(%BooleanExpr{op: op, expr: expr, subqueries: subqueries}) do
     # Alternate implementation could be replace {:subquery, i} expression in expr.
     # Current strategy appends [{:subquery, i, cache}], where cache is the cache key for this subquery.
     {op, expr, Enum.map(subqueries, fn %{cache: cache} -> {:subquery, cache} end)}
   end
 
-  @spec cast_and_merge_params(atom, Ecto.Query.t, any, list, module) :: {params :: list, cacheable? :: boolean}
+  @spec cast_and_merge_params(atom, Ecto.Query.t(), any, list, module) ::
+          {params :: list, cacheable? :: boolean}
   defp cast_and_merge_params(kind, query, expr, params, adapter) do
-    Enum.reduce expr.params, {params, true}, fn
+    Enum.reduce(expr.params, {params, true}, fn
       {:subquery, i}, {acc, cacheable?} ->
         # This is the place holder to intersperse subquery parameters.
         %Ecto.SubQuery{params: subparams, cache: cache} = Enum.fetch!(expr.subqueries, i)
@@ -745,12 +891,12 @@ defmodule Ecto.Query.Planner do
           {:in, v} -> {Enum.reverse(v, acc), false}
           v -> {[v | acc], cacheable?}
         end
-    end
+    end)
   end
 
-  defp merge_cache(_left, _right, false),  do: :nocache
+  defp merge_cache(_left, _right, false), do: :nocache
   defp merge_cache(_left, :nocache, true), do: :nocache
-  defp merge_cache(left, right, true),     do: [left|right]
+  defp merge_cache(left, right, true), do: [left | right]
 
   defp finalize_cache(_query, _operation, :nocache) do
     :nocache
@@ -764,16 +910,17 @@ defmodule Ecto.Query.Planner do
       case select do
         %{take: take} when take != %{} ->
           [take: take] ++ cache
+
         _ ->
           cache
       end
 
     cache =
       cache
-      |> prepend_if(assocs != [],   [assocs: assocs])
-      |> prepend_if(prefix != nil,  [prefix: prefix])
-      |> prepend_if(lock != nil,    [lock: lock])
-      |> prepend_if(aliases != %{}, [aliases: aliases])
+      |> prepend_if(assocs != [], assocs: assocs)
+      |> prepend_if(prefix != nil, prefix: prefix)
+      |> prepend_if(lock != nil, lock: lock)
+      |> prepend_if(aliases != %{}, aliases: aliases)
 
     [operation | cache]
   end
@@ -783,32 +930,51 @@ defmodule Ecto.Query.Planner do
 
   defp source_cache(%{source: {_, nil} = source, prefix: prefix}, params),
     do: {{source, prefix}, params}
+
   defp source_cache(%{source: {bin, schema}, prefix: prefix}, params),
     do: {{bin, schema, schema.__schema__(:hash), prefix}, params}
+
   defp source_cache(%{source: {:fragment, _, _} = source, prefix: prefix}, params),
     do: {{source, prefix}, params}
+
   defp source_cache(%{source: %Ecto.SubQuery{params: inner, cache: key}}, params),
     do: {key, Enum.reverse(inner, params)}
 
   defp cast_param(_kind, query, expr, %DynamicExpr{}, _type, _value) do
-    error! query, expr, "invalid dynamic expression",
-                        "dynamic expressions can only be interpolated at the top level of where, having, group_by, order_by, update or a join's on"
+    error!(
+      query,
+      expr,
+      "invalid dynamic expression",
+      "dynamic expressions can only be interpolated at the top level of where, having, group_by, order_by, update or a join's on"
+    )
   end
+
   defp cast_param(_kind, query, expr, [{key, _} | _], _type, _value) when is_atom(key) do
-    error! query, expr, "invalid keyword list",
-                        "keyword lists are only allowed at the top level of where, having, distinct, order_by, update or a join's on"
+    error!(
+      query,
+      expr,
+      "invalid keyword list",
+      "keyword lists are only allowed at the top level of where, having, distinct, order_by, update or a join's on"
+    )
   end
-  defp cast_param(_kind, query, expr, %x{}, {:in, _type}, _value) when x in [Ecto.Query, Ecto.SubQuery] do
-    error! query, expr, "an #{inspect(x)} struct is not supported as right-side value of `in` operator",
-                        "Did you mean to write `expr in subquery(query)` instead?"
+
+  defp cast_param(_kind, query, expr, %x{}, {:in, _type}, _value)
+       when x in [Ecto.Query, Ecto.SubQuery] do
+    error!(
+      query,
+      expr,
+      "an #{inspect(x)} struct is not supported as right-side value of `in` operator",
+      "Did you mean to write `expr in subquery(query)` instead?"
+    )
   end
+
   defp cast_param(kind, query, expr, v, type, adapter) do
     type = field_type!(kind, query, expr, type)
 
     try do
       case cast_param(kind, type, v, adapter) do
         {:ok, v} -> v
-        {:error, error} -> error! query, expr, error
+        {:error, error} -> error!(query, expr, error)
       end
     catch
       :error, %Ecto.QueryError{} = e ->
@@ -831,55 +997,69 @@ defmodule Ecto.Query.Planner do
   end
 
   defp plan_assocs(_query, _ix, []), do: :ok
+
   defp plan_assocs(query, ix, assocs) do
     # We validate the schema exists when preparing joins above
     {_, parent_schema, _} = get_preload_source!(query, ix)
 
-    Enum.each assocs, fn {assoc, {child_ix, child_assocs}} ->
+    Enum.each(assocs, fn {assoc, {child_ix, child_assocs}} ->
       refl = parent_schema.__schema__(:association, assoc)
 
       unless refl do
-        error! query, "field `#{inspect parent_schema}.#{assoc}` " <>
-                      "in preload is not an association"
+        error!(
+          query,
+          "field `#{inspect(parent_schema)}.#{assoc}` " <>
+            "in preload is not an association"
+        )
       end
 
       case find_source_expr(query, child_ix) do
         %JoinExpr{qual: qual} when qual in [:inner, :left, :inner_lateral, :left_lateral] ->
           :ok
+
         %JoinExpr{qual: qual} ->
-          error! query, "association `#{inspect parent_schema}.#{assoc}` " <>
-                        "in preload requires an inner, left or lateral join, got #{qual} join"
+          error!(
+            query,
+            "association `#{inspect(parent_schema)}.#{assoc}` " <>
+              "in preload requires an inner, left or lateral join, got #{qual} join"
+          )
+
         _ ->
           :ok
       end
 
       plan_assocs(query, child_ix, child_assocs)
-    end
+    end)
   end
 
   defp plan_combinations(query, adapter) do
     combinations =
-      Enum.map query.combinations, fn {type, combination_query} ->
-        {prepared_query, _params, _key} = combination_query |> attach_prefix(query) |> plan(:all, adapter)
+      Enum.map(query.combinations, fn {type, combination_query} ->
+        {prepared_query, _params, _key} =
+          combination_query |> attach_prefix(query) |> plan(:all, adapter)
+
         prepared_query = prepared_query |> ensure_select(true)
         {type, prepared_query}
-      end
+      end)
 
     %{query | combinations: combinations}
   end
 
   defp plan_ctes(%Ecto.Query{with_ctes: nil} = query, _adapter), do: query
+
   defp plan_ctes(%Ecto.Query{with_ctes: %{queries: queries}} = query, adapter) do
     queries =
-      Enum.map queries, fn
+      Enum.map(queries, fn
         {name, %Ecto.Query{} = cte_query} ->
-          {planned_query, _params, _key} = cte_query |> attach_prefix(query) |> plan(:all, adapter)
+          {planned_query, _params, _key} =
+            cte_query |> attach_prefix(query) |> plan(:all, adapter)
+
           planned_query = planned_query |> ensure_select(true)
           {name, planned_query}
 
         {name, other} ->
           {name, other}
-      end
+      end)
 
     put_in(query.with_ctes.queries, queries)
   end
@@ -889,7 +1069,7 @@ defmodule Ecto.Query.Planner do
   end
 
   defp find_source_expr(query, ix) do
-    Enum.find(query.joins, & &1.ix == ix)
+    Enum.find(query.joins, &(&1.ix == ix))
   end
 
   @doc """
@@ -898,19 +1078,31 @@ defmodule Ecto.Query.Planner do
   def ensure_select(%{select: select} = query, _fields) when select != nil do
     query
   end
+
   def ensure_select(%{select: nil}, []) do
     raise ArgumentError, ":returning expects at least one field to be given, got an empty list"
   end
+
   def ensure_select(%{select: nil} = query, fields) when is_list(fields) do
-    %{query | select: %SelectExpr{expr: {:&, [], [0]}, take: %{0 => {:any, fields}},
-                                  line: __ENV__.line, file: __ENV__.file}}
+    %{
+      query
+      | select: %SelectExpr{
+          expr: {:&, [], [0]},
+          take: %{0 => {:any, fields}},
+          line: __ENV__.line,
+          file: __ENV__.file
+        }
+    }
   end
+
   def ensure_select(%{select: nil, from: %{source: {_, nil}}} = query, true) do
-    error! query, "queries that do not have a schema need to explicitly pass a :select clause"
+    error!(query, "queries that do not have a schema need to explicitly pass a :select clause")
   end
+
   def ensure_select(%{select: nil} = query, true) do
     %{query | select: %SelectExpr{expr: {:&, [], [0]}, line: __ENV__.line, file: __ENV__.file}}
   end
+
   def ensure_select(%{select: nil} = query, false) do
     query
   end
@@ -930,7 +1122,7 @@ defmodule Ecto.Query.Planner do
   rescue
     e ->
       # Reraise errors so we ignore the planner inner stacktrace
-      filter_and_reraise e, __STACKTRACE__
+      filter_and_reraise(e, __STACKTRACE__)
   end
 
   defp keep_literals?(%{combinations: combinations}), do: combinations != []
@@ -939,30 +1131,39 @@ defmodule Ecto.Query.Planner do
     case operation do
       :all ->
         assert_no_update!(query, operation)
+
       :insert_all ->
         assert_no_update!(query, operation)
+
       :update_all ->
         assert_update!(query, operation)
         assert_only_filter_expressions!(query, operation)
+
       :delete_all ->
         assert_no_update!(query, operation)
         assert_only_filter_expressions!(query, operation)
     end
 
-    traverse_exprs(query, operation, counter,
-                   &validate_and_increment(&1, &2, &3, &4, operation, adapter))
+    traverse_exprs(
+      query,
+      operation,
+      counter,
+      &validate_and_increment(&1, &2, &3, &4, operation, adapter)
+    )
   end
 
-  defp validate_and_increment(:from, query, %{source: %Ecto.SubQuery{}}, _counter, kind, _adapter) when kind != :all do
-    error! query, "`#{kind}` does not allow subqueries in `from`"
+  defp validate_and_increment(:from, query, %{source: %Ecto.SubQuery{}}, _counter, kind, _adapter)
+       when kind != :all do
+    error!(query, "`#{kind}` does not allow subqueries in `from`")
   end
+
   defp validate_and_increment(:from, query, %{source: source} = expr, counter, _kind, adapter) do
     {source, acc} = prewalk_source(source, :from, query, expr, counter, adapter)
     {%{expr | source: source}, acc}
   end
 
   defp validate_and_increment(kind, query, expr, counter, _operation, adapter)
-      when kind in ~w(select distinct limit offset)a do
+       when kind in ~w(select distinct limit offset)a do
     if expr do
       prewalk(kind, query, expr, counter, adapter)
     else
@@ -972,15 +1173,16 @@ defmodule Ecto.Query.Planner do
 
   defp validate_and_increment(kind, query, exprs, counter, _operation, adapter)
        when kind in ~w(where group_by having order_by update)a do
-
     {exprs, counter} =
       Enum.reduce(exprs, {[], counter}, fn
         %{expr: []}, {list, acc} ->
           {list, acc}
+
         expr, {list, acc} ->
           {expr, acc} = prewalk(kind, query, expr, acc, adapter)
-          {[expr|list], acc}
+          {[expr | list], acc}
       end)
+
     {Enum.reverse(exprs), counter}
   end
 
@@ -992,7 +1194,7 @@ defmodule Ecto.Query.Planner do
     fun = &validate_and_increment(&1, &2, &3, &4, :all, adapter)
 
     {queries, counter} =
-      Enum.reduce with_expr.queries, {[], counter}, fn
+      Enum.reduce(with_expr.queries, {[], counter}, fn
         {name, %Ecto.Query{} = inner_query}, {queries, counter} ->
           inner_query = put_in(inner_query.aliases[@parent_as], query)
 
@@ -1012,27 +1214,29 @@ defmodule Ecto.Query.Planner do
           {[{name, inner_query} | queries], counter}
 
         {name, %QueryExpr{expr: {:fragment, _, _} = fragment} = query_expr}, {queries, counter} ->
-          {fragment, counter} = prewalk_source(fragment, :with_cte, query, with_expr, counter, adapter)
+          {fragment, counter} =
+            prewalk_source(fragment, :with_cte, query, with_expr, counter, adapter)
+
           query_expr = %{query_expr | expr: fragment}
           {[{name, query_expr} | queries], counter}
-      end
+      end)
 
     {%{with_expr | queries: Enum.reverse(queries)}, counter}
   end
 
   defp validate_and_increment(:join, query, exprs, counter, _operation, adapter) do
-    Enum.map_reduce exprs, counter, fn join, acc ->
+    Enum.map_reduce(exprs, counter, fn join, acc ->
       {source, acc} = prewalk_source(join.source, :join, query, join, acc, adapter)
       {on, acc} = prewalk(:join, query, join.on, acc, adapter)
       {%{join | on: on, source: source, params: nil}, acc}
-    end
+    end)
   end
 
   defp validate_and_increment(:windows, query, exprs, counter, _operation, adapter) do
     {exprs, counter} =
       Enum.reduce(exprs, {[], counter}, fn {name, expr}, {list, acc} ->
         {expr, acc} = prewalk(:windows, query, expr, acc, adapter)
-        {[{name, expr}|list], acc}
+        {[{name, expr} | list], acc}
       end)
 
     {Enum.reverse(exprs), counter}
@@ -1042,11 +1246,12 @@ defmodule Ecto.Query.Planner do
     fun = &validate_and_increment(&1, &2, &3, &4, operation, adapter)
 
     {combinations, counter} =
-      Enum.reduce combinations, {[], counter}, fn {type, combination_query}, {combinations, counter} ->
+      Enum.reduce(combinations, {[], counter}, fn {type, combination_query},
+                                                  {combinations, counter} ->
         {combination_query, counter} = traverse_exprs(combination_query, operation, counter, fun)
         {combination_query, _} = combination_query |> normalize_select(true)
         {[{type, combination_query} | combinations], counter}
-      end
+      end)
 
     {Enum.reverse(combinations), counter}
   end
@@ -1054,7 +1259,7 @@ defmodule Ecto.Query.Planner do
   defp validate_json_path!([path_field | rest], field, embed) do
     case embed do
       %{related: related, cardinality: :one} ->
-        unless Enum.any?(related.__schema__(:fields), &Atom.to_string(&1) == path_field) do
+        unless Enum.any?(related.__schema__(:fields), &(Atom.to_string(&1) == path_field)) do
           raise "field `#{path_field}` does not exist in #{inspect(related)}"
         end
 
@@ -1081,15 +1286,23 @@ defmodule Ecto.Query.Planner do
     {fragments, acc} = prewalk(fragments, kind, query, expr, acc, adapter)
     {{:fragment, meta, fragments}, acc}
   end
-  defp prewalk_source(%Ecto.SubQuery{query: inner_query} = subquery, kind, query, _expr, counter, adapter) do
+
+  defp prewalk_source(
+         %Ecto.SubQuery{query: inner_query} = subquery,
+         kind,
+         query,
+         _expr,
+         counter,
+         adapter
+       ) do
     try do
-      inner_query = put_in inner_query.aliases[@parent_as], query
+      inner_query = put_in(inner_query.aliases[@parent_as], query)
       {inner_query, counter} = normalize_query(inner_query, :all, adapter, counter)
       {inner_query, _} = normalize_select(inner_query, true)
       {_, inner_query} = pop_in(inner_query.aliases[@parent_as])
 
+      # If the subquery comes from a select, we are not really interested on the fields
       inner_query =
-        # If the subquery comes from a select, we are not really interested on the fields
         if kind == :where do
           inner_query
         else
@@ -1103,6 +1316,7 @@ defmodule Ecto.Query.Planner do
       e -> raise Ecto.SubQueryError, query: query, exception: e
     end
   end
+
   defp prewalk_source(source, _kind, _query, _expr, acc, _adapter) do
     {source, acc}
   end
@@ -1111,17 +1325,19 @@ defmodule Ecto.Query.Planner do
     source = get_source!(:update, query, 0)
 
     {inner, acc} =
-      Enum.map_reduce expr.expr, counter, fn {op, kw}, counter ->
+      Enum.map_reduce(expr.expr, counter, fn {op, kw}, counter ->
         {kw, acc} =
-          Enum.map_reduce kw, counter, fn {field, value}, counter ->
+          Enum.map_reduce(kw, counter, fn {field, value}, counter ->
             {value, acc} = prewalk(value, :update, query, expr, counter, adapter)
             {{field_source(source, field), value}, acc}
-          end
+          end)
+
         {{op, kw}, acc}
-      end
+      end)
 
     {%{expr | expr: inner, params: nil}, acc}
   end
+
   defp prewalk(kind, query, expr, counter, adapter) do
     {inner, acc} = prewalk(expr.expr, kind, query, expr, counter, adapter)
     {%{expr | expr: inner, params: nil}, acc}
@@ -1135,17 +1351,26 @@ defmodule Ecto.Query.Planner do
 
   defp prewalk({:in, in_meta, [left, {:subquery, i}]}, kind, query, expr, acc, adapter) do
     {left, acc} = prewalk(left, kind, query, expr, acc, adapter)
-    {right, acc} = prewalk_source(Enum.fetch!(expr.subqueries, i), kind, query, expr, acc, adapter)
+
+    {right, acc} =
+      prewalk_source(Enum.fetch!(expr.subqueries, i), kind, query, expr, acc, adapter)
 
     case right.query.select.fields do
-      [_] -> :ok
-      _ -> error!(query, "subquery must return a single field in order to be used on the right-side of `in`")
+      [_] ->
+        :ok
+
+      _ ->
+        error!(
+          query,
+          "subquery must return a single field in order to be used on the right-side of `in`"
+        )
     end
 
     {{:in, in_meta, [left, right]}, acc}
   end
 
-  defp prewalk({quantifier, meta, [{:subquery, i}]}, kind, query, expr, acc, adapter) when quantifier in [:exists, :any, :all] do
+  defp prewalk({quantifier, meta, [{:subquery, i}]}, kind, query, expr, acc, adapter)
+       when quantifier in [:exists, :any, :all] do
     subquery = Enum.fetch!(expr.subqueries, i)
     {subquery, acc} = prewalk_source(subquery, kind, query, expr, acc, adapter)
 
@@ -1166,8 +1391,7 @@ defmodule Ecto.Query.Planner do
     {{quantifier, meta, [subquery]}, acc}
   end
 
-  defp prewalk({{:., dot_meta, [left, field]}, meta, []},
-               kind, query, expr, acc, _adapter) do
+  defp prewalk({{:., dot_meta, [left, field]}, meta, []}, kind, query, expr, acc, _adapter) do
     {ix, ix_expr, ix_query} = get_ix!(left, kind, query)
     extra = if kind == :select, do: [type: type!(kind, ix_query, expr, ix, field)], else: []
     field = field_source(get_source!(kind, ix_query, ix), field)
@@ -1244,10 +1468,14 @@ defmodule Ecto.Query.Planner do
     case dump_param(kind, type, v, adapter) do
       {:ok, v} ->
         v
+
       {:error, error} ->
-        error = error <> ". Or the value is incompatible or it must be " <>
-                         "interpolated (using ^) so it may be cast accordingly"
-        error! query, expr, error
+        error =
+          error <>
+            ". Or the value is incompatible or it must be " <>
+            "interpolated (using ^) so it may be cast accordingly"
+
+        error!(query, expr, error)
     end
   end
 
@@ -1289,8 +1517,7 @@ defmodule Ecto.Query.Planner do
           {take, :any}
       end
 
-    {postprocess, fields, from} =
-      collect_fields(expr, [], :none, query, take, keep_literals?)
+    {postprocess, fields, from} = collect_fields(expr, [], :none, query, take, keep_literals?)
 
     {fields, preprocess, from} =
       case from do
@@ -1301,7 +1528,10 @@ defmodule Ecto.Query.Planner do
           {fields, preprocess, {from_tag, from_expr}}
 
         :none when preloads != [] or assocs != [] ->
-          error! query, "the binding used in `from` must be selected in `select` when using `preload`"
+          error!(
+            query,
+            "the binding used in `from` must be selected in `select` when using `preload`"
+          )
 
         :none ->
           {Enum.reverse(fields), [], :none}
@@ -1320,7 +1550,14 @@ defmodule Ecto.Query.Planner do
 
   # Handling of source
 
-  defp collect_fields({:merge, _, [{:&, _, [0]}, right]}, fields, :none, query, take, keep_literals?) do
+  defp collect_fields(
+         {:merge, _, [{:&, _, [0]}, right]},
+         fields,
+         :none,
+         query,
+         take,
+         keep_literals?
+       ) do
     {expr, taken} = source_take!(:select, query, take, 0, 0)
     from = {:ok, {:source, :from}, expr, taken}
 
@@ -1349,8 +1586,14 @@ defmodule Ecto.Query.Planner do
 
   @aggs ~w(count avg min max sum row_number rank dense_rank percent_rank cume_dist ntile lag lead first_value last_value nth_value)a
 
-  defp collect_fields({agg, _, [{{:., dot_meta, [{:&, _, [_]}, _]}, _, []} | _]} = expr,
-                      fields, from, _query, _take, _keep_literals?)
+  defp collect_fields(
+         {agg, _, [{{:., dot_meta, [{:&, _, [_]}, _]}, _, []} | _]} = expr,
+         fields,
+         from,
+         _query,
+         _take,
+         _keep_literals?
+       )
        when agg in @aggs do
     type =
       case agg do
@@ -1373,7 +1616,14 @@ defmodule Ecto.Query.Planner do
     {type, [expr | fields], from}
   end
 
-  defp collect_fields({:coalesce, _, [left, right]} = expr, fields, from, query, take, _keep_literals?) do
+  defp collect_fields(
+         {:coalesce, _, [left, right]} = expr,
+         fields,
+         from,
+         query,
+         take,
+         _keep_literals?
+       ) do
     {left_type, _, _} = collect_fields(left, fields, from, query, take, true)
     {right_type, _, _} = collect_fields(right, fields, from, query, take, true)
 
@@ -1381,22 +1631,37 @@ defmodule Ecto.Query.Planner do
     {type, [expr | fields], from}
   end
 
-  defp collect_fields({:over, _, [call, window]} = expr, fields, from, query, take, keep_literals?) do
+  defp collect_fields(
+         {:over, _, [call, window]} = expr,
+         fields,
+         from,
+         query,
+         take,
+         keep_literals?
+       ) do
     if is_atom(window) and not Keyword.has_key?(query.windows, window) do
-      error!(query, "unknown window #{inspect window} given to over/2")
+      error!(query, "unknown window #{inspect(window)} given to over/2")
     end
 
     {type, _, _} = collect_fields(call, fields, from, query, take, keep_literals?)
     {type, [expr | fields], from}
   end
 
-  defp collect_fields({{:., dot_meta, [{:&, _, [_]}, _]}, _, []} = expr,
-                      fields, from, _query, _take, _keep_literals?) do
+  defp collect_fields(
+         {{:., dot_meta, [{:&, _, [_]}, _]}, _, []} = expr,
+         fields,
+         from,
+         _query,
+         _take,
+         _keep_literals?
+       ) do
     {{:value, Keyword.fetch!(dot_meta, :type)}, [expr | fields], from}
   end
 
   defp collect_fields({left, right}, fields, from, query, take, keep_literals?) do
-    {args, fields, from} = collect_args([left, right], fields, from, query, take, keep_literals?, [])
+    {args, fields, from} =
+      collect_args([left, right], fields, from, query, take, keep_literals?, [])
+
     {{:tuple, args}, fields, from}
   end
 
@@ -1405,7 +1670,14 @@ defmodule Ecto.Query.Planner do
     {{:tuple, args}, fields, from}
   end
 
-  defp collect_fields({:%{}, _, [{:|, _, [data, args]}]}, fields, from, query, take, keep_literals?) do
+  defp collect_fields(
+         {:%{}, _, [{:|, _, [data, args]}]},
+         fields,
+         from,
+         query,
+         take,
+         keep_literals?
+       ) do
     {data, fields, from} = collect_fields(data, fields, from, query, take, keep_literals?)
     {args, fields, from} = collect_kv(args, fields, from, query, take, keep_literals?, [])
     {{:map, data, args}, fields, from}
@@ -1416,8 +1688,14 @@ defmodule Ecto.Query.Planner do
     {{:map, args}, fields, from}
   end
 
-  defp collect_fields({:%, _, [name, {:%{}, _, [{:|, _, [data, args]}]}]},
-                      fields, from, query, take, keep_literals?) do
+  defp collect_fields(
+         {:%, _, [name, {:%{}, _, [{:|, _, [data, args]}]}]},
+         fields,
+         from,
+         query,
+         take,
+         keep_literals?
+       ) do
     {data, fields, from} = collect_fields(data, fields, from, query, take, keep_literals?)
     {args, fields, from} = collect_kv(args, fields, from, query, take, keep_literals?, [])
     struct!(name, args)
@@ -1431,7 +1709,9 @@ defmodule Ecto.Query.Planner do
   end
 
   defp collect_fields({:merge, _, args}, fields, from, query, take, keep_literals?) do
-    {[left, right], fields, from} = collect_args(args, fields, from, query, take, keep_literals?, [])
+    {[left, right], fields, from} =
+      collect_args(args, fields, from, query, take, keep_literals?, [])
+
     {{:merge, left, right}, fields, from}
   end
 
@@ -1442,7 +1722,14 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp collect_fields({:datetime_add, _, [arg | _]} = expr, fields, from, query, take, keep_literals?) do
+  defp collect_fields(
+         {:datetime_add, _, [arg | _]} = expr,
+         fields,
+         from,
+         query,
+         take,
+         keep_literals?
+       ) do
     case collect_fields(arg, fields, from, query, take, keep_literals?) do
       {{:value, :any}, _, _} -> {{:value, :naive_datetime}, [expr | fields], from}
       {type, _, _} -> {type, [expr | fields], from}
@@ -1483,7 +1770,14 @@ defmodule Ecto.Query.Planner do
     {expr, fields, from}
   end
 
-  defp collect_fields(%Ecto.Query.Tagged{tag: tag} = expr, fields, from, _query, _take, _keep_literals?) do
+  defp collect_fields(
+         %Ecto.Query.Tagged{tag: tag} = expr,
+         fields,
+         from,
+         _query,
+         _take,
+         _keep_literals?
+       ) do
     {{:value, tag}, [expr | fields], from}
   end
 
@@ -1506,6 +1800,7 @@ defmodule Ecto.Query.Planner do
     {value, fields, from} = collect_fields(value, fields, from, query, take, keep_literals?)
     collect_kv(elems, fields, from, query, take, keep_literals?, [{key, value} | acc])
   end
+
   defp collect_kv([], fields, from, _query, _take, _keep_literals?, acc) do
     {Enum.reverse(acc), fields, from}
   end
@@ -1514,6 +1809,7 @@ defmodule Ecto.Query.Planner do
     {elem, fields, from} = collect_fields(elem, fields, from, query, take, keep_literals?)
     collect_args(elems, fields, from, query, take, keep_literals?, [elem | acc])
   end
+
   defp collect_args([], fields, from, _query, _take, _keep_literals?, acc) do
     {Enum.reverse(acc), fields, from}
   end
@@ -1526,15 +1822,19 @@ defmodule Ecto.Query.Planner do
       Map.update(acc, field, {index, children}, fn
         {^index, current_children} ->
           {index, merge_assocs(children ++ current_children, query)}
+
         {other_index, _} ->
-          error! query, "association `#{field}` is being set to binding at position #{index} " <>
-                        "and at position #{other_index} at the same time"
+          error!(
+            query,
+            "association `#{field}` is being set to binding at position #{index} " <>
+              "and at position #{other_index} at the same time"
+          )
       end)
     end)
     |> Map.to_list()
   end
 
-  defp collect_assocs(exprs, fields, query, tag, take, [{assoc, {ix, children}}|tail]) do
+  defp collect_assocs(exprs, fields, query, tag, take, [{assoc, {ix, children}} | tail]) do
     to_take = get_preload_source!(query, ix)
     {fetch, take_children} = fetch_assoc(tag, take, assoc)
     {expr, taken} = take!(to_take, query, fetch, assoc, ix)
@@ -1544,6 +1844,7 @@ defmodule Ecto.Query.Planner do
     {exprs, fields} = collect_assocs(exprs, fields, query, tag, take, tail)
     {exprs, fields}
   end
+
   defp collect_assocs(exprs, fields, _query, _tag, _take, []) do
     {exprs, fields}
   end
@@ -1563,16 +1864,19 @@ defmodule Ecto.Query.Planner do
   defp take!(source, query, fetched, field, ix) do
     case {fetched, source} do
       {{:ok, {:struct, _}}, {:fragment, _, _}} ->
-        error! query, "it is not possible to return a struct subset of a fragment"
+        error!(query, "it is not possible to return a struct subset of a fragment")
 
       {{:ok, {:struct, _}}, %Ecto.SubQuery{}} ->
-        error! query, "it is not possible to return a struct subset of a subquery"
+        error!(query, "it is not possible to return a struct subset of a subquery")
 
       {{:ok, {_, []}}, {_, _, _}} ->
-        error! query, "at least one field must be selected for binding `#{field}`, got an empty list"
+        error!(
+          query,
+          "at least one field must be selected for binding `#{field}`, got an empty list"
+        )
 
       {{:ok, {:struct, _}}, {_, nil, _}} ->
-        error! query, "struct/2 in select expects a source with a schema"
+        error!(query, "struct/2 in select expects a source with a schema")
 
       {{:ok, {kind, fields}}, {source, schema, prefix}} when is_binary(source) ->
         dumper = if schema, do: schema.__schema__(:dump), else: %{}
@@ -1590,7 +1894,9 @@ defmodule Ecto.Query.Planner do
         {{:value, :map}, [{:&, [], [ix]}]}
 
       {:error, {source, schema, prefix}} ->
-        {types, fields} = select_dump(schema.__schema__(:query_fields), schema.__schema__(:dump), ix)
+        {types, fields} =
+          select_dump(schema.__schema__(:query_fields), schema.__schema__(:dump), ix)
+
         {{:source, {source, schema}, prefix || query.prefix, types}, fields}
 
       {:error, %Ecto.SubQuery{select: select}} ->
@@ -1601,11 +1907,12 @@ defmodule Ecto.Query.Planner do
 
   defp select_dump(fields, dumper, ix) do
     fields
-    |> Enum.reverse
+    |> Enum.reverse()
     |> Enum.reduce({[], []}, fn
       field, {types, exprs} when is_atom(field) ->
         {source, type} = Map.get(dumper, field, {field, :any})
         {[{field, type} | types], [select_field(source, ix) | exprs]}
+
       _field, acc ->
         acc
     end)
@@ -1630,7 +1937,10 @@ defmodule Ecto.Query.Planner do
     case query.aliases[@parent_as] do
       %{aliases: %{^as => ix}, sources: sources} = query ->
         if kind == :select and not (ix < tuple_size(sources)) do
-          error!(query, "the parent_as in a subquery select used as a join can only access the `from` binding")
+          error!(
+            query,
+            "the parent_as in a subquery select used as a join can only access the `from` binding"
+          )
         else
           {ix, {:parent_as, [], [as]}, query}
         end
@@ -1647,17 +1957,24 @@ defmodule Ecto.Query.Planner do
     elem(sources, ix)
   rescue
     ArgumentError ->
-      error! query, "invalid query has specified more bindings than bindings available " <>
-                    "in `#{where}` (look for `unknown_binding!` in the printed query below)"
+      error!(
+        query,
+        "invalid query has specified more bindings than bindings available " <>
+          "in `#{where}` (look for `unknown_binding!` in the printed query below)"
+      )
   end
 
   defp get_preload_source!(query, ix) do
     case get_source!(:preload, query, ix) do
       {source, schema, _} = all when is_binary(source) and schema != nil ->
         all
+
       _ ->
-        error! query, "can only preload sources with a schema " <>
-                      "(fragments, binary and subqueries are not supported)"
+        error!(
+          query,
+          "can only preload sources with a schema " <>
+            "(fragments, binary and subqueries are not supported)"
+        )
     end
   end
 
@@ -1667,20 +1984,44 @@ defmodule Ecto.Query.Planner do
   def attach_prefix(query, opts) when is_list(opts) do
     attach_prefix(query, Map.new(opts))
   end
+
   def attach_prefix(%{prefix: nil} = query, %{prefix: prefix}), do: %{query | prefix: prefix}
   def attach_prefix(query, _), do: query
 
   ## Helpers
 
-  @all_exprs [with_cte: :with_ctes, distinct: :distinct, select: :select, from: :from, join: :joins,
-              where: :wheres, group_by: :group_bys, having: :havings, windows: :windows,
-              combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset]
+  @all_exprs [
+    with_cte: :with_ctes,
+    distinct: :distinct,
+    select: :select,
+    from: :from,
+    join: :joins,
+    where: :wheres,
+    group_by: :group_bys,
+    having: :havings,
+    windows: :windows,
+    combination: :combinations,
+    order_by: :order_bys,
+    limit: :limit,
+    offset: :offset
+  ]
 
-  @update_all_exprs [with_cte: :with_ctes, update: :updates, from: :from,
-                     join: :joins, where: :wheres, select: :select]
+  @update_all_exprs [
+    with_cte: :with_ctes,
+    update: :updates,
+    from: :from,
+    join: :joins,
+    where: :wheres,
+    select: :select
+  ]
 
-  @delete_all_exprs [with_cte: :with_ctes, from: :from, join: :joins,
-                     where: :wheres, select: :select]
+  @delete_all_exprs [
+    with_cte: :with_ctes,
+    from: :from,
+    join: :joins,
+    where: :wheres,
+    select: :select
+  ]
 
   # Traverse all query components with expressions.
   # Therefore from, preload, assocs and lock are not traversed.
@@ -1693,18 +2034,20 @@ defmodule Ecto.Query.Planner do
         :delete_all -> @delete_all_exprs
       end
 
-    Enum.reduce exprs, {query, acc}, fn {kind, key}, {query, acc} ->
+    Enum.reduce(exprs, {query, acc}, fn {kind, key}, {query, acc} ->
       {traversed, acc} = fun.(kind, query, Map.fetch!(query, key), acc)
       {%{query | key => traversed}, acc}
-    end
+    end)
   end
 
   defp field_type!(kind, query, expr, {composite, {ix, field}}) when is_integer(ix) do
     {composite, type!(kind, query, expr, ix, field)}
   end
+
   defp field_type!(kind, query, expr, {ix, field}) when is_integer(ix) do
     type!(kind, query, expr, ix, field)
   end
+
   defp field_type!(_kind, _query, _expr, type) do
     type
   end
@@ -1733,23 +2076,35 @@ defmodule Ecto.Query.Planner do
         type
 
       Map.has_key?(schema.__struct__(), field) ->
-        error! query, expr, "field `#{field}` in `#{kind}` is a virtual field in schema #{inspect schema}"
+        error!(
+          query,
+          expr,
+          "field `#{field}` in `#{kind}` is a virtual field in schema #{inspect(schema)}"
+        )
 
       true ->
-        error! query, expr, "field `#{field}` in `#{kind}` does not exist in schema #{inspect schema}"
+        error!(
+          query,
+          expr,
+          "field `#{field}` in `#{kind}` does not exist in schema #{inspect(schema)}"
+        )
     end
   end
 
   defp normalize_param(_kind, {:out, {:array, type}}, _value) do
     {:ok, type}
   end
+
   defp normalize_param(_kind, {:out, :any}, _value) do
     {:ok, :any}
   end
+
   defp normalize_param(kind, {:out, other}, value) do
-    {:error, "value `#{inspect value}` in `#{kind}` expected to be part of an array " <>
-             "but matched type is #{inspect other}"}
+    {:error,
+     "value `#{inspect(value)}` in `#{kind}` expected to be part of an array " <>
+       "but matched type is #{inspect(other)}"}
   end
+
   defp normalize_param(_kind, type, _value) do
     {:ok, type}
   end
@@ -1758,8 +2113,9 @@ defmodule Ecto.Query.Planner do
     case Ecto.Type.cast(type, v) do
       {:ok, v} ->
         {:ok, v}
+
       _ ->
-        {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"}
+        {:error, "value `#{inspect(v)}` in `#{kind}` cannot be cast to type #{inspect(type)}"}
     end
   end
 
@@ -1767,8 +2123,9 @@ defmodule Ecto.Query.Planner do
     case Ecto.Type.adapter_dump(adapter, type, v) do
       {:ok, v} ->
         {:ok, v}
+
       :error ->
-        {:error, "value `#{inspect v}` cannot be dumped to type #{inspect type}"}
+        {:error, "value `#{inspect(v)}` cannot be dumped to type #{inspect(type)}"}
     end
   end
 
@@ -1777,6 +2134,7 @@ defmodule Ecto.Query.Planner do
     # which will be checked and raise later.
     schema.__schema__(:field_source, field) || field
   end
+
   defp field_source(_, field) do
     field
   end
@@ -1787,7 +2145,7 @@ defmodule Ecto.Query.Planner do
         Enum.reduce(update.expr, acc, fn {_op, kw}, acc ->
           Enum.reduce(kw, acc, fn {k, v}, acc ->
             if Map.has_key?(acc, k) do
-              error! query, "duplicate field `#{k}` for `#{operation}`"
+              error!(query, "duplicate field `#{k}` for `#{operation}`")
             else
               Map.put(acc, k, v)
             end
@@ -1796,28 +2154,44 @@ defmodule Ecto.Query.Planner do
       end)
 
     if changes == %{} do
-      error! query, "`#{operation}` requires at least one field to be updated"
+      error!(query, "`#{operation}` requires at least one field to be updated")
     end
   end
 
   defp assert_no_update!(query, operation) do
     case query do
-      %Ecto.Query{updates: []} -> query
+      %Ecto.Query{updates: []} ->
+        query
+
       _ ->
-        error! query, "`#{operation}` does not allow `update` expressions"
+        error!(query, "`#{operation}` does not allow `update` expressions")
     end
   end
 
   defp assert_only_filter_expressions!(query, operation) do
     case query do
-      %Ecto.Query{order_bys: [], limit: nil, offset: nil, group_bys: [],
-                  havings: [], preloads: [], assocs: [], distinct: nil, lock: nil,
-                  windows: [], combinations: []} ->
+      %Ecto.Query{
+        order_bys: [],
+        limit: nil,
+        offset: nil,
+        group_bys: [],
+        havings: [],
+        preloads: [],
+        assocs: [],
+        distinct: nil,
+        lock: nil,
+        windows: [],
+        combinations: []
+      } ->
         query
+
       _ ->
-        error! query, "`#{operation}` allows only `with_cte`, `where` and `join` expressions. " <>
-                      "You can exclude unwanted expressions from a query by using " <>
-                      "Ecto.Query.exclude/2. Error found"
+        error!(
+          query,
+          "`#{operation}` allows only `with_cte`, `where` and `join` expressions. " <>
+            "You can exclude unwanted expressions from a query by using " <>
+            "Ecto.Query.exclude/2. Error found"
+        )
     end
   end
 
@@ -1834,6 +2208,11 @@ defmodule Ecto.Query.Planner do
   end
 
   defp error!(query, expr, message, hint) do
-    raise Ecto.QueryError, message: message, query: query, file: expr.file, line: expr.line, hint: hint
+    raise Ecto.QueryError,
+      message: message,
+      query: query,
+      file: expr.file,
+      line: expr.line,
+      hint: hint
   end
 end

--- a/lib/ecto/query/window_api.ex
+++ b/lib/ecto/query/window_api.ex
@@ -32,49 +32,49 @@ defmodule Ecto.Query.WindowAPI do
 
       from p in Post, select: count()
   """
-  def count, do: doc! []
+  def count, do: doc!([])
 
   @doc """
   Counts the given entry.
 
       from p in Post, select: count(p.id)
   """
-  def count(value), do: doc! [value]
+  def count(value), do: doc!([value])
 
   @doc """
   Calculates the average for the given entry.
 
       from p in Payment, select: avg(p.value)
   """
-  def avg(value), do: doc! [value]
+  def avg(value), do: doc!([value])
 
   @doc """
   Calculates the sum for the given entry.
 
       from p in Payment, select: sum(p.value)
   """
-  def sum(value), do: doc! [value]
+  def sum(value), do: doc!([value])
 
   @doc """
   Calculates the minimum for the given entry.
 
       from p in Payment, select: min(p.value)
   """
-  def min(value), do: doc! [value]
+  def min(value), do: doc!([value])
 
   @doc """
   Calculates the maximum for the given entry.
 
       from p in Payment, select: max(p.value)
   """
-  def max(value), do: doc! [value]
+  def max(value), do: doc!([value])
 
   @doc """
   Defines a value based on the function and the window. See moduledoc for more information.
 
       from e in Employee, select: over(avg(e.salary, partition_by: e.depname))
   """
-  def over(window_function, window_name), do: doc! [window_function, window_name]
+  def over(window_function, window_name), do: doc!([window_function, window_name])
 
   @doc """
   Returns number of the current row within its partition, counting from 1.
@@ -84,7 +84,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def row_number(), do: doc! []
+  def row_number(), do: doc!([])
 
   @doc """
   Returns rank of the current row with gaps; same as `row_number/0` of its first peer.
@@ -94,7 +94,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def rank(), do: doc! []
+  def rank(), do: doc!([])
 
   @doc """
   Returns rank of the current row without gaps; this function counts peer groups.
@@ -104,7 +104,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def dense_rank(), do: doc! []
+  def dense_rank(), do: doc!([])
 
   @doc """
   Returns relative rank of the current row: (rank - 1) / (total rows - 1).
@@ -114,7 +114,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def percent_rank(), do: doc! []
+  def percent_rank(), do: doc!([])
 
   @doc """
   Returns relative rank of the current row:
@@ -125,7 +125,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def cume_dist(), do: doc! []
+  def cume_dist(), do: doc!([])
 
   @doc """
   Returns integer ranging from 1 to the argument value, dividing the partition as equally as possible.
@@ -135,7 +135,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def ntile(num_buckets), do: doc! [num_buckets]
+  def ntile(num_buckets), do: doc!([num_buckets])
 
   @doc """
   Returns value evaluated at the row that is the first row of the window frame.
@@ -145,7 +145,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def first_value(value), do: doc! [value]
+  def first_value(value), do: doc!([value])
 
   @doc """
   Returns value evaluated at the row that is the last row of the window frame.
@@ -155,8 +155,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def last_value(value), do: doc! [value]
-
+  def last_value(value), do: doc!([value])
 
   @doc """
   Applies the given expression as a FILTER clause against an
@@ -168,7 +167,7 @@ defmodule Ecto.Query.WindowAPI do
                    |> over(partition_by: p.category_id, order_by: p.date)
   """
 
-  def filter(value, filter), do: doc! [value, filter]
+  def filter(value, filter), do: doc!([value, filter])
 
   @doc """
   Returns value evaluated at the row that is the nth row of the window
@@ -179,7 +178,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def nth_value(value, nth), do: doc! [value, nth]
+  def nth_value(value, nth), do: doc!([value, nth])
 
   @doc """
   Returns value evaluated at the row that is offset rows before
@@ -201,7 +200,7 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def lag(value, offset \\ 1, default \\ nil), do: doc! [value, offset, default]
+  def lag(value, offset \\ 1, default \\ nil), do: doc!([value, offset, default])
 
   @doc """
   Returns value evaluated at the row that is offset rows after
@@ -223,10 +222,10 @@ defmodule Ecto.Query.WindowAPI do
 
   Note that this function must be invoked using window function syntax.
   """
-  def lead(value, offset \\ 1, default \\ nil), do: doc! [value, offset, default]
+  def lead(value, offset \\ 1, default \\ nil), do: doc!([value, offset, default])
 
   defp doc!(_) do
     raise "the functions in Ecto.Query.WindowAPI should not be invoked directly, " <>
-          "they serve for documentation purposes only"
+            "they serve for documentation purposes only"
   end
 end

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -31,14 +31,14 @@ defimpl Ecto.Queryable, for: Atom do
       module.__schema__(:query)
     rescue
       UndefinedFunctionError ->
-        message = if :code.is_loaded(module) do
-          "the given module does not provide a schema"
-        else
-          "the given module does not exist"
-        end
+        message =
+          if :code.is_loaded(module) do
+            "the given module does not provide a schema"
+          else
+            "the given module does not exist"
+          end
 
-        raise Protocol.UndefinedError,
-          protocol: @protocol, value: module, description: message
+        raise Protocol.UndefinedError, protocol: @protocol, value: module, description: message
     end
   end
 end

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -193,8 +193,7 @@ defmodule Ecto.Repo do
     quote bind_quoted: [opts: opts] do
       @behaviour Ecto.Repo
 
-      {otp_app, adapter, behaviours} =
-        Ecto.Repo.Supervisor.compile_config(__MODULE__, opts)
+      {otp_app, adapter, behaviours} = Ecto.Repo.Supervisor.compile_config(__MODULE__, opts)
 
       @otp_app otp_app
       @adapter adapter
@@ -263,7 +262,12 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Transaction in behaviours do
         def transaction(fun_or_multi, opts \\ []) do
-          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, with_default_options(:transaction, opts))
+          Ecto.Repo.Transaction.transaction(
+            __MODULE__,
+            get_dynamic_repo(),
+            fun_or_multi,
+            with_default_options(:transaction, opts)
+          )
         end
 
         def in_transaction? do
@@ -280,39 +284,85 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Schema in behaviours and not @read_only do
         def insert(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, with_default_options(:insert, opts))
+          Ecto.Repo.Schema.insert(
+            __MODULE__,
+            get_dynamic_repo(),
+            struct,
+            with_default_options(:insert, opts)
+          )
         end
 
         def update(struct, opts \\ []) do
-          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, with_default_options(:update, opts))
+          Ecto.Repo.Schema.update(
+            __MODULE__,
+            get_dynamic_repo(),
+            struct,
+            with_default_options(:update, opts)
+          )
         end
 
         def insert_or_update(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, with_default_options(:insert_or_update, opts))
+          Ecto.Repo.Schema.insert_or_update(
+            __MODULE__,
+            get_dynamic_repo(),
+            changeset,
+            with_default_options(:insert_or_update, opts)
+          )
         end
 
         def delete(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, with_default_options(:delete, opts))
+          Ecto.Repo.Schema.delete(
+            __MODULE__,
+            get_dynamic_repo(),
+            struct,
+            with_default_options(:delete, opts)
+          )
         end
 
         def insert!(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:insert, opts))
+          Ecto.Repo.Schema.insert!(
+            __MODULE__,
+            get_dynamic_repo(),
+            struct,
+            with_default_options(:insert, opts)
+          )
         end
 
         def update!(struct, opts \\ []) do
-          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:update, opts))
+          Ecto.Repo.Schema.update!(
+            __MODULE__,
+            get_dynamic_repo(),
+            struct,
+            with_default_options(:update, opts)
+          )
         end
 
         def insert_or_update!(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, with_default_options(:insert_or_update, opts))
+          Ecto.Repo.Schema.insert_or_update!(
+            __MODULE__,
+            get_dynamic_repo(),
+            changeset,
+            with_default_options(:insert_or_update, opts)
+          )
         end
 
         def delete!(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:delete, opts))
+          Ecto.Repo.Schema.delete!(
+            __MODULE__,
+            get_dynamic_repo(),
+            struct,
+            with_default_options(:delete, opts)
+          )
         end
 
         def insert_all(schema_or_source, entries, opts \\ []) do
-          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, with_default_options(:insert_all, opts))
+          Ecto.Repo.Schema.insert_all(
+            __MODULE__,
+            get_dynamic_repo(),
+            schema_or_source,
+            entries,
+            with_default_options(:insert_all, opts)
+          )
         end
       end
 
@@ -321,11 +371,20 @@ defmodule Ecto.Repo do
       if Ecto.Adapter.Queryable in behaviours do
         if not @read_only do
           def update_all(queryable, updates, opts \\ []) do
-            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, with_default_options(:update_all, opts))
+            Ecto.Repo.Queryable.update_all(
+              get_dynamic_repo(),
+              queryable,
+              updates,
+              with_default_options(:update_all, opts)
+            )
           end
 
           def delete_all(queryable, opts \\ []) do
-            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, with_default_options(:delete_all, opts))
+            Ecto.Repo.Queryable.delete_all(
+              get_dynamic_repo(),
+              queryable,
+              with_default_options(:delete_all, opts)
+            )
           end
         end
 
@@ -334,23 +393,47 @@ defmodule Ecto.Repo do
         end
 
         def stream(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, with_default_options(:stream, opts))
+          Ecto.Repo.Queryable.stream(
+            get_dynamic_repo(),
+            queryable,
+            with_default_options(:stream, opts)
+          )
         end
 
         def get(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get(
+            get_dynamic_repo(),
+            queryable,
+            id,
+            with_default_options(:all, opts)
+          )
         end
 
         def get!(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get!(
+            get_dynamic_repo(),
+            queryable,
+            id,
+            with_default_options(:all, opts)
+          )
         end
 
         def get_by(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get_by(
+            get_dynamic_repo(),
+            queryable,
+            clauses,
+            with_default_options(:all, opts)
+          )
         end
 
         def get_by!(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get_by!(
+            get_dynamic_repo(),
+            queryable,
+            clauses,
+            with_default_options(:all, opts)
+          )
         end
 
         def reload(queryable, opts \\ []) do
@@ -366,32 +449,62 @@ defmodule Ecto.Repo do
         end
 
         def one!(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.one!(
+            get_dynamic_repo(),
+            queryable,
+            with_default_options(:all, opts)
+          )
         end
 
         def aggregate(queryable, aggregate, opts \\ [])
 
         def aggregate(queryable, aggregate, opts)
             when aggregate in [:count] and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.aggregate(
+            get_dynamic_repo(),
+            queryable,
+            aggregate,
+            with_default_options(:all, opts)
+          )
         end
 
         def aggregate(queryable, aggregate, field)
             when aggregate in @aggregates and is_atom(field) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_options(:all, []))
+          Ecto.Repo.Queryable.aggregate(
+            get_dynamic_repo(),
+            queryable,
+            aggregate,
+            field,
+            with_default_options(:all, [])
+          )
         end
 
         def aggregate(queryable, aggregate, field, opts)
             when aggregate in @aggregates and is_atom(field) and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.aggregate(
+            get_dynamic_repo(),
+            queryable,
+            aggregate,
+            field,
+            with_default_options(:all, opts)
+          )
         end
 
         def exists?(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.exists?(
+            get_dynamic_repo(),
+            queryable,
+            with_default_options(:all, opts)
+          )
         end
 
         def preload(struct_or_structs_or_nil, preloads, opts \\ []) do
-          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, with_default_options(:preload, opts))
+          Ecto.Repo.Preloader.preload(
+            struct_or_structs_or_nil,
+            get_dynamic_repo(),
+            preloads,
+            with_default_options(:preload, opts)
+          )
         end
 
         def prepare_query(operation, query, opts), do: {query, opts}
@@ -589,9 +702,22 @@ defmodule Ecto.Repo do
 
   ## Ecto.Adapter.Queryable
 
-  @optional_callbacks get: 3, get!: 3, get_by: 3, get_by!: 3, reload: 2, reload!: 2, aggregate: 3,
-                      aggregate: 4, exists?: 2, one: 2, one!: 2, preload: 3, all: 2, stream: 2,
-                      update_all: 3, delete_all: 2
+  @optional_callbacks get: 3,
+                      get!: 3,
+                      get_by: 3,
+                      get_by!: 3,
+                      reload: 2,
+                      reload!: 2,
+                      aggregate: 3,
+                      aggregate: 4,
+                      exists?: 2,
+                      one: 2,
+                      one!: 2,
+                      preload: 3,
+                      all: 2,
+                      stream: 2,
+                      update_all: 3,
+                      delete_all: 2
 
   @doc """
   Fetches a single struct from the data store where the primary key matches the
@@ -994,8 +1120,17 @@ defmodule Ecto.Repo do
   options returned here will be passed to all following operations.
   """
   @callback default_options(operation) :: Keyword.t()
-            when operation: :all | :insert_all | :update_all | :delete_all | :stream |
-                              :transaction | :insert | :update | :delete | :insert_or_update
+            when operation:
+                   :all
+                   | :insert_all
+                   | :update_all
+                   | :delete_all
+                   | :stream
+                   | :transaction
+                   | :insert
+                   | :update
+                   | :delete
+                   | :insert_or_update
 
   @doc """
   Fetches all entries from the data store matching the given query.
@@ -1135,8 +1270,15 @@ defmodule Ecto.Repo do
 
   ## Ecto.Adapter.Schema
 
-  @optional_callbacks insert_all: 3, insert: 2, insert!: 2, update: 2, update!: 2,
-                      delete: 2, delete!: 2, insert_or_update: 2, insert_or_update!: 2,
+  @optional_callbacks insert_all: 3,
+                      insert: 2,
+                      insert!: 2,
+                      update: 2,
+                      update!: 2,
+                      delete: 2,
+                      delete!: 2,
+                      insert_or_update: 2,
+                      insert_or_update!: 2,
                       prepare_query: 3
 
   @doc """
@@ -1305,7 +1447,7 @@ defmodule Ecto.Repo do
   """
   @callback insert_all(
               schema_or_source :: binary | {binary, module} | module,
-              entries_or_query :: [map | [{atom, term | Ecto.Query.t}]] | Ecto.Query.t,
+              entries_or_query :: [map | [{atom, term | Ecto.Query.t()}]] | Ecto.Query.t(),
               opts :: Keyword.t()
             ) :: {integer, nil | [term]}
 

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -10,7 +10,7 @@ defmodule Ecto.Repo.Preloader do
   Transforms a result set based on query preloads, loading
   the associations onto their parent schema.
   """
-  @spec query([list], Ecto.Repo.t, list, Access.t, fun, Keyword.t) :: [list]
+  @spec query([list], Ecto.Repo.t(), list, Access.t(), fun, Keyword.t()) :: [list]
   def query([], _repo_name, _preloads, _take, _fun, _opts), do: []
   def query(rows, _repo_name, [], _take, fun, _opts), do: Enum.map(rows, fun)
 
@@ -21,19 +21,24 @@ defmodule Ecto.Repo.Preloader do
     |> unextract(rows, fun)
   end
 
-  defp extract([[nil|_]|t2]), do: extract(t2)
-  defp extract([[h|_]|t2]), do: [h|extract(t2)]
+  defp extract([[nil | _] | t2]), do: extract(t2)
+  defp extract([[h | _] | t2]), do: [h | extract(t2)]
   defp extract([]), do: []
 
-  defp unextract(structs, [[nil|_] = h2|t2], fun), do: [fun.(h2)|unextract(structs, t2, fun)]
-  defp unextract([h1|structs], [[_|t1]|t2], fun), do: [fun.([h1|t1])|unextract(structs, t2, fun)]
+  defp unextract(structs, [[nil | _] = h2 | t2], fun),
+    do: [fun.(h2) | unextract(structs, t2, fun)]
+
+  defp unextract([h1 | structs], [[_ | t1] | t2], fun),
+    do: [fun.([h1 | t1]) | unextract(structs, t2, fun)]
+
   defp unextract([], [], _fun), do: []
 
   @doc """
   Implementation for `Ecto.Repo.preload/2`.
   """
-  @spec preload(structs, atom, atom | list, Keyword.t) ::
-                structs when structs: [Ecto.Schema.t] | Ecto.Schema.t | nil
+  @spec preload(structs, atom, atom | list, Keyword.t()) ::
+          structs
+        when structs: [Ecto.Schema.t()] | Ecto.Schema.t() | nil
   def preload(nil, _repo_name, _preloads, _opts) do
     nil
   end
@@ -52,13 +57,14 @@ defmodule Ecto.Repo.Preloader do
   rescue
     e ->
       # Reraise errors so we ignore the preload inner stacktrace
-      filter_and_reraise e, __STACKTRACE__
+      filter_and_reraise(e, __STACKTRACE__)
   end
 
   ## Preloading
 
-  defp preload_each(structs, _repo_name, [], _opts),   do: structs
+  defp preload_each(structs, _repo_name, [], _opts), do: structs
   defp preload_each([], _repo_name, _preloads, _opts), do: []
+
   defp preload_each(structs, repo_name, preloads, opts) do
     if sample = Enum.find(structs, & &1) do
       module = sample.__struct__
@@ -73,8 +79,8 @@ defmodule Ecto.Repo.Preloader do
       throughs = Map.values(throughs)
 
       for struct <- structs do
-        struct = Enum.reduce assocs, struct, &load_assoc/2
-        struct = Enum.reduce throughs, struct, &load_through/2
+        struct = Enum.reduce(assocs, struct, &load_assoc/2)
+        struct = Enum.reduce(throughs, struct, &load_through/2)
         struct
       end
     else
@@ -86,6 +92,7 @@ defmodule Ecto.Repo.Preloader do
     case Keyword.fetch(opts, :prefix) do
       {:ok, prefix} ->
         prefix
+
       :error ->
         case sample do
           %{__meta__: %{prefix: prefix}} -> prefix
@@ -121,7 +128,7 @@ defmodule Ecto.Repo.Preloader do
 
   # Then we execute queries in parallel
   defp maybe_pmap(preloaders, repo_name, opts) do
-    if match?([_,_|_], preloaders) and not checked_out?(repo_name) and
+    if match?([_, _ | _], preloaders) and not checked_out?(repo_name) and
          Keyword.get(opts, :in_parallel, true) do
       # We pass caller: self() so the ownership pool knows where
       # to fetch the connection from and set the proper timeouts.
@@ -131,10 +138,10 @@ defmodule Ecto.Repo.Preloader do
       opts = Keyword.put_new(opts, :caller, self())
 
       preloaders
-      |> Task.async_stream(&(&1.(opts)), timeout: :infinity)
+      |> Task.async_stream(& &1.(opts), timeout: :infinity)
       |> Enum.map(fn {:ok, assoc} -> assoc end)
     else
-      Enum.map(preloaders, &(&1.(opts)))
+      Enum.map(preloaders, & &1.(opts))
     end
   end
 
@@ -152,7 +159,10 @@ defmodule Ecto.Repo.Preloader do
        ) do
     {fetch_ids, fetch_structs, queries} = maybe_unpack_query(query?, queries)
     all = preload_each(Enum.reverse(loaded_structs, fetch_structs), repo_name, preloads, opts)
-    entry = {:assoc, assoc, assoc_map(assoc.cardinality, Enum.reverse(loaded_ids, fetch_ids), all)}
+
+    entry =
+      {:assoc, assoc, assoc_map(assoc.cardinality, Enum.reverse(loaded_ids, fetch_ids), all)}
+
     [entry | preload_assocs(assocs, queries, repo_name, opts)]
   end
 
@@ -165,16 +175,17 @@ defmodule Ecto.Repo.Preloader do
     %{field: field, owner_key: owner_key, cardinality: card} = assoc
     force? = Keyword.get(opts, :force, false)
 
-    Enum.reduce structs, {[], [], []}, fn
+    Enum.reduce(structs, {[], [], []}, fn
       nil, acc ->
         acc
+
       struct, {fetch_ids, loaded_ids, loaded_structs} ->
         assert_struct!(module, struct)
         %{^owner_key => id, ^field => value} = struct
         loaded? = Ecto.assoc_loaded?(value) and not force?
 
         if loaded? and is_nil(id) and not Ecto.Changeset.Relation.empty?(assoc, value) do
-          Logger.warn """
+          Logger.warn("""
           association `#{field}` for `#{inspect(module)}` has a loaded value but \
           its association key `#{owner_key}` is nil. This usually means one of:
 
@@ -182,34 +193,47 @@ defmodule Ecto.Repo.Preloader do
             * the struct was set with default values for `#{field}` which now you want to override
 
           If this is intentional, set force: true to disable this warning
-          """
+          """)
         end
 
         cond do
           card == :one and loaded? ->
             {fetch_ids, [id | loaded_ids], [value | loaded_structs]}
+
           card == :many and loaded? ->
             {fetch_ids, [{id, length(value)} | loaded_ids], value ++ loaded_structs}
+
           is_nil(id) ->
             {fetch_ids, loaded_ids, loaded_structs}
+
           true ->
             {[id | fetch_ids], loaded_ids, loaded_structs}
         end
-    end
+    end)
   end
 
-  defp fetch_query(ids, assoc, _repo_name, query, _prefix, related_key, _take, _opts) when is_function(query, 1) do
+  defp fetch_query(ids, assoc, _repo_name, query, _prefix, related_key, _take, _opts)
+       when is_function(query, 1) do
     # Note we use an explicit sort because we don't want
     # to reorder based on the struct. Only the ID.
     ids
-    |> Enum.uniq
+    |> Enum.uniq()
     |> query.()
     |> fetched_records_to_tuple_ids(assoc, related_key)
     |> Enum.sort(fn {id1, _}, {id2, _} -> id1 <= id2 end)
     |> unzip_ids([], [])
   end
 
-  defp fetch_query(ids, %{cardinality: card} = assoc, repo_name, query, prefix, related_key, take, opts) do
+  defp fetch_query(
+         ids,
+         %{cardinality: card} = assoc,
+         repo_name,
+         query,
+         prefix,
+         related_key,
+         take,
+         opts
+       ) do
     query = assoc.__struct__.assoc_query(assoc, query, Enum.uniq(ids))
     field = related_key_to_field(query, related_key)
 
@@ -217,21 +241,29 @@ defmodule Ecto.Repo.Preloader do
     query = %{Ecto.Query.Planner.ensure_select(query, take || true) | prefix: prefix}
 
     # Add the related key to the query results
-    query = update_in query.select.expr, &{:{}, [], [field, &1]}
+    query = update_in(query.select.expr, &{:{}, [], [field, &1]})
 
     # If we are returning many results, we must sort by the key too
     query =
       case card do
         :many ->
-          update_in query.order_bys, fn order_bys ->
-            [%Ecto.Query.QueryExpr{expr: preload_order(assoc, query, field), params: [],
-                                   file: __ENV__.file, line: __ENV__.line}|order_bys]
-          end
+          update_in(query.order_bys, fn order_bys ->
+            [
+              %Ecto.Query.QueryExpr{
+                expr: preload_order(assoc, query, field),
+                params: [],
+                file: __ENV__.file,
+                line: __ENV__.line
+              }
+              | order_bys
+            ]
+          end)
+
         :one ->
           query
       end
 
-    unzip_ids Ecto.Repo.Queryable.all(repo_name, query, opts), [], []
+    unzip_ids(Ecto.Repo.Queryable.all(repo_name, query, opts), [], [])
   end
 
   defp fetched_records_to_tuple_ids([], _assoc, _related_key),
@@ -244,46 +276,49 @@ defmodule Ecto.Repo.Preloader do
     do: entries
 
   defp fetched_records_to_tuple_ids([entry | _], assoc, _),
-    do: raise """
-    invalid custom preload for `#{assoc.field}` on `#{inspect assoc.owner}`.
+    do:
+      raise("""
+      invalid custom preload for `#{assoc.field}` on `#{inspect(assoc.owner)}`.
 
-    For many_to_many associations, the custom function given to preload should \
-    return a tuple with the associated key as first element and the record as \
-    second element.
+      For many_to_many associations, the custom function given to preload should \
+      return a tuple with the associated key as first element and the record as \
+      second element.
 
-    For example, imagine posts has many to many tags through a posts_tags table. \
-    When preloading the tags, you may write:
+      For example, imagine posts has many to many tags through a posts_tags table. \
+      When preloading the tags, you may write:
 
-        custom_tags = fn post_ids ->
-          Repo.all(
-            from t in Tag,
-                 join: pt in "posts_tags",
-                 where: t.custom and pt.post_id in ^post_ids and pt.tag_id == t.id
-          )
-        end
+          custom_tags = fn post_ids ->
+            Repo.all(
+              from t in Tag,
+                   join: pt in "posts_tags",
+                   where: t.custom and pt.post_id in ^post_ids and pt.tag_id == t.id
+            )
+          end
 
-        from Post, preload: [tags: ^custom_tags]
+          from Post, preload: [tags: ^custom_tags]
 
-    Unfortunately the query above is not enough because Ecto won't know how to \
-    associate the posts with the tags. In those cases, you need to return a tuple \
-    with the `post_id` as first element and the tag record as second. The new query \
-    will have a select field as follows:
+      Unfortunately the query above is not enough because Ecto won't know how to \
+      associate the posts with the tags. In those cases, you need to return a tuple \
+      with the `post_id` as first element and the tag record as second. The new query \
+      will have a select field as follows:
 
-        from t in Tag,
-             join: pt in "posts_tags",
-             where: t.custom and pt.post_id in ^post_ids and pt.tag_id == t.id,
-             select: {pt.post_id, t}
+          from t in Tag,
+               join: pt in "posts_tags",
+               where: t.custom and pt.post_id in ^post_ids and pt.tag_id == t.id,
+               select: {pt.post_id, t}
 
-    We expected a tuple but we got: #{inspect(entry)}
-    """
+      We expected a tuple but we got: #{inspect(entry)}
+      """)
 
   defp preload_order(assoc, query, related_field) do
-    custom_order_by = Enum.map(assoc.preload_order, fn
-      {direction, field} ->
-        {direction, related_key_to_field(query, {0, field})}
-      field ->
-        {:asc, related_key_to_field(query, {0, field})}
-    end)
+    custom_order_by =
+      Enum.map(assoc.preload_order, fn
+        {direction, field} ->
+          {direction, related_key_to_field(query, {0, field})}
+
+        field ->
+          {:asc, related_key_to_field(query, {0, field})}
+      end)
 
     [{:asc, related_field} | custom_order_by]
   end
@@ -301,37 +336,43 @@ defmodule Ecto.Repo.Preloader do
   defp related_key_pos(_query, pos) when pos >= 0, do: pos
   defp related_key_pos(query, pos), do: Ecto.Query.Builder.count_binds(query) + pos
 
-  defp unzip_ids([{k, v}|t], acc1, acc2), do: unzip_ids(t, [k|acc1], [v|acc2])
+  defp unzip_ids([{k, v} | t], acc1, acc2), do: unzip_ids(t, [k | acc1], [v | acc2])
   defp unzip_ids([], acc1, acc2), do: {acc1, acc2}
 
   defp assert_struct!(mod, %{__struct__: mod}), do: true
+
   defp assert_struct!(mod, %{__struct__: struct}) do
-    raise ArgumentError, "expected a homogeneous list containing the same struct, " <>
-                         "got: #{inspect mod} and #{inspect struct}"
+    raise ArgumentError,
+          "expected a homogeneous list containing the same struct, " <>
+            "got: #{inspect(mod)} and #{inspect(struct)}"
   end
 
   defp assoc_map(:one, ids, structs) do
     one_assoc_map(ids, structs, %{})
   end
+
   defp assoc_map(:many, ids, structs) do
     many_assoc_map(ids, structs, %{})
   end
 
-  defp one_assoc_map([id|ids], [struct|structs], map) do
+  defp one_assoc_map([id | ids], [struct | structs], map) do
     one_assoc_map(ids, structs, Map.put(map, id, struct))
   end
+
   defp one_assoc_map([], [], map) do
     map
   end
 
-  defp many_assoc_map([{id, n}|ids], structs, map) do
+  defp many_assoc_map([{id, n} | ids], structs, map) do
     {acc, structs} = split_n(structs, n, [])
     many_assoc_map(ids, structs, Map.put(map, id, acc))
   end
-  defp many_assoc_map([id|ids], [struct|structs], map) do
+
+  defp many_assoc_map([id | ids], [struct | structs], map) do
     {ids, structs, acc} = split_while(ids, structs, id, [struct])
     many_assoc_map(ids, structs, Map.put(map, id, acc))
   end
+
   defp many_assoc_map([], [], map) do
     map
   end
@@ -339,8 +380,9 @@ defmodule Ecto.Repo.Preloader do
   defp split_n(structs, 0, acc), do: {acc, structs}
   defp split_n([struct | structs], n, acc), do: split_n(structs, n - 1, [struct | acc])
 
-  defp split_while([id|ids], [struct|structs], id, acc),
-    do: split_while(ids, structs, id, [struct|acc])
+  defp split_while([id | ids], [struct | structs], id, acc),
+    do: split_while(ids, structs, id, [struct | acc])
+
   defp split_while(ids, structs, _id, acc),
     do: {ids, structs, acc}
 
@@ -375,6 +417,7 @@ defmodule Ecto.Repo.Preloader do
 
   defp recur_through(field, {structs, owner}) do
     assoc = owner.__schema__(:association, field)
+
     case assoc.__struct__.preload_info(assoc) do
       {:assoc, %{related: related}, _} ->
         pk_fields =
@@ -395,8 +438,9 @@ defmodule Ecto.Repo.Preloader do
               case set do
                 %{^pk_values => true} ->
                   {fresh, set}
+
                 _ ->
-                  {[child|fresh], Map.put(set, pk_values, true)}
+                  {[child | fresh], Map.put(set, pk_values, true)}
               end
             end)
           end)
@@ -411,7 +455,7 @@ defmodule Ecto.Repo.Preloader do
   defp validate_has_pk_field!([], related, assoc) do
     raise ArgumentError,
           "cannot preload through association `#{assoc.field}` on " <>
-            "`#{inspect assoc.owner}`. Ecto expected the #{inspect related} schema " <>
+            "`#{inspect(assoc.owner)}`. Ecto expected the #{inspect(related)} schema " <>
             "to have at least one primary key field"
   end
 
@@ -425,9 +469,9 @@ defmodule Ecto.Repo.Preloader do
 
         _ ->
           raise ArgumentError,
-               "cannot preload through association `#{assoc.field}` on " <>
-                 "`#{inspect assoc.owner}`. Ecto expected a map/struct with " <>
-                 "the key `#{pk}` but got: #{inspect map}"
+                "cannot preload through association `#{assoc.field}` on " <>
+                  "`#{inspect(assoc.owner)}`. Ecto expected a map/struct with " <>
+                  "the key `#{pk}` but got: #{inspect(map)}"
       end
     end)
   end
@@ -437,8 +481,8 @@ defmodule Ecto.Repo.Preloader do
       [nil | _] ->
         raise ArgumentError,
               "cannot preload through association `#{assoc.field}` on " <>
-                "`#{inspect assoc.owner}` because the primary key `#{hd(pks)}` " <>
-                "is nil for map/struct: #{inspect map}"
+                "`#{inspect(assoc.owner)}` because the primary key `#{hd(pks)}` " <>
+                "is nil for map/struct: #{inspect(map)}"
 
       _ ->
         values
@@ -454,21 +498,25 @@ defmodule Ecto.Repo.Preloader do
   defp normalize_each({atom, {query, list}}, acc, take, original)
        when is_atom(atom) and (is_map(query) or is_function(query, 1)) do
     fields = take(take, atom)
-    [{atom, {fields, query!(query), normalize_each(wrap(list, original), [], fields, original)}}|acc]
+
+    [
+      {atom, {fields, query!(query), normalize_each(wrap(list, original), [], fields, original)}}
+      | acc
+    ]
   end
 
   defp normalize_each({atom, query}, acc, take, _original)
        when is_atom(atom) and (is_map(query) or is_function(query, 1)) do
-    [{atom, {take(take, atom), query!(query), []}}|acc]
+    [{atom, {take(take, atom), query!(query), []}} | acc]
   end
 
   defp normalize_each({atom, list}, acc, take, original) when is_atom(atom) do
     fields = take(take, atom)
-    [{atom, {fields, nil, normalize_each(wrap(list, original), [], fields, original)}}|acc]
+    [{atom, {fields, nil, normalize_each(wrap(list, original), [], fields, original)}} | acc]
   end
 
   defp normalize_each(atom, acc, take, _original) when is_atom(atom) do
-    [{atom, {take(take, atom), nil, []}}|acc]
+    [{atom, {take(take, atom), nil, []}} | acc]
   end
 
   defp normalize_each(other, acc, take, original) do
@@ -487,11 +535,14 @@ defmodule Ecto.Repo.Preloader do
 
   defp wrap(list, _original) when is_list(list),
     do: list
+
   defp wrap(atom, _original) when is_atom(atom),
     do: atom
+
   defp wrap(other, original) do
-    raise ArgumentError, "invalid preload `#{inspect other}` in `#{inspect original}`. " <>
-                         "preload expects an atom, a (nested) keyword or a (nested) list of atoms"
+    raise ArgumentError,
+          "invalid preload `#{inspect(other)}` in `#{inspect(original)}`. " <>
+            "preload expects an atom, a (nested) keyword or a (nested) list of atoms"
   end
 
   ## Expand
@@ -499,19 +550,21 @@ defmodule Ecto.Repo.Preloader do
   def expand(schema, preloads, acc) do
     Enum.reduce(preloads, acc, fn {preload, {fields, query, sub_preloads}}, {assocs, throughs} ->
       assoc = association_from_schema!(schema, preload)
-      info  = assoc.__struct__.preload_info(assoc)
+      info = assoc.__struct__.preload_info(assoc)
 
       case info do
         {:assoc, _, _} ->
-          value  = {info, fields, query, sub_preloads}
+          value = {info, fields, query, sub_preloads}
           assocs = Map.update(assocs, preload, value, &merge_preloads(preload, value, &1))
           {assocs, throughs}
+
         {:through, _, through} ->
           through =
             through
             |> Enum.reverse()
             |> Enum.reduce({fields, query, sub_preloads}, &{nil, nil, [{&1, &2}]})
             |> elem(2)
+
           expand(schema, through, {assocs, Map.put(throughs, preload, info)})
       end
     end)
@@ -519,11 +572,14 @@ defmodule Ecto.Repo.Preloader do
 
   defp merge_preloads(_preload, {info, _, nil, left}, {info, take, query, right}),
     do: {info, take, query, left ++ right}
+
   defp merge_preloads(_preload, {info, take, query, left}, {info, _, nil, right}),
     do: {info, take, query, left ++ right}
+
   defp merge_preloads(preload, {info, _, left, _}, {info, _, right, _}) do
-    raise ArgumentError, "cannot preload `#{preload}` as it has been supplied more than once " <>
-                         "with different queries: #{inspect left} and #{inspect right}"
+    raise ArgumentError,
+          "cannot preload `#{preload}` as it has been supplied more than once " <>
+            "with different queries: #{inspect(left)} and #{inspect(right)}"
   end
 
   # Since there is some ambiguity between assoc and queries.
@@ -531,14 +587,14 @@ defmodule Ecto.Repo.Preloader do
   defp association_from_schema!(schema, assoc) do
     schema.__schema__(:association, assoc) ||
       raise ArgumentError,
-            "schema #{inspect schema} does not have association #{inspect assoc}#{maybe_module(assoc)}"
+            "schema #{inspect(schema)} does not have association #{inspect(assoc)}#{maybe_module(assoc)}"
   end
 
   defp maybe_module(assoc) do
     case Atom.to_string(assoc) do
       "Elixir." <> _ ->
         " (if you were trying to pass a schema as a query to preload, " <>
-          "you have to explicitly convert it to a query by doing `from x in #{inspect assoc}` " <>
+          "you have to explicitly convert it to a query by doing `from x in #{inspect(assoc)}` " <>
           "or by calling Ecto.Queryable.to_query/1)"
 
       _ ->

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -83,7 +83,7 @@ defmodule Ecto.Repo.Queryable do
 
     for struct <- structs do
       struct_pk = Map.fetch!(struct, pk)
-      Enum.find(results, &Map.fetch!(&1, pk) == struct_pk)
+      Enum.find(results, &(Map.fetch!(&1, pk) == struct_pk))
     end
   end
 
@@ -99,7 +99,9 @@ defmodule Ecto.Repo.Queryable do
 
     for struct <- structs do
       struct_pk = Map.fetch!(struct, pk)
-      Enum.find(results, &Map.fetch!(&1, pk) == struct_pk) || raise "could not reload #{inspect(struct)}, maybe it doesn't exist or was deleted"
+
+      Enum.find(results, &(Map.fetch!(&1, pk) == struct_pk)) ||
+        raise "could not reload #{inspect(struct)}, maybe it doesn't exist or was deleted"
     end
   end
 
@@ -135,9 +137,10 @@ defmodule Ecto.Repo.Queryable do
   defp rewrite_combinations(%{combinations: []} = query), do: query
 
   defp rewrite_combinations(%{combinations: combinations} = query) do
-    combinations = Enum.map(combinations, fn {type, query} ->
-      {type, query |> Query.exclude(:select) |> Query.select(1)}
-    end)
+    combinations =
+      Enum.map(combinations, fn {type, query} ->
+        {type, query |> Query.exclude(:select) |> Query.select(1)}
+      end)
 
     %{query | combinations: combinations}
   end
@@ -451,7 +454,7 @@ defmodule Ecto.Repo.Queryable do
     Query.where(queryable, [], ^Enum.to_list(clauses))
   end
 
-  defp query_for_reload([head| _] = structs) do
+  defp query_for_reload([head | _] = structs) do
     assert_structs!(structs)
 
     schema = head.__struct__
@@ -548,7 +551,9 @@ defmodule Ecto.Repo.Queryable do
     |> Map.fetch!(pk)
     |> case do
       nil ->
-        raise ArgumentError, "Ecto.Repo.reload/2 expects existent structs, found a `nil` primary key"
+        raise ArgumentError,
+              "Ecto.Repo.reload/2 expects existent structs, found a `nil` primary key"
+
       key ->
         key
     end

--- a/lib/ecto/repo/registry.ex
+++ b/lib/ecto/repo/registry.ex
@@ -19,7 +19,9 @@ defmodule Ecto.Repo.Registry do
 
   def lookup(repo) when is_atom(repo) do
     GenServer.whereis(repo)
-    |> Kernel.||(raise "could not lookup Ecto repo #{inspect repo} because it was not started or it does not exist")
+    |> Kernel.||(
+      raise "could not lookup Ecto repo #{inspect(repo)} because it was not started or it does not exist"
+    )
     |> lookup()
   end
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -13,8 +13,15 @@ defmodule Ecto.Repo.Schema do
   Implementation for `Ecto.Repo.insert_all/3`.
   """
   def insert_all(repo, name, schema, rows, opts) when is_atom(schema) do
-    do_insert_all(repo, name, schema, schema.__schema__(:prefix),
-                  schema.__schema__(:source), rows, opts)
+    do_insert_all(
+      repo,
+      name,
+      schema,
+      schema.__schema__(:prefix),
+      schema.__schema__(:source),
+      rows,
+      opts
+    )
   end
 
   def insert_all(repo, name, table, rows, opts) when is_binary(table) do
@@ -45,7 +52,16 @@ defmodule Ecto.Repo.Schema do
       |> fields_to_sources(dumper)
 
     {rows_or_query, header, placeholder_values, counter} =
-      extract_header_and_fields(repo, rows_or_query, schema, dumper, autogen_id, placeholder_map, adapter, opts)
+      extract_header_and_fields(
+        repo,
+        rows_or_query,
+        schema,
+        dumper,
+        autogen_id,
+        placeholder_map,
+        adapter,
+        opts
+      )
 
     schema_meta = metadata(schema, prefix, source, autogen_id, nil, opts)
 
@@ -55,7 +71,16 @@ defmodule Ecto.Repo.Schema do
     on_conflict = on_conflict(on_conflict, conflict_target, schema_meta, counter, adapter)
 
     {count, rows_or_query} =
-      adapter.insert_all(adapter_meta, schema_meta, header, rows_or_query, on_conflict, return_sources, placeholder_values, opts)
+      adapter.insert_all(
+        adapter_meta,
+        schema_meta,
+        header,
+        rows_or_query,
+        on_conflict,
+        return_sources,
+        placeholder_values,
+        opts
+      )
 
     {count, postprocess(rows_or_query, return_fields_or_types, adapter, schema, schema_meta)}
   end
@@ -77,13 +102,24 @@ defmodule Ecto.Repo.Schema do
     end
   end
 
-  defp extract_header_and_fields(_repo, rows, schema, dumper, autogen_id, placeholder_map, adapter, _opts)
+  defp extract_header_and_fields(
+         _repo,
+         rows,
+         schema,
+         dumper,
+         autogen_id,
+         placeholder_map,
+         adapter,
+         _opts
+       )
        when is_list(rows) do
     mapper = init_mapper(schema, dumper, adapter, placeholder_map)
 
     {rows, {header, has_query?, placeholder_dump, _}} =
       Enum.map_reduce(rows, {%{}, false, %{}, 1}, fn fields, acc ->
-        {fields, {header, has_query?, placeholder_dump, counter}} = Enum.map_reduce(fields, acc, mapper)
+        {fields, {header, has_query?, placeholder_dump, counter}} =
+          Enum.map_reduce(fields, acc, mapper)
+
         {fields, header} = autogenerate_id(autogen_id, fields, header, adapter)
         {fields, {header, has_query?, placeholder_dump, counter}}
       end)
@@ -103,7 +139,7 @@ defmodule Ecto.Repo.Schema do
     placeholder_vals_list =
       placeholder_dump
       |> Enum.map(fn {_, {idx, _, value}} -> {idx, value} end)
-      |> Enum.sort
+      |> Enum.sort()
       |> Enum.map(&elem(&1, 1))
 
     if has_query? do
@@ -114,43 +150,63 @@ defmodule Ecto.Repo.Schema do
     end
   end
 
-  defp extract_header_and_fields(repo, %Ecto.Query{} = query, _schema, _dumper, _autogen_id, _placeholder_map, adapter, opts) do
+  defp extract_header_and_fields(
+         repo,
+         %Ecto.Query{} = query,
+         _schema,
+         _dumper,
+         _autogen_id,
+         _placeholder_map,
+         adapter,
+         opts
+       ) do
     {query, opts} = repo.prepare_query(:insert_all, query, opts)
     query = attach_prefix(query, opts)
 
     {query, params} = Ecto.Adapter.Queryable.plan_query(:insert_all, adapter, query)
 
-    header = case query.select do
-      %Ecto.Query.SelectExpr{expr: {:%{}, _ctx, args}} ->
-        Enum.map(args, &elem(&1, 0))
+    header =
+      case query.select do
+        %Ecto.Query.SelectExpr{expr: {:%{}, _ctx, args}} ->
+          Enum.map(args, &elem(&1, 0))
 
-      _ ->
-        raise ArgumentError, """
-        cannot generate a fields list for insert_all from the given source query
-        because it does not have a select clause that uses a map:
+        _ ->
+          raise ArgumentError, """
+          cannot generate a fields list for insert_all from the given source query
+          because it does not have a select clause that uses a map:
 
-          #{inspect query}
+            #{inspect(query)}
 
-        Please add a select clause that selects into a map, like this:
+          Please add a select clause that selects into a map, like this:
 
-          from x in Source,
-            ...,
-            select: %{
-              field_a: x.bar,
-              field_b: x.foo
-            }
+            from x in Source,
+              ...,
+              select: %{
+                field_a: x.bar,
+                field_b: x.foo
+              }
 
-        The keys must exist in the schema that is being inserted into
-        """
-    end
+          The keys must exist in the schema that is being inserted into
+          """
+      end
 
     counter = fn -> length(params) end
 
     {{query, params}, header, [], counter}
   end
 
-  defp extract_header_and_fields(_repo, rows_or_query, _schema, _dumper, _autogen_id, _placeholder_map, _adapter, _opts) do
-    raise ArgumentError, "expected a list of rows or a query, but got #{inspect rows_or_query} as rows_or_query argument in insert_all"
+  defp extract_header_and_fields(
+         _repo,
+         rows_or_query,
+         _schema,
+         _dumper,
+         _autogen_id,
+         _placeholder_map,
+         _adapter,
+         _opts
+       ) do
+    raise ArgumentError,
+          "expected a list of rows or a query, but got #{inspect(rows_or_query)} as rows_or_query argument in insert_all"
   end
 
   defp init_mapper(nil, _dumper, _adapter, placeholder_map) do
@@ -186,8 +242,7 @@ defmodule Ecto.Repo.Schema do
         {value, placeholder_dump, counter} =
           extract_placeholder(key, type, placeholder_map, placeholder_dump, counter, dumper)
 
-        {{source, value},
-          {Map.put(header, source, true), has_query?, placeholder_dump, counter}}
+        {{source, value}, {Map.put(header, source, true), has_query?, placeholder_dump, counter}}
 
       value ->
         {{source, dumper.(value)},
@@ -360,7 +415,13 @@ defmodule Ecto.Repo.Schema do
           dump_changes!(:insert, Map.take(changes, fields), schema, extra, dumper, adapter)
 
         on_conflict =
-          on_conflict(on_conflict, conflict_target, schema_meta, fn -> length(changes) end, adapter)
+          on_conflict(
+            on_conflict,
+            conflict_target,
+            schema_meta,
+            fn -> length(changes) end,
+            adapter
+          )
 
         args = [adapter_meta, schema_meta, changes, on_conflict, return_sources, opts]
 
@@ -393,9 +454,10 @@ defmodule Ecto.Repo.Schema do
   end
 
   def update(_repo, _name, %{__struct__: _}, opts) when is_list(opts) do
-    raise ArgumentError, "giving a struct to Ecto.Repo.update/2 is not supported. " <>
-                         "Ecto is unable to properly track changes when a struct is given, " <>
-                         "an Ecto.Changeset must be given instead"
+    raise ArgumentError,
+          "giving a struct to Ecto.Repo.update/2 is not supported. " <>
+            "Ecto is unable to properly track changes when a struct is given, " <>
+            "an Ecto.Changeset must be given instead"
   end
 
   defp do_update(repo, name, %Changeset{valid?: true} = changeset, opts) do
@@ -445,13 +507,21 @@ defmodule Ecto.Repo.Schema do
           # If there are no changes or all the changes were autogenerated but not forced, we skip
           {action, autogen} =
             if original != %{} or (autogen != [] and force?),
-               do: {:update, autogen},
-               else: {:noop, []}
+              do: {:update, autogen},
+              else: {:noop, []}
 
           case apply(user_changeset, adapter, action, args) do
             {:ok, values} ->
               changeset
-              |> load_changes(:loaded, return_types, values, embeds, autogen, adapter, schema_meta)
+              |> load_changes(
+                :loaded,
+                return_types,
+                values,
+                embeds,
+                autogen,
+                adapter,
+                schema_meta
+              )
               |> process_children(children, user_changeset, adapter, assoc_opts)
 
             {:error, _} = error ->
@@ -475,10 +545,16 @@ defmodule Ecto.Repo.Schema do
   """
   def insert_or_update(repo, name, changeset, opts) do
     case get_state(changeset) do
-      :built  -> insert(repo, name, changeset, opts)
-      :loaded -> update(repo, name, changeset, opts)
-      state   -> raise ArgumentError, "the changeset has an invalid state " <>
-                                      "for Repo.insert_or_update/2: #{state}"
+      :built ->
+        insert(repo, name, changeset, opts)
+
+      :loaded ->
+        update(repo, name, changeset, opts)
+
+      state ->
+        raise ArgumentError,
+              "the changeset has an invalid state " <>
+                "for Repo.insert_or_update/2: #{state}"
     end
   end
 
@@ -487,18 +563,26 @@ defmodule Ecto.Repo.Schema do
   """
   def insert_or_update!(repo, name, changeset, opts) do
     case get_state(changeset) do
-      :built  -> insert!(repo, name, changeset, opts)
-      :loaded -> update!(repo, name, changeset, opts)
-      state   -> raise ArgumentError, "the changeset has an invalid state " <>
-                                      "for Repo.insert_or_update!/2: #{state}"
+      :built ->
+        insert!(repo, name, changeset, opts)
+
+      :loaded ->
+        update!(repo, name, changeset, opts)
+
+      state ->
+        raise ArgumentError,
+              "the changeset has an invalid state " <>
+                "for Repo.insert_or_update!/2: #{state}"
     end
   end
 
   defp get_state(%Changeset{data: %{__meta__: %{state: state}}}), do: state
+
   defp get_state(%{__struct__: _}) do
-    raise ArgumentError, "giving a struct to Repo.insert_or_update/2 or " <>
-                         "Repo.insert_or_update!/2 is not supported. " <>
-                         "Please use an Ecto.Changeset"
+    raise ArgumentError,
+          "giving a struct to Repo.insert_or_update/2 or " <>
+            "Repo.insert_or_update!/2 is not supported. " <>
+            "Please use an Ecto.Changeset"
   end
 
   @doc """
@@ -541,7 +625,9 @@ defmodule Ecto.Repo.Schema do
 
         case apply(changeset, adapter, :delete, args) do
           {:ok, values} ->
-            changeset = load_changes(changeset, :deleted, [], values, %{}, [], adapter, schema_meta)
+            changeset =
+              load_changes(changeset, :deleted, [], values, %{}, [], adapter, schema_meta)
+
             {:ok, changeset.data}
 
           {:error, _} = error ->
@@ -563,10 +649,13 @@ defmodule Ecto.Repo.Schema do
 
   defp do_load(schema, data, loader) when is_list(data),
     do: do_load(schema, Map.new(data), loader)
+
   defp do_load(schema, {fields, values}, loader) when is_list(fields) and is_list(values),
     do: do_load(schema, Enum.zip(fields, values), loader)
+
   defp do_load(schema, data, loader) when is_atom(schema),
     do: Ecto.Schema.Loader.unsafe_load(schema, data, loader)
+
   defp do_load(types, data, loader) when is_map(types),
     do: Ecto.Schema.Loader.unsafe_load(%{}, types, data, loader)
 
@@ -576,12 +665,17 @@ defmodule Ecto.Repo.Schema do
     case Keyword.get(opts, :returning, false) do
       [_ | _] = fields ->
         fields
+
       [] ->
-        raise ArgumentError, ":returning expects at least one field to be given, got an empty list"
+        raise ArgumentError,
+              ":returning expects at least one field to be given, got an empty list"
+
       true when is_nil(schema) ->
         raise ArgumentError, ":returning option can only be set to true if a schema is given"
+
       true ->
         schema.__schema__(:fields)
+
       false ->
         []
     end
@@ -596,6 +690,7 @@ defmodule Ecto.Repo.Schema do
   defp fields_to_sources(fields, nil) do
     {fields, fields}
   end
+
   defp fields_to_sources(fields, dumper) do
     Enum.reduce(fields, {[], []}, fn field, {types, sources} ->
       {source, type} = Map.fetch!(dumper, field)
@@ -605,30 +700,41 @@ defmodule Ecto.Repo.Schema do
 
   defp struct_from_changeset!(action, %{data: nil}),
     do: raise(ArgumentError, "cannot #{action} a changeset without :data")
+
   defp struct_from_changeset!(_action, %{data: struct}),
     do: struct
 
   defp put_repo_and_action(%{action: :ignore, valid?: valid?} = changeset, action, repo, opts) do
     if valid? do
-      raise ArgumentError, "a valid changeset with action :ignore was given to " <>
-                           "#{inspect repo}.#{action}/2. Changesets can only be ignored " <>
-                           "in a repository action if they are also invalid"
+      raise ArgumentError,
+            "a valid changeset with action :ignore was given to " <>
+              "#{inspect(repo)}.#{action}/2. Changesets can only be ignored " <>
+              "in a repository action if they are also invalid"
     else
       %{changeset | action: action, repo: repo, repo_opts: opts}
     end
   end
-  defp put_repo_and_action(%{action: given}, action, repo, _opts) when given != nil and given != action,
-    do: raise ArgumentError, "a changeset with action #{inspect given} was given to #{inspect repo}.#{action}/2"
+
+  defp put_repo_and_action(%{action: given}, action, repo, _opts)
+       when given != nil and given != action,
+       do:
+         raise(
+           ArgumentError,
+           "a changeset with action #{inspect(given)} was given to #{inspect(repo)}.#{action}/2"
+         )
+
   defp put_repo_and_action(changeset, action, repo, opts),
     do: %{changeset | action: action, repo: repo, repo_opts: opts}
 
   defp run_prepare(changeset, prepare) do
     Enum.reduce(Enum.reverse(prepare), changeset, fn fun, acc ->
       case fun.(acc) do
-        %Ecto.Changeset{} = acc -> acc
+        %Ecto.Changeset{} = acc ->
+          acc
+
         other ->
-          raise "expected function #{inspect fun} given to Ecto.Changeset.prepare_changes/2 " <>
-                "to return an Ecto.Changeset, got: `#{inspect other}`"
+          raise "expected function #{inspect(fun)} given to Ecto.Changeset.prepare_changes/2 " <>
+                  "to return an Ecto.Changeset, got: `#{inspect(other)}`"
       end
     end)
   end
@@ -642,10 +748,15 @@ defmodule Ecto.Repo.Schema do
       prefix: Keyword.get(opts, :prefix, prefix)
     }
   end
-  defp metadata(%{__struct__: schema, __meta__: %{context: context, source: source, prefix: prefix}},
-                autogen_id, opts) do
+
+  defp metadata(
+         %{__struct__: schema, __meta__: %{context: context, source: source, prefix: prefix}},
+         autogen_id,
+         opts
+       ) do
     metadata(schema, prefix, source, autogen_id, context, opts)
   end
+
   defp metadata(%{__struct__: schema}, _, _) do
     raise ArgumentError, "#{inspect(schema)} needs to be a schema with source"
   end
@@ -653,13 +764,16 @@ defmodule Ecto.Repo.Schema do
   defp conflict_target({:unsafe_fragment, fragment}, _dumper) when is_binary(fragment) do
     {:unsafe_fragment, fragment}
   end
+
   defp conflict_target(conflict_target, dumper) do
     for target <- List.wrap(conflict_target) do
       case dumper do
         %{^target => {alias, _}} ->
           alias
+
         %{} when is_atom(target) ->
           raise ArgumentError, "unknown field `#{inspect(target)}` in conflict_target"
+
         _ ->
           target
       end
@@ -691,14 +805,14 @@ defmodule Ecto.Repo.Schema do
 
       [_ | _] = on_conflict ->
         from = if schema, do: {source, schema}, else: source
-        query = Ecto.Query.from from, update: ^on_conflict
+        query = Ecto.Query.from(from, update: ^on_conflict)
         on_conflict_query(query, {source, schema}, prefix, counter_fun, adapter, conflict_target)
 
       %Ecto.Query{} = query ->
         on_conflict_query(query, {source, schema}, prefix, counter_fun, adapter, conflict_target)
 
       other ->
-        raise ArgumentError, "unknown value for :on_conflict, got: #{inspect other}"
+        raise ArgumentError, "unknown value for :on_conflict, got: #{inspect(other)}"
     end
   end
 
@@ -720,14 +834,14 @@ defmodule Ecto.Repo.Schema do
   end
 
   defp on_conflict_query(query, from, prefix, counter_fun, adapter, conflict_target) do
-    {query, params, _} =
-      Ecto.Query.Planner.plan(%{query | prefix: prefix}, :update_all, adapter)
+    {query, params, _} = Ecto.Query.Planner.plan(%{query | prefix: prefix}, :update_all, adapter)
 
     unless query.from.source == from do
-      raise ArgumentError, "cannot run on_conflict: query because the query " <>
-                           "has a different {source, schema} pair than the " <>
-                           "original struct/changeset/query. Got #{inspect query.from} " <>
-                           "and #{inspect from} respectively"
+      raise ArgumentError,
+            "cannot run on_conflict: query because the query " <>
+              "has a different {source, schema} pair than the " <>
+              "original struct/changeset/query. Got #{inspect(query.from)} " <>
+              "and #{inspect(from)} respectively"
     end
 
     {query, _} = Ecto.Query.Planner.normalize(query, :update_all, adapter, counter_fun.())
@@ -752,7 +866,10 @@ defmodule Ecto.Repo.Schema do
         case Keyword.fetch(opts, :stale_error_field) do
           {:ok, stale_error_field} when is_atom(stale_error_field) ->
             stale_message = Keyword.get(opts, :stale_error_message, "is stale")
-            user_changeset = Changeset.add_error(user_changeset, stale_error_field, stale_message, [stale: true])
+
+            user_changeset =
+              Changeset.add_error(user_changeset, stale_error_field, stale_message, stale: true)
+
             {:error, user_changeset}
 
           _other ->
@@ -761,12 +878,16 @@ defmodule Ecto.Repo.Schema do
     end
   end
 
-  defp constraints_to_errors(%{constraints: user_constraints, errors: errors} = changeset, action, constraints) do
+  defp constraints_to_errors(
+         %{constraints: user_constraints, errors: errors} = changeset,
+         action,
+         constraints
+       ) do
     constraint_errors =
-      Enum.map constraints, fn {type, constraint} ->
+      Enum.map(constraints, fn {type, constraint} ->
         user_constraint =
           Enum.find(user_constraints, fn c ->
-            case {c.type, c.constraint,  c.match} do
+            case {c.type, c.constraint, c.match} do
               {^type, ^constraint, :exact} -> true
               {^type, cc, :suffix} -> String.ends_with?(constraint, cc)
               {^type, cc, :prefix} -> String.starts_with?(constraint, cc)
@@ -777,11 +898,15 @@ defmodule Ecto.Repo.Schema do
         case user_constraint do
           %{field: field, error_message: error_message, error_type: error_type} ->
             {field, {error_message, [constraint: error_type, constraint_name: constraint]}}
+
           nil ->
-            raise Ecto.ConstraintError, action: action, type: type,
-                                        constraint: constraint, changeset: changeset
+            raise Ecto.ConstraintError,
+              action: action,
+              type: type,
+              constraint: constraint,
+              changeset: changeset
         end
-      end
+      end)
 
     %{changeset | errors: constraint_errors ++ errors, valid?: false}
   end
@@ -821,11 +946,14 @@ defmodule Ecto.Repo.Schema do
     case Ecto.Type.adapter_load(adapter, type, value) do
       {:ok, value} ->
         load_each(%{struct | key => value}, kv, types, adapter)
+
       :error ->
-        raise ArgumentError, "cannot load `#{inspect value}` as type #{inspect type} " <>
-                             "for field `#{key}` in schema #{inspect struct.__struct__}"
+        raise ArgumentError,
+              "cannot load `#{inspect(value)}` as type #{inspect(type)} " <>
+                "for field `#{key}` in schema #{inspect(struct.__struct__)}"
     end
   end
+
   defp load_each(struct, [], _types, _adapter) do
     struct
   end
@@ -833,23 +961,27 @@ defmodule Ecto.Repo.Schema do
   defp pop_assocs(changeset, []) do
     {changeset, [], []}
   end
+
   defp pop_assocs(%{changes: changes, types: types} = changeset, assocs) do
     {changes, parent, child} =
-      Enum.reduce assocs, {changes, [], []}, fn assoc, {changes, parent, child} ->
+      Enum.reduce(assocs, {changes, [], []}, fn assoc, {changes, parent, child} ->
         case Map.fetch(changes, assoc) do
           {:ok, value} ->
             changes = Map.delete(changes, assoc)
 
             case Map.fetch!(types, assoc) do
               {:assoc, %{relationship: :parent} = refl} ->
-                {changes, [{refl, value}|parent], child}
+                {changes, [{refl, value} | parent], child}
+
               {:assoc, %{relationship: :child} = refl} ->
-                {changes, parent, [{refl, value}|child]}
+                {changes, parent, [{refl, value} | child]}
             end
+
           :error ->
             {changes, parent, child}
         end
-      end
+      end)
+
     {%{changeset | changes: changes}, parent, child}
   end
 
@@ -865,30 +997,35 @@ defmodule Ecto.Repo.Schema do
       {:ok, struct} ->
         changes = change_parents(changes, struct, assocs)
         %{changeset | changes: changes, data: struct}
+
       {:error, changes} ->
         %{changeset | changes: changes, valid?: false}
     end
   end
 
   defp change_parents(changes, struct, assocs) do
-    Enum.reduce assocs, changes, fn {refl, _}, acc ->
+    Enum.reduce(assocs, changes, fn {refl, _}, acc ->
       %{field: field, owner_key: owner_key, related_key: related_key} = refl
       related = Map.get(struct, field)
       value = related && Map.fetch!(related, related_key)
+
       case Map.fetch(changes, owner_key) do
         {:ok, current} when current != value ->
           raise ArgumentError,
-            "cannot change belongs_to association `#{field}` because there is " <>
-            "already a change setting its foreign key `#{owner_key}` to `#{inspect current}`"
+                "cannot change belongs_to association `#{field}` because there is " <>
+                  "already a change setting its foreign key `#{owner_key}` to `#{inspect(current)}`"
+
         _ ->
           Map.put(acc, owner_key, value)
       end
-    end
+    end)
   end
 
   defp process_children(changeset, assocs, user_changeset, adapter, opts) do
     case Ecto.Association.on_repo_change(changeset, assocs, adapter, opts) do
-      {:ok, struct} -> {:ok, struct}
+      {:ok, struct} ->
+        {:ok, struct}
+
       {:error, changes} ->
         {:error, %{user_changeset | valid?: false, changes: changes}}
     end
@@ -907,21 +1044,29 @@ defmodule Ecto.Repo.Schema do
 
   defp autogenerate_id({key, source, type}, changes, return_types, return_sources, adapter) do
     cond do
-      Map.has_key?(changes, key) -> # Set by user
+      # Set by user
+      Map.has_key?(changes, key) ->
         {changes, [], return_types, return_sources}
-      value = Ecto.Type.adapter_autogenerate(adapter, type) -> # Autogenerated now
+
+      # Autogenerated now
+      value = Ecto.Type.adapter_autogenerate(adapter, type) ->
         {changes, [{source, value}], [{key, type} | return_types], return_sources}
-      true -> # Autogenerated in storage
-        {changes, [], [{key, type} | return_types], [source | List.delete(return_sources, source)]}
+
+      # Autogenerated in storage
+      true ->
+        {changes, [], [{key, type} | return_types],
+         [source | List.delete(return_sources, source)]}
     end
   end
 
   defp dump_changes!(action, changes, schema, extra, dumper, adapter) do
     autogen = autogenerate_changes(schema, action, changes)
+
     dumped =
       dump_fields!(action, schema, changes, dumper, adapter) ++
-      dump_fields!(action, schema, autogen, dumper, adapter) ++
-      extra
+        dump_fields!(action, schema, autogen, dumper, adapter) ++
+        extra
+
     {dumped, autogen}
   end
 
@@ -944,12 +1089,13 @@ defmodule Ecto.Repo.Schema do
   defp action_to_auto(:update), do: :autoupdate
 
   defp add_pk_filter!(filters, struct) do
-    Enum.reduce Ecto.primary_key!(struct), filters, fn
+    Enum.reduce(Ecto.primary_key!(struct), filters, fn
       {_k, nil}, _acc ->
         raise Ecto.NoPrimaryKeyValueError, struct: struct
+
       {k, v}, acc ->
         Map.put(acc, k, v)
-    end
+    end)
   end
 
   defp wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fun) do
@@ -961,8 +1107,8 @@ defmodule Ecto.Repo.Schema do
 
   defp wrap_in_transaction(adapter, adapter_meta, opts, relations_changed?, prepare, fun) do
     if (relations_changed? or prepare != []) and
-       function_exported?(adapter, :transaction, 3) and
-       not adapter.in_transaction?(adapter_meta) do
+         function_exported?(adapter, :transaction, 3) and
+         not adapter.in_transaction?(adapter_meta) do
       adapter.transaction(adapter_meta, opts, fn ->
         case fun.() do
           {:ok, struct} -> struct
@@ -978,10 +1124,11 @@ defmodule Ecto.Repo.Schema do
     case Ecto.Type.adapter_dump(adapter, type, value) do
       {:ok, value} ->
         value
+
       :error ->
         raise Ecto.ChangeError,
               "value `#{inspect(value)}` for `#{inspect(schema)}.#{field}` " <>
-              "in `#{action}` does not match type #{inspect type}"
+                "in `#{action}` does not match type #{inspect(type)}"
     end
   end
 

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -35,7 +35,7 @@ defmodule Ecto.Repo.Supervisor do
   defp telemetry_prefix(repo) do
     repo
     |> Module.split()
-    |> Enum.map(& &1 |> Macro.underscore() |> String.to_atom())
+    |> Enum.map(&(&1 |> Macro.underscore() |> String.to_atom()))
   end
 
   defp repo_init(type, repo, config) do
@@ -58,8 +58,9 @@ defmodule Ecto.Repo.Supervisor do
     end
 
     if Code.ensure_compiled(adapter) != {:module, adapter} do
-      raise ArgumentError, "adapter #{inspect adapter} was not compiled, " <>
-                           "ensure it is correct and it is included as a project dependency"
+      raise ArgumentError,
+            "adapter #{inspect(adapter)} was not compiled, " <>
+              "ensure it is correct and it is included as a project dependency"
     end
 
     behaviours =
@@ -124,6 +125,7 @@ defmodule Ecto.Repo.Supervisor do
 
   defp parse_uri_query(%URI{query: nil}),
     do: []
+
   defp parse_uri_query(%URI{query: query} = url) do
     query
     |> URI.query_decoder()
@@ -149,8 +151,8 @@ defmodule Ecto.Repo.Supervisor do
 
       _ ->
         raise Ecto.InvalidURLError,
-              url: url,
-              message: "can not parse value `#{value}` for parameter `#{key}` as an integer"
+          url: url,
+          message: "can not parse value `#{value}` for parameter `#{key}` as an integer"
     end
   end
 

--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -6,7 +6,7 @@ defmodule Ecto.Repo.Transaction do
     {adapter, meta} = Ecto.Repo.Registry.lookup(name)
     adapter.transaction(meta, opts, fun)
   end
-  
+
   def transaction(repo, name, fun, opts) when is_function(fun, 1) do
     {adapter, meta} = Ecto.Repo.Registry.lookup(name)
     adapter.transaction(meta, opts, fn -> fun.(repo) end)
@@ -18,9 +18,14 @@ defmodule Ecto.Repo.Transaction do
     return = &adapter.rollback(meta, &1)
 
     case Ecto.Multi.__apply__(multi, repo, wrap, return) do
-      {:ok, values} -> {:ok, values}
-      {:error, {key, error_value, values}} -> {:error, key, error_value, values}
-      {:error, operation} -> raise "operation #{inspect operation} is manually rolling back, which is not supported by Ecto.Multi"
+      {:ok, values} ->
+        {:ok, values}
+
+      {:error, {key, error_value, values}} ->
+        {:error, key, error_value, values}
+
+      {:error, operation} ->
+        raise "operation #{inspect(operation)} is manually rolling back, which is not supported by Ecto.Multi"
     end
   end
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -447,9 +447,9 @@ defmodule Ecto.Schema do
 
   alias Ecto.Schema.Metadata
 
-  @type source :: String.t
-  @type prefix :: String.t | nil
-  @type schema :: %{optional(atom) => any, __struct__: atom, __meta__: Metadata.t}
+  @type source :: String.t()
+  @type prefix :: String.t() | nil
+  @type schema :: %{optional(atom) => any, __struct__: atom, __meta__: Metadata.t()}
   @type embedded_schema :: %{optional(atom) => any, __struct__: atom}
   @type t :: schema | embedded_schema
   @type belongs_to(t) :: t | Ecto.Association.NotLoaded.t()
@@ -498,7 +498,7 @@ defmodule Ecto.Schema do
   to `:binary_id` but such can be configured with the
   `@primary_key` attribute.
   """
-  defmacro embedded_schema([do: block]) do
+  defmacro embedded_schema(do: block) do
     schema(__CALLER__, nil, false, :binary_id, block)
   end
 
@@ -509,7 +509,7 @@ defmodule Ecto.Schema do
   internal Ecto state. This field always has a `Ecto.Schema.Metadata` struct
   as value and can be manipulated with the `Ecto.put_meta/2` function.
   """
-  defmacro schema(source, [do: block]) do
+  defmacro schema(source, do: block) do
     schema(__CALLER__, source, true, :id, block)
   end
 
@@ -526,7 +526,7 @@ defmodule Ecto.Schema do
         Module.register_attribute(__MODULE__, :changeset_fields, accumulate: true)
         Module.register_attribute(__MODULE__, :struct_fields, accumulate: true)
 
-        meta?  = unquote(meta?)
+        meta? = unquote(meta?)
         source = unquote(source)
         prefix = @schema_prefix
         context = @schema_context
@@ -538,7 +538,7 @@ defmodule Ecto.Schema do
 
         if meta? do
           unless is_binary(source) do
-            raise ArgumentError, "schema source must be a string, got: #{inspect source}"
+            raise ArgumentError, "schema source must be a string, got: #{inspect(source)}"
           end
 
           meta = %Metadata{
@@ -560,9 +560,11 @@ defmodule Ecto.Schema do
           case @primary_key do
             false ->
               []
+
             {name, type, opts} ->
               Ecto.Schema.__field__(__MODULE__, name, type, [primary_key: true] ++ opts)
               [name]
+
             other ->
               raise ArgumentError, "@primary_key must be false or {name, type, opts}"
           end
@@ -577,14 +579,14 @@ defmodule Ecto.Schema do
 
     postlude =
       quote unquote: false do
-        primary_key_fields = @ecto_primary_keys |> Enum.reverse
-        autogenerate = @ecto_autogenerate |> Enum.reverse
-        autoupdate = @ecto_autoupdate |> Enum.reverse
-        fields = @ecto_fields |> Enum.reverse
-        query_fields = @ecto_query_fields |> Enum.reverse
-        field_sources = @ecto_field_sources |> Enum.reverse
-        assocs = @ecto_assocs |> Enum.reverse
-        embeds = @ecto_embeds |> Enum.reverse
+        primary_key_fields = @ecto_primary_keys |> Enum.reverse()
+        autogenerate = @ecto_autogenerate |> Enum.reverse()
+        autoupdate = @ecto_autoupdate |> Enum.reverse()
+        fields = @ecto_fields |> Enum.reverse()
+        query_fields = @ecto_query_fields |> Enum.reverse()
+        field_sources = @ecto_field_sources |> Enum.reverse()
+        assocs = @ecto_assocs |> Enum.reverse()
+        embeds = @ecto_embeds |> Enum.reverse()
         redacted_fields = @ecto_redact_fields
         loaded = Ecto.Schema.__loaded__(__MODULE__, @struct_fields)
 
@@ -956,6 +958,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_many(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__has_many__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1027,6 +1030,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_one(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__has_one__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1232,6 +1236,7 @@ defmodule Ecto.Schema do
   """
   defmacro belongs_to(name, queryable, opts \\ []) do
     queryable = expand_alias(queryable, __CALLER__)
+
     quote do
       Ecto.Schema.__belongs_to__(__MODULE__, unquote(name), unquote(queryable), unquote(opts))
     end
@@ -1631,6 +1636,7 @@ defmodule Ecto.Schema do
 
   defmacro embeds_one(name, schema, opts) do
     schema = expand_alias(schema, __CALLER__)
+
     quote do
       Ecto.Schema.__embeds_one__(__MODULE__, unquote(name), unquote(schema), unquote(opts))
     end
@@ -1643,7 +1649,14 @@ defmodule Ecto.Schema do
   """
   defmacro embeds_one(name, schema, opts, do: block) do
     quote do
-      {schema, opts} = Ecto.Schema.__embeds_module__(__ENV__, unquote(schema), unquote(opts), unquote(Macro.escape(block)))
+      {schema, opts} =
+        Ecto.Schema.__embeds_module__(
+          __ENV__,
+          unquote(schema),
+          unquote(opts),
+          unquote(Macro.escape(block))
+        )
+
       Ecto.Schema.__embeds_one__(__MODULE__, unquote(name), schema, opts)
     end
   end
@@ -1798,6 +1811,7 @@ defmodule Ecto.Schema do
 
   defmacro embeds_many(name, schema, opts) do
     schema = expand_alias(schema, __CALLER__)
+
     quote do
       Ecto.Schema.__embeds_many__(__MODULE__, unquote(name), unquote(schema), unquote(opts))
     end
@@ -1810,7 +1824,14 @@ defmodule Ecto.Schema do
   """
   defmacro embeds_many(name, schema, opts, do: block) do
     quote do
-      {schema, opts} = Ecto.Schema.__embeds_module__(__ENV__, unquote(schema), unquote(opts), unquote(Macro.escape(block)))
+      {schema, opts} =
+        Ecto.Schema.__embeds_module__(
+          __ENV__,
+          unquote(schema),
+          unquote(opts),
+          unquote(Macro.escape(block))
+        )
+
       Ecto.Schema.__embeds_many__(__MODULE__, unquote(name), schema, opts)
     end
   end
@@ -1825,7 +1846,7 @@ defmodule Ecto.Schema do
   # the association name, the association module (that implements
   # `Ecto.Association` callbacks) and a keyword list of options.
   @doc false
-  @spec association(module, :one | :many, atom(), module, Keyword.t) :: Ecto.Association.t
+  @spec association(module, :one | :many, atom(), module, Keyword.t()) :: Ecto.Association.t()
   def association(schema, cardinality, name, association, opts) do
     not_loaded = %Ecto.Association.NotLoaded{
       __owner__: schema,
@@ -1874,8 +1895,9 @@ defmodule Ecto.Schema do
   @doc false
   def __field__(mod, name, type, opts) do
     if type == :any and !opts[:virtual] do
-      raise ArgumentError, "only virtual fields can have type :any, " <>
-                           "invalid type for field #{inspect name}"
+      raise ArgumentError,
+            "only virtual fields can have type :any, " <>
+              "invalid type for field #{inspect(name)}"
     end
 
     type = check_field_type!(mod, name, type, opts)
@@ -1931,7 +1953,16 @@ defmodule Ecto.Schema do
     end
   end
 
-  @valid_has_options [:foreign_key, :references, :through, :on_delete, :defaults, :on_replace, :where, :preload_order]
+  @valid_has_options [
+    :foreign_key,
+    :references,
+    :through,
+    :on_delete,
+    :defaults,
+    :on_replace,
+    :where,
+    :preload_order
+  ]
 
   @doc false
   def __has_many__(mod, name, queryable, opts) do
@@ -1959,8 +1990,17 @@ defmodule Ecto.Schema do
 
   # :primary_key is valid here to support associative entity
   # https://en.wikipedia.org/wiki/Associative_entity
-  @valid_belongs_to_options [:foreign_key, :references, :define_field, :type,
-                             :on_replace, :defaults, :primary_key, :source, :where]
+  @valid_belongs_to_options [
+    :foreign_key,
+    :references,
+    :define_field,
+    :type,
+    :on_replace,
+    :defaults,
+    :primary_key,
+    :source,
+    :where
+  ]
 
   @doc false
   def __belongs_to__(mod, name, queryable, opts) do
@@ -1970,7 +2010,8 @@ defmodule Ecto.Schema do
     foreign_key_type = opts[:type] || Module.get_attribute(mod, :foreign_key_type)
 
     if name == Keyword.get(opts, :foreign_key) do
-      raise ArgumentError, "foreign_key #{inspect name} must be distinct from corresponding association name"
+      raise ArgumentError,
+            "foreign_key #{inspect(name)} must be distinct from corresponding association name"
     end
 
     if Keyword.get(opts, :define_field, true) do
@@ -1979,10 +2020,22 @@ defmodule Ecto.Schema do
 
     struct =
       association(mod, :one, name, Ecto.Association.BelongsTo, [queryable: queryable] ++ opts)
+
     Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
   end
 
-  @valid_many_to_many_options [:join_through, :join_defaults, :join_keys, :on_delete, :defaults, :on_replace, :unique, :where, :join_where, :preload_order]
+  @valid_many_to_many_options [
+    :join_through,
+    :join_defaults,
+    :join_keys,
+    :on_delete,
+    :defaults,
+    :on_replace,
+    :unique,
+    :where,
+    :join_where,
+    :preload_order
+  ]
 
   @doc false
   def __many_to_many__(mod, name, queryable, opts) do
@@ -1990,6 +2043,7 @@ defmodule Ecto.Schema do
 
     struct =
       association(mod, :many, name, Ecto.Association.ManyToMany, [queryable: queryable] ++ opts)
+
     Module.put_attribute(mod, :changeset_fields, {name, {:assoc, struct}})
   end
 
@@ -2046,8 +2100,10 @@ defmodule Ecto.Schema do
             :ok
 
           {:error, message} ->
-            IO.warn "invalid association `#{assoc.field}` in schema #{inspect module}: #{message}",
-                    Macro.Env.stacktrace(env)
+            IO.warn(
+              "invalid association `#{assoc.field}` in schema #{inspect(module)}: #{message}",
+              Macro.Env.stacktrace(env)
+            )
         end
       end
     end
@@ -2122,7 +2178,7 @@ defmodule Ecto.Schema do
   ## Private
 
   defp embed(mod, cardinality, name, schema, opts) do
-    opts   = [cardinality: cardinality, related: schema, owner: mod, field: name] ++ opts
+    opts = [cardinality: cardinality, related: schema, owner: mod, field: name] ++ opts
     struct = Ecto.Embedded.init(opts)
 
     Module.put_attribute(mod, :changeset_fields, {name, {:embed, struct}})
@@ -2134,7 +2190,7 @@ defmodule Ecto.Schema do
     fields = Module.get_attribute(mod, :struct_fields)
 
     if List.keyfind(fields, name, 0) do
-      raise ArgumentError, "field/association #{inspect name} is already set on schema"
+      raise ArgumentError, "field/association #{inspect(name)} is already set on schema"
     end
 
     Module.put_attribute(mod, :struct_fields, {name, assoc})
@@ -2144,28 +2200,32 @@ defmodule Ecto.Schema do
     case Ecto.Type.dump(type, value) do
       {:ok, _} ->
         :ok
+
       _ ->
-        raise ArgumentError, "value #{inspect(value)} is invalid for type #{inspect(type)}, can't set default"
+        raise ArgumentError,
+              "value #{inspect(value)} is invalid for type #{inspect(type)}, can't set default"
     end
   end
 
   defp check_options!(opts, valid, fun_arity) do
     type = Keyword.get(opts, :type)
 
-    if is_atom(type) and Code.ensure_compiled(type) == {:module, type} and function_exported?(type, :type, 1) do
+    if is_atom(type) and Code.ensure_compiled(type) == {:module, type} and
+         function_exported?(type, :type, 1) do
       :ok
     else
-      case Enum.find(opts, fn {k, _} -> not(k in valid) end) do
-        {k, _} -> raise ArgumentError, "invalid option #{inspect k} for #{fun_arity}"
+      case Enum.find(opts, fn {k, _} -> k not in valid end) do
+        {k, _} -> raise ArgumentError, "invalid option #{inspect(k)} for #{fun_arity}"
         nil -> :ok
       end
     end
   end
 
   defp check_field_type!(_mod, name, :datetime, _opts) do
-    raise ArgumentError, "invalid type :datetime for field #{inspect name}. " <>
-                           "You probably meant to choose one between :naive_datetime " <>
-                           "(no time zone information) or :utc_datetime (time zone is set to UTC)"
+    raise ArgumentError,
+          "invalid type :datetime for field #{inspect(name)}. " <>
+            "You probably meant to choose one between :naive_datetime " <>
+            "(no time zone information) or :utc_datetime (time zone is set to UTC)"
   end
 
   defp check_field_type!(mod, name, type, opts) do
@@ -2194,11 +2254,11 @@ defmodule Ecto.Schema do
 
       kind == :module and function_exported?(type, :__schema__, 1) ->
         raise ArgumentError,
-          "schema #{inspect type} is not a valid type for field #{inspect name}." <>
-          " Did you mean to use belongs_to, has_one, has_many, embeds_one, or embeds_many instead?"
+              "schema #{inspect(type)} is not a valid type for field #{inspect(name)}." <>
+                " Did you mean to use belongs_to, has_one, has_many, embeds_one, or embeds_many instead?"
 
       true ->
-        raise ArgumentError, "invalid or unknown type #{inspect type} for field #{inspect name}"
+        raise ArgumentError, "invalid or unknown type #{inspect(type)} for field #{inspect(name)}"
     end
   end
 
@@ -2207,8 +2267,8 @@ defmodule Ecto.Schema do
       true
     else
       raise ArgumentError,
-        "invalid or unknown composite #{inspect type} for field #{inspect name}. " <>
-        "Did you mean to use array or map as first element of tuple instead?"
+            "invalid or unknown composite #{inspect(type)} for field #{inspect(name)}. " <>
+              "Did you mean to use array or map as first element of tuple instead?"
     end
   end
 
@@ -2228,11 +2288,16 @@ defmodule Ecto.Schema do
         :ok
 
       not function_exported?(typemod, :autogenerate, 1) ->
-        raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "parameterized type #{inspect type} that does not define autogenerate/1"
+        raise ArgumentError,
+              "field #{inspect(name)} does not support :autogenerate because it uses a " <>
+                "parameterized type #{inspect(type)} that does not define autogenerate/1"
 
       true ->
-        Module.put_attribute(mod, :ecto_autogenerate, {[name], {typemod, :autogenerate, [params]}})
+        Module.put_attribute(
+          mod,
+          :ecto_autogenerate,
+          {[name], {typemod, :autogenerate, [params]}}
+        )
     end
   end
 
@@ -2242,13 +2307,15 @@ defmodule Ecto.Schema do
         :ok
 
       Ecto.Type.primitive?(type) ->
-        raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "primitive type #{inspect type}"
+        raise ArgumentError,
+              "field #{inspect(name)} does not support :autogenerate because it uses a " <>
+                "primitive type #{inspect(type)}"
 
       # Note the custom type has already been loaded in check_type!/3
       not function_exported?(type, :autogenerate, 0) ->
-        raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "custom type #{inspect type} that does not define autogenerate/0"
+        raise ArgumentError,
+              "field #{inspect(name)} does not support :autogenerate because it uses a " <>
+                "custom type #{inspect(type)} that does not define autogenerate/0"
 
       true ->
         Module.put_attribute(mod, :ecto_autogenerate, {[name], {type, :autogenerate, []}})
@@ -2261,8 +2328,9 @@ defmodule Ecto.Schema do
         false
 
       not pk? ->
-        raise ArgumentError, "only primary keys allow :autogenerate for type #{inspect type}, " <>
-                             "field #{inspect name} is not a primary key"
+        raise ArgumentError,
+              "only primary keys allow :autogenerate for type #{inspect(type)}, " <>
+                "field #{inspect(name)} is not a primary key"
 
       Module.get_attribute(mod, :ecto_autogenerate_id) ->
         raise ArgumentError, "only one primary key with ID type may be marked as autogenerated"
@@ -2277,6 +2345,7 @@ defmodule Ecto.Schema do
 
   defp expand_alias({:__aliases__, _, _} = ast, env),
     do: Macro.expand(ast, %{env | function: {:__schema__, 2}})
+
   defp expand_alias(ast, _env),
     do: ast
 

--- a/lib/ecto/schema/loader.ex
+++ b/lib/ecto/schema/loader.ex
@@ -97,9 +97,11 @@ defmodule Ecto.Schema.Loader do
       case dumper.(type, value) do
         {:ok, value} ->
           Map.put(acc, source, value)
+
         :error ->
-          raise ArgumentError, "cannot dump `#{inspect value}` as type #{inspect type} " <>
-                               "for field `#{field}` in schema #{inspect struct.__struct__}"
+          raise ArgumentError,
+                "cannot dump `#{inspect(value)}` as type #{inspect(type)} " <>
+                  "for field `#{field}` in schema #{inspect(struct.__struct__)}"
       end
     end)
   end

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -163,7 +163,7 @@ defmodule Ecto.Type do
       @behaviour Ecto.Type
       def embed_as(_), do: :self
       def equal?(term1, term2), do: term1 == term2
-      defoverridable [embed_as: 1, equal?: 2]
+      defoverridable embed_as: 1, equal?: 2
     end
   end
 
@@ -176,10 +176,24 @@ defmodule Ecto.Type do
   @typedoc "Custom types are represented by user-defined modules."
   @type custom :: module | {:parameterized, module, term}
 
-  @type base :: :integer | :float | :boolean | :string | :map |
-                 :binary | :decimal | :id | :binary_id |
-                 :utc_datetime | :naive_datetime | :date | :time | :any |
-                 :utc_datetime_usec | :naive_datetime_usec | :time_usec
+  @type base ::
+          :integer
+          | :float
+          | :boolean
+          | :string
+          | :map
+          | :binary
+          | :decimal
+          | :id
+          | :binary_id
+          | :utc_datetime
+          | :naive_datetime
+          | :date
+          | :time
+          | :any
+          | :utc_datetime_usec
+          | :naive_datetime_usec
+          | :time_usec
 
   @type composite :: {:array, t} | {:map, t} | private_composite
 
@@ -422,7 +436,7 @@ defmodule Ecto.Type do
     end
   end
 
-  defp do_match?(_left, :any),  do: true
+  defp do_match?(_left, :any), do: true
   defp do_match?(:any, _right), do: true
   defp do_match?({outer, left}, {outer, right}), do: match?(left, right)
   defp do_match?(:decimal, type) when type in [:float, :integer], do: true
@@ -528,8 +542,8 @@ defmodule Ecto.Type do
   defp dump_any_datetime(%DateTime{} = term), do: {:ok, term}
   defp dump_any_datetime(_), do: :error
 
-  defp dump_naive_datetime(%NaiveDateTime{} = term), do:
-    {:ok, check_no_usec!(term, :naive_datetime)}
+  defp dump_naive_datetime(%NaiveDateTime{} = term),
+    do: {:ok, check_no_usec!(term, :naive_datetime)}
 
   defp dump_naive_datetime(_), do: :error
 
@@ -623,7 +637,9 @@ defmodule Ecto.Type do
   # the adapter will either explicitly error (Postgres) or it will
   # accept the data (MySQL), which is fine as we always assume UTC
   defp load_naive_datetime(%DateTime{} = datetime),
-    do: {:ok, datetime |> check_utc_timezone!(:naive_datetime) |> DateTime.to_naive() |> truncate_usec()}
+    do:
+      {:ok,
+       datetime |> check_utc_timezone!(:naive_datetime) |> DateTime.to_naive() |> truncate_usec()}
 
   defp load_naive_datetime(%NaiveDateTime{} = naive_datetime),
     do: {:ok, truncate_usec(naive_datetime)}
@@ -631,7 +647,9 @@ defmodule Ecto.Type do
   defp load_naive_datetime(_), do: :error
 
   defp load_naive_datetime_usec(%DateTime{} = datetime),
-    do: {:ok, datetime |> check_utc_timezone!(:naive_datetime_usec) |> DateTime.to_naive() |> pad_usec()}
+    do:
+      {:ok,
+       datetime |> check_utc_timezone!(:naive_datetime_usec) |> DateTime.to_naive() |> pad_usec()}
 
   defp load_naive_datetime_usec(%NaiveDateTime{} = naive_datetime),
     do: {:ok, pad_usec(naive_datetime)}
@@ -827,9 +845,10 @@ defmodule Ecto.Type do
       :error -> :error
     end
   end
+
   defp cast_decimal(term), do: same_decimal(term)
 
-  defp cast_boolean(term) when term in ~w(true 1),  do: {:ok, true}
+  defp cast_boolean(term) when term in ~w(true 1), do: {:ok, true}
   defp cast_boolean(term) when term in ~w(false 0), do: {:ok, false}
   defp cast_boolean(term) when is_boolean(term), do: {:ok, term}
   defp cast_boolean(_), do: :error
@@ -876,9 +895,11 @@ defmodule Ecto.Type do
   def adapter_load(adapter, {:parameterized, module, params} = type, value) do
     process_loaders(adapter.loaders(module.type(params), type), {:ok, value}, adapter)
   end
+
   def adapter_load(_adapter, _type, nil) do
     {:ok, nil}
   end
+
   def adapter_load(adapter, type, value) do
     if of_base_type?(type, value) do
       {:ok, value}
@@ -889,10 +910,13 @@ defmodule Ecto.Type do
 
   defp process_loaders(_, :error, _adapter),
     do: :error
-  defp process_loaders([fun|t], {:ok, value}, adapter) when is_function(fun),
+
+  defp process_loaders([fun | t], {:ok, value}, adapter) when is_function(fun),
     do: process_loaders(t, fun.(value), adapter)
-  defp process_loaders([type|t], {:ok, value}, adapter),
+
+  defp process_loaders([type | t], {:ok, value}, adapter),
     do: process_loaders(t, load(type, value, &adapter_load(adapter, &1, &2)), adapter)
+
   defp process_loaders([], {:ok, _} = acc, _adapter),
     do: acc
 
@@ -900,19 +924,24 @@ defmodule Ecto.Type do
   def adapter_dump(adapter, {:parameterized, module, params} = type, value) do
     process_dumpers(adapter.dumpers(module.type(params), type), {:ok, value}, adapter)
   end
+
   def adapter_dump(_adapter, type, nil) do
     dump(type, nil)
   end
+
   def adapter_dump(adapter, type, value) do
     process_dumpers(adapter.dumpers(type(type), type), {:ok, value}, adapter)
   end
 
   defp process_dumpers(_, :error, _adapter),
     do: :error
-  defp process_dumpers([fun|t], {:ok, value}, adapter) when is_function(fun),
+
+  defp process_dumpers([fun | t], {:ok, value}, adapter) when is_function(fun),
     do: process_dumpers(t, fun.(value), adapter)
-  defp process_dumpers([type|t], {:ok, value}, adapter),
+
+  defp process_dumpers([type | t], {:ok, value}, adapter),
     do: process_dumpers(t, dump(type, value, &adapter_dump(adapter, &1, &2)), adapter)
+
   defp process_dumpers([], {:ok, _} = acc, _adapter),
     do: acc
 
@@ -922,6 +951,7 @@ defmodule Ecto.Type do
     case Date.from_iso8601(binary) do
       {:ok, _} = ok ->
         ok
+
       {:error, _} ->
         case NaiveDateTime.from_iso8601(binary) do
           {:ok, naive_datetime} -> {:ok, NaiveDateTime.to_date(naive_datetime)}
@@ -929,23 +959,30 @@ defmodule Ecto.Type do
         end
     end
   end
+
   defp cast_date(%{"year" => empty, "month" => empty, "day" => empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_date(%{year: empty, month: empty, day: empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_date(%{"year" => year, "month" => month, "day" => day}),
     do: cast_date(to_i(year), to_i(month), to_i(day))
+
   defp cast_date(%{year: year, month: month, day: day}),
     do: cast_date(to_i(year), to_i(month), to_i(day))
+
   defp cast_date(_),
     do: :error
 
-  defp cast_date(year, month, day) when is_integer(year) and is_integer(month) and is_integer(day) do
+  defp cast_date(year, month, day)
+       when is_integer(year) and is_integer(month) and is_integer(day) do
     case Date.new(year, month, day) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_date(_, _, _),
     do: :error
 
@@ -953,39 +990,66 @@ defmodule Ecto.Type do
 
   defp cast_time(<<hour::2-bytes, ?:, minute::2-bytes>>),
     do: cast_time(to_i(hour), to_i(minute), 0, nil)
+
   defp cast_time(binary) when is_binary(binary) do
     case Time.from_iso8601(binary) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_time(%{"hour" => empty, "minute" => empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_time(%{hour: empty, minute: empty}) when empty in ["", nil],
     do: {:ok, nil}
+
   defp cast_time(%{"hour" => hour, "minute" => minute} = map),
-    do: cast_time(to_i(hour), to_i(minute), to_i(Map.get(map, "second")), to_i(Map.get(map, "microsecond")))
-  defp cast_time(%{hour: hour, minute: minute, second: second, microsecond: {microsecond, precision}}),
-    do: cast_time(to_i(hour), to_i(minute), to_i(second), {to_i(microsecond), to_i(precision)})
+    do:
+      cast_time(
+        to_i(hour),
+        to_i(minute),
+        to_i(Map.get(map, "second")),
+        to_i(Map.get(map, "microsecond"))
+      )
+
+  defp cast_time(%{
+         hour: hour,
+         minute: minute,
+         second: second,
+         microsecond: {microsecond, precision}
+       }),
+       do: cast_time(to_i(hour), to_i(minute), to_i(second), {to_i(microsecond), to_i(precision)})
+
   defp cast_time(%{hour: hour, minute: minute} = map),
-    do: cast_time(to_i(hour), to_i(minute), to_i(Map.get(map, :second)), to_i(Map.get(map, :microsecond)))
+    do:
+      cast_time(
+        to_i(hour),
+        to_i(minute),
+        to_i(Map.get(map, :second)),
+        to_i(Map.get(map, :microsecond))
+      )
+
   defp cast_time(_),
     do: :error
 
   defp cast_time(hour, minute, sec, usec) when is_integer(usec) do
     cast_time(hour, minute, sec, {usec, 6})
   end
+
   defp cast_time(hour, minute, sec, nil) do
     cast_time(hour, minute, sec, {0, 0})
   end
+
   defp cast_time(hour, minute, sec, {usec, precision})
        when is_integer(hour) and is_integer(minute) and
-            (is_integer(sec) or is_nil(sec)) and is_integer(usec) and is_integer(precision) do
+              (is_integer(sec) or is_nil(sec)) and is_integer(usec) and is_integer(precision) do
     case Time.new(hour, minute, sec || 0, {usec, precision}) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_time(_, _, _, _) do
     :error
   end
@@ -1001,7 +1065,10 @@ defmodule Ecto.Type do
     end
   end
 
-  defp cast_naive_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:, minute::2-bytes>>)
+  defp cast_naive_datetime(
+         <<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:,
+           minute::2-bytes>>
+       )
        when sep in [?\s, ?T] do
     case NaiveDateTime.new(to_i(year), to_i(month), to_i(day), to_i(hour), to_i(minute), 0) do
       {:ok, _} = ok -> ok
@@ -1016,13 +1083,19 @@ defmodule Ecto.Type do
     end
   end
 
-  defp cast_naive_datetime(%{"year" => empty, "month" => empty, "day" => empty,
-                             "hour" => empty, "minute" => empty}) when empty in ["", nil],
-    do: {:ok, nil}
+  defp cast_naive_datetime(%{
+         "year" => empty,
+         "month" => empty,
+         "day" => empty,
+         "hour" => empty,
+         "minute" => empty
+       })
+       when empty in ["", nil],
+       do: {:ok, nil}
 
-  defp cast_naive_datetime(%{year: empty, month: empty, day: empty,
-                             hour: empty, minute: empty}) when empty in ["", nil],
-    do: {:ok, nil}
+  defp cast_naive_datetime(%{year: empty, month: empty, day: empty, hour: empty, minute: empty})
+       when empty in ["", nil],
+       do: {:ok, nil}
 
   defp cast_naive_datetime(%{} = map) do
     with {:ok, %Date{} = date} <- cast_date(map),
@@ -1045,7 +1118,10 @@ defmodule Ecto.Type do
     end
   end
 
-  defp cast_utc_datetime(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:, minute::2-bytes>>)
+  defp cast_utc_datetime(
+         <<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:,
+           minute::2-bytes>>
+       )
        when sep in [?\s, ?T] do
     case NaiveDateTime.new(to_i(year), to_i(month), to_i(day), to_i(hour), to_i(minute), 0) do
       {:ok, naive_datetime} -> {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
@@ -1055,28 +1131,37 @@ defmodule Ecto.Type do
 
   defp cast_utc_datetime(binary) when is_binary(binary) do
     case DateTime.from_iso8601(binary) do
-      {:ok, datetime, _offset} -> {:ok, datetime}
+      {:ok, datetime, _offset} ->
+        {:ok, datetime}
+
       {:error, :missing_offset} ->
         case NaiveDateTime.from_iso8601(binary) do
           {:ok, naive_datetime} -> {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
           {:error, _} -> :error
         end
-      {:error, _} -> :error
+
+      {:error, _} ->
+        :error
     end
   end
+
   defp cast_utc_datetime(%DateTime{time_zone: "Etc/UTC"} = datetime), do: {:ok, datetime}
+
   defp cast_utc_datetime(%DateTime{} = datetime) do
-    case (datetime |> DateTime.to_unix(:microsecond) |> DateTime.from_unix(:microsecond)) do
+    case datetime |> DateTime.to_unix(:microsecond) |> DateTime.from_unix(:microsecond) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
     end
   end
+
   defp cast_utc_datetime(value) do
     case cast_naive_datetime(value) do
       {:ok, %NaiveDateTime{} = naive_datetime} ->
         {:ok, DateTime.from_naive!(naive_datetime, "Etc/UTC")}
+
       {:ok, _} = ok ->
         ok
+
       :error ->
         :error
     end
@@ -1131,7 +1216,10 @@ defmodule Ecto.Type do
   defp equal_fun(:decimal), do: &equal_decimal?/2
   defp equal_fun(t) when t in [:time, :time_usec], do: &equal_time?/2
   defp equal_fun(t) when t in [:utc_datetime, :utc_datetime_usec], do: &equal_utc_datetime?/2
-  defp equal_fun(t) when t in [:naive_datetime, :naive_datetime_usec], do: &equal_naive_datetime?/2
+
+  defp equal_fun(t) when t in [:naive_datetime, :naive_datetime_usec],
+    do: &equal_naive_datetime?/2
+
   defp equal_fun(t) when t in @base, do: nil
 
   defp equal_fun({:array, type}) do
@@ -1163,6 +1251,7 @@ defmodule Ecto.Type do
 
   defp equal_naive_datetime?(%NaiveDateTime{} = a, %NaiveDateTime{} = b),
     do: NaiveDateTime.compare(a, b) == :eq
+
   defp equal_naive_datetime?(_, _),
     do: false
 
@@ -1228,7 +1317,7 @@ defmodule Ecto.Type do
     end
   end
 
-  defp array([], _fun, _skip_nil?,acc) do
+  defp array([], _fun, _skip_nil?, acc) do
     {:ok, Enum.reverse(acc)}
   end
 
@@ -1300,6 +1389,7 @@ defmodule Ecto.Type do
 
   defp to_i(nil), do: nil
   defp to_i(int) when is_integer(int), do: int
+
   defp to_i(bin) when is_binary(bin) do
     case Integer.parse(bin) do
       {int, ""} -> int
@@ -1327,7 +1417,7 @@ defmodule Ecto.Type do
 
   defp check_utc_timezone!(datetime, kind) do
     raise ArgumentError,
-          "#{inspect kind} expects the time zone to be \"Etc/UTC\", got `#{inspect(datetime)}`"
+          "#{inspect(kind)} expects the time zone to be \"Etc/UTC\", got `#{inspect(datetime)}`"
   end
 
   defp check_usec!(%{microsecond: {_, 6}} = datetime, _kind), do: datetime
@@ -1349,6 +1439,7 @@ defmodule Ecto.Type do
 
   defp check_decimal(%Decimal{coef: coef} = decimal, _) when is_integer(coef), do: {:ok, decimal}
   defp check_decimal(_decimal, false), do: :error
+
   defp check_decimal(decimal, true) do
     raise ArgumentError, """
     #{inspect(decimal)} is not allowed for type :decimal

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -22,26 +22,20 @@ defmodule Ecto.UUID do
   Casts to a UUID.
   """
   @spec cast(t | raw | any) :: {:ok, t} | :error
-  def cast(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
-              b1, b2, b3, b4, ?-,
-              c1, c2, c3, c4, ?-,
-              d1, d2, d3, d4, ?-,
-              e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
-    << c(a1), c(a2), c(a3), c(a4),
-       c(a5), c(a6), c(a7), c(a8), ?-,
-       c(b1), c(b2), c(b3), c(b4), ?-,
-       c(c1), c(c2), c(c3), c(c4), ?-,
-       c(d1), c(d2), c(d3), c(d4), ?-,
-       c(e1), c(e2), c(e3), c(e4),
-       c(e5), c(e6), c(e7), c(e8),
-       c(e9), c(e10), c(e11), c(e12) >>
+  def cast(
+        <<a1, a2, a3, a4, a5, a6, a7, a8, ?-, b1, b2, b3, b4, ?-, c1, c2, c3, c4, ?-, d1, d2, d3,
+          d4, ?-, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12>>
+      ) do
+    <<c(a1), c(a2), c(a3), c(a4), c(a5), c(a6), c(a7), c(a8), ?-, c(b1), c(b2), c(b3), c(b4), ?-,
+      c(c1), c(c2), c(c3), c(c4), ?-, c(d1), c(d2), c(d3), c(d4), ?-, c(e1), c(e2), c(e3), c(e4),
+      c(e5), c(e6), c(e7), c(e8), c(e9), c(e10), c(e11), c(e12)>>
   catch
     :error -> :error
   else
     hex_uuid -> {:ok, hex_uuid}
   end
 
-  def cast(<< _::128 >> = raw_uuid), do: {:ok, encode(raw_uuid)}
+  def cast(<<_::128>> = raw_uuid), do: {:ok, encode(raw_uuid)}
   def cast(_), do: :error
 
   @doc """
@@ -79,25 +73,20 @@ defmodule Ecto.UUID do
   defp c(?d), do: ?d
   defp c(?e), do: ?e
   defp c(?f), do: ?f
-  defp c(_),  do: throw(:error)
+  defp c(_), do: throw(:error)
 
   @doc """
   Converts a string representing a UUID into a raw binary.
   """
   @spec dump(t | any) :: {:ok, raw} | :error
-  def dump(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
-              b1, b2, b3, b4, ?-,
-              c1, c2, c3, c4, ?-,
-              d1, d2, d3, d4, ?-,
-              e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
-    << d(a1)::4, d(a2)::4, d(a3)::4, d(a4)::4,
-       d(a5)::4, d(a6)::4, d(a7)::4, d(a8)::4,
-       d(b1)::4, d(b2)::4, d(b3)::4, d(b4)::4,
-       d(c1)::4, d(c2)::4, d(c3)::4, d(c4)::4,
-       d(d1)::4, d(d2)::4, d(d3)::4, d(d4)::4,
-       d(e1)::4, d(e2)::4, d(e3)::4, d(e4)::4,
-       d(e5)::4, d(e6)::4, d(e7)::4, d(e8)::4,
-       d(e9)::4, d(e10)::4, d(e11)::4, d(e12)::4 >>
+  def dump(
+        <<a1, a2, a3, a4, a5, a6, a7, a8, ?-, b1, b2, b3, b4, ?-, c1, c2, c3, c4, ?-, d1, d2, d3,
+          d4, ?-, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12>>
+      ) do
+    <<d(a1)::4, d(a2)::4, d(a3)::4, d(a4)::4, d(a5)::4, d(a6)::4, d(a7)::4, d(a8)::4, d(b1)::4,
+      d(b2)::4, d(b3)::4, d(b4)::4, d(c1)::4, d(c2)::4, d(c3)::4, d(c4)::4, d(d1)::4, d(d2)::4,
+      d(d3)::4, d(d4)::4, d(e1)::4, d(e2)::4, d(e3)::4, d(e4)::4, d(e5)::4, d(e6)::4, d(e7)::4,
+      d(e8)::4, d(e9)::4, d(e10)::4, d(e11)::4, d(e12)::4>>
   catch
     :error -> :error
   else
@@ -130,7 +119,7 @@ defmodule Ecto.UUID do
   defp d(?d), do: 13
   defp d(?e), do: 14
   defp d(?f), do: 15
-  defp d(_),  do: throw(:error)
+  defp d(_), do: throw(:error)
 
   @doc """
   Same as `dump/1` but raises `Ecto.ArgumentError` on invalid arguments.
@@ -150,8 +139,9 @@ defmodule Ecto.UUID do
   def load(<<_::128>> = raw_uuid), do: {:ok, encode(raw_uuid)}
 
   def load(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = string) do
-    raise ArgumentError, "trying to load string UUID as Ecto.UUID: #{inspect string}. " <>
-                         "Maybe you wanted to declare :uuid as your database field?"
+    raise ArgumentError,
+          "trying to load string UUID as Ecto.UUID: #{inspect(string)}. " <>
+            "Maybe you wanted to declare :uuid as your database field?"
   end
 
   def load(_), do: :error
@@ -187,33 +177,28 @@ defmodule Ecto.UUID do
   def autogenerate, do: generate()
 
   @spec encode(raw) :: t
-  defp encode(<< a1::4, a2::4, a3::4, a4::4,
-                 a5::4, a6::4, a7::4, a8::4,
-                 b1::4, b2::4, b3::4, b4::4,
-                 c1::4, c2::4, c3::4, c4::4,
-                 d1::4, d2::4, d3::4, d4::4,
-                 e1::4, e2::4, e3::4, e4::4,
-                 e5::4, e6::4, e7::4, e8::4,
-                 e9::4, e10::4, e11::4, e12::4 >>) do
-    << e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-,
-       e(b1), e(b2), e(b3), e(b4), ?-,
-       e(c1), e(c2), e(c3), e(c4), ?-,
-       e(d1), e(d2), e(d3), e(d4), ?-,
-       e(e1), e(e2), e(e3), e(e4), e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12) >>
+  defp encode(
+         <<a1::4, a2::4, a3::4, a4::4, a5::4, a6::4, a7::4, a8::4, b1::4, b2::4, b3::4, b4::4,
+           c1::4, c2::4, c3::4, c4::4, d1::4, d2::4, d3::4, d4::4, e1::4, e2::4, e3::4, e4::4,
+           e5::4, e6::4, e7::4, e8::4, e9::4, e10::4, e11::4, e12::4>>
+       ) do
+    <<e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-, e(b1), e(b2), e(b3), e(b4), ?-,
+      e(c1), e(c2), e(c3), e(c4), ?-, e(d1), e(d2), e(d3), e(d4), ?-, e(e1), e(e2), e(e3), e(e4),
+      e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12)>>
   end
 
   @compile {:inline, e: 1}
 
-  defp e(0),  do: ?0
-  defp e(1),  do: ?1
-  defp e(2),  do: ?2
-  defp e(3),  do: ?3
-  defp e(4),  do: ?4
-  defp e(5),  do: ?5
-  defp e(6),  do: ?6
-  defp e(7),  do: ?7
-  defp e(8),  do: ?8
-  defp e(9),  do: ?9
+  defp e(0), do: ?0
+  defp e(1), do: ?1
+  defp e(2), do: ?2
+  defp e(3), do: ?3
+  defp e(4), do: ?4
+  defp e(5), do: ?5
+  defp e(6), do: ?6
+  defp e(7), do: ?7
+  defp e(8), do: ?8
+  defp e(9), do: ?9
   defp e(10), do: ?a
   defp e(11), do: ?b
   defp e(12), do: ?c

--- a/lib/mix/ecto.ex
+++ b/lib/mix/ecto.ex
@@ -8,17 +8,17 @@ defmodule Mix.Ecto do
 
   If no repo option is given, it is retrieved from the application environment.
   """
-  @spec parse_repo([term]) :: [Ecto.Repo.t]
+  @spec parse_repo([term]) :: [Ecto.Repo.t()]
   def parse_repo(args) do
     parse_repo(args, [])
   end
 
-  defp parse_repo([key, value|t], acc) when key in ~w(--repo -r) do
-    parse_repo t, [Module.concat([value])|acc]
+  defp parse_repo([key, value | t], acc) when key in ~w(--repo -r) do
+    parse_repo(t, [Module.concat([value]) | acc])
   end
 
-  defp parse_repo([_|t], acc) do
-    parse_repo t, acc
+  defp parse_repo([_ | t], acc) do
+    parse_repo(t, acc)
   end
 
   defp parse_repo([], []) do
@@ -39,15 +39,17 @@ defmodule Mix.Ecto do
     |> Enum.uniq()
     |> case do
       [] ->
-        Mix.shell().error """
-        warning: could not find Ecto repos in any of the apps: #{inspect apps}.
+        Mix.shell().error("""
+        warning: could not find Ecto repos in any of the apps: #{inspect(apps)}.
 
         You can avoid this warning by passing the -r flag or by setting the
         repositories managed by those applications in your config/config.exs:
 
-            config #{inspect hd(apps)}, ecto_repos: [...]
-        """
+            config #{inspect(hd(apps))}, ecto_repos: [...]
+        """)
+
         []
+
       repos ->
         repos
     end
@@ -60,7 +62,7 @@ defmodule Mix.Ecto do
   @doc """
   Ensures the given module is an Ecto.Repo.
   """
-  @spec ensure_repo(module, list) :: Ecto.Repo.t
+  @spec ensure_repo(module, list) :: Ecto.Repo.t()
   def ensure_repo(repo, args) do
     # Do not pass the --force switch used by some tasks downstream
     args = List.delete(args, "--force")
@@ -78,13 +80,17 @@ defmodule Mix.Ecto do
         if function_exported?(repo, :__adapter__, 0) do
           repo
         else
-          Mix.raise "Module #{inspect repo} is not an Ecto.Repo. " <>
-                    "Please configure your app accordingly or pass a repo with the -r option."
+          Mix.raise(
+            "Module #{inspect(repo)} is not an Ecto.Repo. " <>
+              "Please configure your app accordingly or pass a repo with the -r option."
+          )
         end
 
       {:error, error} ->
-        Mix.raise "Could not load #{inspect repo}, error: #{inspect error}. " <>
-                  "Please configure your app accordingly or pass a repo with the -r option."
+        Mix.raise(
+          "Could not load #{inspect(repo)}, error: #{inspect(error)}. " <>
+            "Please configure your app accordingly or pass a repo with the -r option."
+        )
     end
   end
 
@@ -139,8 +145,10 @@ defmodule Mix.Ecto do
   """
   def no_umbrella!(task) do
     if Mix.Project.umbrella?() do
-      Mix.raise "Cannot run task #{inspect task} from umbrella project root. " <>
-                  "Change directory to one of the umbrella applications and try again"
+      Mix.raise(
+        "Cannot run task #{inspect(task)} from umbrella project root. " <>
+          "Change directory to one of the umbrella applications and try again"
+      )
     end
   end
 
@@ -149,9 +157,12 @@ defmodule Mix.Ecto do
   """
   def ensure_implements(module, behaviour, message) do
     all = Keyword.take(module.__info__(:attributes), [:behaviour])
+
     unless [behaviour] in Keyword.values(all) do
-      Mix.raise "Expected #{inspect module} to implement #{inspect behaviour} " <>
-                "in order to #{message}"
+      Mix.raise(
+        "Expected #{inspect(module)} to implement #{inspect(behaviour)} " <>
+          "in order to #{message}"
+      )
     end
   end
 end

--- a/lib/mix/tasks/ecto.create.ex
+++ b/lib/mix/tasks/ecto.create.ex
@@ -44,26 +44,34 @@ defmodule Mix.Tasks.Ecto.Create do
   @impl true
   def run(args) do
     repos = parse_repo(args)
-    {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
+    {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
 
-    Enum.each repos, fn repo ->
+    Enum.each(repos, fn repo ->
       ensure_repo(repo, args)
-      ensure_implements(repo.__adapter__, Ecto.Adapter.Storage,
-                                          "create storage for #{inspect repo}")
+
+      ensure_implements(
+        repo.__adapter__,
+        Ecto.Adapter.Storage,
+        "create storage for #{inspect(repo)}"
+      )
+
       case repo.__adapter__.storage_up(repo.config) do
         :ok ->
           unless opts[:quiet] do
-            Mix.shell().info "The database for #{inspect repo} has been created"
+            Mix.shell().info("The database for #{inspect(repo)} has been created")
           end
+
         {:error, :already_up} ->
           unless opts[:quiet] do
-            Mix.shell().info "The database for #{inspect repo} has already been created"
+            Mix.shell().info("The database for #{inspect(repo)} has already been created")
           end
+
         {:error, term} when is_binary(term) ->
-          Mix.raise "The database for #{inspect repo} couldn't be created: #{term}"
+          Mix.raise("The database for #{inspect(repo)} couldn't be created: #{term}")
+
         {:error, term} ->
-          Mix.raise "The database for #{inspect repo} couldn't be created: #{inspect term}"
+          Mix.raise("The database for #{inspect(repo)} couldn't be created: #{inspect(term)}")
       end
-    end
+    end)
   end
 end

--- a/lib/mix/tasks/ecto.drop.ex
+++ b/lib/mix/tasks/ecto.drop.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Ecto.Drop do
     quiet: :boolean,
     repo: [:keep, :string],
     no_compile: :boolean,
-    no_deps_check: :boolean,
+    no_deps_check: :boolean
   ]
 
   @moduledoc """
@@ -53,20 +53,26 @@ defmodule Mix.Tasks.Ecto.Drop do
   @impl true
   def run(args) do
     repos = parse_repo(args)
-    {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
+    {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
     opts = Keyword.merge(@default_opts, opts)
 
-    Enum.each repos, fn repo ->
+    Enum.each(repos, fn repo ->
       ensure_repo(repo, args)
-      ensure_implements(repo.__adapter__, Ecto.Adapter.Storage,
-                                          "drop storage for #{inspect repo}")
+
+      ensure_implements(
+        repo.__adapter__,
+        Ecto.Adapter.Storage,
+        "drop storage for #{inspect(repo)}"
+      )
 
       if skip_safety_warnings?() or
-         opts[:force] or
-         Mix.shell().yes?("Are you sure you want to drop the database for repo #{inspect repo}?") do
+           opts[:force] or
+           Mix.shell().yes?(
+             "Are you sure you want to drop the database for repo #{inspect(repo)}?"
+           ) do
         drop_database(repo, opts)
       end
-    end
+    end)
   end
 
   defp skip_safety_warnings? do
@@ -78,19 +84,23 @@ defmodule Mix.Tasks.Ecto.Drop do
       opts
       |> Keyword.take([:force_drop])
       |> Keyword.merge(repo.config)
+
     case repo.__adapter__.storage_down(config) do
       :ok ->
         unless opts[:quiet] do
-          Mix.shell().info "The database for #{inspect repo} has been dropped"
+          Mix.shell().info("The database for #{inspect(repo)} has been dropped")
         end
+
       {:error, :already_down} ->
         unless opts[:quiet] do
-          Mix.shell().info "The database for #{inspect repo} has already been dropped"
+          Mix.shell().info("The database for #{inspect(repo)} has already been dropped")
         end
+
       {:error, term} when is_binary(term) ->
-        Mix.raise "The database for #{inspect repo} couldn't be dropped: #{term}"
+        Mix.raise("The database for #{inspect(repo)} couldn't be dropped: #{term}")
+
       {:error, term} ->
-        Mix.raise "The database for #{inspect repo} couldn't be dropped: #{inspect term}"
+        Mix.raise("The database for #{inspect(repo)} couldn't be dropped: #{inspect(term)}")
     end
   end
 end

--- a/lib/mix/tasks/ecto.ex
+++ b/lib/mix/tasks/ecto.ex
@@ -16,15 +16,15 @@ defmodule Mix.Tasks.Ecto do
 
     case args do
       [] -> general()
-      _ -> Mix.raise "Invalid arguments, expected: mix ecto"
+      _ -> Mix.raise("Invalid arguments, expected: mix ecto")
     end
   end
 
   defp general() do
     Application.ensure_all_started(:ecto)
-    Mix.shell().info "Ecto v#{Application.spec(:ecto, :vsn)}"
-    Mix.shell().info "A toolkit for data mapping and language integrated query for Elixir."
-    Mix.shell().info "\nAvailable tasks:\n"
+    Mix.shell().info("Ecto v#{Application.spec(:ecto, :vsn)}")
+    Mix.shell().info("A toolkit for data mapping and language integrated query for Elixir.")
+    Mix.shell().info("\nAvailable tasks:\n")
     Mix.Tasks.Help.run(["--search", "ecto."])
   end
 end

--- a/lib/mix/tasks/ecto.gen.repo.ex
+++ b/lib/mix/tasks/ecto.gen.repo.ex
@@ -7,11 +7,11 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
   @shortdoc "Generates a new repository"
 
   @switches [
-    repo: [:string, :keep],
+    repo: [:string, :keep]
   ]
 
   @aliases [
-    r: :repo,
+    r: :repo
   ]
 
   @moduledoc """
@@ -40,21 +40,21 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
 
     repo =
       case Keyword.get_values(opts, :repo) do
-        [] -> Mix.raise "ecto.gen.repo expects the repository to be given as -r MyApp.Repo"
+        [] -> Mix.raise("ecto.gen.repo expects the repository to be given as -r MyApp.Repo")
         [repo] -> Module.concat([repo])
-        [_ | _] -> Mix.raise "ecto.gen.repo expects a single repository to be given"
+        [_ | _] -> Mix.raise("ecto.gen.repo expects a single repository to be given")
       end
 
-    config      = Mix.Project.config()
+    config = Mix.Project.config()
     underscored = Macro.underscore(inspect(repo))
 
     base = Path.basename(underscored)
     file = Path.join("lib", underscored) <> ".ex"
-    app  = config[:app] || :YOUR_APP_NAME
+    app = config[:app] || :YOUR_APP_NAME
     opts = [mod: repo, app: app, base: base]
 
-    create_directory Path.dirname(file)
-    create_file file, repo_template(opts)
+    create_directory(Path.dirname(file))
+    create_file(file, repo_template(opts))
     config_path = config[:config_path] || "config/config.exs"
 
     case File.read(config_path) do
@@ -62,46 +62,47 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
         check = String.contains?(contents, "import Config")
         config_first_line = get_first_config_line(check) <> "\n"
         new_contents = config_first_line <> "\n" <> config_template(opts)
-        Mix.shell().info [:green, "* updating ", :reset, config_path]
-        File.write! config_path, String.replace(contents, config_first_line, new_contents)
+        Mix.shell().info([:green, "* updating ", :reset, config_path])
+        File.write!(config_path, String.replace(contents, config_first_line, new_contents))
+
       {:error, _} ->
         config_first_line = Config |> Code.ensure_loaded?() |> get_first_config_line()
-        create_file config_path, config_first_line <> "\n\n" <> config_template(opts)
+        create_file(config_path, config_first_line <> "\n\n" <> config_template(opts))
     end
 
     open?(config_path, 3)
 
-    Mix.shell().info """
+    Mix.shell().info("""
     Don't forget to add your new repo to your supervision tree
     (typically in lib/#{app}/application.ex):
 
-        {#{inspect repo}, []}
+        {#{inspect(repo)}, []}
 
     And to add it to the list of Ecto repositories in your
     configuration files (so Ecto tasks work as expected):
 
-        config #{inspect app},
-          ecto_repos: [#{inspect repo}]
+        config #{inspect(app)},
+          ecto_repos: [#{inspect(repo)}]
 
-    """
+    """)
   end
 
   defp get_first_config_line(true), do: "import Config"
   defp get_first_config_line(false), do: "use Mix.Config"
 
-  embed_template :repo, """
+  embed_template(:repo, """
   defmodule <%= inspect @mod %> do
     use Ecto.Repo,
       otp_app: <%= inspect @app %>,
       adapter: Ecto.Adapters.Postgres
   end
-  """
+  """)
 
-  embed_template :config, """
+  embed_template(:config, """
   config <%= inspect @app %>, <%= inspect @mod %>,
     database: "<%= @app %>_<%= @base %>",
     username: "user",
     password: "pass",
     hostname: "localhost"
-  """
+  """)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule Ecto.MixProject do
         # Ecto.Schema.Metadata,
         # Mix.Ecto,
 
-        "Types": [
+        Types: [
           Ecto.Enum,
           Ecto.ParameterizedType,
           Ecto.Type,
@@ -124,7 +124,7 @@ defmodule Ecto.MixProject do
 
   defp groups_for_extras do
     [
-      "Introduction": ~r/guides\/introduction\/.?/,
+      Introduction: ~r/guides\/introduction\/.?/,
       "How-To's": ~r/guides\/howtos\/.?/
     ]
   end

--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -13,11 +13,17 @@ defmodule Ecto.Changeset.BelongsToTest do
 
     schema "authors" do
       field :title, :string
+
       belongs_to :profile, {"authors_profiles", Profile},
-        on_replace: :delete, defaults: [name: "default"]
+        on_replace: :delete,
+        defaults: [name: "default"]
+
       belongs_to :raise_profile, Profile, on_replace: :raise
       belongs_to :invalid_profile, Profile, on_replace: :mark_as_invalid, defaults: :send_to_self
-      belongs_to :update_profile, Profile, on_replace: :update, defaults: {__MODULE__, :send_to_self, [:extra]}
+
+      belongs_to :update_profile, Profile,
+        on_replace: :update,
+        defaults: {__MODULE__, :send_to_self, [:extra]}
     end
 
     def send_to_self(struct, owner, extra \\ :default) do
@@ -62,7 +68,7 @@ defmodule Ecto.Changeset.BelongsToTest do
     profile = changeset.changes.profile
     assert profile.changes == %{name: "michal"}
     assert profile.errors == []
-    assert profile.action  == :insert
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
   end
@@ -70,8 +76,8 @@ defmodule Ecto.Changeset.BelongsToTest do
   test "cast belongs_to with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{name: nil}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: {"can't be blank", [validation: :required]}]
-    assert changeset.changes.profile.action  == :insert
+    assert changeset.changes.profile.errors == [name: {"can't be blank", [validation: :required]}]
+    assert changeset.changes.profile.action == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
 
@@ -81,13 +87,17 @@ defmodule Ecto.Changeset.BelongsToTest do
   end
 
   test "cast belongs_to with existing struct updating" do
-    changeset = cast(%Author{profile: %Profile{name: "michal", id: 1}},
-                     %{"profile" => %{"name" => "new", "id" => 1}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal", id: 1}},
+        %{"profile" => %{"name" => "new", "id" => 1}},
+        :profile
+      )
 
     profile = changeset.changes.profile
     assert profile.changes == %{name: "new"}
-    assert profile.errors  == []
-    assert profile.action  == :update
+    assert profile.errors == []
+    assert profile.action == :update
     assert profile.valid?
     assert changeset.valid?
   end
@@ -99,58 +109,92 @@ defmodule Ecto.Changeset.BelongsToTest do
     assert cast(%Author{}, %{"profile" => ""}, :profile).changes == %{}
     assert cast(%Author{profile: nil}, %{"profile" => ""}, :profile).changes == %{}
 
-    loaded = put_in %Author{}.__meta__.state, :loaded
-    assert_raise RuntimeError, ~r"attempting to cast or change association `profile` .* that was not loaded", fn ->
-      cast(loaded, %{"profile" => nil}, :profile)
-    end
-    assert_raise RuntimeError, ~r"attempting to cast or change association `profile` .* that was not loaded", fn ->
-      cast(loaded, %{"profile" => ""}, :profile)
-    end
+    loaded = put_in(%Author{}.__meta__.state, :loaded)
+
+    assert_raise RuntimeError,
+                 ~r"attempting to cast or change association `profile` .* that was not loaded",
+                 fn ->
+                   cast(loaded, %{"profile" => nil}, :profile)
+                 end
+
+    assert_raise RuntimeError,
+                 ~r"attempting to cast or change association `profile` .* that was not loaded",
+                 fn ->
+                   cast(loaded, %{"profile" => ""}, :profile)
+                 end
+
     assert cast(loaded, %{}, :profile).changes == %{}
   end
 
   test "cast belongs_to discards changesets marked as ignore" do
-    changeset = cast(%Author{},
-                     %{"profile" => %{name: "michal", id: "id", action: :ignore}},
-                     :profile, with: &Profile.set_action/2)
+    changeset =
+      cast(
+        %Author{},
+        %{"profile" => %{name: "michal", id: "id", action: :ignore}},
+        :profile,
+        with: &Profile.set_action/2
+      )
+
     assert changeset.changes == %{}
   end
 
   test "cast belongs_to with existing struct replacing" do
-    changeset = cast(%Author{profile: %Profile{name: "michal", id: 1}},
-                     %{"profile" => %{"name" => "new"}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal", id: 1}},
+        %{"profile" => %{"name" => "new"}},
+        :profile
+      )
 
     profile = changeset.changes.profile
     assert profile.changes == %{name: "new"}
-    assert profile.errors  == []
-    assert profile.action  == :insert
+    assert profile.errors == []
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
 
-    changeset = cast(%Author{profile: %Profile{name: "michal", id: 2}},
-                     %{"profile" => %{"name" => "new", "id" => 5}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal", id: 2}},
+        %{"profile" => %{"name" => "new", "id" => 5}},
+        :profile
+      )
+
     profile = changeset.changes.profile
     assert profile.changes == %{name: "new", id: 5}
-    assert profile.errors  == []
-    assert profile.action  == :insert
+    assert profile.errors == []
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
 
     assert_raise RuntimeError, ~r"cannot update related", fn ->
-      cast(%Author{profile: %Profile{name: "michal", id: "michal"}},
-           %{"profile" => %{"name" => "new", "id" => "new"}},
-           :profile, with: &Profile.set_action/2)
+      cast(
+        %Author{profile: %Profile{name: "michal", id: "michal"}},
+        %{"profile" => %{"name" => "new", "id" => "new"}},
+        :profile,
+        with: &Profile.set_action/2
+      )
     end
   end
 
   test "cast belongs_to without changes skips" do
-    changeset = cast(%Author{profile: %Profile{name: "michal", id: 1}},
-                     %{"profile" => %{"id" => 1}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal", id: 1}},
+        %{"profile" => %{"id" => 1}},
+        :profile
+      )
+
     assert changeset.changes == %{}
     assert changeset.errors == []
 
-    changeset = cast(%Author{profile: %Profile{name: "michal", id: 1}},
-                     %{"profile" => %{"id" => "1"}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal", id: 1}},
+        %{"profile" => %{"id" => "1"}},
+        :profile
+      )
+
     assert changeset.changes == %{}
     assert changeset.errors == []
   end
@@ -161,7 +205,9 @@ defmodule Ecto.Changeset.BelongsToTest do
     assert changeset.changes == %{}
     assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
-    changeset = cast(%Author{}, %{}, :profile, required: true, required_message: "a custom message")
+    changeset =
+      cast(%Author{}, %{}, :profile, required: true, required_message: "a custom message")
+
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
     assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
@@ -194,28 +240,38 @@ defmodule Ecto.Changeset.BelongsToTest do
   end
 
   test "cast belongs_to with custom changeset" do
-    changeset = cast(%Author{}, %{"profile" => %{}}, :profile, with: &Profile.optional_changeset/2)
-    assert (changeset.types.profile |> elem(1)).on_cast == &Profile.optional_changeset/2
+    changeset =
+      cast(%Author{}, %{"profile" => %{}}, :profile, with: &Profile.optional_changeset/2)
+
+    assert (changeset.types.profile |> elem(1)).on_cast == (&Profile.optional_changeset/2)
 
     profile = changeset.changes.profile
     assert profile.data.__meta__.source == "authors_profiles"
     assert profile.changes == %{}
-    assert profile.errors  == []
-    assert profile.action  == :insert
+    assert profile.errors == []
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
   end
 
   test "cast belongs_to keeps appropriate action from changeset" do
-    changeset = cast(%Author{profile: %Profile{id: "id"}},
-                     %{"profile" => %{"name" => "michal", "id" => "id"}},
-                     :profile, with: &Profile.set_action/2)
+    changeset =
+      cast(
+        %Author{profile: %Profile{id: "id"}},
+        %{"profile" => %{"name" => "michal", "id" => "id"}},
+        :profile,
+        with: &Profile.set_action/2
+      )
+
     assert changeset.changes.profile.action == :update
 
     assert_raise RuntimeError, ~r"cannot update related", fn ->
-      cast(%Author{profile: %Profile{id: "old"}},
-           %{"profile" => %{"name" => "michal", "id" => "new"}},
-           :profile, with: &Profile.set_action/2)
+      cast(
+        %Author{profile: %Profile{id: "old"}},
+        %{"profile" => %{"name" => "michal", "id" => "new"}},
+        :profile,
+        with: &Profile.set_action/2
+      )
     end
   end
 
@@ -238,11 +294,13 @@ defmodule Ecto.Changeset.BelongsToTest do
     assert changeset.changes.raise_profile.action == :update
 
     params = %{"raise_profile" => nil}
+
     assert_raise RuntimeError, ~r"you are attempting to change relation", fn ->
       cast(schema, params, :raise_profile)
     end
 
     params = %{"raise_profile" => %{"name" => "new", "id" => 2}}
+
     assert_raise RuntimeError, ~r"you are attempting to change relation", fn ->
       cast(schema, params, :raise_profile)
     end
@@ -261,9 +319,17 @@ defmodule Ecto.Changeset.BelongsToTest do
     assert changeset.errors == [invalid_profile: {"is invalid", [validation: :assoc, type: :map]}]
     refute changeset.valid?
 
-    changeset = cast(schema, %{"invalid_profile" => nil}, :invalid_profile, invalid_message: "a custom message")
+    changeset =
+      cast(schema, %{"invalid_profile" => nil}, :invalid_profile,
+        invalid_message: "a custom message"
+      )
+
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: {"a custom message", [validation: :assoc, type: :map]}]
+
+    assert changeset.errors == [
+             invalid_profile: {"a custom message", [validation: :assoc, type: :map]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -294,8 +360,8 @@ defmodule Ecto.Changeset.BelongsToTest do
   end
 
   test "cast belongs_to with on_replace: :update" do
-    {:ok, schema} = TestRepo.insert(%Author{title: "Title",
-      update_profile: %Profile{id: 1, name: "Enio"}})
+    {:ok, schema} =
+      TestRepo.insert(%Author{title: "Title", update_profile: %Profile{id: 1, name: "Enio"}})
 
     changeset = cast(schema, %{"update_profile" => %{id: 2, name: "Jose"}}, :update_profile)
     assert changeset.changes.update_profile.changes == %{name: "Jose", id: 2}
@@ -307,7 +373,7 @@ defmodule Ecto.Changeset.BelongsToTest do
   test "cast belongs_to twice" do
     schema = %Author{}
     params = %{profile: %{name: "Bruce Wayne", id: 1}}
-    schema = cast(schema, params, :profile) |> Changeset.apply_changes
+    schema = cast(schema, params, :profile) |> Changeset.apply_changes()
     params = %{profile: %{name: "Batman", id: 1}}
     changeset = cast(schema, params, :profile)
     changeset = cast(changeset, params, :profile)
@@ -331,13 +397,11 @@ defmodule Ecto.Changeset.BelongsToTest do
     assoc_schema = %Profile{}
     assoc_schema_changeset = Changeset.change(assoc_schema, name: "michal")
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, assoc_schema_changeset, nil)
+    assert {:ok, changeset, true} = Relation.change(assoc, assoc_schema_changeset, nil)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, assoc_schema_changeset, assoc_schema)
+    assert {:ok, changeset, true} = Relation.change(assoc, assoc_schema_changeset, assoc_schema)
     assert changeset.action == :update
     assert changeset.changes == %{name: "michal"}
 
@@ -347,50 +411,42 @@ defmodule Ecto.Changeset.BelongsToTest do
     assert :ignore = Relation.change(assoc, empty_changeset, assoc_schema)
 
     assoc_with_id = %Profile{id: 2}
-    assert {:ok, _, true} =
-      Relation.change(assoc, %Profile{id: 1}, assoc_with_id)
+    assert {:ok, _, true} = Relation.change(assoc, %Profile{id: 1}, assoc_with_id)
   end
 
   test "change belongs_to with attributes" do
     assoc = Author.__schema__(:association, :profile)
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, %{name: "michal"}, nil)
+    assert {:ok, changeset, true} = Relation.change(assoc, %{name: "michal"}, nil)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
     profile = %Profile{name: "other"} |> Ecto.put_meta(state: :loaded)
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, %{name: "michal"}, profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, %{name: "michal"}, profile)
     assert changeset.action == :update
     assert changeset.changes == %{name: "michal"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, [name: "michal"], profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, [name: "michal"], profile)
     assert changeset.action == :update
     assert changeset.changes == %{name: "michal"}
 
     profile = %Profile{name: "other"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, %{name: "michal"}, profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, %{name: "michal"}, profile)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, [name: "michal"], profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, [name: "michal"], profile)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
     # Empty attributes
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, %{}, profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, %{}, profile)
     assert changeset.action == :insert
     assert changeset.changes == %{}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, [], profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, [], profile)
     assert changeset.action == :insert
     assert changeset.changes == %{}
   end
@@ -399,16 +455,17 @@ defmodule Ecto.Changeset.BelongsToTest do
     assoc = Author.__schema__(:association, :profile)
     profile = %Profile{name: "michal"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, profile, nil)
+    assert {:ok, changeset, true} = Relation.change(assoc, profile, nil)
     assert changeset.action == :insert
 
     assert {:ok, changeset, true} =
-      Relation.change(assoc, Ecto.put_meta(profile, state: :loaded), nil)
+             Relation.change(assoc, Ecto.put_meta(profile, state: :loaded), nil)
+
     assert changeset.action == :update
 
     assert {:ok, changeset, true} =
-      Relation.change(assoc, Ecto.put_meta(profile, state: :deleted), nil)
+             Relation.change(assoc, Ecto.put_meta(profile, state: :deleted), nil)
+
     assert changeset.action == :delete
   end
 
@@ -431,6 +488,7 @@ defmodule Ecto.Changeset.BelongsToTest do
 
     # Replacing
     changeset = %{Changeset.change(assoc_schema, name: "michal") | action: :insert}
+
     assert_raise RuntimeError, ~r/cannot insert related/, fn ->
       Relation.change(assoc, changeset, assoc_schema)
     end
@@ -538,8 +596,9 @@ defmodule Ecto.Changeset.BelongsToTest do
 
     changeset =
       %Author{}
-      |> Changeset.change
+      |> Changeset.change()
       |> Changeset.put_assoc(:profile, profile_changeset)
+
     assert Changeset.get_field(changeset, :profile) == profile
     assert Changeset.fetch_field(changeset, :profile) == {:changes, profile}
 

--- a/test/ecto/changeset/embedded_no_pk_test.exs
+++ b/test/ecto/changeset/embedded_no_pk_test.exs
@@ -87,7 +87,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     profile = changeset.changes.profile
     assert profile.changes == %{name: "michal"}
     assert profile.errors == []
-    assert profile.action  == :insert
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
   end
@@ -95,8 +95,8 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   test "cast embeds_one with invalid params" do
     changeset = cast(%Author{}, %{"profile" => %{}}, :profile)
     assert changeset.changes.profile.changes == %{}
-    assert changeset.changes.profile.errors  == [name: {"can't be blank", [validation: :required]}]
-    assert changeset.changes.profile.action  == :insert
+    assert changeset.changes.profile.errors == [name: {"can't be blank", [validation: :required]}]
+    assert changeset.changes.profile.action == :insert
     refute changeset.changes.profile.valid?
     refute changeset.valid?
 
@@ -106,28 +106,41 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   test "cast embeds_one replacing" do
-    changeset = cast(%Author{profile: %Profile{name: "michal"}},
-                     %{"profile" => %{"name" => "new"}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal"}},
+        %{"profile" => %{"name" => "new"}},
+        :profile
+      )
+
     profile = changeset.changes.profile
     assert profile.changes == %{name: "new"}
-    assert profile.errors  == []
-    assert profile.action  == :insert
+    assert profile.errors == []
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
 
-    changeset = cast(%Author{profile: %Profile{name: "michal"}},
-                     %{"profile" => %{name: "michal"}}, :profile)
+    changeset =
+      cast(
+        %Author{profile: %Profile{name: "michal"}},
+        %{"profile" => %{name: "michal"}},
+        :profile
+      )
+
     profile = changeset.changes.profile
     assert profile.changes == %{name: "michal"}
-    assert profile.errors  == []
-    assert profile.action  == :insert
+    assert profile.errors == []
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
 
     assert_raise RuntimeError, ~r"cannot update related", fn ->
-      cast(%Author{profile: %Profile{name: "michal"}},
-           %{"profile" => %{"name" => "new"}},
-           :profile, with: &Profile.set_action/2)
+      cast(
+        %Author{profile: %Profile{name: "michal"}},
+        %{"profile" => %{"name" => "new"}},
+        :profile,
+        with: &Profile.set_action/2
+      )
     end
   end
 
@@ -137,7 +150,12 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     assert changeset.changes == %{}
     assert changeset.errors == [profile: {"can't be blank", [validation: :required]}]
 
-    changeset = cast(%Author{profile: nil}, %{}, :profile, required: true, required_message: "a custom message")
+    changeset =
+      cast(%Author{profile: nil}, %{}, :profile,
+        required: true,
+        required_message: "a custom message"
+      )
+
     assert changeset.required == [:profile]
     assert changeset.changes == %{}
     assert changeset.errors == [profile: {"a custom message", [validation: :required]}]
@@ -165,14 +183,16 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   test "cast embeds_one with custom changeset" do
-    changeset = cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile,
-                     with: &Profile.optional_changeset/2)
+    changeset =
+      cast(%Author{}, %{"profile" => %{"name" => "michal"}}, :profile,
+        with: &Profile.optional_changeset/2
+      )
 
-    assert (changeset.types.profile |> elem(1)).on_cast == &Profile.optional_changeset/2
+    assert (changeset.types.profile |> elem(1)).on_cast == (&Profile.optional_changeset/2)
     profile = changeset.changes.profile
     assert profile.changes == %{name: "michal"}
-    assert profile.errors  == []
-    assert profile.action  == :insert
+    assert profile.errors == []
+    assert profile.action == :insert
     assert profile.valid?
     assert changeset.valid?
   end
@@ -189,11 +209,13 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     schema = %Author{raise_profile: %Profile{}}
 
     params = %{"raise_profile" => nil}
+
     assert_raise RuntimeError, ~r"you are attempting to change relation", fn ->
       cast(schema, params, :raise_profile)
     end
 
     params = %{"raise_profile" => %{"name" => "new"}}
+
     assert_raise RuntimeError, ~r"you are attempting to change relation", fn ->
       cast(schema, params, :raise_profile)
     end
@@ -212,15 +234,22 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     assert changeset.errors == [invalid_profile: {"is invalid", [validation: :embed, type: :map]}]
     refute changeset.valid?
 
-    changeset = cast(schema, %{"invalid_profile" => nil}, :invalid_profile, invalid_message: "a custom message")
+    changeset =
+      cast(schema, %{"invalid_profile" => nil}, :invalid_profile,
+        invalid_message: "a custom message"
+      )
+
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_profile: {"a custom message", [validation: :embed, type: :map]}]
+
+    assert changeset.errors == [
+             invalid_profile: {"a custom message", [validation: :embed, type: :map]}
+           ]
+
     refute changeset.valid?
   end
 
   test "cast embeds_one with on_replace: :update" do
-    {:ok, schema} = TestRepo.insert(%Author{name: "Enio",
-      update_profile: %Profile{name: "Enio"}})
+    {:ok, schema} = TestRepo.insert(%Author{name: "Enio", update_profile: %Profile{name: "Enio"}})
 
     changeset = cast(schema, %{"update_profile" => %{id: 2, name: "Jose"}}, :update_profile)
     assert changeset.changes.update_profile.changes == %{name: "Jose"}
@@ -230,8 +259,10 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   test "raises when :update is used on embeds_many" do
-    error_message = "invalid `:on_replace` option for :tags. The only valid " <>
-      "options are: `:raise`, `:mark_as_invalid`, `:delete`"
+    error_message =
+      "invalid `:on_replace` option for :tags. The only valid " <>
+        "options are: `:raise`, `:mark_as_invalid`, `:delete`"
+
     assert_raise ArgumentError, error_message, fn ->
       defmodule Topic do
         use Ecto.Schema
@@ -249,8 +280,8 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts)
     [post_change] = changeset.changes.posts
     assert post_change.changes == %{title: "hello"}
-    assert post_change.errors  == []
-    assert post_change.action  == :insert
+    assert post_change.errors == []
+    assert post_change.action == :insert
     assert post_change.valid?
     assert changeset.valid?
   end
@@ -259,14 +290,26 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     changeset = cast(%Author{}, %{"posts" => %{0 => %{"title" => "hello"}}}, :posts)
     [post_change] = changeset.changes.posts
     assert post_change.changes == %{title: "hello"}
-    assert post_change.errors  == []
-    assert post_change.action  == :insert
+    assert post_change.errors == []
+    assert post_change.action == :insert
     assert post_change.valid?
     assert changeset.valid?
   end
 
   test "cast embeds_many with map with numbered string keys" do
-    changeset = cast(%Author{}, %{"posts" => %{"1" => %{"title" => "one"}, "2" => %{"title" => "two"}, "10" => %{"title" => "ten"}}}, :posts)
+    changeset =
+      cast(
+        %Author{},
+        %{
+          "posts" => %{
+            "1" => %{"title" => "one"},
+            "2" => %{"title" => "two"},
+            "10" => %{"title" => "ten"}
+          }
+        },
+        :posts
+      )
+
     [one, two, ten] = changeset.changes.posts
     assert one.changes == %{title: "one"}
     assert two.changes == %{title: "two"}
@@ -275,7 +318,13 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   test "cast embeds_many with map with non-numbered keys" do
-    changeset = cast(%Author{}, %{"posts" => %{"b" => %{"title" => "two"}, "a" => %{"title" => "one"}}}, :posts)
+    changeset =
+      cast(
+        %Author{},
+        %{"posts" => %{"b" => %{"title" => "two"}, "a" => %{"title" => "one"}}},
+        :posts
+      )
+
     [one, two] = changeset.changes.posts
     assert one.changes == %{title: "one"}
     assert two.changes == %{title: "two"}
@@ -283,18 +332,22 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   test "cast embeds_many with custom changeset" do
-    changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]},
-                     :posts, with: &Post.optional_changeset/2)
+    changeset =
+      cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts,
+        with: &Post.optional_changeset/2
+      )
+
     [post_change] = changeset.changes.posts
     assert post_change.changes == %{title: "hello"}
-    assert post_change.errors  == []
-    assert post_change.action  == :insert
+    assert post_change.errors == []
+    assert post_change.action == :insert
     assert post_change.valid?
     assert changeset.valid?
   end
 
   test "cast embeds_many with invalid operation" do
     params = %{"posts" => [%{"title" => "new"}]}
+
     assert_raise RuntimeError, ~r"cannot update related", fn ->
       cast(%Author{posts: []}, params, :posts, with: &Post.set_action/2)
     end
@@ -315,8 +368,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
   end
 
   test "cast embeds_many replacing" do
-    changeset = cast(%Author{posts: [%Post{title: "hello"}]},
-                     %{"posts" => [%{}]}, :posts)
+    changeset = cast(%Author{posts: [%Post{title: "hello"}]}, %{"posts" => [%{}]}, :posts)
     [old_changeset, new_changeset] = changeset.changes.posts
     assert old_changeset.changes == %{}
     assert old_changeset.action == :replace
@@ -345,6 +397,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
 
   test "cast embeds_many with on_replace: :raise" do
     schema = %Author{raise_posts: [%Post{}]}
+
     assert_raise RuntimeError, ~r"you are attempting to change relation", fn ->
       cast(schema, %{"raise_posts" => []}, :raise_posts)
     end
@@ -359,12 +412,20 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
 
     changeset = cast(schema, %{"invalid_posts" => []}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: {"is invalid", [validation: :embed, type: {:array, :map}]}]
+
+    assert changeset.errors == [
+             invalid_posts: {"is invalid", [validation: :embed, type: {:array, :map}]}
+           ]
+
     refute changeset.valid?
 
     changeset = cast(schema, %{"invalid_posts" => [%{}]}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: {"is invalid", [validation: :embed, type: {:array, :map}]}]
+
+    assert changeset.errors == [
+             invalid_posts: {"is invalid", [validation: :embed, type: {:array, :map}]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -379,37 +440,31 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     embed_schema = %Profile{}
     embed_schema_changeset = Changeset.change(embed_schema, name: "michal")
 
-    assert {:ok, changeset, true} =
-      Relation.change(embed, embed_schema_changeset, nil)
+    assert {:ok, changeset, true} = Relation.change(embed, embed_schema_changeset, nil)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
     empty_changeset = Changeset.change(embed_schema)
-    assert {:ok, _, true} =
-      Relation.change(embed, empty_changeset, embed_schema)
+    assert {:ok, _, true} = Relation.change(embed, empty_changeset, embed_schema)
 
     embed_with_id = %Profile{}
-    assert {:ok, _, true} =
-      Relation.change(embed, %Profile{}, embed_with_id)
+    assert {:ok, _, true} = Relation.change(embed, %Profile{}, embed_with_id)
   end
 
   test "change embeds_one with attributes" do
     assoc = Author.__schema__(:embed, :profile)
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, %{name: "michal"}, nil)
+    assert {:ok, changeset, true} = Relation.change(assoc, %{name: "michal"}, nil)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
     profile = %Profile{name: "other"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, %{name: "michal"}, profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, %{name: "michal"}, profile)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(assoc, [name: "michal"], profile)
+    assert {:ok, changeset, true} = Relation.change(assoc, [name: "michal"], profile)
     assert changeset.action == :insert
     assert changeset.changes == %{name: "michal"}
   end
@@ -418,8 +473,7 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     embed = Author.__schema__(:embed, :profile)
     profile = %Profile{name: "michal"}
 
-    assert {:ok, changeset, true} =
-      Relation.change(embed, profile, nil)
+    assert {:ok, changeset, true} = Relation.change(embed, profile, nil)
     assert changeset.action == :insert
   end
 
@@ -488,45 +542,46 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     assert {:ok, [], true} = Relation.change(embed, [], [])
 
     assert {:ok, [old_changeset, new_changeset], true} =
-      Relation.change(embed, [%Post{}], [%Post{}])
+             Relation.change(embed, [%Post{}], [%Post{}])
+
     assert old_changeset.action == :replace
     assert new_changeset.action == :insert
 
     embed_schema_changeset = Changeset.change(%Post{}, title: "hello")
-    assert {:ok, [changeset], true} =
-      Relation.change(embed, [embed_schema_changeset], [])
+    assert {:ok, [changeset], true} = Relation.change(embed, [embed_schema_changeset], [])
     assert changeset.action == :insert
     assert changeset.changes == %{title: "hello"}
 
     embed_schema = %Post{}
     embed_schema_changeset = Changeset.change(embed_schema, title: "hello")
+
     assert {:ok, [old_changeset, new_changeset], true} =
-      Relation.change(embed, [embed_schema_changeset], [embed_schema])
+             Relation.change(embed, [embed_schema_changeset], [embed_schema])
+
     assert old_changeset.action == :replace
     assert old_changeset.changes == %{}
     assert new_changeset.action == :insert
     assert new_changeset.changes == %{title: "hello"}
 
-    assert {:ok, [changeset], true} =
-      Relation.change(embed, [], [embed_schema_changeset])
+    assert {:ok, [changeset], true} = Relation.change(embed, [], [embed_schema_changeset])
     assert changeset.action == :replace
 
     empty_changeset = Changeset.change(embed_schema)
-    assert {:ok, _, true} =
-      Relation.change(embed, [empty_changeset], [embed_schema])
+    assert {:ok, _, true} = Relation.change(embed, [empty_changeset], [embed_schema])
   end
 
   test "change embeds_many with attributes" do
     assoc = Author.__schema__(:embed, :posts)
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [%{title: "hello"}], [])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [%{title: "hello"}], [])
     assert changeset.action == :insert
     assert changeset.changes == %{title: "hello"}
 
     post = %Post{title: "other"} |> Ecto.put_meta(state: :loaded)
+
     assert {:ok, [old_changeset, new_changeset], true} =
-      Relation.change(assoc, [[title: "hello"]], [post])
+             Relation.change(assoc, [[title: "hello"]], [post])
+
     assert old_changeset.action == :replace
     assert old_changeset.changes == %{}
     assert new_changeset.action == :insert
@@ -537,16 +592,17 @@ defmodule Ecto.Changeset.EmbeddedNoPkTest do
     embed = Author.__schema__(:embed, :posts)
     post = %Post{title: "hello"}
 
-    assert {:ok, [changeset], true} =
-      Relation.change(embed, [post], [])
+    assert {:ok, [changeset], true} = Relation.change(embed, [post], [])
     assert changeset.action == :insert
 
     assert {:ok, [changeset], true} =
-      Relation.change(embed, [Ecto.put_meta(post, state: :loaded)], [])
+             Relation.change(embed, [Ecto.put_meta(post, state: :loaded)], [])
+
     assert changeset.action == :update
 
     assert {:ok, [changeset], true} =
-      Relation.change(embed, [Ecto.put_meta(post, state: :deleted)], [])
+             Relation.change(embed, [Ecto.put_meta(post, state: :deleted)], [])
+
     assert changeset.action == :delete
   end
 

--- a/test/ecto/changeset/many_to_many_test.exs
+++ b/test/ecto/changeset/many_to_many_test.exs
@@ -30,9 +30,20 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
     schema "authors" do
       field :title, :string
-      many_to_many :posts, Post, join_through: "authors_posts", on_replace: :delete, defaults: [title: "default"]
-      many_to_many :raise_posts, Post, join_through: "authors_posts", on_replace: :raise, defaults: {__MODULE__, :send_to_self, [:extra]}
-      many_to_many :invalid_posts, Post, join_through: "authors_posts", on_replace: :mark_as_invalid
+
+      many_to_many :posts, Post,
+        join_through: "authors_posts",
+        on_replace: :delete,
+        defaults: [title: "default"]
+
+      many_to_many :raise_posts, Post,
+        join_through: "authors_posts",
+        on_replace: :raise,
+        defaults: {__MODULE__, :send_to_self, [:extra]}
+
+      many_to_many :invalid_posts, Post,
+        join_through: "authors_posts",
+        on_replace: :mark_as_invalid
     end
 
     def send_to_self(struct, owner, extra) do
@@ -56,7 +67,9 @@ defmodule Ecto.Changeset.ManyToManyTest do
   end
 
   test "cast many_to_many with MFA defaults" do
-    changeset = cast(%Author{title: "Title"}, %{"raise_posts" => [%{title: "Title"}]}, :raise_posts)
+    changeset =
+      cast(%Author{title: "Title"}, %{"raise_posts" => [%{title: "Title"}]}, :raise_posts)
+
     assert_received {:defaults, %Post{id: nil}, %Author{title: "Title"}, :extra}
     [post_change] = changeset.changes.raise_posts
     assert post_change.data.id == 13
@@ -69,8 +82,8 @@ defmodule Ecto.Changeset.ManyToManyTest do
     changeset = cast(%Author{}, %{"posts" => [%{"title" => "hello"}]}, :posts)
     [post_change] = changeset.changes.posts
     assert post_change.changes == %{title: "hello"}
-    assert post_change.errors  == []
-    assert post_change.action  == :insert
+    assert post_change.errors == []
+    assert post_change.action == :insert
     assert post_change.valid?
     assert changeset.valid?
   end
@@ -79,8 +92,8 @@ defmodule Ecto.Changeset.ManyToManyTest do
     changeset = cast(%Author{}, %{"posts" => %{0 => %{"title" => "hello"}}}, :posts)
     [post_change] = changeset.changes.posts
     assert post_change.changes == %{title: "hello"}
-    assert post_change.errors  == []
-    assert post_change.action  == :insert
+    assert post_change.errors == []
+    assert post_change.action == :insert
     assert post_change.valid?
     assert changeset.valid?
   end
@@ -89,27 +102,37 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assert cast(%Author{}, %{"posts" => []}, :posts).changes == %{posts: []}
     assert cast(%Author{posts: []}, %{"posts" => []}, :posts).changes == %{}
 
-    loaded = put_in %Author{}.__meta__.state, :loaded
-    assert_raise RuntimeError, ~r"attempting to cast or change association `posts` .* that was not loaded", fn ->
-      cast(loaded, %{"posts" => []}, :posts)
-    end
+    loaded = put_in(%Author{}.__meta__.state, :loaded)
+
+    assert_raise RuntimeError,
+                 ~r"attempting to cast or change association `posts` .* that was not loaded",
+                 fn ->
+                   cast(loaded, %{"posts" => []}, :posts)
+                 end
+
     assert cast(loaded, %{}, :posts).changes == %{}
   end
 
   # Please note the order is important in this test.
   test "cast many_to_many changing schemas" do
-    posts = [%Post{title: "first", id: 1},
-             %Post{title: "second", id: 2},
-             %Post{title: "third", id: 3}]
-    params = [%{"title" => "new"},
-              %{"id" => 2, "title" => nil},
-              %{"id" => 3, "title" => "new name"}]
+    posts = [
+      %Post{title: "first", id: 1},
+      %Post{title: "second", id: 2},
+      %Post{title: "third", id: 3}
+    ]
+
+    params = [
+      %{"title" => "new"},
+      %{"id" => 2, "title" => nil},
+      %{"id" => 3, "title" => "new name"}
+    ]
 
     changeset = cast(%Author{posts: posts}, %{"posts" => params}, :posts)
     [first, new, second, third] = changeset.changes.posts
 
     assert first.data.id == 1
-    assert first.required == [] # Check for not running changeset function
+    # Check for not running changeset function
+    assert first.required == []
     assert first.action == :replace
     assert first.valid?
 
@@ -131,6 +154,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
   test "cast many_to_many with invalid operation" do
     params = %{"posts" => [%{"id" => 1, "title" => "new"}]}
+
     assert_raise RuntimeError, ~r"cannot update related", fn ->
       cast(%Author{posts: []}, params, :posts, with: &Post.set_action/2)
     end
@@ -155,16 +179,21 @@ defmodule Ecto.Changeset.ManyToManyTest do
   end
 
   test "cast many_to_many without changes skips" do
-    changeset = cast(%Author{posts: [%Post{title: "hello", id: 1}]},
-                     %{"posts" => [%{"id" => 1}]}, :posts)
+    changeset =
+      cast(%Author{posts: [%Post{title: "hello", id: 1}]}, %{"posts" => [%{"id" => 1}]}, :posts)
 
     refute Map.has_key?(changeset.changes, :posts)
   end
 
   test "cast many_to_many discards changesets marked as ignore" do
-    changeset = cast(%Author{},
-                     %{"posts" => [%{title: "oops", action: :ignore}]},
-                     :posts, with: &Post.set_action/2)
+    changeset =
+      cast(
+        %Author{},
+        %{"posts" => [%{title: "oops", action: :ignore}]},
+        :posts,
+        with: &Post.set_action/2
+      )
+
     assert changeset.changes == %{}
 
     posts = [
@@ -172,10 +201,11 @@ defmodule Ecto.Changeset.ManyToManyTest do
       %{title: "oops", action: :ignore},
       %{title: "world", action: :insert}
     ]
-    changeset = cast(%Author{}, %{"posts" => posts},
-                     :posts, with: &Post.set_action/2)
+
+    changeset = cast(%Author{}, %{"posts" => posts}, :posts, with: &Post.set_action/2)
+
     assert Enum.map(changeset.changes.posts, &Ecto.Changeset.get_change(&1, :title)) ==
-           ["hello", "world"]
+             ["hello", "world"]
   end
 
   test "cast many_to_many when required" do
@@ -189,7 +219,9 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assert changeset.changes == %{}
     assert changeset.errors == [posts: {"can't be blank", [validation: :required]}]
 
-    changeset = cast(%Author{posts: []}, %{}, :posts, required: true, required_message: "a custom message")
+    changeset =
+      cast(%Author{posts: []}, %{}, :posts, required: true, required_message: "a custom message")
+
     assert changeset.required == [:posts]
     assert changeset.changes == %{}
     assert changeset.errors == [posts: {"a custom message", [validation: :required]}]
@@ -213,6 +245,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
   test "cast many_to_many with on_replace: :raise" do
     schema = %Author{raise_posts: [%Post{id: 1}]}
+
     assert_raise RuntimeError, ~r"you are attempting to change relation", fn ->
       cast(schema, %{"raise_posts" => []}, :raise_posts)
     end
@@ -227,17 +260,33 @@ defmodule Ecto.Changeset.ManyToManyTest do
 
     changeset = cast(schema, %{"invalid_posts" => []}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: {"is invalid", [validation: :assoc, type: {:array, :map}]}]
+
+    assert changeset.errors == [
+             invalid_posts: {"is invalid", [validation: :assoc, type: {:array, :map}]}
+           ]
+
     refute changeset.valid?
 
     changeset = cast(schema, %{"invalid_posts" => [%{"id" => 2}]}, :invalid_posts)
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: {"is invalid", [validation: :assoc, type: {:array, :map}]}]
+
+    assert changeset.errors == [
+             invalid_posts: {"is invalid", [validation: :assoc, type: {:array, :map}]}
+           ]
+
     refute changeset.valid?
 
-    changeset = cast(schema, %{"invalid_posts" => [%{"id" => 2}]}, :invalid_posts, invalid_message: "a custom message")
+    changeset =
+      cast(schema, %{"invalid_posts" => [%{"id" => 2}]}, :invalid_posts,
+        invalid_message: "a custom message"
+      )
+
     assert changeset.changes == %{}
-    assert changeset.errors == [invalid_posts: {"a custom message", [validation: :assoc, type: {:array, :map}]}]
+
+    assert changeset.errors == [
+             invalid_posts: {"a custom message", [validation: :assoc, type: {:array, :map}]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -245,7 +294,7 @@ defmodule Ecto.Changeset.ManyToManyTest do
     schema = %Author{}
 
     params = %{posts: [%{title: "hello", id: 1}]}
-    schema = cast(schema, params, :posts) |> Changeset.apply_changes
+    schema = cast(schema, params, :posts) |> Changeset.apply_changes()
     params = %{posts: []}
     changeset = cast(schema, params, :posts)
     changeset = cast(changeset, params, :posts)
@@ -264,55 +313,52 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assert {:ok, [], true} = Relation.change(assoc, [], [])
 
     assert {:ok, [old_changeset, new_changeset], true} =
-      Relation.change(assoc, [%Post{id: 1}], [%Post{id: 2}])
+             Relation.change(assoc, [%Post{id: 1}], [%Post{id: 2}])
+
     assert old_changeset.action == :replace
     assert new_changeset.action == :insert
 
     assoc_schema_changeset = Changeset.change(%Post{}, title: "hello")
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [assoc_schema_changeset], [])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [assoc_schema_changeset], [])
     assert changeset.action == :insert
     assert changeset.changes == %{title: "hello"}
 
     assoc_schema = %Post{id: 1}
     assoc_schema_changeset = Changeset.change(assoc_schema, title: "hello")
+
     assert {:ok, [changeset], true} =
-      Relation.change(assoc, [assoc_schema_changeset], [assoc_schema])
+             Relation.change(assoc, [assoc_schema_changeset], [assoc_schema])
+
     assert changeset.action == :update
     assert changeset.changes == %{title: "hello"}
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [], [assoc_schema_changeset])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [], [assoc_schema_changeset])
     assert changeset.action == :replace
 
     assert :ignore =
-      Relation.change(assoc, [%{assoc_schema_changeset | action: :ignore}], [assoc_schema])
-    assert :ignore =
-      Relation.change(assoc, [%{assoc_schema_changeset | action: :ignore}], [])
+             Relation.change(assoc, [%{assoc_schema_changeset | action: :ignore}], [assoc_schema])
+
+    assert :ignore = Relation.change(assoc, [%{assoc_schema_changeset | action: :ignore}], [])
 
     empty_changeset = Changeset.change(assoc_schema)
-    assert :ignore =
-      Relation.change(assoc, [empty_changeset], [assoc_schema])
+    assert :ignore = Relation.change(assoc, [empty_changeset], [assoc_schema])
   end
 
   test "change many_to_many with attributes" do
     assoc = Author.__schema__(:association, :posts)
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [%{title: "hello"}], [])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [%{title: "hello"}], [])
     assert changeset.action == :insert
     assert changeset.changes == %{title: "hello"}
 
     post = %Post{title: "other"} |> Ecto.put_meta(state: :loaded)
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [%{title: "hello"}], [post])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [%{title: "hello"}], [post])
     assert changeset.action == :update
     assert changeset.changes == %{title: "hello"}
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [[title: "hello"]], [post])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [[title: "hello"]], [post])
     assert changeset.action == :update
     assert changeset.changes == %{title: "hello"}
   end
@@ -321,16 +367,17 @@ defmodule Ecto.Changeset.ManyToManyTest do
     assoc = Author.__schema__(:association, :posts)
     post = %Post{title: "hello"}
 
-    assert {:ok, [changeset], true} =
-      Relation.change(assoc, [post], [])
+    assert {:ok, [changeset], true} = Relation.change(assoc, [post], [])
     assert changeset.action == :insert
 
     assert {:ok, [changeset], true} =
-      Relation.change(assoc, [Ecto.put_meta(post, state: :loaded)], [])
+             Relation.change(assoc, [Ecto.put_meta(post, state: :loaded)], [])
+
     assert changeset.action == :update
 
     assert {:ok, [changeset], true} =
-      Relation.change(assoc, [Ecto.put_meta(post, state: :deleted)], [])
+             Relation.change(assoc, [Ecto.put_meta(post, state: :deleted)], [])
+
     assert changeset.action == :delete
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -77,26 +77,26 @@ defmodule Ecto.ChangesetTest do
 
   defmodule CustomError do
     use Ecto.Type
-    def type,      do: :any
-    def cast(_),   do: {:error, message: "custom error message", reason: :foobar}
-    def load(_),   do: :error
-    def dump(_),   do: :error
+    def type, do: :any
+    def cast(_), do: {:error, message: "custom error message", reason: :foobar}
+    def load(_), do: :error
+    def dump(_), do: :error
   end
 
   defmodule CustomErrorWithType do
     use Ecto.Type
-    def type,      do: :any
-    def cast(_),   do: {:error, message: "custom error message", reason: :foobar, type: :some_type}
-    def load(_),   do: :error
-    def dump(_),   do: :error
+    def type, do: :any
+    def cast(_), do: {:error, message: "custom error message", reason: :foobar, type: :some_type}
+    def load(_), do: :error
+    def dump(_), do: :error
   end
 
   defmodule CustomErrorWithoutMessage do
     use Ecto.Type
-    def type,      do: :any
-    def cast(_),   do: {:error, reason: :foobar}
-    def load(_),   do: :error
-    def dump(_),   do: :error
+    def type, do: :any
+    def cast(_), do: {:error, reason: :foobar}
+    def load(_), do: :error
+    def dump(_), do: :error
   end
 
   defmodule CustomErrorTest do
@@ -118,7 +118,7 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(title body)a)
     assert changeset.params == params
-    assert changeset.data  == struct
+    assert changeset.data == struct
     assert changeset.changes == %{title: "hello", body: "world"}
     assert changeset.errors == []
     assert validations(changeset) == []
@@ -132,7 +132,7 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(title body)a)
     assert changeset.params == %{"title" => "hello", "body" => "world"}
-    assert changeset.data  == struct
+    assert changeset.data == struct
     assert changeset.changes == %{title: "hello", body: "world"}
     assert changeset.errors == []
     assert validations(changeset) == []
@@ -166,12 +166,12 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "cast/4: with data and types" do
-    data   = {%{title: "hello"}, %{title: :string, upvotes: :integer}}
+    data = {%{title: "hello"}, %{title: :string, upvotes: :integer}}
     params = %{"title" => "world", "upvotes" => "0"}
 
     changeset = cast(data, params, ~w(title upvotes)a)
     assert changeset.params == params
-    assert changeset.data  == %{title: "hello"}
+    assert changeset.data == %{title: "hello"}
     assert changeset.changes == %{title: "world", upvotes: 0}
     assert changeset.errors == []
     assert changeset.valid?
@@ -179,12 +179,12 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "cast/4: with data struct and types" do
-    data   = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
+    data = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
     params = %{"title" => "world", "upvotes" => "0"}
 
     changeset = cast(data, params, ~w(title upvotes)a)
     assert changeset.params == params
-    assert changeset.data  == %NoSchemaPost{title: "hello"}
+    assert changeset.data == %NoSchemaPost{title: "hello"}
     assert changeset.changes == %{title: "world", upvotes: 0}
     assert changeset.errors == []
     assert changeset.valid?
@@ -213,7 +213,10 @@ defmodule Ecto.ChangesetTest do
       }
     }
 
-    params = %{"title" => "world", "source" => %{"origin" => "facebook", "url" => "http://example.com/social"}}
+    params = %{
+      "title" => "world",
+      "source" => %{"origin" => "facebook", "url" => "http://example.com/social"}
+    }
 
     changeset =
       data
@@ -221,24 +224,32 @@ defmodule Ecto.ChangesetTest do
       |> cast_embed(:source, required: true)
 
     assert changeset.params == params
-    assert changeset.data  == %{title: "hello"}
+    assert changeset.data == %{title: "hello"}
     assert %{title: "world", source: %Ecto.Changeset{}} = changeset.changes
     assert changeset.errors == []
     assert changeset.valid?
+
     assert apply_changes(changeset) ==
-      %{title: "world", source: %Ecto.ChangesetTest.SocialSource{origin: "facebook", url: "http://example.com/social"}}
+             %{
+               title: "world",
+               source: %Ecto.ChangesetTest.SocialSource{
+                 origin: "facebook",
+                 url: "http://example.com/social"
+               }
+             }
   end
 
   test "cast/4: with changeset" do
-    base_changeset = cast(%Post{title: "valid"}, %{}, ~w(title)a)
-                     |> validate_required(:title)
-                     |> validate_length(:title, min: 3)
-                     |> unique_constraint(:title)
+    base_changeset =
+      cast(%Post{title: "valid"}, %{}, ~w(title)a)
+      |> validate_required(:title)
+      |> validate_length(:title, min: 3)
+      |> unique_constraint(:title)
 
     # No changes
     changeset = cast(base_changeset, %{}, ~w())
     assert changeset.valid?
-    assert changeset.changes  == %{}
+    assert changeset.changes == %{}
     assert changeset.required == [:title]
     assert length(validations(changeset)) == 1
     assert length(constraints(changeset)) == 1
@@ -246,7 +257,7 @@ defmodule Ecto.ChangesetTest do
     # Value changes
     changeset = cast(changeset, %{body: "new body"}, ~w(body)a)
     assert changeset.valid?
-    assert changeset.changes  == %{body: "new body"}
+    assert changeset.changes == %{body: "new body"}
     assert changeset.required == [:title]
     assert length(validations(changeset)) == 1
     assert length(constraints(changeset)) == 1
@@ -254,7 +265,7 @@ defmodule Ecto.ChangesetTest do
     # Nil changes
     changeset = cast(changeset, %{body: nil}, ~w(body)a)
     assert changeset.valid?
-    assert changeset.changes  == %{body: nil}
+    assert changeset.changes == %{body: nil}
     assert changeset.required == [:title]
     assert length(validations(changeset)) == 1
     assert length(constraints(changeset)) == 1
@@ -296,7 +307,13 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(custom_error)a)
-    assert changeset.errors == [custom_error: {"custom error message", [type: Ecto.ChangesetTest.CustomError, validation: :cast, reason: :foobar]}]
+
+    assert changeset.errors == [
+             custom_error:
+               {"custom error message",
+                [type: Ecto.ChangesetTest.CustomError, validation: :cast, reason: :foobar]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -305,7 +322,13 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(custom_error_with_type)a)
-    assert changeset.errors == [custom_error_with_type: {"custom error message", [type: Ecto.ChangesetTest.CustomErrorWithType, validation: :cast, reason: :foobar]}]
+
+    assert changeset.errors == [
+             custom_error_with_type:
+               {"custom error message",
+                [type: Ecto.ChangesetTest.CustomErrorWithType, validation: :cast, reason: :foobar]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -314,7 +337,17 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(custom_error_without_message)a)
-    assert changeset.errors == [custom_error_without_message: {"is invalid", [type: Ecto.ChangesetTest.CustomErrorWithoutMessage, validation: :cast, reason: :foobar]}]
+
+    assert changeset.errors == [
+             custom_error_without_message:
+               {"is invalid",
+                [
+                  type: Ecto.ChangesetTest.CustomErrorWithoutMessage,
+                  validation: :cast,
+                  reason: :foobar
+                ]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -323,7 +356,12 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(array_custom_error)a)
-    assert changeset.errors == [array_custom_error: {"is invalid", [type: {:array, Ecto.ChangesetTest.CustomError}, validation: :cast]}]
+
+    assert changeset.errors == [
+             array_custom_error:
+               {"is invalid", [type: {:array, Ecto.ChangesetTest.CustomError}, validation: :cast]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -332,7 +370,12 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(map_custom_error)a)
-    assert changeset.errors == [map_custom_error: {"is invalid", [type: {:map, Ecto.ChangesetTest.CustomError}, validation: :cast]}]
+
+    assert changeset.errors == [
+             map_custom_error:
+               {"is invalid", [type: {:map, Ecto.ChangesetTest.CustomError}, validation: :cast]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -374,8 +417,9 @@ defmodule Ecto.ChangesetTest do
     params = %{"body" => :world}
     struct = %Post{}
 
-    changeset = cast(struct, params, [:body])
-                |> validate_required([:body])
+    changeset =
+      cast(struct, params, [:body])
+      |> validate_required([:body])
 
     assert changeset.changes == %{}
     assert changeset.errors == [body: {"is invalid", [type: :string, validation: :cast]}]
@@ -388,7 +432,7 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(title decimal)a)
     assert changeset.params == %{}
-    assert changeset.data  == struct
+    assert changeset.data == struct
     assert changeset.changes == %{}
     assert changeset.errors == []
     assert validations(changeset) == []
@@ -437,15 +481,22 @@ defmodule Ecto.ChangesetTest do
     cs2 = cast(%Post{}, %{}, ~w(title body)a) |> validate_required([:title, :body])
     changeset = merge(cs1, cs2)
     refute changeset.valid?
+
     assert changeset.errors ==
-           [title: {"can't be blank", [validation: :required]}, body: {"can't be blank", [validation: :required]}]
+             [
+               title: {"can't be blank", [validation: :required]},
+               body: {"can't be blank", [validation: :required]}
+             ]
   end
 
   test "merge/2: merges validations" do
-    cs1 = cast(%Post{}, %{title: "Title"}, ~w(title)a)
-                |> validate_length(:title, min: 1, max: 10)
-    cs2 = cast(%Post{}, %{body: "Body"}, ~w(body)a)
-                |> validate_format(:body, ~r/B/)
+    cs1 =
+      cast(%Post{}, %{title: "Title"}, ~w(title)a)
+      |> validate_length(:title, min: 1, max: 10)
+
+    cs2 =
+      cast(%Post{}, %{body: "Body"}, ~w(body)a)
+      |> validate_format(:body, ~r/B/)
 
     changeset = merge(cs1, cs2)
     assert changeset.valid?
@@ -455,17 +506,20 @@ defmodule Ecto.ChangesetTest do
   end
 
   test "merge/2: repo opts" do
-    cs1 = %Post{} |> change() |> Map.put(:repo_opts, [a: 1, b: 2])
-    cs2 = %Post{} |> change() |> Map.put(:repo_opts, [b: 3, c: 4])
+    cs1 = %Post{} |> change() |> Map.put(:repo_opts, a: 1, b: 2)
+    cs2 = %Post{} |> change() |> Map.put(:repo_opts, b: 3, c: 4)
     changeset = merge(cs1, cs2)
     assert changeset.repo_opts == [a: 1, b: 3, c: 4]
   end
 
   test "merge/2: merges constraints" do
-    cs1 = cast(%Post{}, %{title: "Title"}, ~w(title)a)
-                |> unique_constraint(:title)
-    cs2 = cast(%Post{}, %{body: "Body"}, ~w(body)a)
-                |> unique_constraint(:body)
+    cs1 =
+      cast(%Post{}, %{title: "Title"}, ~w(title)a)
+      |> unique_constraint(:title)
+
+    cs2 =
+      cast(%Post{}, %{body: "Body"}, ~w(body)a)
+      |> unique_constraint(:body)
 
     changeset = merge(cs1, cs2)
     assert changeset.valid?
@@ -474,8 +528,8 @@ defmodule Ecto.ChangesetTest do
 
   test "merge/2: merges parameters" do
     empty = cast(%Post{}, %{}, ~w(title)a)
-    cs1   = cast(%Post{}, %{body: "foo"}, ~w(body)a)
-    cs2   = cast(%Post{}, %{body: "bar"}, ~w(body)a)
+    cs1 = cast(%Post{}, %{body: "foo"}, ~w(body)a)
+    cs2 = cast(%Post{}, %{body: "bar"}, ~w(body)a)
     assert merge(cs1, cs2).params == %{"body" => "bar"}
 
     assert merge(cs1, empty).params == %{"body" => "foo"}
@@ -521,13 +575,17 @@ defmodule Ecto.ChangesetTest do
       merge(cs1, cs2)
     end
 
-    assert_raise ArgumentError, "different repos (`:foo` and `:bar`) when merging changesets", fn ->
-      merge(%Ecto.Changeset{repo: :foo}, %Ecto.Changeset{repo: :bar})
-    end
+    assert_raise ArgumentError,
+                 "different repos (`:foo` and `:bar`) when merging changesets",
+                 fn ->
+                   merge(%Ecto.Changeset{repo: :foo}, %Ecto.Changeset{repo: :bar})
+                 end
 
-    assert_raise ArgumentError, "different actions (`:insert` and `:update`) when merging changesets", fn ->
-      merge(%Ecto.Changeset{action: :insert}, %Ecto.Changeset{action: :update})
-    end
+    assert_raise ArgumentError,
+                 "different actions (`:insert` and `:update`) when merging changesets",
+                 fn ->
+                   merge(%Ecto.Changeset{action: :insert}, %Ecto.Changeset{action: :update})
+                 end
   end
 
   test "change/2 with a struct" do
@@ -698,22 +756,26 @@ defmodule Ecto.ChangesetTest do
   test "update_change/3" do
     changeset =
       changeset(%{"title" => "foo"})
-      |> update_change(:title, & &1 <> "bar")
+      |> update_change(:title, &(&1 <> "bar"))
+
     assert changeset.changes.title == "foobar"
 
     changeset =
       changeset(%{"upvotes" => nil})
-      |> update_change(:upvotes, & &1 || 10)
+      |> update_change(:upvotes, &(&1 || 10))
+
     assert changeset.changes.upvotes == 10
 
     changeset =
       changeset(%{})
-      |> update_change(:title, & &1 || "bar")
+      |> update_change(:title, &(&1 || "bar"))
+
     assert changeset.changes == %{}
 
     changeset =
       changeset(%Post{title: "mytitle"}, %{title: "MyTitle"})
       |> update_change(:title, &String.downcase/1)
+
     assert changeset.changes == %{}
   end
 
@@ -761,9 +823,10 @@ defmodule Ecto.ChangesetTest do
 
     assert post.title == ""
 
-    changeset = post
-    |> changeset(%{"title" => "foo"})
-    |> put_assoc(:category, category)
+    changeset =
+      post
+      |> changeset(%{"title" => "foo"})
+      |> put_assoc(:category, category)
 
     changed_post = apply_changes(changeset)
 
@@ -771,9 +834,10 @@ defmodule Ecto.ChangesetTest do
     assert changed_post.title == "foo"
     assert changed_post.category_id == category.category_id
 
-    changeset = post
-    |> changeset(%{"title" => "foo"})
-    |> put_assoc(:category, nil)
+    changeset =
+      post
+      |> changeset(%{"title" => "foo"})
+      |> put_assoc(:category, nil)
 
     changed_post = apply_changes(changeset)
 
@@ -841,11 +905,13 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{})
       |> add_error(:foo, "bar")
+
     assert changeset.errors == [foo: {"bar", []}]
 
     changeset =
       changeset(%{})
       |> add_error(:foo, "bar", additional: "information")
+
     assert changeset.errors == [foo: {"bar", [additional: "information"]}]
   end
 
@@ -899,7 +965,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == []
 
     # When unknown field
-    assert_raise ArgumentError, ~r/unknown field :bad in/, fn  ->
+    assert_raise ArgumentError, ~r/unknown field :bad in/, fn ->
       changeset(%{"title" => "hello"})
       |> validate_change(:bad, fn _, _ -> [] end)
     end
@@ -928,6 +994,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "hello", "body" => "something"})
       |> validate_required(:title)
+
     assert changeset.valid?
     assert changeset.errors == []
 
@@ -941,10 +1008,15 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{title: nil, body: "\n"})
       |> validate_required([:title, :body], message: "is blank")
+
     refute changeset.valid?
     assert changeset.required == [:title, :body]
     assert changeset.changes == %{}
-    assert changeset.errors == [title: {"is blank", [validation: :required]}, body: {"is blank", [validation: :required]}]
+
+    assert changeset.errors == [
+             title: {"is blank", [validation: :required]},
+             body: {"is blank", [validation: :required]}
+           ]
 
     # When :trim option is false
     changeset = changeset(%{title: " "}) |> validate_required(:title, trim: false)
@@ -956,7 +1028,7 @@ defmodule Ecto.ChangesetTest do
     assert changeset.errors == []
 
     # When unknown field
-    assert_raise ArgumentError, ~r/unknown field :bad in/, fn  ->
+    assert_raise ArgumentError, ~r/unknown field :bad in/, fn ->
       changeset(%{"title" => "hello", "body" => "something"})
       |> validate_required(:bad)
     end
@@ -978,6 +1050,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "foo@bar"})
       |> validate_format(:title, ~r/@/)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [title: {:format, ~r/@/}]
@@ -985,6 +1058,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "foobar"})
       |> validate_format(:title, ~r/@/)
+
     refute changeset.valid?
     assert changeset.errors == [title: {"has invalid format", [validation: :format]}]
     assert validations(changeset) == [title: {:format, ~r/@/}]
@@ -992,6 +1066,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "foobar"})
       |> validate_format(:title, ~r/@/, message: "yada")
+
     assert changeset.errors == [title: {"yada", [validation: :format]}]
   end
 
@@ -999,6 +1074,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(hello))
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [title: {:inclusion, ~w(hello)}]
@@ -1006,6 +1082,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world))
+
     refute changeset.valid?
     assert changeset.errors == [title: {"is invalid", [validation: :inclusion, enum: ~w(world)]}]
     assert validations(changeset) == [title: {:inclusion, ~w(world)}]
@@ -1013,6 +1090,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "hello"})
       |> validate_inclusion(:title, ~w(world), message: "yada")
+
     assert changeset.errors == [title: {"yada", [validation: :inclusion, enum: ~w(world)]}]
 
     changeset =
@@ -1027,6 +1105,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"topics" => ["cat", "dog"]})
       |> validate_subset(:topics, ~w(cat dog))
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [topics: {:subset, ~w(cat dog)}]
@@ -1034,19 +1113,26 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"topics" => ["cat", "laptop"]})
       |> validate_subset(:topics, ~w(cat dog))
+
     refute changeset.valid?
-    assert changeset.errors == [topics: {"has an invalid entry", [validation: :subset, enum: ~w(cat dog)]}]
+
+    assert changeset.errors == [
+             topics: {"has an invalid entry", [validation: :subset, enum: ~w(cat dog)]}
+           ]
+
     assert validations(changeset) == [topics: {:subset, ~w(cat dog)}]
 
     changeset =
       changeset(%{"topics" => ["laptop"]})
       |> validate_subset(:topics, ~w(cat dog), message: "yada")
+
     assert changeset.errors == [topics: {"yada", [validation: :subset, enum: ~w(cat dog)]}]
 
     changeset =
       {%{}, %{value: {:array, :decimal}}}
       |> Ecto.Changeset.cast(%{value: [0, 0.2]}, [:value])
       |> validate_subset(:value, Enum.map([0.0, 0.2], &Decimal.from_float/1))
+
     assert changeset.valid?
   end
 
@@ -1054,6 +1140,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(hello))
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [title: {:exclusion, ~w(hello)}]
@@ -1061,6 +1148,7 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world))
+
     refute changeset.valid?
     assert changeset.errors == [title: {"is reserved", [validation: :exclusion, enum: ~w(world)]}]
     assert validations(changeset) == [title: {:exclusion, ~w(world)}]
@@ -1068,14 +1156,17 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"title" => "world"})
       |> validate_exclusion(:title, ~w(world), message: "yada")
+
     assert changeset.errors == [title: {"yada", [validation: :exclusion, enum: ~w(world)]}]
 
     decimals = Enum.map([0.0, 0.2], &Decimal.from_float/1)
+
     changeset =
       {%{}, %{value: :decimal}}
       |> Ecto.Changeset.cast(%{value: 0}, [:value])
       |> validate_exclusion(:value, decimals)
-    assert changeset.errors ==  [value: {"is reserved", [validation: :exclusion, enum: decimals]}]
+
+    assert changeset.errors == [value: {"is reserved", [validation: :exclusion, enum: decimals]}]
   end
 
   test "validate_length/3 with string" do
@@ -1092,25 +1183,52 @@ defmodule Ecto.ChangesetTest do
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, min: 6)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at least %{count} character(s)", count: 6, validation: :length, kind: :min, type: :string}]
+
+    assert changeset.errors == [
+             title:
+               {"should be at least %{count} character(s)",
+                count: 6, validation: :length, kind: :min, type: :string}
+           ]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, max: 4)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 4, validation: :length, kind: :max, type: :string}]
+
+    assert changeset.errors == [
+             title:
+               {"should be at most %{count} character(s)",
+                count: 4, validation: :length, kind: :max, type: :string}
+           ]
 
     changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10)
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be %{count} character(s)", count: 10, validation: :length, kind: :is, type: :string}]
 
-    changeset = changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
-    assert changeset.errors == [title: {"yada", count: 10, validation: :length, kind: :is, type: :string}]
+    assert changeset.errors == [
+             title:
+               {"should be %{count} character(s)",
+                count: 10, validation: :length, kind: :is, type: :string}
+           ]
+
+    changeset =
+      changeset(%{"title" => "world"}) |> validate_length(:title, is: 10, message: "yada")
+
+    assert changeset.errors == [
+             title: {"yada", count: 10, validation: :length, kind: :is, type: :string}
+           ]
 
     changeset = changeset(%{"title" => "\u0065\u0301"}) |> validate_length(:title, max: 1)
     assert changeset.valid?
 
-    changeset = changeset(%{"title" => "\u0065\u0301"}) |> validate_length(:title, max: 1, count: :codepoints)
+    changeset =
+      changeset(%{"title" => "\u0065\u0301"})
+      |> validate_length(:title, max: 1, count: :codepoints)
+
     refute changeset.valid?
-    assert changeset.errors == [title: {"should be at most %{count} character(s)", count: 1, validation: :length, kind: :max, type: :string}]
+
+    assert changeset.errors == [
+             title:
+               {"should be at most %{count} character(s)",
+                count: 1, validation: :length, kind: :max, type: :string}
+           ]
   end
 
   test "validate_length/3 with binary" do
@@ -1140,7 +1258,8 @@ defmodule Ecto.ChangesetTest do
 
     assert changeset.errors == [
              body:
-               {"should be at least %{count} byte(s)", count: 6, validation: :length, kind: :min, type: :binary}
+               {"should be at least %{count} byte(s)",
+                count: 6, validation: :length, kind: :min, type: :binary}
            ]
 
     changeset =
@@ -1149,7 +1268,9 @@ defmodule Ecto.ChangesetTest do
     refute changeset.valid?
 
     assert changeset.errors == [
-             body: {"should be at most %{count} byte(s)", count: 4, validation: :length, kind: :max, type: :binary}
+             body:
+               {"should be at most %{count} byte(s)",
+                count: 4, validation: :length, kind: :max, type: :binary}
            ]
 
     changeset =
@@ -1158,217 +1279,369 @@ defmodule Ecto.ChangesetTest do
     refute changeset.valid?
 
     assert changeset.errors == [
-             body: {"should be %{count} byte(s)", count: 10, validation: :length, kind: :is, type: :binary}
+             body:
+               {"should be %{count} byte(s)",
+                count: 10, validation: :length, kind: :is, type: :binary}
            ]
 
     changeset =
       changeset(%{"body" => <<0, 1, 2, 3, 4>>})
       |> validate_length(:body, count: :bytes, is: 10, message: "yada")
 
-    assert changeset.errors == [body: {"yada", count: 10, validation: :length, kind: :is, type: :binary}]
+    assert changeset.errors == [
+             body: {"yada", count: 10, validation: :length, kind: :is, type: :binary}
+           ]
   end
 
   test "validate_length/3 with list" do
-    changeset = changeset(%{"topics" => ["Politics", "Security", "Economy", "Elections"]}) |> validate_length(:topics, min: 3, max: 7)
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security", "Economy", "Elections"]})
+      |> validate_length(:topics, min: 3, max: 7)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [topics: {:length, [min: 3, max: 7]}]
 
-    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 2, max: 2)
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security"]})
+      |> validate_length(:topics, min: 2, max: 2)
+
     assert changeset.valid?
 
-    changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, is: 3)
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security", "Economy"]})
+      |> validate_length(:topics, is: 3)
+
     assert changeset.valid?
 
-    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, min: 6, foo: true)
-    refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at least %{count} item(s)", count: 6, validation: :length, kind: :min, type: :list}]
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security"]})
+      |> validate_length(:topics, min: 6, foo: true)
 
-    changeset = changeset(%{"topics" => ["Politics", "Security", "Economy"]}) |> validate_length(:topics, max: 2)
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have at most %{count} item(s)", count: 2, validation: :length, kind: :max, type: :list}]
 
-    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10)
+    assert changeset.errors == [
+             topics:
+               {"should have at least %{count} item(s)",
+                count: 6, validation: :length, kind: :min, type: :list}
+           ]
+
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security", "Economy"]})
+      |> validate_length(:topics, max: 2)
+
     refute changeset.valid?
-    assert changeset.errors == [topics: {"should have %{count} item(s)", count: 10, validation: :length, kind: :is, type: :list}]
 
-    changeset = changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10, message: "yada")
-    assert changeset.errors == [topics: {"yada", count: 10, validation: :length, kind: :is, type: :list}]
+    assert changeset.errors == [
+             topics:
+               {"should have at most %{count} item(s)",
+                count: 2, validation: :length, kind: :max, type: :list}
+           ]
+
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security"]}) |> validate_length(:topics, is: 10)
+
+    refute changeset.valid?
+
+    assert changeset.errors == [
+             topics:
+               {"should have %{count} item(s)",
+                count: 10, validation: :length, kind: :is, type: :list}
+           ]
+
+    changeset =
+      changeset(%{"topics" => ["Politics", "Security"]})
+      |> validate_length(:topics, is: 10, message: "yada")
+
+    assert changeset.errors == [
+             topics: {"yada", count: 10, validation: :length, kind: :is, type: :list}
+           ]
   end
 
   test "validate_length/3 with associations" do
     post = %Post{comments: [%Comment{id: 1}]}
     changeset = change(post) |> put_assoc(:comments, []) |> validate_length(:comments, min: 1)
-    assert changeset.errors == [comments: {"should have at least %{count} item(s)", count: 1, validation: :length, kind: :min, type: :list}]
 
-    changeset = change(post) |> put_assoc(:comments, [%Comment{id: 2}, %Comment{id: 3}]) |> validate_length(:comments, max: 2)
+    assert changeset.errors == [
+             comments:
+               {"should have at least %{count} item(s)",
+                count: 1, validation: :length, kind: :min, type: :list}
+           ]
+
+    changeset =
+      change(post)
+      |> put_assoc(:comments, [%Comment{id: 2}, %Comment{id: 3}])
+      |> validate_length(:comments, max: 2)
+
     assert changeset.valid?
   end
 
   test "validate_number/3" do
-    changeset = changeset(%{"upvotes" => 3})
-                |> validate_number(:upvotes, greater_than: 0)
+    changeset =
+      changeset(%{"upvotes" => 3})
+      |> validate_number(:upvotes, greater_than: 0)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [upvotes: {:number, [greater_than: 0]}]
 
     # Single error
-    changeset = changeset(%{"upvotes" => -1})
-                |> validate_number(:upvotes, greater_than: 0)
+    changeset =
+      changeset(%{"upvotes" => -1})
+      |> validate_number(:upvotes, greater_than: 0)
+
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be greater than %{number}", validation: :number, kind: :greater_than, number: 0}]
+
+    assert changeset.errors == [
+             upvotes:
+               {"must be greater than %{number}",
+                validation: :number, kind: :greater_than, number: 0}
+           ]
+
     assert validations(changeset) == [upvotes: {:number, [greater_than: 0]}]
 
     # Non equality error
-    changeset = changeset(%{"upvotes" => 1})
-                |> validate_number(:upvotes, not_equal_to: 1)
+    changeset =
+      changeset(%{"upvotes" => 1})
+      |> validate_number(:upvotes, not_equal_to: 1)
+
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be not equal to %{number}", validation: :number, kind: :not_equal_to, number: 1}]
+
+    assert changeset.errors == [
+             upvotes:
+               {"must be not equal to %{number}",
+                validation: :number, kind: :not_equal_to, number: 1}
+           ]
+
     assert validations(changeset) == [upvotes: {:number, [not_equal_to: 1]}]
 
     # Multiple validations
-    changeset = changeset(%{"upvotes" => 3})
-                |> validate_number(:upvotes, greater_than: 0, less_than: 100)
+    changeset =
+      changeset(%{"upvotes" => 3})
+      |> validate_number(:upvotes, greater_than: 0, less_than: 100)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [upvotes: {:number, [greater_than: 0, less_than: 100]}]
 
     # Multiple validations with multiple errors
-    changeset = changeset(%{"upvotes" => 3})
-                |> validate_number(:upvotes, greater_than: 100, less_than: 0)
+    changeset =
+      changeset(%{"upvotes" => 3})
+      |> validate_number(:upvotes, greater_than: 100, less_than: 0)
+
     refute changeset.valid?
-    assert changeset.errors == [upvotes: {"must be greater than %{number}", validation: :number, kind: :greater_than, number: 100}]
+
+    assert changeset.errors == [
+             upvotes:
+               {"must be greater than %{number}",
+                validation: :number, kind: :greater_than, number: 100}
+           ]
 
     # Multiple validations with custom message errors
-    changeset = changeset(%{"upvotes" => 3})
-                |> validate_number(:upvotes, greater_than: 100, less_than: 0, message: "yada")
-    assert changeset.errors == [upvotes: {"yada", validation: :number, kind: :greater_than, number: 100}]
+    changeset =
+      changeset(%{"upvotes" => 3})
+      |> validate_number(:upvotes, greater_than: 100, less_than: 0, message: "yada")
+
+    assert changeset.errors == [
+             upvotes: {"yada", validation: :number, kind: :greater_than, number: 100}
+           ]
   end
 
   test "validate_number/3 with decimal" do
-    changeset = changeset(%{"decimal" => Decimal.new(1)})
-                |> validate_number(:decimal, greater_than: Decimal.new(-3))
+    changeset =
+      changeset(%{"decimal" => Decimal.new(1)})
+      |> validate_number(:decimal, greater_than: Decimal.new(-3))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new(-3)})
-                |> validate_number(:decimal, less_than: Decimal.new(1))
+    changeset =
+      changeset(%{"decimal" => Decimal.new(-3)})
+      |> validate_number(:decimal, less_than: Decimal.new(1))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new(-1)})
-                |> validate_number(:decimal, equal_to: Decimal.new(-1))
+    changeset =
+      changeset(%{"decimal" => Decimal.new(-1)})
+      |> validate_number(:decimal, equal_to: Decimal.new(-1))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new(0)})
-                |> validate_number(:decimal, not_equal_to: Decimal.new(-1))
+    changeset =
+      changeset(%{"decimal" => Decimal.new(0)})
+      |> validate_number(:decimal, not_equal_to: Decimal.new(-1))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new(-3)})
-                |> validate_number(:decimal, less_than_or_equal_to: Decimal.new(-1))
-    assert changeset.valid?
-    changeset = changeset(%{"decimal" => Decimal.new(-3)})
-                |> validate_number(:decimal, less_than_or_equal_to: Decimal.new(-3))
+    changeset =
+      changeset(%{"decimal" => Decimal.new(-3)})
+      |> validate_number(:decimal, less_than_or_equal_to: Decimal.new(-1))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new(-1)})
-                |> validate_number(:decimal, greater_than_or_equal_to: Decimal.new("-1.5"))
-    assert changeset.valid?
-    changeset = changeset(%{"decimal" => Decimal.new("1.5")})
-                |> validate_number(:decimal, greater_than_or_equal_to: Decimal.new("1.5"))
+    changeset =
+      changeset(%{"decimal" => Decimal.new(-3)})
+      |> validate_number(:decimal, less_than_or_equal_to: Decimal.new(-3))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new("4.9")})
-                |> validate_number(:decimal, greater_than_or_equal_to: 4.9)
+    changeset =
+      changeset(%{"decimal" => Decimal.new(-1)})
+      |> validate_number(:decimal, greater_than_or_equal_to: Decimal.new("-1.5"))
+
     assert changeset.valid?
 
-    changeset = changeset(%{"decimal" => Decimal.new(5)})
-                |> validate_number(:decimal, less_than: 4)
+    changeset =
+      changeset(%{"decimal" => Decimal.new("1.5")})
+      |> validate_number(:decimal, greater_than_or_equal_to: Decimal.new("1.5"))
+
+    assert changeset.valid?
+
+    changeset =
+      changeset(%{"decimal" => Decimal.new("4.9")})
+      |> validate_number(:decimal, greater_than_or_equal_to: 4.9)
+
+    assert changeset.valid?
+
+    changeset =
+      changeset(%{"decimal" => Decimal.new(5)})
+      |> validate_number(:decimal, less_than: 4)
+
     refute changeset.valid?
   end
 
   test "validate_number/3 with bad options" do
-    assert_raise ArgumentError, ~r"unknown option :min given to validate_number/3", fn  ->
+    assert_raise ArgumentError, ~r"unknown option :min given to validate_number/3", fn ->
       validate_number(changeset(%{"upvotes" => 1}), :upvotes, min: Decimal.new("1.5"))
     end
   end
 
-  test "validate_number/3 with bad value" do 
-    assert_raise ArgumentError, "expected value to be of type Decimal, Integer or Float, got: \"Oops\"", fn -> 
-      validate_number(changeset(%{"virtual" => "Oops"}), :virtual, greater_than: 0)
-    end
+  test "validate_number/3 with bad value" do
+    assert_raise ArgumentError,
+                 "expected value to be of type Decimal, Integer or Float, got: \"Oops\"",
+                 fn ->
+                   validate_number(changeset(%{"virtual" => "Oops"}), :virtual, greater_than: 0)
+                 end
   end
 
   test "validate_confirmation/3" do
-    changeset = changeset(%{"title" => "title", "title_confirmation" => "title"})
-                |> validate_confirmation(:title)
+    changeset =
+      changeset(%{"title" => "title", "title_confirmation" => "title"})
+      |> validate_confirmation(:title)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [{:title, {:confirmation, []}}]
 
-    changeset = changeset(%{"title" => "title"})
-                |> validate_confirmation(:title)
+    changeset =
+      changeset(%{"title" => "title"})
+      |> validate_confirmation(:title)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [{:title, {:confirmation, []}}]
 
-    changeset = changeset(%{"title" => "title"})
-                |> validate_confirmation(:title, required: false)
+    changeset =
+      changeset(%{"title" => "title"})
+      |> validate_confirmation(:title, required: false)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [{:title, {:confirmation, [required: false]}}]
 
-    changeset = changeset(%{"title" => "title"})
-                |> validate_confirmation(:title, required: true)
+    changeset =
+      changeset(%{"title" => "title"})
+      |> validate_confirmation(:title, required: true)
+
     refute changeset.valid?
     assert changeset.errors == [title_confirmation: {"can't be blank", [validation: :required]}]
     assert validations(changeset) == [{:title, {:confirmation, [required: true]}}]
 
-    changeset = changeset(%{"title" => "title", "title_confirmation" => nil})
-                |> validate_confirmation(:title)
+    changeset =
+      changeset(%{"title" => "title", "title_confirmation" => nil})
+      |> validate_confirmation(:title)
+
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+
+    assert changeset.errors == [
+             title_confirmation: {"does not match confirmation", [validation: :confirmation]}
+           ]
+
     assert validations(changeset) == [{:title, {:confirmation, []}}]
 
-    changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
-                |> validate_confirmation(:title)
+    changeset =
+      changeset(%{"title" => "title", "title_confirmation" => "not title"})
+      |> validate_confirmation(:title)
+
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+
+    assert changeset.errors == [
+             title_confirmation: {"does not match confirmation", [validation: :confirmation]}
+           ]
+
     assert validations(changeset) == [{:title, {:confirmation, []}}]
 
-    changeset = changeset(%{"title" => "title", "title_confirmation" => "not title"})
-                |> validate_confirmation(:title, message: "doesn't match field below")
+    changeset =
+      changeset(%{"title" => "title", "title_confirmation" => "not title"})
+      |> validate_confirmation(:title, message: "doesn't match field below")
+
     refute changeset.valid?
-    assert changeset.errors == [title_confirmation: {"doesn't match field below", [validation: :confirmation]}]
-    assert validations(changeset) == [{:title, {:confirmation, [message: "doesn't match field below"]}}]
+
+    assert changeset.errors == [
+             title_confirmation: {"doesn't match field below", [validation: :confirmation]}
+           ]
+
+    assert validations(changeset) == [
+             {:title, {:confirmation, [message: "doesn't match field below"]}}
+           ]
 
     # Skip when no parameter
-    changeset = changeset(%{"title" => "title"})
-                |> validate_confirmation(:title, message: "password doesn't match")
+    changeset =
+      changeset(%{"title" => "title"})
+      |> validate_confirmation(:title, message: "password doesn't match")
+
     assert changeset.valid?
     assert changeset.errors == []
-    assert validations(changeset) == [{:title, {:confirmation, [message: "password doesn't match"]}}]
+
+    assert validations(changeset) == [
+             {:title, {:confirmation, [message: "password doesn't match"]}}
+           ]
 
     # With casting
-    changeset = changeset(%{"upvotes" => "1", "upvotes_confirmation" => "1"})
-                |> validate_confirmation(:upvotes)
+    changeset =
+      changeset(%{"upvotes" => "1", "upvotes_confirmation" => "1"})
+      |> validate_confirmation(:upvotes)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [{:upvotes, {:confirmation, []}}]
 
     # With blank change
-    changeset = changeset(%{"password" => "", "password_confirmation" => "password"})
-                |> validate_confirmation(:password)
+    changeset =
+      changeset(%{"password" => "", "password_confirmation" => "password"})
+      |> validate_confirmation(:password)
+
     refute changeset.valid?
-    assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+
+    assert changeset.errors == [
+             password_confirmation: {"does not match confirmation", [validation: :confirmation]}
+           ]
 
     # With missing change
-    changeset = changeset(%{"password_confirmation" => "password"})
-                |> validate_confirmation(:password)
+    changeset =
+      changeset(%{"password_confirmation" => "password"})
+      |> validate_confirmation(:password)
+
     refute changeset.valid?
-    assert changeset.errors == [password_confirmation: {"does not match confirmation", [validation: :confirmation]}]
+
+    assert changeset.errors == [
+             password_confirmation: {"does not match confirmation", [validation: :confirmation]}
+           ]
 
     # invalid params
-    changeset = changeset(:invalid)
-                |> validate_confirmation(:password)
+    changeset =
+      changeset(:invalid)
+      |> validate_confirmation(:password)
+
     refute changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == []
@@ -1376,45 +1649,60 @@ defmodule Ecto.ChangesetTest do
 
   test "validate_acceptance/3" do
     # accepted
-    changeset = changeset(%{"terms_of_service" => "true"})
-                |> validate_acceptance(:terms_of_service)
+    changeset =
+      changeset(%{"terms_of_service" => "true"})
+      |> validate_acceptance(:terms_of_service)
+
     assert changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [terms_of_service: {:acceptance, []}]
 
     # not accepted
-    changeset = changeset(%{"terms_of_service" => "false"})
-                |> validate_acceptance(:terms_of_service)
+    changeset =
+      changeset(%{"terms_of_service" => "false"})
+      |> validate_acceptance(:terms_of_service)
+
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be accepted", [validation: :acceptance]}]
     assert validations(changeset) == [terms_of_service: {:acceptance, []}]
 
-    changeset = changeset(%{"terms_of_service" => "other"})
-                |> validate_acceptance(:terms_of_service)
+    changeset =
+      changeset(%{"terms_of_service" => "other"})
+      |> validate_acceptance(:terms_of_service)
+
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be accepted", [validation: :acceptance]}]
     assert validations(changeset) == [terms_of_service: {:acceptance, []}]
 
     # empty params
-    changeset = changeset(%{})
-                |> validate_acceptance(:terms_of_service)
+    changeset =
+      changeset(%{})
+      |> validate_acceptance(:terms_of_service)
+
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be accepted", [validation: :acceptance]}]
     assert validations(changeset) == [terms_of_service: {:acceptance, []}]
 
     # invalid params
-    changeset = changeset(:invalid)
-                |> validate_acceptance(:terms_of_service)
+    changeset =
+      changeset(:invalid)
+      |> validate_acceptance(:terms_of_service)
+
     refute changeset.valid?
     assert changeset.errors == []
     assert validations(changeset) == [terms_of_service: {:acceptance, []}]
 
     # custom message
-    changeset = changeset(%{})
-                |> validate_acceptance(:terms_of_service, message: "must be abided")
+    changeset =
+      changeset(%{})
+      |> validate_acceptance(:terms_of_service, message: "must be abided")
+
     refute changeset.valid?
     assert changeset.errors == [terms_of_service: {"must be abided", [validation: :acceptance]}]
-    assert validations(changeset) == [terms_of_service: {:acceptance, [message: "must be abided"]}]
+
+    assert validations(changeset) == [
+             terms_of_service: {:acceptance, [message: "must be abided"]}
+           ]
   end
 
   alias Ecto.TestRepo
@@ -1466,24 +1754,37 @@ defmodule Ecto.ChangesetTest do
 
     test "does not validate uniqueness if there is any prior error on a field", context do
       Process.put(:test_repo_all_results, context.dup_result)
+
       changeset =
         context.base_changeset
         |> validate_length(:title, max: 3)
         |> unsafe_validate_unique(:title, TestRepo)
 
       refute changeset.valid?
-      assert changeset.errors == [title: {"should be at most %{count} character(s)", [count: 3, validation: :length, kind: :max, type: :string]}]
+
+      assert changeset.errors == [
+               title:
+                 {"should be at most %{count} character(s)",
+                  [count: 3, validation: :length, kind: :max, type: :string]}
+             ]
     end
 
-    test "does not validate uniqueness if there is any prior error on a combination of fields", context do
+    test "does not validate uniqueness if there is any prior error on a combination of fields",
+         context do
       Process.put(:test_repo_all_results, context.dup_result)
+
       changeset =
         context.base_changeset
         |> validate_length(:title, max: 3)
         |> unsafe_validate_unique([:title, :body], TestRepo)
 
       refute changeset.valid?
-      assert changeset.errors == [title: {"should be at most %{count} character(s)", [count: 3, validation: :length, kind: :max, type: :string]}]
+
+      assert changeset.errors == [
+               title:
+                 {"should be at most %{count} character(s)",
+                  [count: 3, validation: :length, kind: :max, type: :string]}
+             ]
     end
 
     test "allows setting a custom error message", context do
@@ -1500,7 +1801,10 @@ defmodule Ecto.ChangesetTest do
       Process.put(:test_repo_all_results, context.dup_result)
 
       changeset =
-        unsafe_validate_unique(context.base_changeset, [:title], TestRepo, message: "is taken", error_key: :foo)
+        unsafe_validate_unique(context.base_changeset, [:title], TestRepo,
+          message: "is taken",
+          error_key: :foo
+        )
 
       assert changeset.errors ==
                [foo: {"is taken", validation: :unsafe_unique, fields: [:title]}]
@@ -1520,7 +1824,11 @@ defmodule Ecto.ChangesetTest do
 
     test "accepts query options" do
       body_change = changeset(%Post{title: "Hello World", body: "hi"}, %{body: "ho"})
-      unsafe_validate_unique(body_change, :body, MockRepo, query: Ecto.Query.from(p in Post, where: is_nil(p.published_at)))
+
+      unsafe_validate_unique(body_change, :body, MockRepo,
+        query: Ecto.Query.from(p in Post, where: is_nil(p.published_at))
+      )
+
       assert_receive [MockRepo, function: :one, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: check_expr}] = wheres
 
@@ -1550,7 +1858,11 @@ defmodule Ecto.ChangesetTest do
 
     test "generates correct where clause for single primary key with query option" do
       body_change = cast(%SinglePkSchema{id: 0, body: "hi"}, %{body: "ho"}, [:body])
-      unsafe_validate_unique(body_change, :body, MockRepo, query: Ecto.Query.from(p in SinglePkSchema, where: is_nil(p.published_at)))
+
+      unsafe_validate_unique(body_change, :body, MockRepo,
+        query: Ecto.Query.from(p in SinglePkSchema, where: is_nil(p.published_at))
+      )
+
       assert_receive [MockRepo, function: :one, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: pk_expr}, %{expr: check_expr}] = wheres
 
@@ -1561,7 +1873,11 @@ defmodule Ecto.ChangesetTest do
 
     test "generates correct where clause for composite primary keys with query option" do
       body_change = changeset(%Post{id: 0, token: 1, body: "hi"}, %{body: "ho"})
-      unsafe_validate_unique(body_change, :body, MockRepo, query: Ecto.Query.from(p in Post, where: is_nil(p.published_at)))
+
+      unsafe_validate_unique(body_change, :body, MockRepo,
+        query: Ecto.Query.from(p in Post, where: is_nil(p.published_at))
+      )
+
       assert_receive [MockRepo, function: :one, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: pk_expr}, %{expr: check_expr}] = wheres
 
@@ -1612,11 +1928,14 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes == %{}
     assert prepared_changes(changeset) == %{upvotes: 1}
 
-    changeset = changeset(%Post{upvotes: 2_147_483_647}, %{upvotes: 2_147_483_648}) |> optimistic_lock(:upvotes)
+    changeset =
+      changeset(%Post{upvotes: 2_147_483_647}, %{upvotes: 2_147_483_648})
+      |> optimistic_lock(:upvotes)
+
     assert changeset.filters == %{upvotes: 2_147_483_648}
     assert changeset.changes == %{upvotes: 2_147_483_648}
     assert prepared_changes(changeset) == %{upvotes: 1}
- end
+  end
 
   test "optimistic_lock/3 with struct" do
     changeset = %Post{} |> optimistic_lock(:upvotes)
@@ -1635,17 +1954,41 @@ defmodule Ecto.ChangesetTest do
   ## Constraints
   test "check_constraint/3" do
     changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short)
-    assert constraints(changeset) ==
-           [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
-              error_message: "is invalid", error_type: :check}]
 
-    changeset = change(%Post{}) |> check_constraint(:title, name: :title_must_be_short, message: "cannot be more than 15 characters")
     assert constraints(changeset) ==
-           [%{type: :check, field: :title, constraint: "title_must_be_short", match: :exact,
-              error_message: "cannot be more than 15 characters", error_type: :check}]
+             [
+               %{
+                 type: :check,
+                 field: :title,
+                 constraint: "title_must_be_short",
+                 match: :exact,
+                 error_message: "is invalid",
+                 error_type: :check
+               }
+             ]
+
+    changeset =
+      change(%Post{})
+      |> check_constraint(:title,
+        name: :title_must_be_short,
+        message: "cannot be more than 15 characters"
+      )
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :check,
+                 field: :title,
+                 constraint: "title_must_be_short",
+                 match: :exact,
+                 error_message: "cannot be more than 15 characters",
+                 error_type: :check
+               }
+             ]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
-      change(%Post{}) |> check_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
+      change(%Post{})
+      |> check_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
     end
 
     assert_raise ArgumentError, ~r/supply the name/, fn ->
@@ -1657,23 +2000,66 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> unique_constraint(:title)
 
     assert constraints(changeset) ==
-           [%{type: :unique, field: :title, constraint: "posts_title_index", match: :exact,
-              error_message: "has already been taken", error_type: :unique}]
+             [
+               %{
+                 type: :unique,
+                 field: :title,
+                 constraint: "posts_title_index",
+                 match: :exact,
+                 error_message: "has already been taken",
+                 error_type: :unique
+               }
+             ]
 
     changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, message: "is taken")
-    assert constraints(changeset) ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :exact, error_message: "is taken", error_type: :unique}]
 
-    changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :suffix, message: "is taken")
     assert constraints(changeset) ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :suffix, error_message: "is taken", error_type: :unique}]
+             [
+               %{
+                 type: :unique,
+                 field: :title,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is taken",
+                 error_type: :unique
+               }
+             ]
 
-    changeset = change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :prefix, message: "is taken")
+    changeset =
+      change(%Post{})
+      |> unique_constraint(:title, name: :whatever, match: :suffix, message: "is taken")
+
     assert constraints(changeset) ==
-           [%{type: :unique, field: :title, constraint: "whatever", match: :prefix, error_message: "is taken", error_type: :unique}]
+             [
+               %{
+                 type: :unique,
+                 field: :title,
+                 constraint: "whatever",
+                 match: :suffix,
+                 error_message: "is taken",
+                 error_type: :unique
+               }
+             ]
+
+    changeset =
+      change(%Post{})
+      |> unique_constraint(:title, name: :whatever, match: :prefix, message: "is taken")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :unique,
+                 field: :title,
+                 constraint: "whatever",
+                 match: :prefix,
+                 error_message: "is taken",
+                 error_type: :unique
+               }
+             ]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
-      change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
+      change(%Post{})
+      |> unique_constraint(:title, name: :whatever, match: :invalid, message: "is taken")
     end
   end
 
@@ -1681,19 +2067,51 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> unique_constraint(:permalink)
 
     assert constraints(changeset) ==
-           [%{type: :unique, field: :permalink, constraint: "posts_url_index", match: :exact,
-              error_message: "has already been taken", error_type: :unique}]
+             [
+               %{
+                 type: :unique,
+                 field: :permalink,
+                 constraint: "posts_url_index",
+                 match: :exact,
+                 error_message: "has already been taken",
+                 error_type: :unique
+               }
+             ]
 
-    changeset = change(%Post{}) |> unique_constraint(:permalink, name: :whatever, message: "is taken")
-    assert constraints(changeset) ==
-           [%{type: :unique, field: :permalink, constraint: "whatever", match: :exact, error_message: "is taken", error_type: :unique}]
+    changeset =
+      change(%Post{}) |> unique_constraint(:permalink, name: :whatever, message: "is taken")
 
-    changeset = change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :suffix, message: "is taken")
     assert constraints(changeset) ==
-           [%{type: :unique, field: :permalink, constraint: "whatever", match: :suffix, error_message: "is taken", error_type: :unique}]
+             [
+               %{
+                 type: :unique,
+                 field: :permalink,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is taken",
+                 error_type: :unique
+               }
+             ]
+
+    changeset =
+      change(%Post{})
+      |> unique_constraint(:permalink, name: :whatever, match: :suffix, message: "is taken")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :unique,
+                 field: :permalink,
+                 constraint: "whatever",
+                 match: :suffix,
+                 error_message: "is taken",
+                 error_type: :unique
+               }
+             ]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
-      change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :invalid, message: "is taken")
+      change(%Post{})
+      |> unique_constraint(:permalink, name: :whatever, match: :invalid, message: "is taken")
     end
   end
 
@@ -1701,61 +2119,154 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> unique_constraint([:permalink, :color])
 
     assert constraints(changeset) ==
-           [%{type: :unique, field: :permalink, constraint: "posts_url_color_index", match: :exact,
-              error_message: "has already been taken", error_type: :unique}]
+             [
+               %{
+                 type: :unique,
+                 field: :permalink,
+                 constraint: "posts_url_color_index",
+                 match: :exact,
+                 error_message: "has already been taken",
+                 error_type: :unique
+               }
+             ]
   end
 
   test "foreign_key_constraint/3" do
     changeset = change(%Comment{}) |> foreign_key_constraint(:post_id)
-    assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :post_id, constraint: "comments_post_id_fkey", match: :exact,
-              error_message: "does not exist", error_type: :foreign}]
 
-    changeset = change(%Comment{}) |> foreign_key_constraint(:post_id, name: :whatever, message: "is not available")
     assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :post_id, constraint: "whatever", match: :exact, error_message: "is not available", error_type: :foreign}]
+             [
+               %{
+                 type: :foreign_key,
+                 field: :post_id,
+                 constraint: "comments_post_id_fkey",
+                 match: :exact,
+                 error_message: "does not exist",
+                 error_type: :foreign
+               }
+             ]
+
+    changeset =
+      change(%Comment{})
+      |> foreign_key_constraint(:post_id, name: :whatever, message: "is not available")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :foreign_key,
+                 field: :post_id,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is not available",
+                 error_type: :foreign
+               }
+             ]
   end
 
   test "foreign_key_constraint/3 on field with :source" do
     changeset = change(%Post{}) |> foreign_key_constraint(:permalink)
-    assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :permalink, constraint: "posts_url_fkey", match: :exact,
-              error_message: "does not exist", error_type: :foreign}]
 
-    changeset = change(%Post{}) |> foreign_key_constraint(:permalink, name: :whatever, message: "is not available")
     assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :permalink, constraint: "whatever", match: :exact, error_message: "is not available", error_type: :foreign}]
+             [
+               %{
+                 type: :foreign_key,
+                 field: :permalink,
+                 constraint: "posts_url_fkey",
+                 match: :exact,
+                 error_message: "does not exist",
+                 error_type: :foreign
+               }
+             ]
+
+    changeset =
+      change(%Post{})
+      |> foreign_key_constraint(:permalink, name: :whatever, message: "is not available")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :foreign_key,
+                 field: :permalink,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is not available",
+                 error_type: :foreign
+               }
+             ]
   end
 
   test "assoc_constraint/3" do
     changeset = change(%Comment{}) |> assoc_constraint(:post)
-    assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :post, constraint: "comments_post_id_fkey", match: :exact,
-              error_message: "does not exist", error_type: :assoc}]
 
-    changeset = change(%Comment{}) |> assoc_constraint(:post, name: :whatever, message: "is not available")
     assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :exact, error_message: "is not available", error_type: :assoc}]
+             [
+               %{
+                 type: :foreign_key,
+                 field: :post,
+                 constraint: "comments_post_id_fkey",
+                 match: :exact,
+                 error_message: "does not exist",
+                 error_type: :assoc
+               }
+             ]
+
+    changeset =
+      change(%Comment{}) |> assoc_constraint(:post, name: :whatever, message: "is not available")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :foreign_key,
+                 field: :post,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is not available",
+                 error_type: :assoc
+               }
+             ]
   end
 
   test "assoc_constraint/3 on field with :source" do
     changeset = change(%Post{}) |> assoc_constraint(:category)
-    assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :category, constraint: "posts_category_id_fkey", match: :exact,
-              error_message: "does not exist", error_type: :assoc}]
 
-    changeset = change(%Post{}) |> assoc_constraint(:category, name: :whatever, message: "is not available")
     assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :category, constraint: "whatever", match: :exact, error_message: "is not available", error_type: :assoc}]
+             [
+               %{
+                 type: :foreign_key,
+                 field: :category,
+                 constraint: "posts_category_id_fkey",
+                 match: :exact,
+                 error_message: "does not exist",
+                 error_type: :assoc
+               }
+             ]
+
+    changeset =
+      change(%Post{}) |> assoc_constraint(:category, name: :whatever, message: "is not available")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :foreign_key,
+                 field: :category,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is not available",
+                 error_type: :assoc
+               }
+             ]
   end
 
   test "assoc_constraint/3 with errors" do
-    message = ~r"cannot add constraint to changeset because association `unknown` does not exist. Did you mean one of `category`, `comment`, `comments`?"
+    message =
+      ~r"cannot add constraint to changeset because association `unknown` does not exist. Did you mean one of `category`, `comment`, `comments`?"
+
     assert_raise ArgumentError, message, fn ->
       change(%Post{}) |> assoc_constraint(:unknown)
     end
 
     message = ~r"assoc_constraint can only be added to belongs to associations"
+
     assert_raise ArgumentError, message, fn ->
       change(%Post{}) |> assoc_constraint(:comments)
     end
@@ -1763,35 +2274,75 @@ defmodule Ecto.ChangesetTest do
 
   test "no_assoc_constraint/3 with has_many" do
     changeset = change(%Post{}) |> no_assoc_constraint(:comments)
-    assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey", match: :exact,
-              error_message: "are still associated with this entry", error_type: :no_assoc}]
 
-    changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: :whatever, message: "exists")
     assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :comments, constraint: "whatever", match: :exact,
-              error_message: "exists", error_type: :no_assoc}]
+             [
+               %{
+                 type: :foreign_key,
+                 field: :comments,
+                 constraint: "comments_post_id_fkey",
+                 match: :exact,
+                 error_message: "are still associated with this entry",
+                 error_type: :no_assoc
+               }
+             ]
+
+    changeset =
+      change(%Post{}) |> no_assoc_constraint(:comments, name: :whatever, message: "exists")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :foreign_key,
+                 field: :comments,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "exists",
+                 error_type: :no_assoc
+               }
+             ]
   end
 
   test "no_assoc_constraint/3 with has_one" do
     changeset = change(%Post{}) |> no_assoc_constraint(:comment)
-    assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :comment, constraint: "comments_post_id_fkey", match: :exact,
-              error_message: "is still associated with this entry", error_type: :no_assoc}]
 
-    changeset = change(%Post{}) |> no_assoc_constraint(:comment, name: :whatever, message: "exists")
     assert constraints(changeset) ==
-           [%{type: :foreign_key, field: :comment, constraint: "whatever", match: :exact,
-              error_message: "exists", error_type: :no_assoc}]
+             [
+               %{
+                 type: :foreign_key,
+                 field: :comment,
+                 constraint: "comments_post_id_fkey",
+                 match: :exact,
+                 error_message: "is still associated with this entry",
+                 error_type: :no_assoc
+               }
+             ]
+
+    changeset =
+      change(%Post{}) |> no_assoc_constraint(:comment, name: :whatever, message: "exists")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :foreign_key,
+                 field: :comment,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "exists",
+                 error_type: :no_assoc
+               }
+             ]
   end
 
   test "no_assoc_constraint/3 with errors" do
     message = ~r"cannot add constraint to changeset because association `unknown` does not exist"
+
     assert_raise ArgumentError, message, fn ->
       change(%Post{}) |> no_assoc_constraint(:unknown)
     end
 
     message = ~r"no_assoc_constraint can only be added to has one/many associations"
+
     assert_raise ArgumentError, message, fn ->
       change(%Comment{}) |> no_assoc_constraint(:post)
     end
@@ -1799,17 +2350,41 @@ defmodule Ecto.ChangesetTest do
 
   test "exclusion_constraint/3" do
     changeset = change(%Post{}) |> exclusion_constraint(:title)
-    assert constraints(changeset) ==
-           [%{type: :exclusion, field: :title, constraint: "posts_title_exclusion", match: :exact,
-              error_message: "violates an exclusion constraint", error_type: :exclusion}]
 
-    changeset = change(%Post{}) |> exclusion_constraint(:title, name: :whatever, message: "is invalid")
     assert constraints(changeset) ==
-           [%{type: :exclusion, field: :title, constraint: "whatever", match: :exact,
-              error_message: "is invalid", error_type: :exclusion}]
+             [
+               %{
+                 type: :exclusion,
+                 field: :title,
+                 constraint: "posts_title_exclusion",
+                 match: :exact,
+                 error_message: "violates an exclusion constraint",
+                 error_type: :exclusion
+               }
+             ]
+
+    changeset =
+      change(%Post{}) |> exclusion_constraint(:title, name: :whatever, message: "is invalid")
+
+    assert constraints(changeset) ==
+             [
+               %{
+                 type: :exclusion,
+                 field: :title,
+                 constraint: "whatever",
+                 match: :exact,
+                 error_message: "is invalid",
+                 error_type: :exclusion
+               }
+             ]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
-      change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
+      change(%Post{})
+      |> exclusion_constraint(:title,
+        name: :whatever,
+        match: :invalid,
+        message: "match is invalid"
+      )
     end
   end
 
@@ -1822,22 +2397,25 @@ defmodule Ecto.ChangesetTest do
       |> validate_format(:body, ~r/888/)
       |> add_error(:title, "is taken", name: "your title")
 
-    errors = traverse_errors(changeset, fn
-      {"is invalid", [type: type, validation: :cast]} ->
-        "expected to be #{inspect(type)}"
-      {"is taken", keys} ->
-        String.upcase("#{keys[:name]} is taken")
-      {msg, keys} ->
-        msg
-        |> String.replace("%{count}", to_string(keys[:count]))
-        |> String.upcase()
-    end)
+    errors =
+      traverse_errors(changeset, fn
+        {"is invalid", [type: type, validation: :cast]} ->
+          "expected to be #{inspect(type)}"
+
+        {"is taken", keys} ->
+          String.upcase("#{keys[:name]} is taken")
+
+        {msg, keys} ->
+          msg
+          |> String.replace("%{count}", to_string(keys[:count]))
+          |> String.upcase()
+      end)
 
     assert errors == %{
-      body: ["HAS INVALID FORMAT", "SHOULD BE AT LEAST 3 CHARACTER(S)"],
-      title: ["YOUR TITLE IS TAKEN"],
-      upvotes: ["expected to be :integer"],
-    }
+             body: ["HAS INVALID FORMAT", "SHOULD BE AT LEAST 3 CHARACTER(S)"],
+             title: ["YOUR TITLE IS TAKEN"],
+             upvotes: ["expected to be :integer"]
+           }
   end
 
   test "traverses changeset errors with field" do
@@ -1848,31 +2426,42 @@ defmodule Ecto.ChangesetTest do
       |> validate_inclusion(:body, ["hola", "bonjour", "hallo"])
       |> add_error(:title, "is taken", name: "your title")
 
-    errors = traverse_errors(changeset, fn
-      %Ecto.Changeset{}, field, {_, [type: type, validation: :cast]} ->
-        "expected #{field} to be #{inspect(type)}"
-      %Ecto.Changeset{}, field, {_, [name: "your title"]} ->
-        "value in #{field} is taken"
-        |> String.upcase()
-      %Ecto.Changeset{}, field, {_, [count: 3, validation: :length, kind: :min, type: :string] = keys} ->
-        "should be at least #{keys[:count]} character(s) in field #{field}"
-        |> String.upcase()
-      %Ecto.Changeset{validations: validations}, field, {_, [validation: :format]} ->
-        validation = Keyword.get_values(validations, field)
-        "field #{field} should match format #{inspect validation[:format]}"
-      %Ecto.Changeset{validations: validations}, field, {_, [validation: :inclusion, enum: _]} ->
-        validation = Keyword.get_values(validations, field)
-        values = Enum.join(validation[:inclusion], ", ")
-        "#{field} value should be in #{values}"
-    end)
+    errors =
+      traverse_errors(changeset, fn
+        %Ecto.Changeset{}, field, {_, [type: type, validation: :cast]} ->
+          "expected #{field} to be #{inspect(type)}"
+
+        %Ecto.Changeset{}, field, {_, [name: "your title"]} ->
+          "value in #{field} is taken"
+          |> String.upcase()
+
+        %Ecto.Changeset{},
+        field,
+        {_, [count: 3, validation: :length, kind: :min, type: :string] = keys} ->
+          "should be at least #{keys[:count]} character(s) in field #{field}"
+          |> String.upcase()
+
+        %Ecto.Changeset{validations: validations}, field, {_, [validation: :format]} ->
+          validation = Keyword.get_values(validations, field)
+          "field #{field} should match format #{inspect(validation[:format])}"
+
+        %Ecto.Changeset{validations: validations},
+        field,
+        {_, [validation: :inclusion, enum: _]} ->
+          validation = Keyword.get_values(validations, field)
+          values = Enum.join(validation[:inclusion], ", ")
+          "#{field} value should be in #{values}"
+      end)
 
     assert errors == %{
-      body: ["body value should be in hola, bonjour, hallo",
-             "field body should match format ~r/888/",
-             "SHOULD BE AT LEAST 3 CHARACTER(S) IN FIELD BODY"],
-      title: ["VALUE IN TITLE IS TAKEN"],
-      upvotes: ["expected upvotes to be :integer"],
-    }
+             body: [
+               "body value should be in hola, bonjour, hallo",
+               "field body should match format ~r/888/",
+               "SHOULD BE AT LEAST 3 CHARACTER(S) IN FIELD BODY"
+             ],
+             title: ["VALUE IN TITLE IS TAKEN"],
+             upvotes: ["expected upvotes to be :integer"]
+           }
   end
 
   ## traverse_validations
@@ -1884,17 +2473,25 @@ defmodule Ecto.ChangesetTest do
       |> validate_format(:body, ~r/888/)
       |> validate_inclusion(:upvotes, [:good, :bad])
 
-    validations = traverse_validations(changeset, fn
-      {:length, opts} -> {:length, "#{Keyword.get(opts, :min, 0)}-#{Keyword.get(opts, :max, 32)}"}
-      {:format, %Regex{source: source}} -> {:format, "/#{source}/"}
-      {:inclusion, enum} -> {:inclusion, Enum.join(enum, ", ")}
-      {other, opts} -> {other, inspect(opts)}
-    end)
+    validations =
+      traverse_validations(changeset, fn
+        {:length, opts} ->
+          {:length, "#{Keyword.get(opts, :min, 0)}-#{Keyword.get(opts, :max, 32)}"}
+
+        {:format, %Regex{source: source}} ->
+          {:format, "/#{source}/"}
+
+        {:inclusion, enum} ->
+          {:inclusion, Enum.join(enum, ", ")}
+
+        {other, opts} ->
+          {other, inspect(opts)}
+      end)
 
     assert validations == %{
-      body: [format: "/888/", length: "3-32"],
-      upvotes: [inclusion: "good, bad"],
-    }
+             body: [format: "/888/", length: "3-32"],
+             upvotes: [inclusion: "good, bad"]
+           }
   end
 
   test "traverses changeset validations with field" do
@@ -1904,19 +2501,22 @@ defmodule Ecto.ChangesetTest do
       |> validate_format(:body, ~r/888/)
       |> validate_inclusion(:upvotes, [:good, :bad])
 
-    validations = traverse_validations(changeset, fn
-      %Ecto.Changeset{}, field, {:length, opts} ->
-        "#{field} must be #{Keyword.get(opts, :min, 0)}-#{Keyword.get(opts, :max, 32)} long"
-      %Ecto.Changeset{}, field, {:format, %Regex{source: source}} ->
-        "#{field} must match /#{source}/"
-      %Ecto.Changeset{}, field, {:inclusion, enum} ->
-        "#{field} must be one of: #{Enum.join(enum, ", ")}"
-    end)
+    validations =
+      traverse_validations(changeset, fn
+        %Ecto.Changeset{}, field, {:length, opts} ->
+          "#{field} must be #{Keyword.get(opts, :min, 0)}-#{Keyword.get(opts, :max, 32)} long"
+
+        %Ecto.Changeset{}, field, {:format, %Regex{source: source}} ->
+          "#{field} must match /#{source}/"
+
+        %Ecto.Changeset{}, field, {:inclusion, enum} ->
+          "#{field} must be one of: #{Enum.join(enum, ", ")}"
+      end)
 
     assert validations == %{
-      body: ["body must match /888/", "body must be 3-32 long"],
-      upvotes: ["upvotes must be one of: good, bad"],
-    }
+             body: ["body must match /888/", "body must be 3-32 long"],
+             upvotes: ["upvotes must be one of: good, bad"]
+           }
   end
 
   ## inspect
@@ -1946,18 +2546,18 @@ defmodule Ecto.ChangesetTest do
   describe "inspect" do
     test "reveals relevant data" do
       assert inspect(%Ecto.Changeset{}) ==
-            "#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>"
+               "#Ecto.Changeset<action: nil, changes: %{}, errors: [], data: nil, valid?: false>"
 
       assert inspect(changeset(%{"title" => "title", "body" => "hi"})) ==
-            "#Ecto.Changeset<action: nil, changes: %{body: \"hi\", title: \"title\"}, " <>
-            "errors: [], data: #Ecto.ChangesetTest.Post<>, valid?: true>"
+               "#Ecto.Changeset<action: nil, changes: %{body: \"hi\", title: \"title\"}, " <>
+                 "errors: [], data: #Ecto.ChangesetTest.Post<>, valid?: true>"
 
-      data   = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
+      data = {%NoSchemaPost{title: "hello"}, %{title: :string, upvotes: :integer}}
       params = %{"title" => "world", "upvotes" => "0"}
 
       assert inspect(cast(data, params, ~w(title upvotes)a)) ==
                "#Ecto.Changeset<action: nil, changes: %{title: \"world\", upvotes: 0}, " <>
-               "errors: [], data: #Ecto.ChangesetTest.NoSchemaPost<>, valid?: true>"
+                 "errors: [], data: #Ecto.ChangesetTest.NoSchemaPost<>, valid?: true>"
     end
 
     test "redacts fields marked redact: true" do
@@ -1965,13 +2565,17 @@ defmodule Ecto.ChangesetTest do
       refute inspect(changeset) =~ "hunter2"
       assert inspect(changeset) =~ "**redacted**"
 
-      changeset = Ecto.Changeset.cast(%RedactedEmbeddedSchema{}, %{password: "hunter2"}, [:password])
+      changeset =
+        Ecto.Changeset.cast(%RedactedEmbeddedSchema{}, %{password: "hunter2"}, [:password])
+
       refute inspect(changeset) =~ "hunter2"
       assert inspect(changeset) =~ "**redacted**"
     end
 
     test "redacts virtual fields marked redact: true" do
-      changeset = Ecto.Changeset.cast(%RedactedSchema{}, %{virtual_pass: "hunter2"}, [:virtual_pass])
+      changeset =
+        Ecto.Changeset.cast(%RedactedSchema{}, %{virtual_pass: "hunter2"}, [:virtual_pass])
+
       refute inspect(changeset) =~ "hunter2"
       assert inspect(changeset) =~ "**redacted**"
     end
@@ -1983,7 +2587,9 @@ defmodule Ecto.ChangesetTest do
     end
 
     test "doesn't redact fields marked redact: false" do
-      changeset = Ecto.Changeset.cast(%RedactedSchema{}, %{display_name: "hunter2"}, [:display_name])
+      changeset =
+        Ecto.Changeset.cast(%RedactedSchema{}, %{display_name: "hunter2"}, [:display_name])
+
       assert inspect(changeset) =~ "hunter2"
       refute inspect(changeset) =~ "**redacted**"
     end

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -36,29 +36,42 @@ defmodule Ecto.EmbeddedTest do
 
   test "__schema__" do
     assert Author.__schema__(:embeds) ==
-      [:profile, :post, :posts]
+             [:profile, :post, :posts]
 
     assert Author.__schema__(:embed, :profile) ==
-      %Embedded{field: :profile, cardinality: :one, owner: Author, on_replace: :delete, related: Profile}
+             %Embedded{
+               field: :profile,
+               cardinality: :one,
+               owner: Author,
+               on_replace: :delete,
+               related: Profile
+             }
 
     assert Author.__schema__(:embed, :posts) ==
-      %Embedded{field: :posts, cardinality: :many, owner: Author, on_replace: :delete, related: Post}
+             %Embedded{
+               field: :posts,
+               cardinality: :many,
+               owner: Author,
+               on_replace: :delete,
+               related: Post
+             }
   end
 
   test "embedded_load/3" do
     uuid = Ecto.UUID.generate()
 
-    assert %UUIDSchema{uuid: ^uuid} =
-             Ecto.embedded_load(UUIDSchema, %{"uuid" => uuid}, :json)
+    assert %UUIDSchema{uuid: ^uuid} = Ecto.embedded_load(UUIDSchema, %{"uuid" => uuid}, :json)
 
-    assert %UUIDSchema{uuid: ^uuid} =
-             Ecto.embedded_load(UUIDSchema, %{uuid: uuid}, :json)
+    assert %UUIDSchema{uuid: ^uuid} = Ecto.embedded_load(UUIDSchema, %{uuid: uuid}, :json)
 
-    assert %UUIDSchema{uuid: nil} =
-             Ecto.embedded_load(UUIDSchema, %{"uuid" => nil}, :json)
+    assert %UUIDSchema{uuid: nil} = Ecto.embedded_load(UUIDSchema, %{"uuid" => nil}, :json)
 
     assert %UUIDSchema{uuid: ^uuid, author: %Author{name: "Bob"}} =
-             Ecto.embedded_load(UUIDSchema, %{"uuid" => uuid, "author" => %{"name" => "Bob"}}, :json)
+             Ecto.embedded_load(
+               UUIDSchema,
+               %{"uuid" => uuid, "author" => %{"name" => "Bob"}},
+               :json
+             )
 
     assert %UUIDSchema{uuid: ^uuid, authors: [%Author{}]} =
              Ecto.embedded_load(UUIDSchema, %{"uuid" => uuid, "authors" => [%{}]}, :json)
@@ -75,10 +88,13 @@ defmodule Ecto.EmbeddedTest do
 
     assert %{uuid: ^uuid} = Ecto.embedded_dump(%UUIDSchema{uuid: uuid}, :json)
 
-    struct = %UUIDSchema{uuid: uuid, authors: [
-      %Author{name: "Bob"},
-      %Author{name: "Alice"}
-    ]}
+    struct = %UUIDSchema{
+      uuid: uuid,
+      authors: [
+        %Author{name: "Bob"},
+        %Author{name: "Alice"}
+      ]
+    }
 
     dumped = Ecto.embedded_dump(struct, :json)
     assert not Map.has_key?(dumped, :__struct__)

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -407,7 +407,7 @@ defmodule Ecto.EnumTest do
 
   describe "dump_values/2" do
     test "returns correct values" do
-      assert Ecto.Enum.dump_values(EnumSchema, :my_enum) == ["foo","bar", "baz"]
+      assert Ecto.Enum.dump_values(EnumSchema, :my_enum) == ["foo", "bar", "baz"]
       assert Ecto.Enum.dump_values(EnumSchema, :my_enums) == ["foo", "bar", "baz"]
       assert Ecto.Enum.dump_values(EnumSchema, :my_string_enum) == ["fooo", "baar", "baaz"]
       assert Ecto.Enum.dump_values(EnumSchema, :my_string_enums) == ["fooo", "baar", "baaz"]
@@ -421,8 +421,19 @@ defmodule Ecto.EnumTest do
     test "returns correct values" do
       assert Ecto.Enum.mappings(EnumSchema, :my_enum) == [foo: "foo", bar: "bar", baz: "baz"]
       assert Ecto.Enum.mappings(EnumSchema, :my_enums) == [foo: "foo", bar: "bar", baz: "baz"]
-      assert Ecto.Enum.mappings(EnumSchema, :my_string_enum) == [foo: "fooo", bar: "baar", baz: "baaz"]
-      assert Ecto.Enum.mappings(EnumSchema, :my_string_enums) == [foo: "fooo", bar: "baar", baz: "baaz"]
+
+      assert Ecto.Enum.mappings(EnumSchema, :my_string_enum) == [
+               foo: "fooo",
+               bar: "baar",
+               baz: "baaz"
+             ]
+
+      assert Ecto.Enum.mappings(EnumSchema, :my_string_enums) == [
+               foo: "fooo",
+               bar: "baar",
+               baz: "baaz"
+             ]
+
       assert Ecto.Enum.mappings(EnumSchema, :my_integer_enum) == [foo: 1, bar: 2, baz: 5]
       assert Ecto.Enum.mappings(EnumSchema, :my_integer_enums) == [foo: 1, bar: 2, baz: 5]
       assert Ecto.Enum.mappings(EnumSchema, :virtual_enum) == [foo: "foo", bar: "bar", baz: "baz"]

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -26,28 +26,31 @@ defmodule Ecto.MultiTest do
 
   test "insert changeset" do
     changeset = Changeset.change(%Comment{})
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.insert(:comment, changeset)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :insert}, []}}]
   end
 
   test "insert struct" do
-    struct    = %Comment{}
+    struct = %Comment{}
     changeset = Changeset.change(struct)
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.insert(:comment, struct)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :insert}, []}}]
   end
 
   test "insert fun" do
     changeset = Changeset.change(%Comment{})
     fun = fn _changes -> {:ok, changeset} end
+
     multi =
       Multi.new()
       |> Multi.insert(:fun, fun)
@@ -58,17 +61,19 @@ defmodule Ecto.MultiTest do
 
   test "update changeset" do
     changeset = Changeset.change(%Comment{})
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.update(:comment, changeset)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :update}, []}}]
   end
 
   test "update fun" do
     changeset = Changeset.change(%Comment{})
     fun = fn _changes -> {:ok, changeset} end
+
     multi =
       Multi.new()
       |> Multi.update(:fun, fun)
@@ -79,11 +84,12 @@ defmodule Ecto.MultiTest do
 
   test "insert_or_update changeset will insert the changeset if not loaded" do
     changeset = Changeset.change(%Comment{})
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.insert_or_update(:comment, changeset)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :insert}, []}}]
   end
 
@@ -99,17 +105,19 @@ defmodule Ecto.MultiTest do
   test "insert_or_update changeset will update the changeset if it was loaded" do
     changeset = Changeset.change(%Comment{id: 1}, x: 2)
     changeset = put_in(changeset.data.__meta__.state, :loaded)
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.insert_or_update(:comment, changeset)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :update}, []}}]
   end
 
   test "insert_or_update fun" do
     changeset = Changeset.change(%Comment{})
     fun = fn _changes -> {:ok, changeset} end
+
     multi =
       Multi.new()
       |> Multi.insert_or_update(:fun, fun)
@@ -120,28 +128,31 @@ defmodule Ecto.MultiTest do
 
   test "delete changeset" do
     changeset = Changeset.change(%Comment{})
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.delete(:comment, changeset)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :delete}, []}}]
   end
 
   test "delete struct" do
-    struct    = %Comment{}
+    struct = %Comment{}
     changeset = Changeset.change(struct)
-    multi     =
+
+    multi =
       Multi.new()
       |> Multi.delete(:comment, struct)
 
-    assert multi.names      == MapSet.new([:comment])
+    assert multi.names == MapSet.new([:comment])
     assert multi.operations == [{:comment, {:changeset, %{changeset | action: :delete}, []}}]
   end
 
   test "delete fun" do
     changeset = Changeset.change(%Comment{})
     fun = fn _changes -> {:ok, changeset} end
+
     multi =
       Multi.new()
       |> Multi.delete(:fun, fun)
@@ -155,37 +166,40 @@ defmodule Ecto.MultiTest do
       Multi.new()
       |> Multi.error(:oops, :value)
 
-    assert multi.names      == MapSet.new([:oops])
+    assert multi.names == MapSet.new([:oops])
     assert multi.operations == [{:oops, {:error, :value}}]
   end
 
   test "run with fun" do
     fun = fn _repo, changes -> {:ok, changes} end
+
     multi =
       Multi.new()
       |> Multi.run(:fun, fun)
 
-    assert multi.names      == MapSet.new([:fun])
+    assert multi.names == MapSet.new([:fun])
     assert multi.operations == [{:fun, {:run, fun}}]
   end
 
   test "run named with tuple" do
     fun = fn _repo, changes -> {:ok, changes} end
+
     multi =
       Multi.new()
       |> Multi.run({:fun, 3}, fun)
 
-    assert multi.names      == MapSet.new([{:fun, 3}])
+    assert multi.names == MapSet.new([{:fun, 3}])
     assert multi.operations == [{{:fun, 3}, {:run, fun}}]
   end
 
   test "run named with char_list" do
     fun = fn _repo, changes -> {:ok, changes} end
+
     multi =
       Multi.new()
       |> Multi.run('myFunction', fun)
 
-    assert multi.names      == MapSet.new(['myFunction'])
+    assert multi.names == MapSet.new(['myFunction'])
     assert multi.operations == [{'myFunction', {:run, fun}}]
   end
 
@@ -194,7 +208,7 @@ defmodule Ecto.MultiTest do
       Multi.new()
       |> Multi.run(:fun, __MODULE__, :run_ok, [])
 
-    assert multi.names      == MapSet.new([:fun])
+    assert multi.names == MapSet.new([:fun])
     assert multi.operations == [{:fun, {:run, {__MODULE__, :run_ok, []}}}]
   end
 
@@ -281,19 +295,19 @@ defmodule Ecto.MultiTest do
     lhs = Multi.new() |> Multi.run(:one, fun) |> Multi.run(:two, fun)
     rhs = Multi.new() |> Multi.run(:three, fun) |> Multi.run(:four, fun)
 
-    merged     = Multi.append(lhs, rhs)
+    merged = Multi.append(lhs, rhs)
     operations = Keyword.keys(merged.operations)
     assert merged.names == MapSet.new([:one, :two, :three, :four])
-    assert operations   == [:four, :three, :two, :one]
+    assert operations == [:four, :three, :two, :one]
 
-    merged     = Multi.prepend(lhs, rhs)
+    merged = Multi.prepend(lhs, rhs)
     operations = Keyword.keys(merged.operations)
     assert merged.names == MapSet.new([:one, :two, :three, :four])
-    assert operations   == [:two, :one, :four, :three]
+    assert operations == [:two, :one, :four, :three]
   end
 
   test "append/prepend with repetition" do
-    fun   = fn _, _ -> {:ok, :ok} end
+    fun = fn _, _ -> {:ok, :ok} end
     multi = Multi.new() |> Multi.run(:run, fun)
 
     assert_raise ArgumentError, ~r"both declared operations: \[:run\]", fn ->
@@ -307,6 +321,7 @@ defmodule Ecto.MultiTest do
 
   test "to_list" do
     changeset = Changeset.change(%Comment{id: 1}, x: 1)
+
     multi =
       Multi.new()
       |> Multi.insert(:insert, changeset)
@@ -322,18 +337,18 @@ defmodule Ecto.MultiTest do
       |> Multi.delete_all({:delete_all, 2}, Comment)
 
     assert [
-      {:insert,          {:insert, _, []}},
-      {{:insert, 1},     {:insert, _, []}},
-      {{:insert, 2},     {:insert, _, []}},
-      {:run,             {:run, _}},
-      {:update,          {:update, _, []}},
-      {:delete,          {:delete, _, []}},
-      {:insert_all,      {:insert_all, _, _, []}},
-      {:update_all,      {:update_all, _, _, []}},
-      {:delete_all,      {:delete_all, _, []}},
-      {{:delete_all, 1}, {:delete_all, _, []}},
-      {{:delete_all, 2}, {:delete_all, _, []}},
-    ] = Ecto.Multi.to_list(multi)
+             {:insert, {:insert, _, []}},
+             {{:insert, 1}, {:insert, _, []}},
+             {{:insert, 2}, {:insert, _, []}},
+             {:run, {:run, _}},
+             {:update, {:update, _, []}},
+             {:delete, {:delete, _, []}},
+             {:insert_all, {:insert_all, _, _, []}},
+             {:update_all, {:update_all, _, _, []}},
+             {:delete_all, {:delete_all, _, []}},
+             {{:delete_all, 1}, {:delete_all, _, []}},
+             {{:delete_all, 2}, {:delete_all, _, []}}
+           ] = Ecto.Multi.to_list(multi)
   end
 
   test "put" do
@@ -371,6 +386,7 @@ defmodule Ecto.MultiTest do
 
   test "repeating an operation" do
     fun = fn _, _ -> {:ok, :ok} end
+
     assert_raise RuntimeError, ~r":run is already a member", fn ->
       Multi.new() |> Multi.run(:run, fun) |> Multi.run(:run, fun)
     end
@@ -379,6 +395,7 @@ defmodule Ecto.MultiTest do
   describe "merge/2" do
     test "with fun" do
       changeset = Changeset.change(%Comment{})
+
       multi =
         Multi.new()
         |> Multi.insert(:insert, changeset)
@@ -393,6 +410,7 @@ defmodule Ecto.MultiTest do
 
     test "with mfa" do
       changeset = Changeset.change(%Comment{})
+
       multi =
         Multi.new()
         |> Multi.insert(:insert, changeset)
@@ -405,7 +423,7 @@ defmodule Ecto.MultiTest do
 
     test "rollbacks on errors" do
       error = fn _, _ -> {:error, :error} end
-      ok    = fn _, _ -> {:ok, :ok} end
+      ok = fn _, _ -> {:ok, :ok} end
 
       multi =
         Multi.new()
@@ -429,9 +447,11 @@ defmodule Ecto.MultiTest do
           repo.rollback(:bar)
         end)
 
-      assert_raise RuntimeError, ~r"operation :bar is manually rolling back, which is not supported by Ecto.Multi", fn ->
-        TestRepo.transaction(multi)
-      end
+      assert_raise RuntimeError,
+                   ~r"operation :bar is manually rolling back, which is not supported by Ecto.Multi",
+                   fn ->
+                     TestRepo.transaction(multi)
+                   end
     end
 
     test "does not allow repeated operations" do
@@ -462,6 +482,7 @@ defmodule Ecto.MultiTest do
   describe "Repo.transaction" do
     test "on success" do
       changeset = Changeset.change(%Comment{id: 1}, x: 1)
+
       multi =
         Multi.new()
         |> Multi.put(:put, 1)
@@ -476,23 +497,25 @@ defmodule Ecto.MultiTest do
 
       assert {:ok, changes} = TestRepo.transaction(multi)
       assert_received {:transaction, _}
-      assert {:messages, [
-        {:insert, %{source: "comments"}},
-        {:update, %{source: "comments"}},
-        {:update, %{source: "comments"}},
-        {:delete, %{source: "comments"}},
-        {:insert_all, %{source: "comments"}, [[x: 1]]},
-        {:update_all, %{from: %{source: {"comments", _}}}},
-        {:delete_all, %{from: %{source: {"comments", _}}}}
-      ]} = Process.info(self(), :messages)
+
+      assert {:messages,
+              [
+                {:insert, %{source: "comments"}},
+                {:update, %{source: "comments"}},
+                {:update, %{source: "comments"}},
+                {:delete, %{source: "comments"}},
+                {:insert_all, %{source: "comments"}, [[x: 1]]},
+                {:update_all, %{from: %{source: {"comments", _}}}},
+                {:delete_all, %{from: %{source: {"comments", _}}}}
+              ]} = Process.info(self(), :messages)
 
       assert %Comment{} = changes.insert
       assert %Comment{} = changes.update
       assert %Comment{} = changes.update_fun
       assert %Comment{} = changes.delete
-      assert {1, nil}   = changes.insert_all
-      assert {1, nil}   = changes.update_all
-      assert {1, nil}   = changes.delete_all
+      assert {1, nil} = changes.insert_all
+      assert {1, nil} = changes.update_all
+      assert {1, nil} = changes.delete_all
       assert Map.has_key?(changes.run, :insert)
       refute Map.has_key?(changes.run, :update)
     end
@@ -509,10 +532,10 @@ defmodule Ecto.MultiTest do
         |> Multi.inspect(only: :put2)
 
       assert capture_io(fn ->
-        assert {:ok, result} = TestRepo.transaction(multi)
-        refute Map.has_key?(result, :before_put)
-        refute Map.has_key?(result, :after_put)
-      end) == "%{}\n%{put: 1}\n%{put2: 1}\n"
+               assert {:ok, result} = TestRepo.transaction(multi)
+               refute Map.has_key?(result, :before_put)
+               refute Map.has_key?(result, :after_put)
+             end) == "%{}\n%{put: 1}\n%{put2: 1}\n"
     end
 
     test "with empty multi" do
@@ -523,6 +546,7 @@ defmodule Ecto.MultiTest do
 
     test "rolls back from run" do
       changeset = Changeset.change(%Comment{id: 1}, x: 1)
+
       multi =
         Multi.new()
         |> Multi.insert(:insert, changeset)
@@ -541,8 +565,10 @@ defmodule Ecto.MultiTest do
 
     test "rolls back from repo" do
       changeset = Changeset.change(%Comment{id: 1}, x: 1)
-      invalid   = put_in(changeset.data.__meta__.context, {:invalid, [unique: "comments_x_index"]})
-                  |> Changeset.unique_constraint(:x)
+
+      invalid =
+        put_in(changeset.data.__meta__.context, {:invalid, [unique: "comments_x_index"]})
+        |> Changeset.unique_constraint(:x)
 
       multi =
         Multi.new()
@@ -557,7 +583,13 @@ defmodule Ecto.MultiTest do
       assert {:messages, [{:insert, %{source: "comments"}}]} = Process.info(self(), :messages)
       assert %Comment{} = changes.insert
       assert "ok" == changes.run
-      assert error.errors == [x: {"has already been taken", [constraint: :unique, constraint_name: "comments_x_index"]}]
+
+      assert error.errors == [
+               x:
+                 {"has already been taken",
+                  [constraint: :unique, constraint_name: "comments_x_index"]}
+             ]
+
       refute Map.has_key?(changes, :update)
     end
 

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -5,11 +5,11 @@ defmodule Ecto.ParameterizedTypeTest do
     use Ecto.ParameterizedType
 
     def params(embed), do: %{embed: embed}
-    def init([some_opt: :some_opt_value, field: :my_type, schema: _]), do: :init
+    def init(some_opt: :some_opt_value, field: :my_type, schema: _), do: :init
     def type(_), do: :custom
     def load(_, _, _), do: {:ok, :load}
-    def dump( _, _, _),  do: {:ok, :dump}
-    def cast( _, _),  do: {:ok, :cast}
+    def dump(_, _, _), do: {:ok, :dump}
+    def cast(_, _), do: {:ok, :cast}
     def equal?(true, _, _), do: true
     def equal?(_, _, _), do: false
     def embed_as(_, %{embed: embed}), do: embed
@@ -30,8 +30,8 @@ defmodule Ecto.ParameterizedTypeTest do
     def init(_), do: %{}
     def type(_), do: :custom
     def load(_, _, _), do: :error
-    def dump( _, _, _),  do: :error
-    def cast( _, _),  do: :error
+    def dump(_, _, _), do: :error
+    def cast(_, _), do: :error
     def equal?(true, _, _), do: true
     def equal?(_, _, _), do: false
     def embed_as(_, _), do: :self
@@ -39,7 +39,7 @@ defmodule Ecto.ParameterizedTypeTest do
 
   test "init" do
     assert Schema.__schema__(:type, :my_type) ==
-      {:parameterized, Ecto.ParameterizedTypeTest.MyParameterizedType, :init}
+             {:parameterized, Ecto.ParameterizedTypeTest.MyParameterizedType, :init}
   end
 
   @p_dump_type {:parameterized, MyParameterizedType, MyParameterizedType.params(:dump)}
@@ -54,13 +54,13 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.embed_as(@p_dump_type, :foo) == :dump
 
     assert Ecto.Type.embedded_load(@p_self_type, :foo, :json) == {:ok, :cast}
-    assert Ecto.Type.embedded_load(@p_self_type, nil,  :json) == {:ok, :cast}
+    assert Ecto.Type.embedded_load(@p_self_type, nil, :json) == {:ok, :cast}
     assert Ecto.Type.embedded_load(@p_dump_type, :foo, :json) == {:ok, :load}
-    assert Ecto.Type.embedded_load(@p_dump_type, nil,  :json) == {:ok, :load}
+    assert Ecto.Type.embedded_load(@p_dump_type, nil, :json) == {:ok, :load}
 
-    assert Ecto.Type.embedded_dump(@p_self_type, :foo,  :json) == {:ok, :foo}
+    assert Ecto.Type.embedded_dump(@p_self_type, :foo, :json) == {:ok, :foo}
     assert Ecto.Type.embedded_dump(@p_self_type, nil, :json) == {:ok, nil}
-    assert Ecto.Type.embedded_dump(@p_dump_type, :foo,  :json) == {:ok, :dump}
+    assert Ecto.Type.embedded_dump(@p_dump_type, :foo, :json) == {:ok, :dump}
     assert Ecto.Type.embedded_dump(@p_dump_type, nil, :json) == {:ok, :dump}
 
     assert Ecto.Type.load(@p_self_type, :foo) == {:ok, :load}
@@ -79,9 +79,9 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.embed_as(@p_error_type, :foo) == :self
 
     assert Ecto.Type.embedded_load(@p_error_type, :foo, :json) == :error
-    assert Ecto.Type.embedded_load(@p_error_type, nil,  :json) == :error
+    assert Ecto.Type.embedded_load(@p_error_type, nil, :json) == :error
 
-    assert Ecto.Type.embedded_dump(@p_error_type, :foo,  :json) == {:ok, :foo}
+    assert Ecto.Type.embedded_dump(@p_error_type, :foo, :json) == {:ok, :foo}
     assert Ecto.Type.embedded_dump(@p_error_type, nil, :json) == {:ok, nil}
 
     assert Ecto.Type.load(@p_error_type, :foo) == :error
@@ -130,18 +130,36 @@ defmodule Ecto.ParameterizedTypeTest do
     assert Ecto.Type.embed_as({:map, @p_dump_type}, :foo) == :dump
     assert Ecto.Type.embed_as({:map, @p_error_type}, :foo) == :self
 
-    assert Ecto.Type.embedded_load({:map, @p_self_type}, %{"x" => "foo"}, :json) == {:ok, %{"x" => :cast}}
-    assert Ecto.Type.embedded_load({:map, @p_self_type}, %{"x" => nil}, :json) == {:ok, %{"x" => :cast}}
+    assert Ecto.Type.embedded_load({:map, @p_self_type}, %{"x" => "foo"}, :json) ==
+             {:ok, %{"x" => :cast}}
+
+    assert Ecto.Type.embedded_load({:map, @p_self_type}, %{"x" => nil}, :json) ==
+             {:ok, %{"x" => :cast}}
+
     assert Ecto.Type.embedded_load({:map, @p_self_type}, nil, :json) == {:ok, nil}
-    assert Ecto.Type.embedded_load({:map, @p_dump_type}, %{"x" => "foo"}, :json) == {:ok, %{"x" => :load}}
-    assert Ecto.Type.embedded_load({:map, @p_dump_type}, %{"x" => nil}, :json) == {:ok, %{"x" => :load}}
+
+    assert Ecto.Type.embedded_load({:map, @p_dump_type}, %{"x" => "foo"}, :json) ==
+             {:ok, %{"x" => :load}}
+
+    assert Ecto.Type.embedded_load({:map, @p_dump_type}, %{"x" => nil}, :json) ==
+             {:ok, %{"x" => :load}}
+
     assert Ecto.Type.embedded_load({:map, @p_dump_type}, nil, :json) == {:ok, nil}
 
-    assert Ecto.Type.embedded_dump({:map, @p_self_type}, %{"x" => "foo"}, :json) == {:ok, %{"x" => "foo"}}
-    assert Ecto.Type.embedded_dump({:map, @p_self_type}, %{"x" => nil}, :json) == {:ok, %{"x" => nil}}
+    assert Ecto.Type.embedded_dump({:map, @p_self_type}, %{"x" => "foo"}, :json) ==
+             {:ok, %{"x" => "foo"}}
+
+    assert Ecto.Type.embedded_dump({:map, @p_self_type}, %{"x" => nil}, :json) ==
+             {:ok, %{"x" => nil}}
+
     assert Ecto.Type.embedded_dump({:map, @p_self_type}, nil, :json) == {:ok, nil}
-    assert Ecto.Type.embedded_dump({:map, @p_dump_type}, %{"x" => "foo"}, :json) == {:ok, %{"x" => :dump}}
-    assert Ecto.Type.embedded_dump({:map, @p_dump_type}, %{"x" => nil}, :json) == {:ok, %{"x" => :dump}}
+
+    assert Ecto.Type.embedded_dump({:map, @p_dump_type}, %{"x" => "foo"}, :json) ==
+             {:ok, %{"x" => :dump}}
+
+    assert Ecto.Type.embedded_dump({:map, @p_dump_type}, %{"x" => nil}, :json) ==
+             {:ok, %{"x" => :dump}}
+
     assert Ecto.Type.embedded_dump({:map, @p_dump_type}, nil, :json) == {:ok, nil}
 
     assert Ecto.Type.load({:map, @p_self_type}, %{"x" => "foo"}) == {:ok, %{"x" => :load}}
@@ -160,10 +178,10 @@ defmodule Ecto.ParameterizedTypeTest do
   test "with maybe" do
     assert Ecto.Type.embedded_load({:maybe, @p_self_type}, :foo, :json) == {:ok, :cast}
     assert Ecto.Type.embedded_load({:maybe, @p_dump_type}, :foo, :json) == {:ok, :load}
-    assert Ecto.Type.embedded_load({:maybe, @p_error_type}, :foo,  :json) == {:ok, :foo}
+    assert Ecto.Type.embedded_load({:maybe, @p_error_type}, :foo, :json) == {:ok, :foo}
 
-    assert Ecto.Type.embedded_dump({:maybe, @p_self_type}, :foo,  :json) == {:ok, :foo}
-    assert Ecto.Type.embedded_dump({:maybe, @p_dump_type}, :foo,  :json) == {:ok, :dump}
+    assert Ecto.Type.embedded_dump({:maybe, @p_self_type}, :foo, :json) == {:ok, :foo}
+    assert Ecto.Type.embedded_dump({:maybe, @p_dump_type}, :foo, :json) == {:ok, :dump}
     assert Ecto.Type.embedded_dump({:maybe, @p_error_type}, :foo, :json) == {:ok, :foo}
 
     assert Ecto.Type.load({:maybe, @p_self_type}, :foo) == {:ok, :load}

--- a/test/ecto/query/builder/cte_test.exs
+++ b/test/ecto/query/builder/cte_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../../support/eval_helpers.exs", __DIR__
+Code.require_file("../../../support/eval_helpers.exs", __DIR__)
 
 defmodule Ecto.Query.Builder.CTETest do
   use ExUnit.Case, async: true
@@ -17,7 +17,9 @@ defmodule Ecto.Query.Builder.CTETest do
       |> with_cte("cte1", as: ^cte1)
       |> with_cte("cte2", as: fragment("SELECT * FROM tbl2"))
 
-    assert [{"cte1", ^cte1}, {"cte2", %Ecto.Query.QueryExpr{expr: expr}}] = query.with_ctes.queries
+    assert [{"cte1", ^cte1}, {"cte2", %Ecto.Query.QueryExpr{expr: expr}}] =
+             query.with_ctes.queries
+
     assert {:fragment, [], [raw: "SELECT * FROM tbl2"]} = expr
   end
 
@@ -59,7 +61,9 @@ defmodule Ecto.Query.Builder.CTETest do
       |> with_cte(^cte1_name, as: ^cte1)
       |> with_cte(^cte2_name, as: fragment("SELECT * FROM tbl2"))
 
-    assert [{^cte1_name, ^cte1}, {^cte2_name, %Ecto.Query.QueryExpr{expr: expr}}] = query.with_ctes.queries
+    assert [{^cte1_name, ^cte1}, {^cte2_name, %Ecto.Query.QueryExpr{expr: expr}}] =
+             query.with_ctes.queries
+
     assert {:fragment, [], [raw: "SELECT * FROM tbl2"]} = expr
   end
 

--- a/test/ecto/query/builder/distinct_test.exs
+++ b/test/ecto/query/builder/distinct_test.exs
@@ -9,25 +9,81 @@ defmodule Ecto.Query.Builder.DistinctTest do
   describe "escape" do
     test "handles expressions and params" do
       assert {true, {[], :acc}} ==
-             escape(true, {[], :acc}, [x: 0], __ENV__)
+               escape(true, {[], :acc}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.y()] end), {[], :acc}} ==
-             escape(quote do x.y() end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   x.y()
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x(), asc: &1.y()] end), {[], :acc}} ==
-             escape(quote do [x.x(), y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x(), asc: &1.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [x.x(), y.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0, y: 1],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], :acc}} ==
-             escape(quote do [x.x(), desc: y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x(), desc: &1.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [x.x(), desc: y.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0, y: 1],
+                 __ENV__
+               )
 
       import Kernel, except: [>: 2]
-      assert {Macro.escape(quote do [asc: 1 > 2] end), {[], :acc}} ==
-             escape(quote do 1 > 2 end, {[], :acc}, [], __ENV__)
+
+      assert {Macro.escape(
+                quote do
+                  [asc: 1 > 2]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   1 > 2
+                 end,
+                 {[], :acc},
+                 [],
+                 __ENV__
+               )
     end
 
     test "raises on unbound variables" do
       assert_raise Ecto.Query.CompileError, ~r"unbound variable `x` in query", fn ->
-        escape(quote do x.y end, {[], :acc}, [], __ENV__)
+        escape(
+          quote do
+            x.y
+          end,
+          {[], :acc},
+          [],
+          __ENV__
+        )
       end
     end
   end
@@ -41,7 +97,7 @@ defmodule Ecto.Query.Builder.DistinctTest do
 
     test "accepts keyword lists" do
       kw = [desc: :title]
-      assert distinct("q", [q], ^kw).distinct == distinct("q", [q], [desc: q.title]).distinct
+      assert distinct("q", [q], ^kw).distinct == distinct("q", [q], desc: q.title).distinct
     end
 
     test "accepts the boolean true" do
@@ -57,14 +113,17 @@ defmodule Ecto.Query.Builder.DistinctTest do
       ]
 
       %{distinct: distinct} = distinct("posts", ^order_by)
+
       assert Macro.to_string(distinct.expr) ==
-             "[asc: &0.foo() == ^0 and &0.bar() == ^1, desc: &0.bar(), asc: &0.baz() == ^2 and &0.bat() == ^3]"
+               "[asc: &0.foo() == ^0 and &0.bar() == ^1, desc: &0.bar(), asc: &0.baz() == ^2 and &0.bat() == ^3]"
+
       assert distinct.params ==
-             [{1, {0, :foo}}, {"bar", {0, :bar}}, {2, {0, :baz}}, {"bat", {0, :bat}}]
+               [{1, {0, :foo}}, {"bar", {0, :bar}}, {2, {0, :baz}}, {"bat", {0, :bat}}]
     end
 
     test "raises on non-atoms" do
       message = "expected a field as an atom in `distinct`, got: `\"temp\"`"
+
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
         distinct("posts", [p], [^temp])
@@ -73,6 +132,7 @@ defmodule Ecto.Query.Builder.DistinctTest do
 
     test "raises non-lists" do
       message = ~r"`distinct` interpolated on root expects a field or a keyword list"
+
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
         distinct("posts", [p], ^temp)

--- a/test/ecto/query/builder/dynamic_test.exs
+++ b/test/ecto/query/builder/dynamic_test.exs
@@ -14,9 +14,14 @@ defmodule Ecto.Query.Builder.DynamicTest do
     test "without params" do
       dynamic = dynamic([p], p.foo == true)
       assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
+
       assert expr ==
-             {:==, [], [{{:., [], [{:&, [], [0]}, :foo]}, [], []},
-                        %Ecto.Query.Tagged{tag: nil, value: true, type: {0, :foo}}]}
+               {:==, [],
+                [
+                  {{:., [], [{:&, [], [0]}, :foo]}, [], []},
+                  %Ecto.Query.Tagged{tag: nil, value: true, type: {0, :foo}}
+                ]}
+
       assert params == []
     end
 
@@ -29,10 +34,12 @@ defmodule Ecto.Query.Builder.DynamicTest do
 
     test "with dynamic interpolation" do
       dynamic = dynamic([p], p.bar == ^2)
-      dynamic = dynamic([p], p.foo == ^1 and ^dynamic or p.baz == ^3)
+      dynamic = dynamic([p], (p.foo == ^1 and ^dynamic) or p.baz == ^3)
       assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
+
       assert Macro.to_string(expr) ==
-             "&0.foo() == ^0 and &0.bar() == ^1 or &0.baz() == ^2"
+               "&0.foo() == ^0 and &0.bar() == ^1 or &0.baz() == ^2"
+
       assert params == [{1, {0, :foo}}, {2, {0, :bar}}, {3, {0, :baz}}]
     end
 
@@ -42,22 +49,36 @@ defmodule Ecto.Query.Builder.DynamicTest do
       dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
       assert {expr, binding, params, [_subquery], _, _} = fully_expand(query(), dynamic)
       assert Macro.to_string(binding) == "[p]"
+
       assert Macro.to_string(expr) ==
-             "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.sq() in {:subquery, 0} or &0.bar3() == ^3) and &0.baz() == ^4"
-      assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {:subquery, 0},
-                        {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
+               "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.sq() in {:subquery, 0} or &0.bar3() == ^3) and &0.baz() == ^4"
+
+      assert params == [
+               {"foo", {0, :foo}},
+               {"bar1", {0, :bar1}},
+               {:subquery, 0},
+               {"bar3", {0, :bar3}},
+               {"baz", {0, :baz}}
+             ]
     end
-    
+
     test "with nested dynamic interpolation" do
       dynamic = dynamic([p], p.bar2 == ^"bar2")
       dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")
       dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
       assert {expr, binding, params, [], _, _} = fully_expand(query(), dynamic)
       assert Macro.to_string(binding) == "[p]"
+
       assert Macro.to_string(expr) ==
-             "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.bar2() == ^2 or &0.bar3() == ^3) and &0.baz() == ^4"
-      assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {"bar2", {0, :bar2}},
-                        {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
+               "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.bar2() == ^2 or &0.bar3() == ^3) and &0.baz() == ^4"
+
+      assert params == [
+               {"foo", {0, :foo}},
+               {"bar1", {0, :bar1}},
+               {"bar2", {0, :bar2}},
+               {"bar3", {0, :bar3}},
+               {"baz", {0, :baz}}
+             ]
     end
 
     test "with multiple bindings" do
@@ -65,8 +86,10 @@ defmodule Ecto.Query.Builder.DynamicTest do
       dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
       assert {expr, binding, params, [], _, _} = fully_expand(query(), dynamic)
       assert Macro.to_string(binding) == "[a, b]"
+
       assert Macro.to_string(expr) ==
-             "&0.foo() == ^0 and &0.bar() == &1.bar() and &0.baz() == ^1"
+               "&0.foo() == ^0 and &0.bar() == &1.bar() and &0.baz() == ^1"
+
       assert params == [{"foo", {0, :foo}}, {"baz", {0, :baz}}]
     end
 
@@ -74,8 +97,10 @@ defmodule Ecto.Query.Builder.DynamicTest do
       dynamic = dynamic([..., c], c.bar == ^"bar")
       dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
       assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
+
       assert Macro.to_string(expr) ==
-             "&0.foo() == ^0 and &1.bar() == ^1 and &0.baz() == ^2"
+               "&0.foo() == ^0 and &1.bar() == ^1 and &0.baz() == ^2"
+
       assert params == [{"foo", {0, :foo}}, {"bar", {1, :bar}}, {"baz", {0, :baz}}]
     end
 
@@ -83,7 +108,7 @@ defmodule Ecto.Query.Builder.DynamicTest do
       dynamic = dynamic([comments: c], c.bar == ^"bar")
       assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
       assert Macro.to_string(expr) == "&1.bar() == ^0"
-      assert params ==  [{"bar", {1, :bar}}]
+      assert params == [{"bar", {1, :bar}}]
     end
   end
 end

--- a/test/ecto/query/builder/filter_test.exs
+++ b/test/ecto/query/builder/filter_test.exs
@@ -10,36 +10,97 @@ defmodule Ecto.Query.Builder.FilterTest do
     test "handles expressions, params" do
       import Kernel, except: [==: 2, and: 2]
 
-      assert escape(:where, quote do [] end, 0, [x: 0], __ENV__) ===
-             {true, {[], []}}
+      assert escape(
+               :where,
+               quote do
+                 []
+               end,
+               0,
+               [x: 0],
+               __ENV__
+             ) ===
+               {true, {[], []}}
 
-      assert escape(:where, quote do {x.x()} == {^"foo"} end, 0, [x: 0], __ENV__) ===
-             {Macro.escape(quote do {&0.x()} == {^0} end),
-             {[{"foo", {0, :x}}], []}}
+      assert escape(
+               :where,
+               quote do
+                 {x.x()} == {^"foo"}
+               end,
+               0,
+               [x: 0],
+               __ENV__
+             ) ===
+               {Macro.escape(
+                  quote do
+                    {&0.x()} == {^0}
+                  end
+                ), {[{"foo", {0, :x}}], []}}
 
-      escaped = Macro.escape(quote do &0.x() == ^0 and &0.y() == ^1 end)
+      escaped =
+        Macro.escape(
+          quote do
+            &0.x() == ^0 and &0.y() == ^1
+          end
+        )
+
       assert {^escaped, {params, []}} =
-              escape(:where, quote do [x: ^"foo", y: ^"bar"] end, 0, [x: 0], __ENV__)
+               escape(
+                 :where,
+                 quote do
+                   [x: ^"foo", y: ^"bar"]
+                 end,
+                 0,
+                 [x: 0],
+                 __ENV__
+               )
+
       assert [{{_, _, ["bar", :y]}, {0, :y}}, {{_, _, ["foo", :x]}, {0, :x}}] = params
     end
 
     test "raises on invalid expressions" do
       assert_raise Ecto.Query.CompileError,
-                   ~r"expected a keyword list at compile time in where, got: `\[\{1, 2\}\]`", fn ->
-        escape(:where, quote do [{1, 2}] end, 0, [], __ENV__)
-      end
+                   ~r"expected a keyword list at compile time in where, got: `\[\{1, 2\}\]`",
+                   fn ->
+                     escape(
+                       :where,
+                       quote do
+                         [{1, 2}]
+                       end,
+                       0,
+                       [],
+                       __ENV__
+                     )
+                   end
 
       assert_raise Ecto.Query.CompileError,
-                   ~r"Tuples can only be used in comparisons with literal tuples of the same size", fn ->
-        escape(:where, quote do {1, 2} > ^foo end, 0, [], __ENV__)
-      end
+                   ~r"Tuples can only be used in comparisons with literal tuples of the same size",
+                   fn ->
+                     escape(
+                       :where,
+                       quote do
+                         {1, 2} > ^foo
+                       end,
+                       0,
+                       [],
+                       __ENV__
+                     )
+                   end
     end
 
     test "raises on nils" do
       assert_raise Ecto.Query.CompileError,
-                   ~r"nil given for `x`. Comparison with nil is forbidden as it is unsafe.", fn ->
-        escape(:where, quote do [x: nil] end, 0, [], __ENV__)
-      end
+                   ~r"nil given for `x`. Comparison with nil is forbidden as it is unsafe.",
+                   fn ->
+                     escape(
+                       :where,
+                       quote do
+                         [x: nil]
+                       end,
+                       0,
+                       [],
+                       __ENV__
+                     )
+                   end
     end
   end
 
@@ -51,28 +112,34 @@ defmodule Ecto.Query.Builder.FilterTest do
 
     test "accepts keyword lists" do
       %{wheres: [where]} = where(from(p in "posts"), [p], ^[foo: 1, bar: "baz"])
+
       assert Macro.to_string(where.expr) ==
-             "&0.foo() == ^0 and &0.bar() == ^1"
+               "&0.foo() == ^0 and &0.bar() == ^1"
+
       assert where.params ==
-             [{1, {0, :foo}}, {"baz", {0, :bar}}]
+               [{1, {0, :foo}}, {"baz", {0, :bar}}]
     end
 
     test "supports dynamic expressions" do
       dynamic = dynamic([p], p.foo == ^1 and p.bar == ^"baz")
       %{wheres: [where]} = where("posts", ^dynamic)
+
       assert Macro.to_string(where.expr) ==
-             "&0.foo() == ^0 and &0.bar() == ^1"
+               "&0.foo() == ^0 and &0.bar() == ^1"
+
       assert where.params ==
-             [{1, {0, :foo}}, {"baz", {0, :bar}}]
+               [{1, {0, :foo}}, {"baz", {0, :bar}}]
     end
 
     test "in subquery" do
       s = from(p in "posts", select: p.id, where: p.public == ^true)
       %{wheres: [where]} = from(p in "posts", where: p.id in subquery(s))
+
       assert Macro.to_string(where.expr) ==
-             "&0.id() in {:subquery, 0}"
+               "&0.id() in {:subquery, 0}"
+
       assert where.params ==
-        [{:subquery, 0}]
+               [{:subquery, 0}]
     end
 
     test "supports exists subquery expressions" do
@@ -81,9 +148,10 @@ defmodule Ecto.Query.Builder.FilterTest do
       %{wheres: [where]} = from(p in "posts", where: exists(s))
 
       assert Macro.to_string(where.expr) ==
-             "exists({:subquery, 0})"
+               "exists({:subquery, 0})"
+
       assert where.params ==
-             [{:subquery, 0}]
+               [{:subquery, 0}]
     end
 
     test "supports comparison with subqueries with all and any quantifiers" do
@@ -91,10 +159,10 @@ defmodule Ecto.Query.Builder.FilterTest do
 
       assert_quantified_subquery = fn %{wheres: [where]}, expected_quantifier ->
         assert Macro.to_string(where.expr) ==
-               "&0.rating() >= #{expected_quantifier}({:subquery, 0})"
+                 "&0.rating() >= #{expected_quantifier}({:subquery, 0})"
 
         assert where.params ==
-                [{:subquery, 0}]
+                 [{:subquery, 0}]
       end
 
       all_query = from(p in "posts", where: p.rating >= all(s))

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -8,21 +8,70 @@ defmodule Ecto.Query.Builder.GroupByTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do [&0.y()] end), {[], :acc}} ==
-             escape(:group_by, quote do x.y() end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [&0.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :group_by,
+                 quote do
+                   x.y()
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [&0.x(), &1.y()] end), {[], :acc}} ==
-             escape(:group_by, quote do [x.x(), y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [&0.x(), &1.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :group_by,
+                 quote do
+                   [x.x(), y.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0, y: 1],
+                 __ENV__
+               )
 
       import Kernel, except: [>: 2]
-      assert {Macro.escape(quote do [1 > 2] end), {[], :acc}} ==
-             escape(:group_by, quote do 1 > 2 end, {[], :acc}, [], __ENV__)
+
+      assert {Macro.escape(
+                quote do
+                  [1 > 2]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :group_by,
+                 quote do
+                   1 > 2
+                 end,
+                 {[], :acc},
+                 [],
+                 __ENV__
+               )
     end
 
     test "raises on unbound variables" do
       message = ~r"unbound variable `x` in query"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:group_by, quote do x.y end, {[], :acc}, [], __ENV__)
+        escape(
+          :group_by,
+          quote do
+            x.y
+          end,
+          {[], :acc},
+          [],
+          __ENV__
+        )
       end
     end
   end
@@ -42,12 +91,14 @@ defmodule Ecto.Query.Builder.GroupByTest do
 
     test "raises when no a field or a list of fields" do
       message = "expected a field as an atom in `group_by`, got: `\"temp\"`"
+
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
         group_by("posts", [p], [^temp])
       end
 
       message = "expected a list of fields and dynamics in `group_by`, got: `\"temp\"`"
+
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
         group_by("posts", [p], ^temp)

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -20,48 +20,53 @@ defmodule Ecto.Query.Builder.JoinTest do
 
   test "accepts keywords on :on" do
     assert %{joins: [join]} =
-            join("posts", :inner, [p], c in "comments", on: [post_id: p.id, public: true])
+             join("posts", :inner, [p], c in "comments", on: [post_id: p.id, public: true])
+
     assert Macro.to_string(join.on.expr) ==
-           "&1.post_id() == &0.id() and &1.public() == %Ecto.Query.Tagged{tag: nil, type: {1, :public}, value: true}"
+             "&1.post_id() == &0.id() and &1.public() == %Ecto.Query.Tagged{tag: nil, type: {1, :public}, value: true}"
+
     assert join.on.params == []
   end
 
   test "accepts queries on interpolation" do
     qual = :left
     source = "comments"
+
     assert %{joins: [%{source: {"comments", nil}}]} =
-            join("posts", qual, [p], c in ^source, on: true)
+             join("posts", qual, [p], c in ^source, on: true)
 
     qual = :right
     source = Comment
+
     assert %{joins: [%{source: {nil, Comment}}]} =
-            join("posts", qual, [p], c in ^source, on: true)
+             join("posts", qual, [p], c in ^source, on: true)
 
     qual = :right
     source = {"user_comments", Comment}
+
     assert %{joins: [%{source: {"user_comments", Comment}}]} =
-            join("posts", qual, [p], c in ^source, on: true)
+             join("posts", qual, [p], c in ^source, on: true)
 
     qual = :inner
     source = from c in "comments", where: c.public
+
     assert %{joins: [%{source: %Ecto.Query{from: %{source: {"comments", nil}}}}]} =
-            join("posts", qual, [p], c in ^source, on: true)
+             join("posts", qual, [p], c in ^source, on: true)
   end
 
   test "accepts interpolation on :on" do
-    assert %{joins: [join]} =
-            join("posts", :inner, [p], "comments", on: [post_id: ^1])
+    assert %{joins: [join]} = join("posts", :inner, [p], "comments", on: [post_id: ^1])
     assert Macro.to_string(join.on.expr) == "&1.post_id() == ^0"
     assert join.on.params == [{1, {1, :post_id}}]
 
     assert %{joins: [join]} =
-            join("posts", :inner, [p], c in "comments", on: ^[post_id: 1, public: true])
+             join("posts", :inner, [p], c in "comments", on: ^[post_id: 1, public: true])
+
     assert Macro.to_string(join.on.expr) == "&1.post_id() == ^0 and &1.public() == ^1"
     assert join.on.params == [{1, {1, :post_id}}, {true, {1, :public}}]
 
     dynamic = dynamic([p, c], c.post_id == p.id and c.public == ^true)
-    assert %{joins: [join]} =
-            join("posts", :inner, [p], c in "comments", on: ^dynamic)
+    assert %{joins: [join]} = join("posts", :inner, [p], c in "comments", on: ^dynamic)
     assert Macro.to_string(join.on.expr) == "&1.post_id() == &0.id() and &1.public() == ^0"
     assert join.on.params == [{true, {1, :public}}]
   end
@@ -78,8 +83,7 @@ defmodule Ecto.Query.Builder.JoinTest do
   end
 
   test "raises on invalid qualifier" do
-    assert_raise ArgumentError,
-                 ~r/invalid join qualifier `:whatever`/, fn ->
+    assert_raise ArgumentError, ~r/invalid join qualifier `:whatever`/, fn ->
       qual = :whatever
       join("posts", qual, [p], c in "comments", on: true)
     end
@@ -94,74 +98,117 @@ defmodule Ecto.Query.Builder.JoinTest do
 
   test "raises on invalid expressions on :on" do
     assert_raise ArgumentError, ~r/invalid expression for join `:on`/, fn ->
-      escape(quote do
-        join("posts", :inner, [p], c in "comments", on: p.id in subquery("posts"))
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :inner, [p], c in "comments", on: p.id in subquery("posts"))
+        end,
+        [],
+        __ENV__
+      )
     end
 
     assert_raise ArgumentError, ~r/invalid expression for join `:on`/, fn ->
-      escape(quote do
-        join("posts", :inner, [p], c in "comments", on: exists(p.id))
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :inner, [p], c in "comments", on: exists(p.id))
+        end,
+        [],
+        __ENV__
+      )
     end
   end
 
   test "raises on invalid assoc/2" do
     assert_raise Ecto.Query.CompileError,
-                 ~r/you passed the variable \`field_var\` to \`assoc\/2\`/, fn ->
-      escape(quote do assoc(join_var, field_var) end, nil, nil)
-    end
+                 ~r/you passed the variable \`field_var\` to \`assoc\/2\`/,
+                 fn ->
+                   escape(
+                     quote do
+                       assoc(join_var, field_var)
+                     end,
+                     nil,
+                     nil
+                   )
+                 end
   end
 
   test "raises on mix of valid and invalid options passed to join/5" do
     assert_raise ArgumentError, ~r/invalid option `foo` passed/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, foo: :bar)
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :left, [p], c in "comments", on: true, foo: :bar)
+        end,
+        [],
+        __ENV__
+      )
     end
   end
 
   test "raises on invalid opts passed to join/5" do
     assert_raise ArgumentError, ~r/invalid opts passed/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", {:foo, :bar})
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :left, [p], c in "comments", {:foo, :bar})
+        end,
+        [],
+        __ENV__
+      )
     end
   end
 
   test "raises on invalid binding passed to join/5" do
     assert_raise ArgumentError, ~r/invalid binding passed/, fn ->
-      escape(quote do
-        join("posts", :inner, [o, p] in subquery(some_subquery), on: o.id == p.org_id)
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :inner, [o, p] in subquery(some_subquery), on: o.id == p.org_id)
+        end,
+        [],
+        __ENV__
+      )
     end
   end
 
   test "raises on non-atom as" do
     assert_raise Ecto.Query.CompileError, ~r/`as` must be a compile time atom/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, as: "string")
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :left, [p], c in "comments", on: true, as: "string")
+        end,
+        [],
+        __ENV__
+      )
     end
 
     assert_raise Ecto.Query.CompileError, ~r/`as` must be a compile time atom/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, as: atom)
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :left, [p], c in "comments", on: true, as: atom)
+        end,
+        [],
+        __ENV__
+      )
     end
   end
 
   test "raises on non-string prefix" do
     assert_raise Ecto.Query.CompileError, ~r/`prefix` must be a compile time string/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, prefix: :atom)
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :left, [p], c in "comments", on: true, prefix: :atom)
+        end,
+        [],
+        __ENV__
+      )
     end
 
     assert_raise Ecto.Query.CompileError, ~r/`prefix` must be a compile time string/, fn ->
-      escape(quote do
-        join("posts", :left, [p], c in "comments", on: true, prefix: string)
-      end, [], __ENV__)
+      escape(
+        quote do
+          join("posts", :left, [p], c in "comments", on: true, prefix: string)
+        end,
+        [],
+        __ENV__
+      )
     end
   end
 end

--- a/test/ecto/query/builder/lock_test.exs
+++ b/test/ecto/query/builder/lock_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../../support/eval_helpers.exs", __DIR__
+Code.require_file("../../../support/eval_helpers.exs", __DIR__)
 
 defmodule Ecto.Query.Builder.LockTest do
   use ExUnit.Case, async: true

--- a/test/ecto/query/builder/order_by_test.exs
+++ b/test/ecto/query/builder/order_by_test.exs
@@ -8,45 +8,180 @@ defmodule Ecto.Query.Builder.OrderByTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do [asc: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do x.y() end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   x.y()
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x(), asc: &1.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [x.x(), y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x(), asc: &1.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   [x.x(), y.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0, y: 1],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [asc: x.x(), desc: y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x(), desc: &1.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   [asc: x.x(), desc: y.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0, y: 1],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [x.x(), desc: y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x(), desc: &1.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   [x.x(), desc: y.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0, y: 1],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x()] end), {[], :acc}} ==
-             escape(:order_by, quote do :x end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   :x
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [:x, desc: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc: &0.x(), desc: &0.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   [:x, desc: :y]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc_nulls_first: &0.x(), desc_nulls_first: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [asc_nulls_first: :x, desc_nulls_first: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc_nulls_first: &0.x(), desc_nulls_first: &0.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   [asc_nulls_first: :x, desc_nulls_first: :y]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [asc_nulls_last: &0.x(), desc_nulls_last: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [asc_nulls_last: :x, desc_nulls_last: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [asc_nulls_last: &0.x(), desc_nulls_last: &0.y()]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   [asc_nulls_last: :x, desc_nulls_last: :y]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
       import Kernel, except: [>: 2]
-      assert {Macro.escape(quote do [asc: 1 > 2] end), {[], :acc}} ==
-             escape(:order_by, quote do 1 > 2 end, {[], :acc}, [], __ENV__)
+
+      assert {Macro.escape(
+                quote do
+                  [asc: 1 > 2]
+                end
+              ),
+              {[], :acc}} ==
+               escape(
+                 :order_by,
+                 quote do
+                   1 > 2
+                 end,
+                 {[], :acc},
+                 [],
+                 __ENV__
+               )
     end
 
     test "raises on unbound variables" do
       assert_raise Ecto.Query.CompileError, ~r"unbound variable `x` in query", fn ->
-        escape(:order_by, quote do x.y end, {[], :acc}, [], __ENV__)
+        escape(
+          :order_by,
+          quote do
+            x.y
+          end,
+          {[], :acc},
+          [],
+          __ENV__
+        )
       end
     end
 
     test "raises on unknown expression" do
       message = ~r":desc_nulls_first or interpolated value in `order_by`, got: `:test`"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:order_by, quote do [test: x.y] end, {[], :acc}, [x: 0], __ENV__)
+        escape(
+          :order_by,
+          quote do
+            [test: x.y]
+          end,
+          {[], :acc},
+          [x: 0],
+          __ENV__
+        )
       end
     end
   end
@@ -55,10 +190,14 @@ defmodule Ecto.Query.Builder.OrderByTest do
     test "accepts fields, lists or keyword lists" do
       key = :title
       dir = :desc
-      assert order_by("q", [q], ^key).order_bys == order_by("q", [q], [asc: q.title]).order_bys
-      assert order_by("q", [q], [^key]).order_bys == order_by("q", [q], [asc: q.title]).order_bys
-      assert order_by("q", [q], [desc: ^key]).order_bys == order_by("q", [q], [desc: q.title]).order_bys
-      assert order_by("q", [q], [{^dir, ^key}]).order_bys == order_by("q", [q], [desc: q.title]).order_bys
+      assert order_by("q", [q], ^key).order_bys == order_by("q", [q], asc: q.title).order_bys
+      assert order_by("q", [q], [^key]).order_bys == order_by("q", [q], asc: q.title).order_bys
+
+      assert order_by("q", [q], desc: ^key).order_bys ==
+               order_by("q", [q], desc: q.title).order_bys
+
+      assert order_by("q", [q], [{^dir, ^key}]).order_bys ==
+               order_by("q", [q], desc: q.title).order_bys
     end
 
     test "supports dynamic expressions" do
@@ -69,10 +208,12 @@ defmodule Ecto.Query.Builder.OrderByTest do
       ]
 
       %{order_bys: [order_by]} = order_by("posts", ^order_by)
+
       assert Macro.to_string(order_by.expr) ==
-             "[asc: &0.foo() == ^0 and &0.bar() == ^1, desc: &0.bar(), asc: &0.baz() == ^2 and &0.bat() == ^3]"
+               "[asc: &0.foo() == ^0 and &0.bar() == ^1, desc: &0.bar(), asc: &0.baz() == ^2 and &0.bat() == ^3]"
+
       assert order_by.params ==
-             [{1, {0, :foo}}, {"bar", {0, :bar}}, {2, {0, :baz}}, {"bat", {0, :bat}}]
+               [{1, {0, :foo}}, {"bar", {0, :bar}}, {2, {0, :baz}}, {"bat", {0, :bat}}]
     end
 
     test "raises on invalid direction" do
@@ -84,14 +225,16 @@ defmodule Ecto.Query.Builder.OrderByTest do
 
     test "raises on invalid field" do
       message = "expected a field as an atom in `order_by`, got: `\"temp\"`"
+
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
-        order_by("posts", [p], [asc: ^temp])
+        order_by("posts", [p], asc: ^temp)
       end
     end
 
     test "raises on invalid interpolation" do
       message = ~r"`order_by` interpolated on root expects a field or a keyword list"
+
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
         order_by("posts", [p], ^temp)

--- a/test/ecto/query/builder/preload_test.exs
+++ b/test/ecto/query/builder/preload_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../../support/eval_helpers.exs", __DIR__
+Code.require_file("../../../support/eval_helpers.exs", __DIR__)
 
 defmodule Ecto.Query.Builder.PreloadTest do
   use ExUnit.Case, async: true
@@ -15,6 +15,7 @@ defmodule Ecto.Query.Builder.PreloadTest do
     end
 
     message = "expected key in preload to be an atom, got: `1`"
+
     assert_raise ArgumentError, message, fn ->
       temp = 1
       preload(%Ecto.Query{}, [{^temp, :foo}])
@@ -30,18 +31,18 @@ defmodule Ecto.Query.Builder.PreloadTest do
     comments = :comments
     assert preload("posts", ^comments).preloads == [:comments]
     assert preload("posts", ^[comments]).preloads == [[:comments]]
-    assert preload("posts", [users: ^comments]).preloads == [users: :comments]
-    assert preload("posts", [users: ^[comments]]).preloads == [users: [:comments]]
+    assert preload("posts", users: ^comments).preloads == [users: :comments]
+    assert preload("posts", users: ^[comments]).preloads == [users: [:comments]]
     assert preload("posts", [{^:users, ^comments}]).preloads == [users: :comments]
 
     query = from u in "users", limit: 10
-    assert preload("posts", [users: ^query]).preloads == [users: query]
+    assert preload("posts", users: ^query).preloads == [users: query]
     assert preload("posts", [{^:users, ^query}]).preloads == [users: query]
-    assert preload("posts", [users: ^{query, :comments}]).preloads == [users: {query, :comments}]
+    assert preload("posts", users: ^{query, :comments}).preloads == [users: {query, :comments}]
 
     fun = fn _ -> [] end
-    assert preload("posts", [users: ^fun]).preloads == [users: fun]
+    assert preload("posts", users: ^fun).preloads == [users: fun]
     assert preload("posts", [{^:users, ^fun}]).preloads == [users: fun]
-    assert preload("posts", [users: ^{fun, :comments}]).preloads == [users: {fun, :comments}]
+    assert preload("posts", users: ^{fun, :comments}).preloads == [users: {fun, :comments}]
   end
 end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -7,50 +7,170 @@ defmodule Ecto.Query.Builder.SelectTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do &0 end), {[], %{}}} ==
-             escape(quote do x end, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  &0
+                end
+              ),
+              {[], %{}}} ==
+               escape(
+                 quote do
+                   x
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do &0.y() end), {[], %{}}} ==
-             escape(quote do x.y() end, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  &0.y()
+                end
+              ),
+              {[], %{}}} ==
+               escape(
+                 quote do
+                   x.y()
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do &0 end), {[], %{0 => {:any, [:foo, :bar, baz: :bat]}}}} ==
-             escape(quote do [:foo, :bar, baz: :bat] end, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  &0
+                end
+              ),
+              {[], %{0 => {:any, [:foo, :bar, baz: :bat]}}}} ==
+               escape(
+                 quote do
+                   [:foo, :bar, baz: :bat]
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do &0 end), {[], %{0 => {:struct, [:foo, :bar, baz: :bat]}}}} ==
-             escape(quote do struct(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  &0
+                end
+              ),
+              {[], %{0 => {:struct, [:foo, :bar, baz: :bat]}}}} ==
+               escape(
+                 quote do
+                   struct(x, [:foo, :bar, baz: :bat])
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do &0 end), {[], %{0 => {:map, [:foo, :bar, baz: :bat]}}}} ==
-             escape(quote do map(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  &0
+                end
+              ),
+              {[], %{0 => {:map, [:foo, :bar, baz: :bat]}}}} ==
+               escape(
+                 quote do
+                   map(x, [:foo, :bar, baz: :bat])
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
       assert {{:{}, [], [:{}, [], [0, 1, 2]]}, {[], %{}}} ==
-             escape(quote do {0, 1, 2} end, [], __ENV__)
+               escape(
+                 quote do
+                   {0, 1, 2}
+                 end,
+                 [],
+                 __ENV__
+               )
 
       assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, {[], %{}}} ==
-             escape(quote do %{a: a} end, [a: 0], __ENV__)
+               escape(
+                 quote do
+                   %{a: a}
+                 end,
+                 [a: 0],
+                 __ENV__
+               )
 
-      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, {[], %{}}} ==
-             escape(quote do %{a => b} end, [a: 0, b: 1], __ENV__)
+      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]},
+              {[], %{}}} ==
+               escape(
+                 quote do
+                   %{a => b}
+                 end,
+                 [a: 0, b: 1],
+                 __ENV__
+               )
 
-      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], {[], %{}}} ==
-             escape(quote do [x.y(), x.z()] end, [x: 0], __ENV__)
+      assert {[
+                Macro.escape(
+                  quote do
+                    &0.y()
+                  end
+                ),
+                Macro.escape(
+                  quote do
+                    &0.z()
+                  end
+                )
+              ],
+              {[], %{}}} ==
+               escape(
+                 quote do
+                   [x.y(), x.z()]
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {[{:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :y]]}, [], []]},
-               {:{}, [], [:^, [], [0]]}], {[{1, :any}], %{}}} ==
-              escape(quote do [x.y(), ^1] end, [x: 0], __ENV__)
+      assert {[
+                {:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :y]]}, [], []]},
+                {:{}, [], [:^, [], [0]]}
+              ],
+              {[{1, :any}], %{}}} ==
+               escape(
+                 quote do
+                   [x.y(), ^1]
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {[], %{}}} ==
-             escape(quote do %Foo{a: a} end, [a: 0], __ENV__)
+      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]},
+              {[], %{}}} ==
+               escape(
+                 quote do
+                   %Foo{a: a}
+                 end,
+                 [a: 0],
+                 __ENV__
+               )
     end
 
     test "on conflicting take" do
       assert {_, {[], %{0 => {:map, [:foo, :bar, baz: :bat]}}}} =
-             escape(quote do {map(x, [:foo, :bar]), map(x, [baz: :bat])} end, [x: 0], __ENV__)
+               escape(
+                 quote do
+                   {map(x, [:foo, :bar]), map(x, baz: :bat)}
+                 end,
+                 [x: 0],
+                 __ENV__
+               )
 
       assert_raise Ecto.Query.CompileError,
                    ~r"cannot select_merge because the binding at position 0",
                    fn ->
-        escape(quote do {map(x, [:foo, :bar]), struct(x, [baz: :bat])} end, [x: 0], __ENV__)
-      end
+                     escape(
+                       quote do
+                         {map(x, [:foo, :bar]), struct(x, baz: :bat)}
+                       end,
+                       [x: 0],
+                       __ENV__
+                     )
+                   end
     end
 
     @fields [:field]
@@ -65,13 +185,25 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert_raise Ecto.Query.CompileError,
                    ~r":foo is not a valid query expression, :select expects a query expression or a list of fields",
                    fn ->
-        escape(quote do :foo end, [x: 0], __ENV__)
-      end
+                     escape(
+                       quote do
+                         :foo
+                       end,
+                       [x: 0],
+                       __ENV__
+                     )
+                   end
     end
 
     test "raises on mixed fields and interpolation" do
       assert_raise Ecto.Query.CompileError, ~r"Cannot mix fields with interpolations", fn ->
-        escape(quote do [:foo, ^:bar] end, [], __ENV__)
+        escape(
+          quote do
+            [:foo, ^:bar]
+          end,
+          [],
+          __ENV__
+        )
       end
     end
   end
@@ -86,6 +218,7 @@ defmodule Ecto.Query.Builder.SelectTest do
 
     test "raises on multiple selects" do
       message = "only one select expression is allowed in query"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         %Ecto.Query{} |> select([], 1) |> select([], 2)
       end
@@ -224,17 +357,30 @@ defmodule Ecto.Query.Builder.SelectTest do
 
     test "on conflicting take" do
       _ = from p in "posts", select: p, select_merge: map(p, [:title]), select_merge: [:body]
-      _ = from p in "posts", select: p, select_merge: map(p, [:title]), select_merge: map(p, [:body])
+
+      _ =
+        from p in "posts",
+          select: p,
+          select_merge: map(p, [:title]),
+          select_merge: map(p, [:body])
+
       _ = from p in "posts", select: p, select_merge: [:title], select_merge: map(p, [:body])
       _ = from p in "posts", select: p, select_merge: [:title], select_merge: struct(p, [:body])
       _ = from p in "posts", select: p, select_merge: struct(p, [:title]), select_merge: [:body]
-      _ = from p in "posts", select: p, select_merge: struct(p, [:title]), select_merge: struct(p, [:body])
+
+      _ =
+        from p in "posts",
+          select: p,
+          select_merge: struct(p, [:title]),
+          select_merge: struct(p, [:body])
 
       assert_raise Ecto.Query.CompileError,
                    ~r"cannot select_merge because the binding at position 0",
                    fn ->
-        from p in "posts", select: map(p, [:title]), select_merge: struct(p, [:title])
-      end
+                     from p in "posts",
+                       select: map(p, [:title]),
+                       select_merge: struct(p, [:title])
+                   end
     end
 
     test "optimizes map/struct merges" do
@@ -242,18 +388,21 @@ defmodule Ecto.Query.Builder.SelectTest do
         from p in "posts",
           select: %{t: {p.title, p.body}},
           select_merge: %{t: p.title, b: p.body}
+
       assert Macro.to_string(query.select.expr) == "%{t: &0.title(), b: &0.body()}"
 
       query =
         from p in "posts",
           select: %Post{title: p.title},
           select_merge: %{title: nil}
+
       assert Macro.to_string(query.select.expr) == "%Post{title: nil}"
 
       query =
         from p in "posts",
           select: %{t: {p.title, ^0}},
           select_merge: %{t: p.title, b: p.body}
+
       assert Macro.to_string(query.select.expr) =~ "merge"
     end
   end

--- a/test/ecto/query/builder/update_test.exs
+++ b/test/ecto/query/builder/update_test.exs
@@ -7,35 +7,81 @@ defmodule Ecto.Query.Builder.UpdateTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert escape(quote do [set: [foo: 1]] end, [x: 0], __ENV__) |> elem(0) ==
-             [set: [foo: {:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: 1, type: {0, :foo}]}]}]]
+      assert escape(
+               quote do
+                 [set: [foo: 1]]
+               end,
+               [x: 0],
+               __ENV__
+             )
+             |> elem(0) ==
+               [
+                 set: [
+                   foo: {:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: 1, type: {0, :foo}]}]}
+                 ]
+               ]
 
-      assert escape(quote do [set: [foo: x.bar()]] end, [x: 0], __ENV__) |> elem(0) ==
-             Macro.escape(quote do [set: [foo: &0.bar()]] end)
+      assert escape(
+               quote do
+                 [set: [foo: x.bar()]]
+               end,
+               [x: 0],
+               __ENV__
+             )
+             |> elem(0) ==
+               Macro.escape(
+                 quote do
+                   [set: [foo: &0.bar()]]
+                 end
+               )
     end
 
     test "performs compile time interpolation" do
       query = "foo" |> update([p], set: [foo: p.foo == ^1])
       [compile] = query.updates
-      assert compile.expr == [set: [foo: {:==, [], [{{:., [], [{:&, [], [0]}, :foo]}, [], []}, {:^, [], [0]}]}]]
+
+      assert compile.expr == [
+               set: [foo: {:==, [], [{{:., [], [{:&, [], [0]}, :foo]}, [], []}, {:^, [], [0]}]}]
+             ]
+
       assert compile.params == [{1, {0, :foo}}]
     end
 
     test "raises on non-keyword lists" do
       assert_raise Ecto.Query.CompileError,
-                   ~r"malformed update `\[1\]` in query expression", fn ->
-        escape(quote do [1] end, [], __ENV__)
-      end
+                   ~r"malformed update `\[1\]` in query expression",
+                   fn ->
+                     escape(
+                       quote do
+                         [1]
+                       end,
+                       [],
+                       __ENV__
+                     )
+                   end
 
       assert_raise Ecto.Query.CompileError,
-                   ~r"malformed :set in update `\[1\]`, expected a keyword list", fn ->
-        escape(quote do [set: [1]] end, [], __ENV__)
-      end
+                   ~r"malformed :set in update `\[1\]`, expected a keyword list",
+                   fn ->
+                     escape(
+                       quote do
+                         [set: [1]]
+                       end,
+                       [],
+                       __ENV__
+                     )
+                   end
     end
 
     test "raises on invalid updates" do
       assert_raise Ecto.Query.CompileError, "unknown key `:unknown` in update", fn ->
-        escape(quote do [unknown: [1]] end, [], __ENV__)
+        escape(
+          quote do
+            [unknown: [1]]
+          end,
+          [],
+          __ENV__
+        )
       end
 
       assert_raise Ecto.Query.CompileError, "unknown key `:unknown` in update", fn ->
@@ -88,8 +134,13 @@ defmodule Ecto.Query.Builder.UpdateTest do
 
       %{updates: [update]} = update("foo", [_], set: [foo: ^1, bar: ^dynamic, baz: ^2])
       assert Macro.to_string(update.expr) == "[set: [foo: ^0, bar: ^1 and ^2, baz: ^3]]"
-      assert update.params == [{1, {0, :foo}}, {false, :boolean},
-                               {true, :boolean}, {2, {0, :baz}}]
+
+      assert update.params == [
+               {1, {0, :foo}},
+               {false, :boolean},
+               {true, :boolean},
+               {2, {0, :baz}}
+             ]
     end
 
     test "raises on malformed updates" do

--- a/test/ecto/query/builder/windows_test.exs
+++ b/test/ecto/query/builder/windows_test.exs
@@ -8,29 +8,103 @@ defmodule Ecto.Query.Builder.WindowsTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do [partition_by: [&0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [partition_by: x.y()] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [partition_by: [&0.y()]]
+                end
+              ), [],
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [partition_by: x.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [partition_by: [&0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [partition_by: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [partition_by: [&0.y()]]
+                end
+              ), [],
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [partition_by: :y]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [order_by: [asc: &0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [order_by: x.y()] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [order_by: [asc: &0.y()]]
+                end
+              ), [],
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [order_by: x.y()]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote do [order_by: [asc: &0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [order_by: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(
+                quote do
+                  [order_by: [asc: &0.y()]]
+                end
+              ), [],
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [order_by: :y]
+                 end,
+                 {[], :acc},
+                 [x: 0],
+                 __ENV__
+               )
     end
 
     test "supports frames" do
-      assert {Macro.escape(quote(do: [frame: fragment({:raw, "ROWS 3 PRECEDING EXCLUDE CURRENT ROW"})])), [], {[], :acc}} ==
-               escape(quote do [frame: fragment("ROWS 3 PRECEDING EXCLUDE CURRENT ROW")] end, {[], :acc}, [], __ENV__)
+      assert {Macro.escape(
+                quote(do: [frame: fragment({:raw, "ROWS 3 PRECEDING EXCLUDE CURRENT ROW"})])
+              ), [],
+              {[], :acc}} ==
+               escape(
+                 quote do
+                   [frame: fragment("ROWS 3 PRECEDING EXCLUDE CURRENT ROW")]
+                 end,
+                 {[], :acc},
+                 [],
+                 __ENV__
+               )
 
-      assert {Macro.escape(quote(do: [frame: fragment({:raw, "ROWS "}, {:expr, ^0}, {:raw, " PRECEDING"})])),
-               [], {[{quote(do: start_frame), :any}], :acc}} ==
-               escape(quote do [frame: fragment("ROWS ? PRECEDING", ^start_frame)] end, {[], :acc}, [], __ENV__)
+      assert {Macro.escape(
+                quote(do: [frame: fragment({:raw, "ROWS "}, {:expr, ^0}, {:raw, " PRECEDING"})])
+              ), [],
+              {[{quote(do: start_frame), :any}], :acc}} ==
+               escape(
+                 quote do
+                   [frame: fragment("ROWS ? PRECEDING", ^start_frame)]
+                 end,
+                 {[], :acc},
+                 [],
+                 __ENV__
+               )
 
       assert_raise Ecto.Query.CompileError, ~r"expected a dynamic or fragment in `:frame`", fn ->
-        escape(quote do [frame: [rows: -3, exclude: :current]] end, {[], :acc}, [], __ENV__)
+        escape(
+          quote do
+            [frame: [rows: -3, exclude: :current]]
+          end,
+          {[], :acc},
+          [],
+          __ENV__
+        )
       end
     end
   end
@@ -78,9 +152,11 @@ defmodule Ecto.Query.Builder.WindowsTest do
     end
 
     test "raises on invalid partition by" do
-      assert_raise ArgumentError, ~r"expected a list of fields and dynamics in `partition_by`", fn ->
-        windows("q", w: [partition_by: ^[1]])
-      end
+      assert_raise ArgumentError,
+                   ~r"expected a list of fields and dynamics in `partition_by`",
+                   fn ->
+                     windows("q", w: [partition_by: ^[1]])
+                   end
     end
 
     test "allows interpolation on order by" do
@@ -105,14 +181,19 @@ defmodule Ecto.Query.Builder.WindowsTest do
     end
 
     test "raises on invalid order by" do
-      assert_raise ArgumentError, ~r"`order_by` interpolated on root expects a field or a keyword list", fn ->
-        windows("q", w: [order_by: ^[1]])
-      end
+      assert_raise ArgumentError,
+                   ~r"`order_by` interpolated on root expects a field or a keyword list",
+                   fn ->
+                     windows("q", w: [order_by: ^[1]])
+                   end
     end
 
     test "allows dynamic on frame" do
       frame = dynamic(fragment("ROWS ? PRECEDING EXCLUDE CURRENT ROW", ^"foo"))
-      query = "q" |> windows([p], w: [partition_by: [p.bar == ^"bar"], order_by: [p.baz], frame: ^frame])
+
+      query =
+        "q"
+        |> windows([p], w: [partition_by: [p.bar == ^"bar"], order_by: [p.baz], frame: ^frame])
 
       assert Keyword.keys(query.windows[:w].expr) == [:partition_by, :order_by, :frame]
 
@@ -123,7 +204,8 @@ defmodule Ecto.Query.Builder.WindowsTest do
                [{:asc, {{:., [], [{:&, [], [0]}, :baz]}, [], []}}]
 
       assert query.windows[:w].expr[:frame] ==
-               {:fragment, [], [raw: "ROWS ", expr: {:^, [], [1]}, raw: " PRECEDING EXCLUDE CURRENT ROW"]}
+               {:fragment, [],
+                [raw: "ROWS ", expr: {:^, [], [1]}, raw: " PRECEDING EXCLUDE CURRENT ROW"]}
 
       assert query.windows[:w].params == [{"bar", {0, :bar}}, {"foo", :any}]
     end
@@ -174,7 +256,8 @@ defmodule Ecto.Query.Builder.WindowsTest do
                  [{:asc, {:==, [], [{{:., [], [{:&, [], [0]}, :bar]}, [], []}, {:^, [], [1]}]}}]
 
         assert query.windows[:w].expr[:frame] ==
-                 {:fragment, [], [raw: "ROWS ", expr: {:^, [], [2]}, raw: " PRECEDING EXCLUDE CURRENT ROW"]}
+                 {:fragment, [],
+                  [raw: "ROWS ", expr: {:^, [], [2]}, raw: " PRECEDING EXCLUDE CURRENT ROW"]}
 
         assert query.windows[:w].params == [{"foo", {0, :foo}}, {"bar", {0, :bar}}, {"baz", :any}]
       end

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -10,101 +10,332 @@ defmodule Ecto.Query.BuilderTest do
   end
 
   test "escape" do
-    assert {Macro.escape(quote do &0.y() end), []} ==
-           escape(quote do x.y() end, [x: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                &0.y()
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 x.y()
+               end,
+               [x: 0],
+               __ENV__
+             )
 
     import Kernel, except: [>: 2]
-    assert {Macro.escape(quote do &0.y() > &0.z() end), []} ==
-           escape(quote do x.y() > x.z() end, [x: 0], __ENV__)
 
-    assert {Macro.escape(quote do &0.y() > &1.z() end), []} ==
-           escape(quote do x.y() > y.z() end, [x: 0, y: 1], __ENV__)
+    assert {Macro.escape(
+              quote do
+                &0.y() > &0.z()
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 x.y() > x.z()
+               end,
+               [x: 0],
+               __ENV__
+             )
+
+    assert {Macro.escape(
+              quote do
+                &0.y() > &1.z()
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 x.y() > y.z()
+               end,
+               [x: 0, y: 1],
+               __ENV__
+             )
 
     import Kernel, except: [+: 2]
-    assert {Macro.escape(quote do &0.y() + &1.z() end), []} ==
-           escape(quote do x.y() + y.z() end, [x: 0, y: 1], __ENV__)
 
-    assert {Macro.escape(quote do avg(0) end), []} ==
-           escape(quote do avg(0) end, [], __ENV__)
+    assert {Macro.escape(
+              quote do
+                &0.y() + &1.z()
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 x.y() + y.z()
+               end,
+               [x: 0, y: 1],
+               __ENV__
+             )
+
+    assert {Macro.escape(
+              quote do
+                avg(0)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 avg(0)
+               end,
+               [],
+               __ENV__
+             )
 
     assert {quote(do: ~s"123"), []} ==
-           escape(quote do ~s"123" end, [], __ENV__)
+             escape(
+               quote do
+                 ~s"123"
+               end,
+               [],
+               __ENV__
+             )
 
-    assert {{:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: {:<<>>, [], [0, 1, 2]}, type: :binary]}]}, []} ==
-           escape(quote do <<0,1,2>> end, [], __ENV__)
+    assert {{:%, [],
+             [Ecto.Query.Tagged, {:%{}, [], [value: {:<<>>, [], [0, 1, 2]}, type: :binary]}]},
+            []} ==
+             escape(
+               quote do
+                 <<0, 1, 2>>
+               end,
+               [],
+               __ENV__
+             )
 
     assert {:some_atom, []} ==
-           escape(quote do :some_atom end, [], __ENV__)
+             escape(
+               quote do
+                 :some_atom
+               end,
+               [],
+               __ENV__
+             )
 
     assert quote(do: &0.z()) ==
-           escape(quote do field(x, :z) end, [x: 0], __ENV__)
-           |> elem(0)
-           |> Code.eval_quoted([], __ENV__)
-           |> elem(0)
+             escape(
+               quote do
+                 field(x, :z)
+               end,
+               [x: 0],
+               __ENV__
+             )
+             |> elem(0)
+             |> Code.eval_quoted([], __ENV__)
+             |> elem(0)
 
-    assert {Macro.escape(quote do -&0.y() end), []} ==
-           escape(quote do -x.y() end, [x: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                -&0.y()
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 -x.y()
+               end,
+               [x: 0],
+               __ENV__
+             )
   end
 
   test "escape json_extract_path" do
     expected = {Macro.escape(quote do: json_extract_path(&0.y(), ["a", "b"])), []}
-    actual = escape(quote do json_extract_path(x.y, ["a", "b"]) end, [x: 0], __ENV__)
+
+    actual =
+      escape(
+        quote do
+          json_extract_path(x.y, ["a", "b"])
+        end,
+        [x: 0],
+        __ENV__
+      )
+
     assert actual == expected
 
-    actual = escape(quote do x.y["a"]["b"] end, [x: 0], __ENV__)
+    actual =
+      escape(
+        quote do
+          x.y["a"]["b"]
+        end,
+        [x: 0],
+        __ENV__
+      )
+
     assert actual == expected
 
     expected = {Macro.escape(quote do: json_extract_path(&0.y(), ["a", 0])), []}
-    actual = escape(quote do x.y["a"][0] end, [x: 0], __ENV__)
+
+    actual =
+      escape(
+        quote do
+          x.y["a"][0]
+        end,
+        [x: 0],
+        __ENV__
+      )
+
     assert actual == expected
 
     expected = {Macro.escape(quote do: json_extract_path(&0.y(), [0, "a"])), []}
-    actual = escape(quote do x.y[0]["a"] end, [x: 0], __ENV__)
+
+    actual =
+      escape(
+        quote do
+          x.y[0]["a"]
+        end,
+        [x: 0],
+        __ENV__
+      )
+
     assert actual == expected
 
-    assert_raise Ecto.Query.CompileError, "`json_extract_path(x, [\"a\"])` is not a valid query expression", fn ->
-      escape(quote do json_extract_path(x, ["a"]) end, [x: 0], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 "`json_extract_path(x, [\"a\"])` is not a valid query expression",
+                 fn ->
+                   escape(
+                     quote do
+                       json_extract_path(x, ["a"])
+                     end,
+                     [x: 0],
+                     __ENV__
+                   )
+                 end
 
     assert_raise Ecto.Query.CompileError, "`x[\"a\"]` is not a valid query expression", fn ->
-      escape(quote do x["a"] end, [x: 0], __ENV__)
+      escape(
+        quote do
+          x["a"]
+        end,
+        [x: 0],
+        __ENV__
+      )
     end
 
-    assert_raise Ecto.Query.CompileError, ~r/expected JSON path to contain literal strings.*got: `a`/, fn ->
-      escape(quote do x.y[a] end, [x: 0], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r/expected JSON path to contain literal strings.*got: `a`/,
+                 fn ->
+                   escape(
+                     quote do
+                       x.y[a]
+                     end,
+                     [x: 0],
+                     __ENV__
+                   )
+                 end
 
-    assert_raise Ecto.Query.CompileError, "expected JSON path to be compile-time list, got: `bad`", fn ->
-      escape(quote do json_extract_path(x.y, bad) end, [x: 0], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 "expected JSON path to be compile-time list, got: `bad`",
+                 fn ->
+                   escape(
+                     quote do
+                       json_extract_path(x.y, bad)
+                     end,
+                     [x: 0],
+                     __ENV__
+                   )
+                 end
   end
 
   test "escape fragments" do
-    assert {Macro.escape(quote do fragment({:raw, "date_add("}, {:expr, &0.created_at()},
-                                           {:raw, ", "}, {:expr, ^0}, {:raw, ")"}) end), [{0, :any}]} ==
-      escape(quote do fragment("date_add(?, ?)", p.created_at(), ^0) end, [p: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                fragment(
+                  {:raw, "date_add("},
+                  {:expr, &0.created_at()},
+                  {:raw, ", "},
+                  {:expr, ^0},
+                  {:raw, ")"}
+                )
+              end
+            ),
+            [{0, :any}]} ==
+             escape(
+               quote do
+                 fragment("date_add(?, ?)", p.created_at(), ^0)
+               end,
+               [p: 0],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote do fragment({:raw, ""}, {:expr, ^0}, {:raw, "::text"}) end), [{0, :any}]} ==
-      escape(quote do fragment(~S"?::text", ^0) end, [p: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                fragment({:raw, ""}, {:expr, ^0}, {:raw, "::text"})
+              end
+            ),
+            [{0, :any}]} ==
+             escape(
+               quote do
+                 fragment(~S"?::text", ^0)
+               end,
+               [p: 0],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote do fragment({:raw, "query?("}, {:expr, &0.created_at()},
-                                           {:raw, ")"}) end), []} ==
-      escape(quote do fragment("query\\?(?)", p.created_at()) end, [p: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                fragment({:raw, "query?("}, {:expr, &0.created_at()}, {:raw, ")"})
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 fragment("query\\?(?)", p.created_at())
+               end,
+               [p: 0],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote do fragment(title: [foo: ^0]) end), [{0, :any}]} ==
-      escape(quote do fragment(title: [foo: ^0]) end, [], __ENV__)
+    assert {Macro.escape(
+              quote do
+                fragment(title: [foo: ^0])
+              end
+            ),
+            [{0, :any}]} ==
+             escape(
+               quote do
+                 fragment(title: [foo: ^0])
+               end,
+               [],
+               __ENV__
+             )
 
-    assert_raise Ecto.Query.CompileError, ~r"fragment\(...\) does not allow strings to be interpolated", fn ->
-      escape(quote do fragment(:invalid) end, [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"fragment\(...\) does not allow strings to be interpolated",
+                 fn ->
+                   escape(
+                     quote do
+                       fragment(:invalid)
+                     end,
+                     [],
+                     __ENV__
+                   )
+                 end
 
     assert_raise Ecto.Query.CompileError,
                  ~r"expects extra arguments in the same amount of question marks in string. It received 0 extra argument\(s\) but expected 1",
-                 fn -> escape(quote do fragment("?") end, [], __ENV__) end
+                 fn ->
+                   escape(
+                     quote do
+                       fragment("?")
+                     end,
+                     [],
+                     __ENV__
+                   )
+                 end
 
     assert_raise Ecto.Query.CompileError,
                  ~r"expects extra arguments in the same amount of question marks in string. It received 1 extra argument\(s\) but expected 0",
-                 fn -> escape(quote do fragment("", 1) end, [], __ENV__) end
+                 fn ->
+                   escape(
+                     quote do
+                       fragment("", 1)
+                     end,
+                     [],
+                     __ENV__
+                   )
+                 end
   end
 
   defmacro my_first_value(expr) do
@@ -114,69 +345,180 @@ defmodule Ecto.Query.BuilderTest do
   end
 
   test "escape over with window name" do
-    assert {Macro.escape(quote(do: over(count(&0.id()), :w))), []}  ==
-           escape(quote(do: count(x.id()) |> over(:w)), [x: 0], __ENV__)
+    assert {Macro.escape(quote(do: over(count(&0.id()), :w))), []} ==
+             escape(quote(do: count(x.id()) |> over(:w)), [x: 0], __ENV__)
 
-    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), :w))), []}  ==
-           escape(quote(do: nth_value(x.id(), 1) |> over(:w)), [x: 0], __ENV__)
+    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), :w))), []} ==
+             escape(quote(do: nth_value(x.id(), 1) |> over(:w)), [x: 0], __ENV__)
 
-    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), :w))), []}  ==
-           escape(quote(do: my_first_value(x.id()) |> over(:w)), [x: 0], __ENV__)
+    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), :w))), []} ==
+             escape(quote(do: my_first_value(x.id()) |> over(:w)), [x: 0], __ENV__)
   end
 
   test "escape over with window parts" do
-    assert {Macro.escape(quote(do: over(row_number(), []))), []}  ==
-           escape(quote(do: over(row_number())), [], __ENV__)
+    assert {Macro.escape(quote(do: over(row_number(), []))), []} ==
+             escape(quote(do: over(row_number())), [], __ENV__)
 
-    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), []))), []}  ==
-           escape(quote(do: over(my_first_value(x.id()))), [x: 0], __ENV__)
+    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), []))), []} ==
+             escape(quote(do: over(my_first_value(x.id()))), [x: 0], __ENV__)
 
     assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), order_by: [asc: &0.id()]))), []} ==
-           escape(quote(do: nth_value(x.id(), 1) |> over(order_by: x.id())), [x: 0], __ENV__)
+             escape(quote(do: nth_value(x.id(), 1) |> over(order_by: x.id())), [x: 0], __ENV__)
 
     assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), partition_by: [&0.id()]))), []} ==
-           escape(quote(do: nth_value(x.id(), 1) |> over(partition_by: x.id())), [x: 0], __ENV__)
+             escape(
+               quote(do: nth_value(x.id(), 1) |> over(partition_by: x.id())),
+               [x: 0],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), frame: fragment({:raw, "ROWS"})))), []} ==
-           escape(quote(do: nth_value(x.id(), 1) |> over(frame: fragment("ROWS"))), [x: 0], __ENV__)
+    assert {Macro.escape(quote(do: over(nth_value(&0.id(), 1), frame: fragment({:raw, "ROWS"})))),
+            []} ==
+             escape(
+               quote(do: nth_value(x.id(), 1) |> over(frame: fragment("ROWS"))),
+               [x: 0],
+               __ENV__
+             )
 
     assert_raise Ecto.Query.CompileError,
                  ~r"windows definitions given to over/2 do not allow interpolations at the root",
                  fn ->
-      escape(quote(do: nth_value(x.id(), 1) |> over(order_by: ^foo)), [x: 0], __ENV__)
-    end
+                   escape(
+                     quote(do: nth_value(x.id(), 1) |> over(order_by: ^foo)),
+                     [x: 0],
+                     __ENV__
+                   )
+                 end
 
     import Kernel, except: [is_nil: 1]
-    assert {Macro.escape(quote(do: over(filter(avg(&0.value()), is_nil(&0.flag())), []))), []}  ==
-      escape(quote(do: avg(x.value()) |> filter(is_nil(x.flag())) |> over([])), [x: 0], __ENV__)
+
+    assert {Macro.escape(quote(do: over(filter(avg(&0.value()), is_nil(&0.flag())), []))), []} ==
+             escape(
+               quote(do: avg(x.value()) |> filter(is_nil(x.flag())) |> over([])),
+               [x: 0],
+               __ENV__
+             )
   end
 
   test "escape type cast" do
     import Kernel, except: [+: 2]
-    assert {Macro.escape(quote do type(&0.y() + &1.z(), :decimal) end), []} ==
-           escape(quote do type(x.y() + y.z(), :decimal) end, [x: 0, y: 1], __ENV__)
 
-    assert {Macro.escape(quote do type(&0.y(), :decimal) end), []} ==
-          escape(quote do type(field(x, :y), :decimal) end, [x: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                type(&0.y() + &1.z(), :decimal)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(x.y() + y.z(), :decimal)
+               end,
+               [x: 0, y: 1],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote do type(&0.y(), :"Elixir.Ecto.UUID") end), []} ==
-          escape(quote do type(field(x, :y), Ecto.UUID) end, [x: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                type(&0.y(), :decimal)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(field(x, :y), :decimal)
+               end,
+               [x: 0],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote do type(&0.y(), :"Elixir.Ecto.UUID") end), []} ==
-          escape(quote do type(field(x, :y), Ecto.UUID) end, [x: 0], {__ENV__, %{}})
+    assert {Macro.escape(
+              quote do
+                type(&0.y(), :"Elixir.Ecto.UUID")
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(field(x, :y), Ecto.UUID)
+               end,
+               [x: 0],
+               __ENV__
+             )
 
-    assert {Macro.escape(quote do type(sum(&0.y()), :decimal) end), []} ==
-          escape(quote do type(sum(x.y()), :decimal) end, [x: 0], {__ENV__, %{}})
+    assert {Macro.escape(
+              quote do
+                type(&0.y(), :"Elixir.Ecto.UUID")
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(field(x, :y), Ecto.UUID)
+               end,
+               [x: 0],
+               {__ENV__, %{}}
+             )
 
-    assert {Macro.escape(quote do type(count(), :decimal) end), []} ==
-          escape(quote do type(count(), :decimal) end, [x: 0], {__ENV__, %{}})
+    assert {Macro.escape(
+              quote do
+                type(sum(&0.y()), :decimal)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(sum(x.y()), :decimal)
+               end,
+               [x: 0],
+               {__ENV__, %{}}
+             )
+
+    assert {Macro.escape(
+              quote do
+                type(count(), :decimal)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(count(), :decimal)
+               end,
+               [x: 0],
+               {__ENV__, %{}}
+             )
 
     import Kernel, except: [>: 2]
-    assert {Macro.escape(quote do type(filter(sum(&0.y()), &0.y() > &0.z()), :decimal) end), []} ==
-          escape(quote do type(filter(sum(x.y()), x.y() > x.z()), :decimal) end, [x: 0], {__ENV__, %{}})
 
-    assert {Macro.escape(quote do type(over(fragment({:raw, "array_agg("}, {:expr, &0.id()}, {:raw, ")"}), :y), {:array, :"Elixir.Ecto.UUID"}) end), []} ==
-      escape(quote do type(over(fragment("array_agg(?)", x.id()), :y), {:array, Ecto.UUID}) end, [x: 0], {__ENV__, %{}})
+    assert {Macro.escape(
+              quote do
+                type(filter(sum(&0.y()), &0.y() > &0.z()), :decimal)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(filter(sum(x.y()), x.y() > x.z()), :decimal)
+               end,
+               [x: 0],
+               {__ENV__, %{}}
+             )
+
+    assert {Macro.escape(
+              quote do
+                type(
+                  over(fragment({:raw, "array_agg("}, {:expr, &0.id()}, {:raw, ")"}), :y),
+                  {:array, :"Elixir.Ecto.UUID"}
+                )
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(over(fragment("array_agg(?)", x.id()), :y), {:array, Ecto.UUID})
+               end,
+               [x: 0],
+               {__ENV__, %{}}
+             )
   end
 
   defmacro wrapped_sum(a) do
@@ -184,36 +526,59 @@ defmodule Ecto.Query.BuilderTest do
   end
 
   test "escape type cast with macro" do
-    assert {Macro.escape(quote do type(sum(&0.y()), :integer) end), []} ==
-          escape(quote do type(wrapped_sum(x.y()), :integer) end, [x: 0], __ENV__)
+    assert {Macro.escape(
+              quote do
+                type(sum(&0.y()), :integer)
+              end
+            ),
+            []} ==
+             escape(
+               quote do
+                 type(wrapped_sum(x.y()), :integer)
+               end,
+               [x: 0],
+               __ENV__
+             )
   end
 
   test "escape type checks" do
-    assert_raise Ecto.Query.CompileError, ~r"It returns a value of type :boolean but a value of type :integer is expected", fn ->
-      escape(quote(do: ^1 == ^2), :integer, %{}, [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"It returns a value of type :boolean but a value of type :integer is expected",
+                 fn ->
+                   escape(quote(do: ^1 == ^2), :integer, %{}, [], __ENV__)
+                 end
 
-    assert_raise Ecto.Query.CompileError, ~r"It returns a value of type :boolean but a value of type :integer is expected", fn ->
-      escape(quote(do: 1 > 2), :integer, %{}, [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"It returns a value of type :boolean but a value of type :integer is expected",
+                 fn ->
+                   escape(quote(do: 1 > 2), :integer, %{}, [], __ENV__)
+                 end
   end
 
   test "escape raise" do
-    assert_raise Ecto.Query.CompileError, ~r"is not a valid query expression. Only literal binaries and strings are allowed", fn ->
-      escape(quote(do: "#{x}"), [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"is not a valid query expression. Only literal binaries and strings are allowed",
+                 fn ->
+                   escape(quote(do: "#{x}"), [], __ENV__)
+                 end
 
-    assert_raise Ecto.Query.CompileError, ~r"short-circuit operators are not supported: `&&`", fn ->
-      escape(quote(do: true && false), [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"short-circuit operators are not supported: `&&`",
+                 fn ->
+                   escape(quote(do: true && false), [], __ENV__)
+                 end
 
-    assert_raise Ecto.Query.CompileError, ~r"`1 = 1` is not a valid query expression. The match operator is not supported: `=`", fn ->
-      escape(quote(do: 1 = 1), [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"`1 = 1` is not a valid query expression. The match operator is not supported: `=`",
+                 fn ->
+                   escape(quote(do: 1 = 1), [], __ENV__)
+                 end
 
-    assert_raise Ecto.Query.CompileError, ~r"`unknown\(1, 2\)` is not a valid query expression", fn ->
-      escape(quote(do: unknown(1, 2)), [], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"`unknown\(1, 2\)` is not a valid query expression",
+                 fn ->
+                   escape(quote(do: unknown(1, 2)), [], __ENV__)
+                 end
 
     assert_raise Ecto.Query.CompileError, ~r"unbound variable", fn ->
       escape(quote(do: x.y), [], __ENV__)
@@ -223,15 +588,21 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: x.y == 1), [], __ENV__)
     end
 
-    assert_raise Ecto.Query.CompileError, ~r"expected literal atom or interpolated value.*got: `var`", fn ->
-      escape(quote(do: field(x, var)), [x: 0], __ENV__) |> elem(0) |> Code.eval_quoted([], __ENV__)
-    end
+    assert_raise Ecto.Query.CompileError,
+                 ~r"expected literal atom or interpolated value.*got: `var`",
+                 fn ->
+                   escape(quote(do: field(x, var)), [x: 0], __ENV__)
+                   |> elem(0)
+                   |> Code.eval_quoted([], __ENV__)
+                 end
 
     assert_raise Ecto.Query.CompileError,
                  ~r"make sure that the module Foo is required and that bar/1 is a macro",
                  fn ->
-      escape(quote(do: Foo.bar(x)), [x: 0], __ENV__) |> elem(0) |> Code.eval_quoted([], __ENV__)
-    end
+                   escape(quote(do: Foo.bar(x)), [x: 0], __ENV__)
+                   |> elem(0)
+                   |> Code.eval_quoted([], __ENV__)
+                 end
 
     assert_raise Ecto.Query.CompileError, ~r"unknown window function lag/0", fn ->
       escape(quote(do: over(lag())), [], __ENV__)
@@ -240,11 +611,12 @@ defmodule Ecto.Query.BuilderTest do
 
   test "doesn't escape interpolation" do
     import Kernel, except: [>: 2, ++: 2]
+
     assert {Macro.escape(quote(do: ^0)), [{quote(do: 1 > 2), :any}]} ==
-           escape(quote(do: ^(1 > 2)), [], __ENV__)
+             escape(quote(do: ^(1 > 2)), [], __ENV__)
 
     assert {Macro.escape(quote(do: ^0)), [{quote(do: [] ++ []), :any}]} ==
-           escape(quote(do: ^([] ++ [])), [], __ENV__)
+             escape(quote(do: ^([] ++ [])), [], __ENV__)
   end
 
   defp params(quoted, type, vars \\ []) do
@@ -253,23 +625,17 @@ defmodule Ecto.Query.BuilderTest do
   end
 
   test "infers the type for parameter" do
-    assert [{_, :integer}] =
-           params(quote(do: ^1 == 2), :any)
+    assert [{_, :integer}] = params(quote(do: ^1 == 2), :any)
 
-    assert [{_, :integer}] =
-           params(quote(do: 2 == ^1), :any)
+    assert [{_, :integer}] = params(quote(do: 2 == ^1), :any)
 
-    assert [{_, :any}, {_, :any}] =
-           params(quote(do: ^1 == ^2), :any)
+    assert [{_, :any}, {_, :any}] = params(quote(do: ^1 == ^2), :any)
 
-    assert [{_, {0, :title}}] =
-           params(quote(do: ^1 == p.title), :any, [p: 0])
+    assert [{_, {0, :title}}] = params(quote(do: ^1 == p.title), :any, p: 0)
 
-    assert [{_, :boolean}] =
-           params(quote(do: ^1 and true), :any)
+    assert [{_, :boolean}] = params(quote(do: ^1 and true), :any)
 
-    assert [{_, :boolean}] =
-           params(quote(do: ^1), :boolean)
+    assert [{_, :boolean}] = params(quote(do: ^1), :boolean)
   end
 
   test "returns the type for quoted query expression" do
@@ -300,9 +666,9 @@ defmodule Ecto.Query.BuilderTest do
     assert quoted_type({:max, [], [1]}, []) == :integer
     assert quoted_type({:avg, [], [1]}, []) == :any
 
-    assert quoted_type({{:., [], [{:p, [], Elixir}, :title]}, [], []}, [p: 0]) == {0, :title}
-    assert quoted_type({:field, [], [{:p, [], Elixir}, :title]}, [p: 0]) == {0, :title}
-    assert quoted_type({:field, [], [{:p, [], Elixir}, {:^, [], [:title]}]}, [p: 0]) == {0, :title}
+    assert quoted_type({{:., [], [{:p, [], Elixir}, :title]}, [], []}, p: 0) == {0, :title}
+    assert quoted_type({:field, [], [{:p, [], Elixir}, :title]}, p: 0) == {0, :title}
+    assert quoted_type({:field, [], [{:p, [], Elixir}, {:^, [], [:title]}]}, p: 0) == {0, :title}
 
     assert quoted_type({:unknown, [], []}, []) == :any
   end
@@ -311,14 +677,57 @@ defmodule Ecto.Query.BuilderTest do
     env = {__ENV__, :ok}
 
     assert validate_type!({:array, :string}, [], env) == {:array, :string}
-    assert validate_type!(quote do ^:string end, [], env) == :string
-    assert validate_type!(quote do Ecto.UUID end, [], env) == Ecto.UUID
-    assert validate_type!(quote do :string end, [], env) == :string
-    assert validate_type!(quote do x.title end, [x: 0], env) == {0, :title}
-    assert validate_type!(quote do field(x, :title) end, [x: 0], env) == {0, :title}
 
-    assert_raise Ecto.Query.CompileError, ~r"^type/2 expects an alias, atom or source.field as second argument, got: ", fn ->
-      validate_type!(quote do "string" end, [x: 0], env)
-    end
+    assert validate_type!(
+             quote do
+               ^:string
+             end,
+             [],
+             env
+           ) == :string
+
+    assert validate_type!(
+             quote do
+               Ecto.UUID
+             end,
+             [],
+             env
+           ) == Ecto.UUID
+
+    assert validate_type!(
+             quote do
+               :string
+             end,
+             [],
+             env
+           ) == :string
+
+    assert validate_type!(
+             quote do
+               x.title
+             end,
+             [x: 0],
+             env
+           ) == {0, :title}
+
+    assert validate_type!(
+             quote do
+               field(x, :title)
+             end,
+             [x: 0],
+             env
+           ) == {0, :title}
+
+    assert_raise Ecto.Query.CompileError,
+                 ~r"^type/2 expects an alias, atom or source.field as second argument, got: ",
+                 fn ->
+                   validate_type!(
+                     quote do
+                       "string"
+                     end,
+                     [x: 0],
+                     env
+                   )
+                 end
   end
 end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -24,57 +24,60 @@ defmodule Ecto.Query.InspectTest do
 
   test "dynamic" do
     assert inspect(dynamic([p], p.foo == true)) ==
-           "dynamic([p], p.foo == true)"
+             "dynamic([p], p.foo == true)"
 
     assert inspect(dynamic([p], p.foo == ^"hello")) ==
-           "dynamic([p], p.foo == ^\"hello\")"
+             "dynamic([p], p.foo == ^\"hello\")"
 
     assert inspect(dynamic([p, c], p.foo == c.bar)) ==
-           "dynamic([p, c], p.foo == c.bar)"
+             "dynamic([p, c], p.foo == c.bar)"
 
     assert inspect(dynamic([p, ..., c], p.foo == c.bar)) ==
-           "dynamic([p, ..., c], p.foo == c.bar)"
+             "dynamic([p, ..., c], p.foo == c.bar)"
 
     assert inspect(dynamic([a, b, ..., c, d], a.foo == b.bar and c.foo == d.bar)) ==
-           "dynamic([a, b, ..., c, d], a.foo == b.bar and c.foo == d.bar)"
+             "dynamic([a, b, ..., c, d], a.foo == b.bar and c.foo == d.bar)"
 
     assert inspect(dynamic([comments: c], c.bar == ^1)) ==
-           "dynamic([comments: c], c.bar == ^1)"
+             "dynamic([comments: c], c.bar == ^1)"
 
     dynamic = dynamic([p], p.bar == ^1)
+
     assert inspect(dynamic([p], ^dynamic and p.foo == ^0)) ==
-           "dynamic([p], p.bar == ^1 and p.foo == ^0)"
+             "dynamic([p], p.bar == ^1 and p.foo == ^0)"
 
     dynamic = dynamic([o, b], b.user_id == ^1 or ^false)
+
     assert inspect(dynamic([o], o.type == ^2 and ^dynamic)) ==
-           "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or ^false))"
+             "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or ^false))"
 
     sq = from(Post, [])
     dynamic = dynamic([o, b], b.user_id == ^1 or b.user_id in subquery(sq))
+
     assert inspect(dynamic([o], o.type == ^2 and ^dynamic)) ==
-           "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or b.user_id in subquery(#Ecto.Query<from p0 in Inspect.Post>)))"
+             "dynamic([o, b], o.type == ^2 and (b.user_id == ^1 or b.user_id in subquery(#Ecto.Query<from p0 in Inspect.Post>)))"
   end
 
   test "invalid query" do
     assert i(select("posts", [a, b], {a.foo, b.bar})) ==
-           "from p0 in \"posts\", select: {p0.foo, unknown_binding_1!.bar}"
+             "from p0 in \"posts\", select: {p0.foo, unknown_binding_1!.bar}"
   end
 
   test "from" do
     assert i(from(Post, [])) ==
-           ~s{from p0 in Inspect.Post}
+             ~s{from p0 in Inspect.Post}
 
     assert i(from(x in Post, [])) ==
-          ~s{from p0 in Inspect.Post}
+             ~s{from p0 in Inspect.Post}
 
     assert i(from(x in "posts", [])) ==
-           ~s{from p0 in "posts"}
+             ~s{from p0 in "posts"}
 
     assert i(from(x in {"user_posts", Post}, [])) ==
-           ~s[from p0 in {"user_posts", Inspect.Post}]
+             ~s[from p0 in {"user_posts", Inspect.Post}]
 
     assert i(from(subquery(Post), [])) ==
-           ~s{from p0 in subquery(from p0 in Inspect.Post)}
+             ~s{from p0 in subquery(from p0 in Inspect.Post)}
   end
 
   test "CTE" do
@@ -97,134 +100,156 @@ defmodule Ecto.Query.InspectTest do
       |> join(:inner, [r], t in "tree", on: t.id == r.category_id)
 
     assert query |> inspect() |> Inspect.Algebra.format(80) |> to_string() ==
-      ~s{#Ecto.Query<from p0 in "products", join: t1 in "tree", on: t1.id == p0.category_id>\n} <>
-      ~s{|> recursive_ctes(true)\n} <>
-      ~s{|> with_cte("tree", as: } <>
-      ~s{#Ecto.Query<from c0 in "categories", } <>
-      ~s{where: is_nil(c0.parent_id), } <>
-      ~s{union_all: (from c0 in "categories",\n  } <>
-      ~s{join: t1 in "tree",\n  } <>
-      ~s{on: t1.id == c0.parent_id,\n  } <>
-      ~s{select: %\{id: c0.id, depth: fragment("? + 1", t1.depth)\}), } <>
-      ~s{select: %\{id: c0.id, depth: fragment("1")\}>)}
+             ~s{#Ecto.Query<from p0 in "products", join: t1 in "tree", on: t1.id == p0.category_id>\n} <>
+               ~s{|> recursive_ctes(true)\n} <>
+               ~s{|> with_cte("tree", as: } <>
+               ~s{#Ecto.Query<from c0 in "categories", } <>
+               ~s{where: is_nil(c0.parent_id), } <>
+               ~s{union_all: (from c0 in "categories",\n  } <>
+               ~s{join: t1 in "tree",\n  } <>
+               ~s{on: t1.id == c0.parent_id,\n  } <>
+               ~s{select: %\{id: c0.id, depth: fragment("? + 1", t1.depth)\}), } <>
+               ~s{select: %\{id: c0.id, depth: fragment("1")\}>)}
   end
 
   test "cte with fragments" do
     assert with_cte("foo", "foo", as: fragment("select 1 as bar"))
-           |> inspect() |> Inspect.Algebra.format(80) |> to_string() ==
-      ~s{#Ecto.Query<from f0 in "foo">\n} <>
-      ~s{|> with_cte("foo", as: fragment("select 1 as bar"))}
+           |> inspect()
+           |> Inspect.Algebra.format(80)
+           |> to_string() ==
+             ~s{#Ecto.Query<from f0 in "foo">\n} <>
+               ~s{|> with_cte("foo", as: fragment("select 1 as bar"))}
   end
 
   test "join" do
     assert i(from(x in Post, join: y in Comment)) ==
-           ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, on: true}
+             ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, on: true}
 
     assert i(from(x in Post, join: y in Comment, on: x.id == y.id)) ==
-           ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, on: p0.id == c1.id}
 
     assert i(from(x in Post, full_join: y in Comment, on: x.id == y.id)) ==
-           ~s{from p0 in Inspect.Post, full_join: c1 in Inspect.Comment, on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, full_join: c1 in Inspect.Comment, on: p0.id == c1.id}
 
     assert i(from(x in Post, full_join: y in {"user_comments", Comment}, on: x.id == y.id)) ==
-           ~s[from p0 in Inspect.Post, full_join: c1 in {"user_comments", Inspect.Comment}, on: p0.id == c1.id]
+             ~s[from p0 in Inspect.Post, full_join: c1 in {"user_comments", Inspect.Comment}, on: p0.id == c1.id]
 
     assert i(from(x in Post, left_join: y in assoc(x, :comments))) ==
-           ~s{from p0 in Inspect.Post, left_join: c1 in assoc(p0, :comments)}
+             ~s{from p0 in Inspect.Post, left_join: c1 in assoc(p0, :comments)}
 
     assert i(from(x in Post, left_join: y in assoc(x, :comments), on: y.published == true)) ==
-           ~s{from p0 in Inspect.Post, left_join: c1 in assoc(p0, :comments), on: c1.published == true}
+             ~s{from p0 in Inspect.Post, left_join: c1 in assoc(p0, :comments), on: c1.published == true}
 
     assert i(from(x in Post, right_join: y in assoc(x, :post), join: z in assoc(y, :post))) ==
-           ~s{from p0 in Inspect.Post, right_join: p1 in assoc(p0, :post), join: p2 in assoc(p1, :post)}
+             ~s{from p0 in Inspect.Post, right_join: p1 in assoc(p0, :post), join: p2 in assoc(p1, :post)}
 
-    assert i(from(x in Post, inner_join: y in fragment("foo ? and ?", x.id, ^1), on: y.id == x.id)) ==
-           ~s{from p0 in Inspect.Post, join: f1 in fragment("foo ? and ?", p0.id, ^1), on: f1.id == p0.id}
+    assert i(
+             from(x in Post, inner_join: y in fragment("foo ? and ?", x.id, ^1), on: y.id == x.id)
+           ) ==
+             ~s{from p0 in Inspect.Post, join: f1 in fragment("foo ? and ?", p0.id, ^1), on: f1.id == p0.id}
 
     assert i(from(x in Post, join: y in subquery(Comment), on: x.id == y.id)) ==
-           ~s{from p0 in Inspect.Post, join: c1 in subquery(from c0 in Inspect.Comment), on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in subquery(from c0 in Inspect.Comment), on: p0.id == c1.id}
 
     assert i(from(x in Post, join: y in ^from(c in Comment, where: true), on: x.id == y.id)) ==
-           ~s{from p0 in Inspect.Post, join: c1 in ^#Ecto.Query<from c0 in Inspect.Comment, where: true>, on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in ^#Ecto.Query<from c0 in Inspect.Comment, where: true>, on: p0.id == c1.id}
   end
 
   test "as" do
     assert i(from(x in Post, as: :post)) ==
-      ~s{from p0 in Inspect.Post, as: :post}
+             ~s{from p0 in Inspect.Post, as: :post}
 
     assert i(from(x in Post, join: y in Comment, as: :comment, on: x.id == y.id)) ==
-      ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, as: :comment, on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, as: :comment, on: p0.id == c1.id}
 
-    assert i(from(x in Post, inner_join: y in fragment("foo ? and ?", x.id, ^1), as: :foo, on: y.id == x.id)) ==
-      ~s{from p0 in Inspect.Post, join: f1 in fragment("foo ? and ?", p0.id, ^1), as: :foo, on: f1.id == p0.id}
+    assert i(
+             from(x in Post,
+               inner_join: y in fragment("foo ? and ?", x.id, ^1),
+               as: :foo,
+               on: y.id == x.id
+             )
+           ) ==
+             ~s{from p0 in Inspect.Post, join: f1 in fragment("foo ? and ?", p0.id, ^1), as: :foo, on: f1.id == p0.id}
 
     assert i(from(x in Post, join: y in subquery(Comment), as: :comment, on: x.id == y.id)) ==
-      ~s{from p0 in Inspect.Post, join: c1 in subquery(from c0 in Inspect.Comment), as: :comment, on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in subquery(from c0 in Inspect.Comment), as: :comment, on: p0.id == c1.id}
   end
 
   test "prefix" do
     assert i(from(x in Post, prefix: "post")) ==
-      ~s{from p0 in Inspect.Post, prefix: "post"}
+             ~s{from p0 in Inspect.Post, prefix: "post"}
 
     assert i(from(x in Post, join: y in Comment, prefix: "comment", on: x.id == y.id)) ==
-      ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, prefix: "comment", on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in Inspect.Comment, prefix: "comment", on: p0.id == c1.id}
 
-    assert i(from(x in Post, inner_join: y in fragment("foo ? and ?", x.id, ^1), prefix: "foo", on: y.id == x.id)) ==
-      ~s{from p0 in Inspect.Post, join: f1 in fragment("foo ? and ?", p0.id, ^1), prefix: "foo", on: f1.id == p0.id}
+    assert i(
+             from(x in Post,
+               inner_join: y in fragment("foo ? and ?", x.id, ^1),
+               prefix: "foo",
+               on: y.id == x.id
+             )
+           ) ==
+             ~s{from p0 in Inspect.Post, join: f1 in fragment("foo ? and ?", p0.id, ^1), prefix: "foo", on: f1.id == p0.id}
 
     assert i(from(x in Post, join: y in subquery(Comment), prefix: "comment", on: x.id == y.id)) ==
-      ~s{from p0 in Inspect.Post, join: c1 in subquery(from c0 in Inspect.Comment), prefix: "comment", on: p0.id == c1.id}
+             ~s{from p0 in Inspect.Post, join: c1 in subquery(from c0 in Inspect.Comment), prefix: "comment", on: p0.id == c1.id}
   end
 
   test "where" do
     assert i(from(x in Post, where: x.foo == x.bar, where: true)) ==
-           ~s{from p0 in Inspect.Post, where: p0.foo == p0.bar, where: true}
+             ~s{from p0 in Inspect.Post, where: p0.foo == p0.bar, where: true}
   end
 
   test "where in subquery" do
     s = from(x in Post, where: x.bar == ^"1", select: x.foo)
+
     assert i(from(x in Post, where: x.foo in subquery(s))) ==
-          ~s{from p0 in Inspect.Post, where: p0.foo in subquery(#Ecto.Query<from p0 in Inspect.Post, where: p0.bar == ^"1", select: p0.foo>)}
+             ~s{from p0 in Inspect.Post, where: p0.foo in subquery(#Ecto.Query<from p0 in Inspect.Post, where: p0.bar == ^"1", select: p0.foo>)}
   end
 
   test "group by" do
     assert i(from(x in Post, group_by: [x.foo, x.bar], group_by: x.foobar)) ==
-           ~s{from p0 in Inspect.Post, group_by: [p0.foo, p0.bar], group_by: [p0.foobar]}
+             ~s{from p0 in Inspect.Post, group_by: [p0.foo, p0.bar], group_by: [p0.foobar]}
   end
 
   test "having" do
     assert i(from(x in Post, having: x.foo == x.bar, having: true)) ==
-           ~s{from p0 in Inspect.Post, having: p0.foo == p0.bar, having: true}
+             ~s{from p0 in Inspect.Post, having: p0.foo == p0.bar, having: true}
   end
 
   test "window" do
     assert i(from(x in Post, windows: [a: [partition_by: x.foo]])) ==
-           "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo]]]"
+             "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo]]]"
 
     assert i(from(x in Post, windows: [a: [partition_by: x.foo], b: [partition_by: x.bar]])) ==
-           "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo]]], windows: [b: [partition_by: [p0.bar]]]"
+             "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo]]], windows: [b: [partition_by: [p0.bar]]]"
 
-    assert i(from(x in Post, windows: [a: [partition_by: x.foo]], windows: [b: [partition_by: x.bar]])) ==
-           "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo]]], windows: [b: [partition_by: [p0.bar]]]"
+    assert i(
+             from(x in Post,
+               windows: [a: [partition_by: x.foo]],
+               windows: [b: [partition_by: x.bar]]
+             )
+           ) ==
+             "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo]]], windows: [b: [partition_by: [p0.bar]]]"
 
     assert i(from(x in Post, windows: [a: [partition_by: [x.foo, x.bar]]])) ==
-           "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo, p0.bar]]]"
+             "from p0 in Inspect.Post, windows: [a: [partition_by: [p0.foo, p0.bar]]]"
   end
 
   test "over" do
     assert i(from(x in Post, select: count(x.x) |> over(:x))) ==
-           "from p0 in Inspect.Post, select: over(count(p0.x), :x)"
+             "from p0 in Inspect.Post, select: over(count(p0.x), :x)"
 
     assert i(from(x in Post, select: count(x.x) |> over)) ==
-           ~s{from p0 in Inspect.Post, select: over(count(p0.x), [])}
+             ~s{from p0 in Inspect.Post, select: over(count(p0.x), [])}
 
     assert i(from(x in Post, select: count(x.x) |> over(partition_by: x.bar))) ==
-           ~s{from p0 in Inspect.Post, select: over(count(p0.x), partition_by: [p0.bar])}
+             ~s{from p0 in Inspect.Post, select: over(count(p0.x), partition_by: [p0.bar])}
   end
 
   test "order by" do
     assert i(from(x in Post, order_by: [asc: x.foo, desc: x.bar], order_by: x.foobar)) ==
-           ~s{from p0 in Inspect.Post, order_by: [asc: p0.foo, desc: p0.bar], order_by: [asc: p0.foobar]}
+             ~s{from p0 in Inspect.Post, order_by: [asc: p0.foo, desc: p0.bar], order_by: [asc: p0.foobar]}
   end
 
   test "union" do
@@ -244,51 +269,52 @@ defmodule Ecto.Query.InspectTest do
 
   test "limit" do
     assert i(from(x in Post, limit: 123)) ==
-           ~s{from p0 in Inspect.Post, limit: 123}
+             ~s{from p0 in Inspect.Post, limit: 123}
   end
 
   test "offset" do
     assert i(from(x in Post, offset: 123)) ==
-           ~s{from p0 in Inspect.Post, offset: 123}
+             ~s{from p0 in Inspect.Post, offset: 123}
   end
 
   test "distinct" do
     assert i(from(x in Post, distinct: true)) ==
-           ~s{from p0 in Inspect.Post, distinct: true}
+             ~s{from p0 in Inspect.Post, distinct: true}
 
     assert i(from(x in Post, distinct: [x.foo])) ==
-           ~s{from p0 in Inspect.Post, distinct: [asc: p0.foo]}
+             ~s{from p0 in Inspect.Post, distinct: [asc: p0.foo]}
 
     assert i(from(x in Post, distinct: [desc: x.foo])) ==
-           ~s{from p0 in Inspect.Post, distinct: [desc: p0.foo]}
+             ~s{from p0 in Inspect.Post, distinct: [desc: p0.foo]}
   end
 
   test "lock" do
     assert i(from(x in Post, lock: "FOOBAR")) ==
-           ~s{from p0 in Inspect.Post, lock: "FOOBAR"}
+             ~s{from p0 in Inspect.Post, lock: "FOOBAR"}
   end
 
   test "preload" do
     assert i(from(x in Post, preload: :comments)) ==
-           ~s"from p0 in Inspect.Post, preload: [:comments]"
+             ~s"from p0 in Inspect.Post, preload: [:comments]"
 
     assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: y])) ==
-           ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: c1]"
+             ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: c1]"
 
     assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: {y, post: x}])) ==
-           ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: {c1, [post: p0]}]"
+             ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: {c1, [post: p0]}]"
   end
 
   test "fragments" do
     value = "foobar"
+
     assert i(from(x in Post, where: fragment("downcase(?) == ?", x.id, ^value))) ==
-           ~s{from p0 in Inspect.Post, where: fragment("downcase(?) == ?", p0.id, ^"foobar")}
+             ~s{from p0 in Inspect.Post, where: fragment("downcase(?) == ?", p0.id, ^"foobar")}
 
     assert i(from(x in Post, where: fragment(^[title: [foo: "foobar"]]))) ==
-           ~s{from p0 in Inspect.Post, where: fragment(title: [foo: "foobar"])}
+             ~s{from p0 in Inspect.Post, where: fragment(title: [foo: "foobar"])}
 
     assert i(from(x in Post, where: fragment(title: [foo: ^value]))) ==
-      ~s{from p0 in Inspect.Post, where: fragment(title: [foo: ^"foobar"])}
+             ~s{from p0 in Inspect.Post, where: fragment(title: [foo: ^"foobar"])}
   end
 
   test "json_extract_path" do
@@ -303,94 +329,125 @@ defmodule Ecto.Query.InspectTest do
   end
 
   test "inspect all" do
-    string = """
-    from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), where: true, or_where: true,
-    group_by: [p0.id], having: true, or_having: true, order_by: [asc: p0.id], limit: 1,
-    offset: 1, lock: "FOO", distinct: [asc: 1], update: [set: [id: ^3]], select: 1,
-    preload: [:likes], preload: [comments: c1]
-    """
-    |> String.trim
-    |> String.replace("\n", " ")
+    string =
+      """
+      from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), where: true, or_where: true,
+      group_by: [p0.id], having: true, or_having: true, order_by: [asc: p0.id], limit: 1,
+      offset: 1, lock: "FOO", distinct: [asc: 1], update: [set: [id: ^3]], select: 1,
+      preload: [:likes], preload: [comments: c1]
+      """
+      |> String.trim()
+      |> String.replace("\n", " ")
 
-    assert i(from(x in Post, join: y in assoc(x, :comments), where: true, or_where: true, group_by: x.id,
-                             having: true, or_having: true, order_by: x.id, limit: 1, offset: 1,
-                             lock: "FOO", select: 1, distinct: 1,
-                             update: [set: [id: ^3]], preload: [:likes, comments: y])) == string
+    assert i(
+             from(x in Post,
+               join: y in assoc(x, :comments),
+               where: true,
+               or_where: true,
+               group_by: x.id,
+               having: true,
+               or_having: true,
+               order_by: x.id,
+               limit: 1,
+               offset: 1,
+               lock: "FOO",
+               select: 1,
+               distinct: 1,
+               update: [set: [id: ^3]],
+               preload: [:likes, comments: y]
+             )
+           ) == string
   end
 
   test "to_string all" do
-    string = """
-    from p0 in Inspect.Post,
-      join: c1 in assoc(p0, :comments),
-      where: true,
-      or_where: true,
-      group_by: [p0.id],
-      having: true,
-      or_having: true,
-      union_all: (from p0 in Inspect.Post),
-      order_by: [asc: p0.id],
-      limit: 1,
-      offset: 1,
-      lock: "FOO",
-      distinct: [asc: 1],
-      update: [set: [id: 3]],
-      select: 1,
-      preload: [:likes],
-      preload: [comments: c1]
-    """
-    |> String.trim
+    string =
+      """
+      from p0 in Inspect.Post,
+        join: c1 in assoc(p0, :comments),
+        where: true,
+        or_where: true,
+        group_by: [p0.id],
+        having: true,
+        or_having: true,
+        union_all: (from p0 in Inspect.Post),
+        order_by: [asc: p0.id],
+        limit: 1,
+        offset: 1,
+        lock: "FOO",
+        distinct: [asc: 1],
+        update: [set: [id: 3]],
+        select: 1,
+        preload: [:likes],
+        preload: [comments: c1]
+      """
+      |> String.trim()
 
     assert Inspect.Ecto.Query.to_string(
-      from(x in Post, join: y in assoc(x, :comments), where: true, or_where: true, group_by: x.id,
-                      having: true, or_having: true, order_by: x.id, limit: 1, offset: 1, update: [set: [id: 3]],
-                      lock: "FOO", distinct: 1, select: 1, preload: [:likes, comments: y],
-                      union_all: ^from(y in Post))
-    ) == string
+             from(x in Post,
+               join: y in assoc(x, :comments),
+               where: true,
+               or_where: true,
+               group_by: x.id,
+               having: true,
+               or_having: true,
+               order_by: x.id,
+               limit: 1,
+               offset: 1,
+               update: [set: [id: 3]],
+               lock: "FOO",
+               distinct: 1,
+               select: 1,
+               preload: [:likes, comments: y],
+               union_all: ^from(y in Post)
+             )
+           ) == string
   end
 
   test "container values" do
     assert i(from(Post, select: <<1, 2, 3>>)) ==
-           "from p0 in Inspect.Post, select: <<1, 2, 3>>"
+             "from p0 in Inspect.Post, select: <<1, 2, 3>>"
 
     foo = <<1, 2, 3>>
+
     assert i(from(p in Post, select: {p, ^foo})) ==
-           "from p0 in Inspect.Post, select: {p0, ^<<1, 2, 3>>}"
+             "from p0 in Inspect.Post, select: {p0, ^<<1, 2, 3>>}"
   end
 
   test "select" do
     assert i(from(p in Post, select: p)) ==
-           ~s{from p0 in Inspect.Post, select: p0}
+             ~s{from p0 in Inspect.Post, select: p0}
 
     assert i(from(p in Post, select: [:foo])) ==
-           ~s{from p0 in Inspect.Post, select: [:foo]}
+             ~s{from p0 in Inspect.Post, select: [:foo]}
 
     assert i(from(p in Post, select: struct(p, [:foo]))) ==
-           ~s{from p0 in Inspect.Post, select: struct(p0, [:foo])}
+             ~s{from p0 in Inspect.Post, select: struct(p0, [:foo])}
 
     assert i(from(p in Post, select: merge(p, %{foo: p.foo}))) ==
-           ~s"from p0 in Inspect.Post, select: merge(p0, %{foo: p0.foo})"
+             ~s"from p0 in Inspect.Post, select: merge(p0, %{foo: p0.foo})"
   end
 
   test "select after planner" do
-    assert i(plan from(p in Post, select: p)) ==
-           ~s{from p0 in Inspect.Post, select: p0}
+    assert i(plan(from(p in Post, select: p))) ==
+             ~s{from p0 in Inspect.Post, select: p0}
 
-    assert i(plan from(p in Post, select: [:foo])) ==
-           ~s{from p0 in Inspect.Post, select: [:foo]}
+    assert i(plan(from(p in Post, select: [:foo]))) ==
+             ~s{from p0 in Inspect.Post, select: [:foo]}
   end
 
   test "params" do
     assert i(from(x in Post, where: ^123 > ^(1 * 3))) ==
-           ~s{from p0 in Inspect.Post, where: ^123 > ^3}
+             ~s{from p0 in Inspect.Post, where: ^123 > ^3}
 
     assert i(from(x in Post, where: x.id in ^[97])) ==
-           ~s{from p0 in Inspect.Post, where: p0.id in ^[97]}
+             ~s{from p0 in Inspect.Post, where: p0.id in ^[97]}
   end
 
   test "params after planner" do
-    query = plan from(x in Post, where: ^123 > ^(1 * 3) and x.id in ^[1, 2, 3])
+    query = plan(from(x in Post, where: ^123 > ^(1 * 3) and x.id in ^[1, 2, 3]))
+
     assert i(query) ==
-           ~s{from p0 in Inspect.Post, where: ^... > ^... and p0.id in ^...}
+             ~s{from p0 in Inspect.Post, where: ^... > ^... and p0.id in ^...}
   end
 
   test "tagged types" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../../integration_test/support/types.exs", __DIR__
+Code.require_file("../../../integration_test/support/types.exs", __DIR__)
 
 defmodule Ecto.Query.PlannerTest do
   use ExUnit.Case, async: true
@@ -20,8 +20,7 @@ defmodule Ecto.Query.PlannerTest do
 
       belongs_to :post, Ecto.Query.PlannerTest.Post
 
-      belongs_to :crazy_post, Ecto.Query.PlannerTest.Post,
-        where: [title: "crazypost"]
+      belongs_to :crazy_post, Ecto.Query.PlannerTest.Post, where: [title: "crazypost"]
 
       belongs_to :crazy_post_with_list, Ecto.Query.PlannerTest.Post,
         where: [title: {:in, ["crazypost1", "crazypost2"]}],
@@ -89,9 +88,19 @@ defmodule Ecto.Query.PlannerTest do
       has_many :comments, Ecto.Query.PlannerTest.Comment
       has_many :extra_comments, Ecto.Query.PlannerTest.Comment
       has_many :special_comments, Ecto.Query.PlannerTest.Comment, where: [text: {:not, nil}]
-      many_to_many :crazy_comments, Comment, join_through: CommentPost, where: [text: "crazycomment"]
-      many_to_many :crazy_comments_with_list, Comment, join_through: CommentPost, where: [text: {:in, ["crazycomment1", "crazycomment2"]}], join_where: [deleted: true]
-      many_to_many :crazy_comments_without_schema, Comment, join_through: "comment_posts", join_where: [deleted: true]
+
+      many_to_many :crazy_comments, Comment,
+        join_through: CommentPost,
+        where: [text: "crazycomment"]
+
+      many_to_many :crazy_comments_with_list, Comment,
+        join_through: CommentPost,
+        where: [text: {:in, ["crazycomment1", "crazycomment2"]}],
+        join_where: [deleted: true]
+
+      many_to_many :crazy_comments_without_schema, Comment,
+        join_through: "comment_posts",
+        join_where: [deleted: true]
     end
   end
 
@@ -140,6 +149,7 @@ defmodule Ecto.Query.PlannerTest do
         offset: ^1
 
     {_query, params, _key} = plan(query)
+
     assert params ==
              ["select", "subquery", "join", "where", "group_by", "having", "windows"] ++
                ["union", "order_by", 0, 1]
@@ -155,9 +165,10 @@ defmodule Ecto.Query.PlannerTest do
     {_query, params, _key} = plan(Post |> where([p], p.id == ^"1"))
     assert params == [1]
 
-    exception = assert_raise Ecto.Query.CastError, fn ->
-      plan(Post |> where([p], p.title == ^1))
-    end
+    exception =
+      assert_raise Ecto.Query.CastError, fn ->
+        plan(Post |> where([p], p.title == ^1))
+      end
 
     assert Exception.message(exception) =~ "value `1` in `where` cannot be cast to type :string"
     assert Exception.message(exception) =~ "where: p0.title == ^1"
@@ -166,12 +177,16 @@ defmodule Ecto.Query.PlannerTest do
   test "plan: Ecto.Query struct as right-side value of in operator" do
     query = from(Post)
 
-    exception = assert_raise Ecto.QueryError, fn ->
-      plan(Post |> where([p], p.id in ^query))
-    end
+    exception =
+      assert_raise Ecto.QueryError, fn ->
+        plan(Post |> where([p], p.id in ^query))
+      end
 
-    assert Exception.message(exception) =~ "an Ecto.Query struct is not supported as right-side value of `in` operator"
-    assert Exception.message(exception) =~ "Did you mean to write `expr in subquery(query)` instead?"
+    assert Exception.message(exception) =~
+             "an Ecto.Query struct is not supported as right-side value of `in` operator"
+
+    assert Exception.message(exception) =~
+             "Did you mean to write `expr in subquery(query)` instead?"
   end
 
   test "plan: raises readable error on dynamic expressions/keyword lists" do
@@ -200,10 +215,11 @@ defmodule Ecto.Query.PlannerTest do
     assert params == [<<0, 1, 2, 3, 4, 5, 70, 7, 136, 9, 10, 11, 12, 13, 14, 15>>]
 
     assert_raise Ecto.Query.CastError,
-                 ~r/`"00010203-0405-4607-8809"` cannot be dumped to type :binary_id/, fn ->
-      uuid = "00010203-0405-4607-8809"
-      plan(Comment |> where([c], c.uuid == ^uuid))
-    end
+                 ~r/`"00010203-0405-4607-8809"` cannot be dumped to type :binary_id/,
+                 fn ->
+                   uuid = "00010203-0405-4607-8809"
+                   plan(Comment |> where([c], c.uuid == ^uuid))
+                 end
   end
 
   test "plan: casts and dumps custom types in left side of in-expressions" do
@@ -211,7 +227,9 @@ defmodule Ecto.Query.PlannerTest do
     {_query, params, _key} = plan(Post |> where([p], ^permalink in p.links))
     assert params == [1]
 
-    message = ~r"value `\"1-hello-world\"` in `where` expected to be part of an array but matched type is :string"
+    message =
+      ~r"value `\"1-hello-world\"` in `where` expected to be part of an array but matched type is :string"
+
     assert_raise Ecto.Query.CastError, message, fn ->
       plan(Post |> where([p], ^permalink in p.text))
     end
@@ -274,24 +292,47 @@ defmodule Ecto.Query.PlannerTest do
     assert source == {"comments", Comment}
     assert Macro.to_string(on.expr) == "&1.post_id() == &0.id()"
 
-    query = from(p in Post, left_join: c in assoc(p, :comments), on: p.title == c.text) |> plan |> elem(0)
+    query =
+      from(p in Post, left_join: c in assoc(p, :comments), on: p.title == c.text)
+      |> plan
+      |> elem(0)
+
     assert %JoinExpr{on: on, source: source, assoc: nil, qual: :left} = hd(query.joins)
     assert source == {"comments", Comment}
     assert Macro.to_string(on.expr) == "&1.post_id() == &0.id() and &0.title() == &1.text()"
 
-    query = from(p in Post, left_join: c in assoc(p, :comments), on: p.meta["slug"] |> type(:string) == c.text) |> plan |> elem(0)
-    assert %JoinExpr{on: on, source: source, assoc: nil, qual: :left} = hd(query.joins)
-    assert source == {"comments", Comment}
-    assert Macro.to_string(on.expr) == "&1.post_id() == &0.id() and type(json_extract_path(&0.meta(), [\"slug\"]), :string) == &1.text()"
+    query =
+      from(p in Post,
+        left_join: c in assoc(p, :comments),
+        on: p.meta["slug"] |> type(:string) == c.text
+      )
+      |> plan
+      |> elem(0)
 
-    query = from(p in Post, left_join: c in assoc(p, :comments), on: json_extract_path(p.meta, ["slug"]) |> type(:string) == c.text) |> plan |> elem(0)
     assert %JoinExpr{on: on, source: source, assoc: nil, qual: :left} = hd(query.joins)
     assert source == {"comments", Comment}
-    assert Macro.to_string(on.expr) == "&1.post_id() == &0.id() and type(json_extract_path(&0.meta(), [\"slug\"]), :string) == &1.text()"
+
+    assert Macro.to_string(on.expr) ==
+             "&1.post_id() == &0.id() and type(json_extract_path(&0.meta(), [\"slug\"]), :string) == &1.text()"
+
+    query =
+      from(p in Post,
+        left_join: c in assoc(p, :comments),
+        on: json_extract_path(p.meta, ["slug"]) |> type(:string) == c.text
+      )
+      |> plan
+      |> elem(0)
+
+    assert %JoinExpr{on: on, source: source, assoc: nil, qual: :left} = hd(query.joins)
+    assert source == {"comments", Comment}
+
+    assert Macro.to_string(on.expr) ==
+             "&1.post_id() == &0.id() and type(json_extract_path(&0.meta(), [\"slug\"]), :string) == &1.text()"
   end
 
   test "plan: nested joins associations" do
     query = from(c in Comment, left_join: assoc(c, :post_comments)) |> plan |> elem(0)
+
     # The association query builder will optimize has_many through [:posts, :comments] by skipping :posts and joining
     # comments to comments on post_id
     assert {{"comments", _, _}, {"comments", _, _}} = query.sources
@@ -299,8 +340,13 @@ defmodule Ecto.Query.PlannerTest do
     assert Enum.map(query.joins, & &1.ix) == [1]
     assert Macro.to_string(join1.on.expr) == "&0.post_id() == &1.post_id()"
 
-    query = from(p in Comment, left_join: assoc(p, :post),
-                               left_join: assoc(p, :post_comments)) |> plan |> elem(0)
+    query =
+      from(p in Comment,
+        left_join: assoc(p, :post),
+        left_join: assoc(p, :post_comments)
+      )
+      |> plan
+      |> elem(0)
 
     assert {{"comments", _, _}, {"posts", _, _}, {"comments", _, _}} = query.sources
     assert [join1, join2] = query.joins
@@ -308,8 +354,14 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(join1.on.expr) == "&1.id() == &0.post_id()"
     assert Macro.to_string(join2.on.expr) == "&0.post_id() == &2.post_id()"
 
-    query = from(p in Comment, left_join: assoc(p, :post_comments),
-                               left_join: assoc(p, :post)) |> plan |> elem(0)
+    query =
+      from(p in Comment,
+        left_join: assoc(p, :post_comments),
+        left_join: assoc(p, :post)
+      )
+      |> plan
+      |> elem(0)
+
     assert {{"comments", _, _}, {"comments", _, _}, {"posts", _, _}} = query.sources
     assert [join1, join2] = query.joins
     assert Enum.map(query.joins, & &1.ix) == [1, 2]
@@ -323,31 +375,39 @@ defmodule Ecto.Query.PlannerTest do
     assert {{"posts", _, _}, {"comments", _, _}} = query.sources
     assert [join] = query.joins
     assert join.ix == 1
+
     assert Macro.to_string(join.on.expr) =~
              ~r"&1.post_id\(\) == &0.id\(\) and not[\s\(]is_nil\(&1.text\(\)\)\)?"
   end
 
   test "plan: nested joins associations with custom queries" do
-    query = from(p in Post,
-                   join: c1 in assoc(p, :special_comments),
-                   join: p2 in assoc(c1, :post),
-                   join: cp in assoc(c1, :comment_posts),
-                   join: c2 in assoc(cp, :special_comment),
-                   join: c3 in assoc(cp, :special_long_comment))
-                   |> plan
-                   |> elem(0)
+    query =
+      from(p in Post,
+        join: c1 in assoc(p, :special_comments),
+        join: p2 in assoc(c1, :post),
+        join: cp in assoc(c1, :comment_posts),
+        join: c2 in assoc(cp, :special_comment),
+        join: c3 in assoc(cp, :special_long_comment)
+      )
+      |> plan
+      |> elem(0)
 
     assert [join1, join2, join3, join4, join5] = query.joins
-    assert {{"posts", _, _}, {"comments", _, _}, {"posts", _, _},
-            {"comment_posts", _, _}, {"comments", _, _}, {"comments", _, _}} = query.sources
+
+    assert {{"posts", _, _}, {"comments", _, _}, {"posts", _, _}, {"comment_posts", _, _},
+            {"comments", _, _}, {"comments", _, _}} = query.sources
 
     assert Macro.to_string(join1.on.expr) =~
-           ~r"&1.post_id\(\) == &0.id\(\) and not[\s\(]is_nil\(&1.text\(\)\)\)?"
+             ~r"&1.post_id\(\) == &0.id\(\) and not[\s\(]is_nil\(&1.text\(\)\)\)?"
+
     assert Macro.to_string(join2.on.expr) == "&2.id() == &1.post_id()"
     assert Macro.to_string(join3.on.expr) == "&3.comment_id() == &1.id()"
-    assert Macro.to_string(join4.on.expr) == "&4.id() == &3.special_comment_id() and is_nil(&4.text())"
+
+    assert Macro.to_string(join4.on.expr) ==
+             "&4.id() == &3.special_comment_id() and is_nil(&4.text())"
+
     assert Macro.to_string(join5.on.expr) ==
-           "&5.id() == &3.special_long_comment_id() and fragment({:raw, \"LEN(\"}, {:expr, &5.text()}, {:raw, \") > 100\"})"
+             "&5.id() == &3.special_long_comment_id() and fragment({:raw, \"LEN(\"}, {:expr, &5.text()}, {:raw, \") > 100\"})"
   end
 
   test "plan: raises on invalid binding index in join" do
@@ -361,7 +421,7 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "plan: cannot associate without schema" do
-    query   = from(p in "posts", join: assoc(p, :comments))
+    query = from(p in "posts", join: assoc(p, :comments))
     message = ~r"cannot perform association join on \"posts\" because it does not have a schema"
 
     assert_raise Ecto.QueryError, message, fn ->
@@ -379,22 +439,31 @@ defmodule Ecto.Query.PlannerTest do
 
   test "plan: handles specific param type-casting" do
     value = NaiveDateTime.utc_now()
-    {_, params, _} = from(p in Post, where: p.posted > datetime_add(^value, 1, "second")) |> plan()
+
+    {_, params, _} =
+      from(p in Post, where: p.posted > datetime_add(^value, 1, "second")) |> plan()
+
     assert params == [value]
 
     value = DateTime.utc_now()
-    {_, params, _} = from(p in Post, where: p.posted > datetime_add(^value, 1, "second")) |> plan()
+
+    {_, params, _} =
+      from(p in Post, where: p.posted > datetime_add(^value, 1, "second")) |> plan()
+
     assert params == [value]
 
     value = ~N[2010-04-17 14:00:00]
+
     {_, params, _} =
-      from(p in Post, where: p.posted > datetime_add(^"2010-04-17 14:00:00", 1, "second")) |> plan()
+      from(p in Post, where: p.posted > datetime_add(^"2010-04-17 14:00:00", 1, "second"))
+      |> plan()
+
     assert params == [value]
   end
 
   test "plan: generates a cache key" do
     {_query, _params, key} = plan(from(Post, []))
-    assert key == [:all, {:from, {"posts", Post, 69355382, "my_prefix"}, []}]
+    assert key == [:all, {:from, {"posts", Post, 69_355_382, "my_prefix"}, []}]
 
     query =
       from(
@@ -412,13 +481,16 @@ defmodule Ecto.Query.PlannerTest do
       )
 
     {_query, _params, key} = plan(%{query | prefix: "foo"})
-    assert key == [:all,
-                   {:lock, "foo"},
-                   {:prefix, "foo"},
-                   {:where, [{:and, {:is_nil, [], [nil]}}, {:or, {:is_nil, [], [nil]}}]},
-                   {:join, [{:inner, {"comments", Comment, 38292156, "world"}, true, ["join hint"]}]},
-                   {:from, {"posts", Post, 69355382, "hello"}, ["hint"]},
-                   {:select, 1}]
+
+    assert key == [
+             :all,
+             {:lock, "foo"},
+             {:prefix, "foo"},
+             {:where, [{:and, {:is_nil, [], [nil]}}, {:or, {:is_nil, [], [nil]}}]},
+             {:join, [{:inner, {"comments", Comment, 38_292_156, "world"}, true, ["join hint"]}]},
+             {:from, {"posts", Post, 69_355_382, "hello"}, ["hint"]},
+             {:select, 1}
+           ]
   end
 
   test "plan: generates a cache key for in based on the adapter" do
@@ -451,7 +523,9 @@ defmodule Ecto.Query.PlannerTest do
     {query, _, _} = from(Comment, select: 1) |> Map.put(:prefix, "global") |> plan()
     assert query.sources == {{"comments", Comment, "global"}}
 
-    {query, _, _} = from(Comment, prefix: "local", select: 1) |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(Comment, prefix: "local", select: 1) |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"comments", Comment, "local"}}
 
     # Schema prefix in from
@@ -471,74 +545,134 @@ defmodule Ecto.Query.PlannerTest do
     {query, _, _} = from(c in Comment, join: Post) |> Map.put(:prefix, "global") |> plan()
     assert query.sources == {{"comments", Comment, "global"}, {"posts", Post, "my_prefix"}}
 
-    {query, _, _} = from(c in Comment, join: Post, prefix: "local") |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(c in Comment, join: Post, prefix: "local") |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"comments", Comment, "global"}, {"posts", Post, "local"}}
 
     # Schema prefix in query join
     {query, _, _} = from(p in Post, join: ^from(c in Comment)) |> plan()
     assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, nil}}
 
-    {query, _, _} = from(p in Post, join: ^from(c in Comment)) |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(p in Post, join: ^from(c in Comment)) |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, "global"}}
 
-    {query, _, _} = from(p in Post, join: ^from(c in Comment), prefix: "local") |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(p in Post, join: ^from(c in Comment), prefix: "local")
+      |> Map.put(:prefix, "global")
+      |> plan()
+
     assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, "local"}}
 
     # No schema prefix in assoc join
     {query, _, _} = from(c in Comment, join: assoc(c, :comment_posts)) |> plan()
     assert query.sources == {{"comments", Comment, nil}, {"comment_posts", CommentPost, nil}}
 
-    {query, _, _} = from(c in Comment, join: assoc(c, :comment_posts)) |> Map.put(:prefix, "global") |> plan()
-    assert query.sources == {{"comments", Comment, "global"}, {"comment_posts", CommentPost, "global"}}
+    {query, _, _} =
+      from(c in Comment, join: assoc(c, :comment_posts)) |> Map.put(:prefix, "global") |> plan()
 
-    {query, _, _} = from(c in Comment, join: assoc(c, :comment_posts), prefix: "local") |> Map.put(:prefix, "global") |> plan()
-    assert query.sources == {{"comments", Comment, "global"}, {"comment_posts", CommentPost, "local"}}
+    assert query.sources ==
+             {{"comments", Comment, "global"}, {"comment_posts", CommentPost, "global"}}
+
+    {query, _, _} =
+      from(c in Comment, join: assoc(c, :comment_posts), prefix: "local")
+      |> Map.put(:prefix, "global")
+      |> plan()
+
+    assert query.sources ==
+             {{"comments", Comment, "global"}, {"comment_posts", CommentPost, "local"}}
 
     # Schema prefix in assoc join
     {query, _, _} = from(c in Comment, join: assoc(c, :post)) |> plan()
     assert query.sources == {{"comments", Comment, nil}, {"posts", Post, "my_prefix"}}
 
-    {query, _, _} = from(c in Comment, join: assoc(c, :post)) |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(c in Comment, join: assoc(c, :post)) |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"comments", Comment, "global"}, {"posts", Post, "my_prefix"}}
 
-    {query, _, _} = from(c in Comment, join: assoc(c, :post), prefix: "local") |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(c in Comment, join: assoc(c, :post), prefix: "local")
+      |> Map.put(:prefix, "global")
+      |> plan()
+
     assert query.sources == {{"comments", Comment, "global"}, {"posts", Post, "local"}}
 
     # Schema prefix for assoc many-to-many joins
     {query, _, _} = from(c in Post, join: assoc(c, :crazy_comments)) |> plan()
-    assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, nil}, {"comment_posts", CommentPost, nil}}
 
-    {query, _, _} = from(c in Post, join: assoc(c, :crazy_comments)) |> Map.put(:prefix, "global") |> plan()
-    assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, "global"}, {"comment_posts", CommentPost, "global"}}
+    assert query.sources ==
+             {{"posts", Post, "my_prefix"}, {"comments", Comment, nil},
+              {"comment_posts", CommentPost, nil}}
 
-    {query, _, _} = from(c in Post, join: assoc(c, :crazy_comments), prefix: "local") |> Map.put(:prefix, "global") |> plan()
-    assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, "local"}, {"comment_posts", CommentPost, "local"}}
+    {query, _, _} =
+      from(c in Post, join: assoc(c, :crazy_comments)) |> Map.put(:prefix, "global") |> plan()
+
+    assert query.sources ==
+             {{"posts", Post, "my_prefix"}, {"comments", Comment, "global"},
+              {"comment_posts", CommentPost, "global"}}
+
+    {query, _, _} =
+      from(c in Post, join: assoc(c, :crazy_comments), prefix: "local")
+      |> Map.put(:prefix, "global")
+      |> plan()
+
+    assert query.sources ==
+             {{"posts", Post, "my_prefix"}, {"comments", Comment, "local"},
+              {"comment_posts", CommentPost, "local"}}
 
     # Schema prefix for assoc many-to-many joins (when join_through is a table name)
     {query, _, _} = from(c in Post, join: assoc(c, :crazy_comments_without_schema)) |> plan()
-    assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, nil}, {"comment_posts", nil, nil}}
 
-    {query, _, _} = from(c in Post, join: assoc(c, :crazy_comments_without_schema)) |> Map.put(:prefix, "global") |> plan()
-    assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, "global"}, {"comment_posts", nil, "global"}}
+    assert query.sources ==
+             {{"posts", Post, "my_prefix"}, {"comments", Comment, nil},
+              {"comment_posts", nil, nil}}
 
-    {query, _, _} = from(c in Post, join: assoc(c, :crazy_comments_without_schema), prefix: "local") |> Map.put(:prefix, "global") |> plan()
-    assert query.sources == {{"posts", Post, "my_prefix"}, {"comments", Comment, "local"}, {"comment_posts", nil, "local"}}
+    {query, _, _} =
+      from(c in Post, join: assoc(c, :crazy_comments_without_schema))
+      |> Map.put(:prefix, "global")
+      |> plan()
+
+    assert query.sources ==
+             {{"posts", Post, "my_prefix"}, {"comments", Comment, "global"},
+              {"comment_posts", nil, "global"}}
+
+    {query, _, _} =
+      from(c in Post, join: assoc(c, :crazy_comments_without_schema), prefix: "local")
+      |> Map.put(:prefix, "global")
+      |> plan()
+
+    assert query.sources ==
+             {{"posts", Post, "my_prefix"}, {"comments", Comment, "local"},
+              {"comment_posts", nil, "local"}}
 
     # Schema prefix for assoc has through
-    {query, _, _} = from(c in Comment, join: assoc(c, :post_comments)) |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(c in Comment, join: assoc(c, :post_comments)) |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"comments", Comment, "global"}, {"comments", Comment, "global"}}
 
-    {query, _, _} = from(c in Comment, join: assoc(c, :post_comments), prefix: "local") |> Map.put(:prefix, "global") |> plan()
+    {query, _, _} =
+      from(c in Comment, join: assoc(c, :post_comments), prefix: "local")
+      |> Map.put(:prefix, "global")
+      |> plan()
+
     assert query.sources == {{"comments", Comment, "global"}, {"comments", Comment, "local"}}
   end
 
   test "plan: combination queries" do
-    {%{combinations: [{_, query}]}, _, cache} = from(c in Comment, union: ^from(c in Comment)) |> plan()
+    {%{combinations: [{_, query}]}, _, cache} =
+      from(c in Comment, union: ^from(c in Comment)) |> plan()
+
     assert query.sources == {{"comments", Comment, nil}}
     assert %Ecto.Query.SelectExpr{expr: {:&, [], [0]}} = query.select
     assert [:all, {:union, _}, _] = cache
 
-    {%{combinations: [{_, query}]}, _, cache} = from(c in Comment, union: ^from(c in Comment, where: c in ^[1, 2, 3])) |> plan()
+    {%{combinations: [{_, query}]}, _, cache} =
+      from(c in Comment, union: ^from(c in Comment, where: c in ^[1, 2, 3])) |> plan()
+
     assert query.sources == {{"comments", Comment, nil}}
     assert %Ecto.Query.SelectExpr{expr: {:&, [], [0]}} = query.select
     assert :nocache = cache
@@ -546,63 +680,100 @@ defmodule Ecto.Query.PlannerTest do
 
   test "plan: normalizes prefixes for combinations" do
     # No schema prefix in from
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Comment,  union: ^from(Comment)) |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Comment, union: ^from(Comment)) |> plan()
+
     assert query.sources == {{"comments", Comment, nil}}
     assert union_query.sources == {{"comments", Comment, nil}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Comment, union: ^from(Comment)) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Comment, union: ^from(Comment)) |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"comments", Comment, "global"}}
     assert union_query.sources == {{"comments", Comment, "global"}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Comment, prefix: "local", union: ^from(Comment)) |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Comment, prefix: "local", union: ^from(Comment)) |> plan()
+
     assert query.sources == {{"comments", Comment, "local"}}
     assert union_query.sources == {{"comments", Comment, nil}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Comment, prefix: "local", union: ^from(Comment)) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Comment, prefix: "local", union: ^from(Comment))
+             |> Map.put(:prefix, "global")
+             |> plan()
+
     assert query.sources == {{"comments", Comment, "local"}}
     assert union_query.sources == {{"comments", Comment, "global"}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Comment, prefix: "local", union: ^(from(Comment) |> Map.put(:prefix, "union"))) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Comment, prefix: "local", union: ^(from(Comment) |> Map.put(:prefix, "union")))
+             |> Map.put(:prefix, "global")
+             |> plan()
+
     assert query.sources == {{"comments", Comment, "local"}}
     assert union_query.sources == {{"comments", Comment, "union"}}
 
     # With schema prefix
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Post, union: ^from(p in Post)) |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Post, union: ^from(p in Post)) |> plan()
+
     assert query.sources == {{"posts", Post, "my_prefix"}}
     assert union_query.sources == {{"posts", Post, "my_prefix"}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Post, union: ^from(Post)) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Post, union: ^from(Post)) |> Map.put(:prefix, "global") |> plan()
+
     assert query.sources == {{"posts", Post, "my_prefix"}}
     assert union_query.sources == {{"posts", Post, "my_prefix"}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Post, prefix: "local", union: ^from(Post)) |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Post, prefix: "local", union: ^from(Post)) |> plan()
+
     assert query.sources == {{"posts", Post, "local"}}
     assert union_query.sources == {{"posts", Post, "my_prefix"}}
 
-    assert {%{combinations: [{_, union_query}]} = query, _, _} = from(Post, prefix: "local", union: ^from(Post)) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, union_query}]} = query, _, _} =
+             from(Post, prefix: "local", union: ^from(Post))
+             |> Map.put(:prefix, "global")
+             |> plan()
+
     assert query.sources == {{"posts", Post, "local"}}
     assert union_query.sources == {{"posts", Post, "my_prefix"}}
 
     # Deep-nested unions
-    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} = from(Comment, union: ^from(Comment, union: ^from(Comment))) |> plan()
+    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} =
+             from(Comment, union: ^from(Comment, union: ^from(Comment))) |> plan()
+
     assert %{combinations: [{_, deeper_level_union_query}]} = upper_level_union_query
     assert query.sources == {{"comments", Comment, nil}}
     assert upper_level_union_query.sources == {{"comments", Comment, nil}}
     assert deeper_level_union_query.sources == {{"comments", Comment, nil}}
 
-    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} = from(Comment, union: ^from(Comment, union: ^from(Comment))) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} =
+             from(Comment, union: ^from(Comment, union: ^from(Comment)))
+             |> Map.put(:prefix, "global")
+             |> plan()
+
     assert %{combinations: [{_, deeper_level_union_query}]} = upper_level_union_query
     assert query.sources == {{"comments", Comment, "global"}}
     assert upper_level_union_query.sources == {{"comments", Comment, "global"}}
     assert deeper_level_union_query.sources == {{"comments", Comment, "global"}}
 
-    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} = from(Comment, prefix: "local", union: ^from(Comment, union: ^from(Comment))) |> plan()
+    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} =
+             from(Comment, prefix: "local", union: ^from(Comment, union: ^from(Comment)))
+             |> plan()
+
     assert %{combinations: [{_, deeper_level_union_query}]} = upper_level_union_query
     assert query.sources == {{"comments", Comment, "local"}}
     assert upper_level_union_query.sources == {{"comments", Comment, nil}}
     assert deeper_level_union_query.sources == {{"comments", Comment, nil}}
 
-    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} = from(Comment, prefix: "local", union: ^from(Comment, union: ^from(Comment))) |> Map.put(:prefix, "global") |> plan()
+    assert {%{combinations: [{_, upper_level_union_query}]} = query, _, _} =
+             from(Comment, prefix: "local", union: ^from(Comment, union: ^from(Comment)))
+             |> Map.put(:prefix, "global")
+             |> plan()
+
     assert %{combinations: [{_, deeper_level_union_query}]} = upper_level_union_query
     assert query.sources == {{"comments", Comment, "local"}}
     assert upper_level_union_query.sources == {{"comments", Comment, "global"}}
@@ -624,20 +795,28 @@ defmodule Ecto.Query.PlannerTest do
         Comment
         |> with_cte("cte", as: ^put_query_prefix(Comment, "another"))
         |> plan()
+
       %{queries: [{"cte", query}]} = with_expr
       assert query.sources == {{"comments", Comment, "another"}}
       assert %Ecto.Query.SelectExpr{expr: {:&, [], [0]}} = query.select
+
       assert [
-        :all,
-        {:from, {"comments", Comment, _, nil}, []},
-        {:non_recursive_cte, "cte",
-         [:all, {:prefix, "another"}, {:from, {"comments", Comment, _, nil}, []}, {:select, {:&, _, [0]}}]}
-      ] = cache
+               :all,
+               {:from, {"comments", Comment, _, nil}, []},
+               {:non_recursive_cte, "cte",
+                [
+                  :all,
+                  {:prefix, "another"},
+                  {:from, {"comments", Comment, _, nil}, []},
+                  {:select, {:&, _, [0]}}
+                ]}
+             ] = cache
 
       {%{with_ctes: with_expr}, _, cache} =
         Comment
-        |> with_cte("cte", as: ^(from(c in Comment, where: c in ^[1, 2, 3])))
+        |> with_cte("cte", as: ^from(c in Comment, where: c in ^[1, 2, 3]))
         |> plan()
+
       %{queries: [{"cte", query}]} = with_expr
       assert query.sources == {{"comments", Comment, nil}}
       assert %Ecto.Query.SelectExpr{expr: {:&, [], [0]}} = query.select
@@ -648,10 +827,16 @@ defmodule Ecto.Query.PlannerTest do
         |> recursive_ctes(true)
         |> with_cte("cte", as: fragment("SELECT * FROM comments WHERE id = ?", ^123))
         |> plan()
+
       %{queries: [{"cte", query_expr}]} = with_expr
-      expr = {:fragment, [], [raw: "SELECT * FROM comments WHERE id = ", expr: {:^, [], [0]}, raw: ""]}
+
+      expr =
+        {:fragment, [], [raw: "SELECT * FROM comments WHERE id = ", expr: {:^, [], [0]}, raw: ""]}
+
       assert expr == query_expr.expr
-      assert [:all, {:from, {"comments", Comment, _, nil}, []}, {:recursive_cte, "cte", ^expr}] = cache
+
+      assert [:all, {:from, {"comments", Comment, _, nil}, []}, {:recursive_cte, "cte", ^expr}] =
+               cache
     end
 
     test "on update_all" do
@@ -676,6 +861,7 @@ defmodule Ecto.Query.PlannerTest do
       assert %{expr: {:^, [], [0]}, params: [{500, :integer}]} = cte.limit
 
       assert [:update_all, _, _, _, _, {:non_recursive_cte, "recent_comments", cte_cache}] = cache
+
       assert [
                :all,
                {:prefix, "another"},
@@ -708,6 +894,7 @@ defmodule Ecto.Query.PlannerTest do
       assert %{expr: {:^, [], [0]}, params: [{500, :integer}]} = cte.limit
 
       assert [:delete_all, _, _, _, {:non_recursive_cte, "recent_comments", cte_cache}] = cache
+
       assert [
                :all,
                {:prefix, "another"},
@@ -720,17 +907,29 @@ defmodule Ecto.Query.PlannerTest do
     end
 
     test "prefixes" do
-      {%{with_ctes: with_expr} = query, _, _} = Comment |> with_cte("cte", as: ^from(c in Comment)) |> plan()
+      {%{with_ctes: with_expr} = query, _, _} =
+        Comment |> with_cte("cte", as: ^from(c in Comment)) |> plan()
+
       %{queries: [{"cte", cte_query}]} = with_expr
       assert query.sources == {{"comments", Comment, nil}}
       assert cte_query.sources == {{"comments", Comment, nil}}
 
-      {%{with_ctes: with_expr} = query, _, _} = Comment |> with_cte("cte", as: ^from(c in Comment)) |> Map.put(:prefix, "global") |> plan()
+      {%{with_ctes: with_expr} = query, _, _} =
+        Comment
+        |> with_cte("cte", as: ^from(c in Comment))
+        |> Map.put(:prefix, "global")
+        |> plan()
+
       %{queries: [{"cte", cte_query}]} = with_expr
       assert query.sources == {{"comments", Comment, "global"}}
       assert cte_query.sources == {{"comments", Comment, "global"}}
 
-      {%{with_ctes: with_expr} = query, _, _} = Comment |> with_cte("cte", as: ^(from(c in Comment) |> Map.put(:prefix, "cte"))) |> Map.put(:prefix, "global") |> plan()
+      {%{with_ctes: with_expr} = query, _, _} =
+        Comment
+        |> with_cte("cte", as: ^(from(c in Comment) |> Map.put(:prefix, "cte")))
+        |> Map.put(:prefix, "global")
+        |> plan()
+
       %{queries: [{"cte", cte_query}]} = with_expr
       assert query.sources == {{"comments", Comment, "global"}}
       assert cte_query.sources == {{"comments", Comment, "cte"}}
@@ -754,65 +953,93 @@ defmodule Ecto.Query.PlannerTest do
     {_query, params, _key} = normalize_with_params(Post |> where([p], p.status == ^:published))
     assert params == ["published"]
 
-    assert_raise Ecto.QueryError, ~r/value `:atoms_are_not_strings` cannot be dumped to type :string/, fn ->
-      normalize(Post |> where([p], p.title == :atoms_are_not_strings))
-    end
+    assert_raise Ecto.QueryError,
+                 ~r/value `:atoms_are_not_strings` cannot be dumped to type :string/,
+                 fn ->
+                   normalize(Post |> where([p], p.title == :atoms_are_not_strings))
+                 end
 
-    assert_raise Ecto.QueryError, ~r/value `:unknown_status` cannot be dumped to type \{:parameterized, Ecto.Enum/, fn ->
-      normalize(Post |> where([p], p.status == :unknown_status))
-    end
+    assert_raise Ecto.QueryError,
+                 ~r/value `:unknown_status` cannot be dumped to type \{:parameterized, Ecto.Enum/,
+                 fn ->
+                   normalize(Post |> where([p], p.status == :unknown_status))
+                 end
 
-    assert_raise Ecto.Query.CastError, ~r/value `:pinned` in `where` cannot be cast to type {:parameterized, Ecto.Enum/, fn ->
-      normalize(Post |> where([p], p.status == ^:pinned))
-    end
+    assert_raise Ecto.Query.CastError,
+                 ~r/value `:pinned` in `where` cannot be cast to type {:parameterized, Ecto.Enum/,
+                 fn ->
+                   normalize(Post |> where([p], p.status == ^:pinned))
+                 end
   end
 
   test "normalize: tagged types" do
-    {query, params, _select} = from(Post, []) |> select([p], type(^"1", :integer))
-                                              |> normalize_with_params()
+    {query, params, _select} =
+      from(Post, [])
+      |> select([p], type(^"1", :integer))
+      |> normalize_with_params()
+
     assert query.select.expr ==
-           %Ecto.Query.Tagged{type: :integer, value: {:^, [], [0]}, tag: :integer}
+             %Ecto.Query.Tagged{type: :integer, value: {:^, [], [0]}, tag: :integer}
+
     assert params == [1]
 
-    {query, params, _select} = from(Post, []) |> select([p], type(^"1", ^:integer))
-                                              |> normalize_with_params()
+    {query, params, _select} =
+      from(Post, [])
+      |> select([p], type(^"1", ^:integer))
+      |> normalize_with_params()
+
     assert query.select.expr ==
-           %Ecto.Query.Tagged{type: :integer, value: {:^, [], [0]}, tag: :integer}
+             %Ecto.Query.Tagged{type: :integer, value: {:^, [], [0]}, tag: :integer}
+
     assert params == [1]
 
-    {query, params, _select} = from(Post, []) |> select([p], type(^"1", CustomPermalink))
-                                              |> normalize_with_params()
+    {query, params, _select} =
+      from(Post, [])
+      |> select([p], type(^"1", CustomPermalink))
+      |> normalize_with_params()
+
     assert query.select.expr ==
-           %Ecto.Query.Tagged{type: :id, value: {:^, [], [0]}, tag: CustomPermalink}
+             %Ecto.Query.Tagged{type: :id, value: {:^, [], [0]}, tag: CustomPermalink}
+
     assert params == [1]
 
-    {query, params, _select} = from(Post, []) |> select([p], type(^"1", p.visits))
-                                              |> normalize_with_params()
+    {query, params, _select} =
+      from(Post, [])
+      |> select([p], type(^"1", p.visits))
+      |> normalize_with_params()
+
     assert query.select.expr ==
-           %Ecto.Query.Tagged{type: :integer, value: {:^, [], [0]}, tag: :integer}
+             %Ecto.Query.Tagged{type: :integer, value: {:^, [], [0]}, tag: :integer}
+
     assert params == [1]
 
-    expected_tagged_query =
-      %Ecto.Query.Tagged{
-        tag: :binary,
-        type: :binary,
-        value:
-          {:json_extract_path, [], [{{:., [], [{:&, [], [0]}, :meta]}, [], []}, ["slug"]]}
-      }
+    expected_tagged_query = %Ecto.Query.Tagged{
+      tag: :binary,
+      type: :binary,
+      value: {:json_extract_path, [], [{{:., [], [{:&, [], [0]}, :meta]}, [], []}, ["slug"]]}
+    }
 
-    {query, params, _select} = from(Post, []) |> select([p], type(p.meta["slug"], :binary))
-                                              |> normalize_with_params()
+    {query, params, _select} =
+      from(Post, [])
+      |> select([p], type(p.meta["slug"], :binary))
+      |> normalize_with_params()
+
     assert query.select.expr == expected_tagged_query
     assert params == []
 
-    {query, params, _select} = from(Post, []) |> select([p], type(json_extract_path(p.meta, ["slug"]), :binary))
-                                              |> normalize_with_params()
+    {query, params, _select} =
+      from(Post, [])
+      |> select([p], type(json_extract_path(p.meta, ["slug"]), :binary))
+      |> normalize_with_params()
+
     assert query.select.expr == expected_tagged_query
     assert params == []
 
-    assert_raise Ecto.Query.CastError, ~r/value `"1"` in `select` cannot be cast to type Ecto.UUID/, fn ->
-      from(Post, []) |> select([p], type(^"1", Ecto.UUID)) |> normalize
-    end
+    assert_raise Ecto.Query.CastError,
+                 ~r/value `"1"` in `select` cannot be cast to type Ecto.UUID/,
+                 fn ->
+                   from(Post, []) |> select([p], type(^"1", Ecto.UUID)) |> normalize
+                 end
   end
 
   test "normalize: select types" do
@@ -858,16 +1085,22 @@ defmodule Ecto.Query.PlannerTest do
   test "normalize: late parent bindings with as" do
     child = from(c in Comment, where: parent_as(:posts).posted == c.posted)
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).posted() == &0.posted()"
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) ==
+             "parent_as(:posts).posted() == &0.posted()"
 
     child = from(c in Comment, select: %{map: parent_as(:posts).posted})
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
 
-    assert_raise Ecto.SubQueryError, ~r/the parent_as in a subquery select used as a join can only access the `from` binding in query/, fn ->
-      child = from(c in Comment, select: %{map: parent_as(:itself).posted})
-      from(Post, as: :posts, join: c in subquery(child), as: :itself) |> normalize()
-    end
+    assert Macro.to_string(hd(query.joins).source.query.select.expr) ==
+             "%{map: parent_as(:posts).posted()}"
+
+    assert_raise Ecto.SubQueryError,
+                 ~r/the parent_as in a subquery select used as a join can only access the `from` binding in query/,
+                 fn ->
+                   child = from(c in Comment, select: %{map: parent_as(:itself).posted})
+                   from(Post, as: :posts, join: c in subquery(child), as: :itself) |> normalize()
+                 end
 
     assert_raise Ecto.SubQueryError, ~r/could not find named binding `parent_as\(:posts\)`/, fn ->
       from(Post, join: c in subquery(child)) |> normalize()
@@ -883,20 +1116,29 @@ defmodule Ecto.Query.PlannerTest do
 
     child = from(c in Comment, where: parent_as(^as).posted == c.posted)
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).posted() == &0.posted()"
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) ==
+             "parent_as(:posts).posted() == &0.posted()"
 
     child = from(c in Comment, select: %{map: field(parent_as(^as), :posted)})
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
+
+    assert Macro.to_string(hd(query.joins).source.query.select.expr) ==
+             "%{map: parent_as(:posts).posted()}"
   end
 
   test "normalize: nested parent_as" do
     child3 = from(c in Comment, where: parent_as(:posts).deleted == false, select: c.id)
     child2 = from(c in Comment, where: c.id in subquery(child3), select: c.id)
-    child = from(c in Comment, where: parent_as(:posts).posted == c.posted and c.id in subquery(child2))
+
+    child =
+      from(c in Comment, where: parent_as(:posts).posted == c.posted and c.id in subquery(child2))
 
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "parent_as(:posts).posted() == &0.posted()"
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~
+             "parent_as(:posts).posted() == &0.posted()"
+
     assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "in %Ecto.SubQuery{"
   end
 
@@ -904,10 +1146,17 @@ defmodule Ecto.Query.PlannerTest do
     as = :posts
     child3 = from(c in Comment, where: parent_as(^as).deleted == false, select: c.id)
     child2 = from(c in Comment, where: c.id in subquery(child3), select: c.id)
-    child = from(c in Comment, where: field(parent_as(^as), :posted) == c.posted and c.id in subquery(child2))
+
+    child =
+      from(c in Comment,
+        where: field(parent_as(^as), :posted) == c.posted and c.id in subquery(child2)
+      )
 
     query = from(Post, as: :posts, join: c in subquery(child)) |> normalize()
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "parent_as(:posts).posted() == &0.posted()"
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~
+             "parent_as(:posts).posted() == &0.posted()"
+
     assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) =~ "in %Ecto.SubQuery{"
   end
 
@@ -916,16 +1165,21 @@ defmodule Ecto.Query.PlannerTest do
     {_query, params, _select} =
       from(post in Post,
         join: comment in assoc(post, :crazy_comments),
-        join: post in assoc(comment, :crazy_post)) |> normalize_with_params()
+        join: post in assoc(comment, :crazy_post)
+      )
+      |> normalize_with_params()
 
     assert params == ["crazycomment", "crazypost"]
   end
 
   test "normalize: has_many assoc join with wheres" do
     {query, params, _select} =
-      from(comment in Comment, join: post in assoc(comment, :crazy_post_with_list)) |> normalize_with_params()
+      from(comment in Comment, join: post in assoc(comment, :crazy_post_with_list))
+      |> normalize_with_params()
 
-    assert inspect(query) =~ "join: p1 in Ecto.Query.PlannerTest.Post, on: p1.id == c0.crazy_post_id and p1.post_title in ^..."
+    assert inspect(query) =~
+             "join: p1 in Ecto.Query.PlannerTest.Post, on: p1.id == c0.crazy_post_id and p1.post_title in ^..."
+
     assert params == ["crazypost1", "crazypost2"]
 
     {query, params, _} =
@@ -938,34 +1192,44 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: many_to_many assoc join with schema and wheres" do
     {query, params, _select} =
-      from(post in Post, join: comment in assoc(post, :crazy_comments_with_list)) |> normalize_with_params()
+      from(post in Post, join: comment in assoc(post, :crazy_comments_with_list))
+      |> normalize_with_params()
 
-    assert inspect(query) =~ "join: c1 in Ecto.Query.PlannerTest.Comment, on: c2.comment_id == c1.id and c1.text in ^... and c2.deleted == ^..."
+    assert inspect(query) =~
+             "join: c1 in Ecto.Query.PlannerTest.Comment, on: c2.comment_id == c1.id and c1.text in ^... and c2.deleted == ^..."
+
     assert params == ["crazycomment1", "crazycomment2", true]
 
     {query, params, _} =
       Ecto.assoc(%Post{id: 1}, :crazy_comments_with_list)
       |> normalize_with_params()
 
-    assert inspect(query) =~ "join: c1 in Ecto.Query.PlannerTest.CommentPost, on: c0.id == c1.comment_id and c1.deleted == ^..."
+    assert inspect(query) =~
+             "join: c1 in Ecto.Query.PlannerTest.CommentPost, on: c0.id == c1.comment_id and c1.deleted == ^..."
+
     assert inspect(query) =~ "where: c1.post_id in ^... and c0.text in ^..."
-    assert params ==  [true, 1, "crazycomment1", "crazycomment2"]
+    assert params == [true, 1, "crazycomment1", "crazycomment2"]
   end
 
   test "normalize: many_to_many assoc join without schema and wheres" do
     {query, params, _select} =
-      from(post in Post, join: comment in assoc(post, :crazy_comments_without_schema)) |> normalize_with_params()
+      from(post in Post, join: comment in assoc(post, :crazy_comments_without_schema))
+      |> normalize_with_params()
 
-    assert inspect(query) =~ "join: c1 in Ecto.Query.PlannerTest.Comment, on: c2.comment_id == c1.id and c2.deleted == ^..."
+    assert inspect(query) =~
+             "join: c1 in Ecto.Query.PlannerTest.Comment, on: c2.comment_id == c1.id and c2.deleted == ^..."
+
     assert params == [true]
 
     {query, params, _} =
       Ecto.assoc(%Post{id: 1}, :crazy_comments_without_schema)
       |> normalize_with_params()
 
-    assert inspect(query) =~ "join: c1 in \"comment_posts\", on: c0.id == c1.comment_id and c1.deleted == ^..."
+    assert inspect(query) =~
+             "join: c1 in \"comment_posts\", on: c0.id == c1.comment_id and c1.deleted == ^..."
+
     assert inspect(query) =~ "where: c1.post_id in ^..."
-    assert params ==  [true, 1]
+    assert params == [true, 1]
   end
 
   test "normalize: dumps in query expressions" do
@@ -975,13 +1239,17 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "normalize: validate fields" do
-    message = ~r"field `unknown` in `select` does not exist in schema Ecto.Query.PlannerTest.Comment"
+    message =
+      ~r"field `unknown` in `select` does not exist in schema Ecto.Query.PlannerTest.Comment"
+
     assert_raise Ecto.QueryError, message, fn ->
       query = from(Comment, []) |> select([c], c.unknown)
       normalize(query)
     end
 
-    message = ~r"field `temp` in `select` is a virtual field in schema Ecto.Query.PlannerTest.Comment"
+    message =
+      ~r"field `temp` in `select` is a virtual field in schema Ecto.Query.PlannerTest.Comment"
+
     assert_raise Ecto.QueryError, message, fn ->
       query = from(Comment, []) |> select([c], c.temp)
       normalize(query)
@@ -993,6 +1261,7 @@ defmodule Ecto.Query.PlannerTest do
     normalize(query)
 
     message = ~r"value `\[1, 2, 3\]` cannot be dumped to type \{:array, :string\}"
+
     assert_raise Ecto.QueryError, message, fn ->
       query = from(Comment, []) |> where([c], c.text in [1, 2, 3])
       normalize(query)
@@ -1021,42 +1290,52 @@ defmodule Ecto.Query.PlannerTest do
     query = from(p in "posts") |> select([p], p.meta["slug"])
     normalize(query)
 
-    query = from(p  in "posts") |> select([p], p.meta["unknown_field"])
+    query = from(p in "posts") |> select([p], p.meta["unknown_field"])
     normalize(query)
 
-    query = from(p  in "posts") |> select([p], p.meta["author"]["unknown_field"])
+    query = from(p in "posts") |> select([p], p.meta["author"]["unknown_field"])
     normalize(query)
 
-    query = from(p  in "posts") |> select([p], p.metas["not_index"])
+    query = from(p in "posts") |> select([p], p.metas["not_index"])
     normalize(query)
 
-    query = from(p  in "posts") |> select([p], p.metas["not_index"]["unknown_field"])
+    query = from(p in "posts") |> select([p], p.metas["not_index"]["unknown_field"])
     normalize(query)
 
-    assert_raise RuntimeError, "expected field `title` to be an embed or a map, got: `:string`", fn ->
-      query = from(Post, []) |> select([p], p.title["foo"])
-      normalize(query)
-    end
+    assert_raise RuntimeError,
+                 "expected field `title` to be an embed or a map, got: `:string`",
+                 fn ->
+                   query = from(Post, []) |> select([p], p.title["foo"])
+                   normalize(query)
+                 end
 
-    assert_raise RuntimeError, "field `unknown_field` does not exist in Ecto.Query.PlannerTest.PostMeta", fn ->
-      query = from(Post, []) |> select([p], p.meta["unknown_field"])
-      normalize(query)
-    end
+    assert_raise RuntimeError,
+                 "field `unknown_field` does not exist in Ecto.Query.PlannerTest.PostMeta",
+                 fn ->
+                   query = from(Post, []) |> select([p], p.meta["unknown_field"])
+                   normalize(query)
+                 end
 
-    assert_raise RuntimeError, "field `0` does not exist in Ecto.Query.PlannerTest.PostMeta", fn ->
-      query = from(Post, []) |> select([p], p.meta[0])
-      normalize(query)
-    end
+    assert_raise RuntimeError,
+                 "field `0` does not exist in Ecto.Query.PlannerTest.PostMeta",
+                 fn ->
+                   query = from(Post, []) |> select([p], p.meta[0])
+                   normalize(query)
+                 end
 
-    assert_raise RuntimeError, "field `unknown_field` does not exist in Ecto.Query.PlannerTest.Author", fn ->
-      query = from(Post, []) |> select([p], p.meta["author"]["unknown_field"])
-      normalize(query)
-    end
+    assert_raise RuntimeError,
+                 "field `unknown_field` does not exist in Ecto.Query.PlannerTest.Author",
+                 fn ->
+                   query = from(Post, []) |> select([p], p.meta["author"]["unknown_field"])
+                   normalize(query)
+                 end
 
-    assert_raise RuntimeError, "cannot use `not_index` to refer to an item in `embeds_many`", fn ->
-      query = from(Post, []) |> select([p], p.metas["not_index"])
-      normalize(query)
-    end
+    assert_raise RuntimeError,
+                 "cannot use `not_index` to refer to an item in `embeds_many`",
+                 fn ->
+                   query = from(Post, []) |> select([p], p.metas["not_index"])
+                   normalize(query)
+                 end
   end
 
   test "normalize: flattens and expands right side of in expressions" do
@@ -1076,10 +1355,18 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(hd(query.wheres).expr) == "&0.id() in ^(0, 3)"
     assert params == [1, 2, 3]
 
-    {query, params, _select} = where(Post, [p], p.title == ^"foo" and p.id in ^[1, 2, 3] and
-                                                p.title == ^"bar") |> normalize_with_params()
+    {query, params, _select} =
+      where(
+        Post,
+        [p],
+        p.title == ^"foo" and p.id in ^[1, 2, 3] and
+          p.title == ^"bar"
+      )
+      |> normalize_with_params()
+
     assert Macro.to_string(hd(query.wheres).expr) ==
-           "&0.post_title() == ^0 and &0.id() in ^(1, 3) and &0.post_title() == ^4"
+             "&0.post_title() == ^0 and &0.id() in ^(1, 3) and &0.post_title() == ^4"
+
     assert params == ["foo", 1, 2, 3, "bar"]
   end
 
@@ -1100,22 +1387,30 @@ defmodule Ecto.Query.PlannerTest do
         Comment
         |> with_cte("cte", as: ^from(c in "comments", select: %{id: c.id, text: c.text}))
         |> normalize()
+
       %{queries: [{"cte", query}]} = with_expr
       assert query.sources == {{"comments", nil, nil}}
       assert {:%{}, [], [id: _, text: _]} = query.select.expr
-      assert  [id: {{:., _, [{:&, _, [0]}, :id]}, _, []},
-               text: {{:., [{:type, _} | _], [{:&, _, [0]}, :text]}, _, []}] = query.select.fields
+
+      assert [
+               id: {{:., _, [{:&, _, [0]}, :id]}, _, []},
+               text: {{:., [{:type, _} | _], [{:&, _, [0]}, :text]}, _, []}
+             ] = query.select.fields
 
       %{with_ctes: with_expr} =
         Comment
-        |> with_cte("cte", as: ^(from(c in Comment, where: c in ^[1, 2, 3])))
+        |> with_cte("cte", as: ^from(c in Comment, where: c in ^[1, 2, 3]))
         |> normalize()
+
       %{queries: [{"cte", query}]} = with_expr
       assert query.sources == {{"comments", Comment, nil}}
       assert {:&, [], [0]} = query.select.expr
-      assert  [{:id, {{:., _, [{:&, _, [0]}, :id]}, _, []}},
+
+      assert [
+               {:id, {{:., _, [{:&, _, [0]}, :id]}, _, []}},
                {:text, {{:., _, [{:&, _, [0]}, :text]}, _, []}},
-               _ | _] = query.select.fields
+               _ | _
+             ] = query.select.fields
     end
 
     test "multi-level with select" do
@@ -1156,20 +1451,69 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: select" do
     query = from(Post, []) |> normalize()
+
     assert query.select.expr ==
              {:&, [], [0]}
+
     assert query.select.fields ==
-           select_fields([:id, :post_title, :text, :code, :posted, :visits, :links, :prefs, :status, :meta, :metas], 0)
+             select_fields(
+               [
+                 :id,
+                 :post_title,
+                 :text,
+                 :code,
+                 :posted,
+                 :visits,
+                 :links,
+                 :prefs,
+                 :status,
+                 :meta,
+                 :metas
+               ],
+               0
+             )
 
     query = from(Post, []) |> select([p], {p, p.title, "Post"}) |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title, :text, :code, :posted, :visits, :links, :prefs, :status, :meta, :metas], 0) ++
-           [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
+             select_fields(
+               [
+                 :id,
+                 :post_title,
+                 :text,
+                 :code,
+                 :posted,
+                 :visits,
+                 :links,
+                 :prefs,
+                 :status,
+                 :meta,
+                 :metas
+               ],
+               0
+             ) ++
+               [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
 
     query = from(Post, []) |> select([p], {p.title, p, "Post"}) |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title, :text, :code, :posted, :visits, :links, :prefs, :status, :meta, :metas], 0) ++
-           [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
+             select_fields(
+               [
+                 :id,
+                 :post_title,
+                 :text,
+                 :code,
+                 :posted,
+                 :visits,
+                 :links,
+                 :prefs,
+                 :status,
+                 :meta,
+                 :metas
+               ],
+               0
+             ) ++
+               [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
 
     query =
       from(Post, [])
@@ -1177,15 +1521,39 @@ defmodule Ecto.Query.PlannerTest do
       |> preload([_, c], comments: c)
       |> select([p, _], {p.title, p})
       |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title, :text, :code, :posted, :visits, :links, :prefs, :status, :meta, :metas], 0) ++
-           select_fields([:id, :text, :posted, :uuid, :crazy_comment, :post_id, :crazy_post_id], 1) ++
-           [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
+             select_fields(
+               [
+                 :id,
+                 :post_title,
+                 :text,
+                 :code,
+                 :posted,
+                 :visits,
+                 :links,
+                 :prefs,
+                 :status,
+                 :meta,
+                 :metas
+               ],
+               0
+             ) ++
+               select_fields(
+                 [:id, :text, :posted, :uuid, :crazy_comment, :post_id, :crazy_post_id],
+                 1
+               ) ++
+               [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
   end
 
   test "normalize: select with unions" do
     union_query = from(Post, []) |> select([p], %{title: p.title, category: "Post"})
-    query = from(Post, []) |> select([p], %{title: p.title, category: "Post"}) |> union(^union_query) |> normalize()
+
+    query =
+      from(Post, [])
+      |> select([p], %{title: p.title, category: "Post"})
+      |> union(^union_query)
+      |> normalize()
 
     union_query = query.combinations |> List.first() |> elem(1)
     assert "Post" in query.select.fields
@@ -1194,7 +1562,12 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: select with unions and virtual literal" do
     union_query = from(Post, []) |> select([p], %{title: p.title, temp: true})
-    query = from(Post, []) |> select([p], %{title: p.title, temp: false}) |> union(^union_query) |> normalize()
+
+    query =
+      from(Post, [])
+      |> select([p], %{title: p.title, temp: false})
+      |> union(^union_query)
+      |> normalize()
 
     union_query = query.combinations |> List.first() |> elem(1)
     assert false in query.select.fields
@@ -1217,18 +1590,35 @@ defmodule Ecto.Query.PlannerTest do
     assert query.select.fields == select_fields([:id, :post_title], 0)
 
     query = Post |> select([p], {struct(p, [:id, :title]), p.title}) |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title], 0) ++
-           [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
+             select_fields([:id, :post_title], 0) ++
+               [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
 
     query =
       Post
       |> join(:inner, [_], c in Comment)
       |> select([p, c], {p, struct(c, [:id, :text])})
       |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title, :text, :code, :posted, :visits, :links, :prefs, :status, :meta, :metas], 0) ++
-           select_fields([:id, :text], 1)
+             select_fields(
+               [
+                 :id,
+                 :post_title,
+                 :text,
+                 :code,
+                 :posted,
+                 :visits,
+                 :links,
+                 :prefs,
+                 :status,
+                 :meta,
+                 :metas
+               ],
+               0
+             ) ++
+               select_fields([:id, :text], 1)
   end
 
   test "normalize: select with struct/2 on assoc" do
@@ -1238,32 +1628,41 @@ defmodule Ecto.Query.PlannerTest do
       |> select([p, c], struct(p, [:id, :title, comments: [:id, :text]]))
       |> preload([p, c], comments: c)
       |> normalize()
+
     assert query.select.expr == {:&, [], [0]}
+
     assert query.select.fields ==
-           select_fields([:id, :post_title], 0) ++
-           select_fields([:id, :text], 1)
+             select_fields([:id, :post_title], 0) ++
+               select_fields([:id, :text], 1)
 
     query =
       Post
       |> join(:inner, [_], c in Comment)
-      |> select([p, c], struct(p, [:id, :title, comments: [:id, :text, post: :id], extra_comments: :id]))
+      |> select(
+        [p, c],
+        struct(p, [:id, :title, comments: [:id, :text, post: :id], extra_comments: :id])
+      )
       |> preload([p, c], comments: {c, post: p}, extra_comments: c)
       |> normalize()
+
     assert query.select.expr == {:&, [], [0]}
+
     assert query.select.fields ==
-           select_fields([:id, :post_title], 0) ++
-           select_fields([:id, :text], 1) ++
-           select_fields([:id], 0) ++
-           select_fields([:id], 1)
+             select_fields([:id, :post_title], 0) ++
+               select_fields([:id, :text], 1) ++
+               select_fields([:id], 0) ++
+               select_fields([:id], 1)
   end
 
   test "normalize: select with struct/2 on fragment" do
-    assert_raise Ecto.QueryError, ~r"it is not possible to return a struct subset of a fragment", fn ->
-      Post
-      |> join(:inner, [_], c in fragment("comments"))
-      |> select([_, c], struct(c, [:id]))
-      |> normalize()
-    end
+    assert_raise Ecto.QueryError,
+                 ~r"it is not possible to return a struct subset of a fragment",
+                 fn ->
+                   Post
+                   |> join(:inner, [_], c in fragment("comments"))
+                   |> select([_, c], struct(c, [:id]))
+                   |> normalize()
+                 end
   end
 
   test "normalize: select with map/2" do
@@ -1272,18 +1671,35 @@ defmodule Ecto.Query.PlannerTest do
     assert query.select.fields == select_fields([:id, :post_title], 0)
 
     query = Post |> select([p], {map(p, [:id, :title]), p.title}) |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title], 0) ++
-           [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
+             select_fields([:id, :post_title], 0) ++
+               [{{:., [type: :string], [{:&, [], [0]}, :post_title]}, [], []}]
 
     query =
       Post
       |> join(:inner, [_], c in Comment)
       |> select([p, c], {p, map(c, [:id, :text])})
       |> normalize()
+
     assert query.select.fields ==
-           select_fields([:id, :post_title, :text, :code, :posted, :visits, :links, :prefs, :status, :meta, :metas], 0) ++
-           select_fields([:id, :text], 1)
+             select_fields(
+               [
+                 :id,
+                 :post_title,
+                 :text,
+                 :code,
+                 :posted,
+                 :visits,
+                 :links,
+                 :prefs,
+                 :status,
+                 :meta,
+                 :metas
+               ],
+               0
+             ) ++
+               select_fields([:id, :text], 1)
   end
 
   test "normalize: select with map/2 on assoc" do
@@ -1293,23 +1709,30 @@ defmodule Ecto.Query.PlannerTest do
       |> select([p, c], map(p, [:id, :title, comments: [:id, :text]]))
       |> preload([p, c], comments: c)
       |> normalize()
+
     assert query.select.expr == {:&, [], [0]}
+
     assert query.select.fields ==
-           select_fields([:id, :post_title], 0) ++
-           select_fields([:id, :text], 1)
+             select_fields([:id, :post_title], 0) ++
+               select_fields([:id, :text], 1)
 
     query =
       Post
       |> join(:inner, [_], c in Comment)
-      |> select([p, c], map(p, [:id, :title, comments: [:id, :text, post: :id], extra_comments: :id]))
+      |> select(
+        [p, c],
+        map(p, [:id, :title, comments: [:id, :text, post: :id], extra_comments: :id])
+      )
       |> preload([p, c], comments: {c, post: p}, extra_comments: c)
       |> normalize()
+
     assert query.select.expr == {:&, [], [0]}
+
     assert query.select.fields ==
-           select_fields([:id, :post_title], 0) ++
-           select_fields([:id, :text], 1) ++
-            select_fields([:id], 0) ++
-           select_fields([:id], 1)
+             select_fields([:id, :post_title], 0) ++
+               select_fields([:id, :text], 1) ++
+               select_fields([:id], 0) ++
+               select_fields([:id], 1)
   end
 
   test "normalize: select with map/2 on fragment" do
@@ -1337,17 +1760,19 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: preload errors" do
     message = ~r"the binding used in `from` must be selected in `select` when using `preload`"
+
     assert_raise Ecto.QueryError, message, fn ->
       Post |> preload(:hello) |> select([p], p.title) |> normalize
     end
 
     message = ~r"invalid query has specified more bindings than"
+
     assert_raise Ecto.QueryError, message, fn ->
       Post |> preload([p, c], comments: c) |> normalize
     end
   end
 
-  test "normalize: preload assoc merges"  do
+  test "normalize: preload assoc merges" do
     {_, _, select} =
       from(p in Post)
       |> join(:inner, [p], c in assoc(p, :comments))
@@ -1362,12 +1787,14 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: preload assoc errors" do
     message = ~r"field `Ecto.Query.PlannerTest.Post.not_field` in preload is not an association"
+
     assert_raise Ecto.QueryError, message, fn ->
       query = from(p in Post, join: c in assoc(p, :comments), preload: [not_field: c])
       normalize(query)
     end
 
     message = ~r"requires an inner, left or lateral join, got right join"
+
     assert_raise Ecto.QueryError, message, fn ->
       query = from(p in Post, right_join: c in assoc(p, :comments), preload: [comments: c])
       normalize(query)
@@ -1376,6 +1803,7 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: fragments do not support preloads" do
     query = from p in Post, join: c in fragment("..."), preload: [comments: c]
+
     assert_raise Ecto.QueryError, ~r/can only preload sources with a schema/, fn ->
       normalize(query)
     end
@@ -1383,6 +1811,7 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: all does not allow updates" do
     message = ~r"`all` does not allow `update` expressions"
+
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, update: [set: [name: "foo"]]) |> normalize(:all)
     end
@@ -1390,17 +1819,20 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: update all only allow filters and checks updates" do
     message = ~r"`update_all` requires at least one field to be updated"
+
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, select: p, update: []) |> normalize(:update_all)
     end
 
     message = ~r"duplicate field `title` for `update_all`"
+
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, select: p, update: [set: [title: "foo", title: "bar"]])
       |> normalize(:update_all)
     end
 
     message = ~r"`update_all` allows only `with_cte`, `where` and `join` expressions"
+
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, order_by: p.title, update: [set: [title: "foo"]]) |> normalize(:update_all)
     end
@@ -1408,11 +1840,13 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: delete all only allow filters and forbids updates" do
     message = ~r"`delete_all` does not allow `update` expressions"
+
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, update: [set: [name: "foo"]]) |> normalize(:delete_all)
     end
 
     message = ~r"`delete_all` allows only `with_cte`, `where` and `join` expressions"
+
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, order_by: p.title) |> normalize(:delete_all)
     end
@@ -1426,13 +1860,13 @@ defmodule Ecto.Query.PlannerTest do
         from(p in Post, where: p.visits in subquery(subquery))
         |> normalize()
 
-      assert {:in, _, [_, %Ecto.SubQuery{}] } = where.expr
+      assert {:in, _, [_, %Ecto.SubQuery{}]} = where.expr
 
       %{wheres: [where]} =
         from(p in Post, where: p.visits >= all(subquery))
         |> normalize()
 
-      assert {:>=, _, [_, {:all, _, [%Ecto.SubQuery{}] }]} = where.expr
+      assert {:>=, _, [_, {:all, _, [%Ecto.SubQuery{}]}]} = where.expr
 
       %{wheres: [where]} =
         from(p in Post, where: exists(subquery))

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../support/eval_helpers.exs", __DIR__
+Code.require_file("../support/eval_helpers.exs", __DIR__)
 
 defmodule Ecto.QueryTest do
   use ExUnit.Case, async: true
@@ -9,6 +9,7 @@ defmodule Ecto.QueryTest do
 
   defmodule Schema do
     use Ecto.Schema
+
     schema "schema" do
     end
   end
@@ -21,8 +22,7 @@ defmodule Ecto.QueryTest do
 
   defmacro macro_map(key) do
     quote do
-      %{"1" => unquote(key),
-        "2" => unquote(key)}
+      %{"1" => unquote(key), "2" => unquote(key)}
     end
   end
 
@@ -40,6 +40,7 @@ defmodule Ecto.QueryTest do
 
     defmacrop macrotest(x), do: quote(do: is_nil(unquote(x)) or unquote(x) == "A")
     defmacrop deeper_macrotest(x), do: quote(do: macrotest(unquote(x)) or unquote(x) == "B")
+
     test "allows macro in where" do
       _ = from(p in "posts", where: p.title == "C" or macrotest(p.title))
       _ = from(p in "posts", where: p.title == "C" or deeper_macrotest(p.title))
@@ -47,14 +48,14 @@ defmodule Ecto.QueryTest do
 
     test "does not allow nils in comparison at compile time" do
       assert_raise Ecto.Query.CompileError,
-                   ~r"comparison with nil is forbidden as it is unsafe", fn ->
-        quote_and_eval from p in "posts", where: p.id == nil
-      end
+                   ~r"comparison with nil is forbidden as it is unsafe",
+                   fn ->
+                     quote_and_eval(from p in "posts", where: p.id == nil)
+                   end
     end
 
     test "does not allow interpolated nils at runtime" do
-      assert_raise ArgumentError,
-                   ~r"comparison with nil is forbidden as it is unsafe", fn ->
+      assert_raise ArgumentError, ~r"comparison with nil is forbidden as it is unsafe", fn ->
         id = nil
         from p in "posts", where: [id: ^id]
       end
@@ -172,7 +173,7 @@ defmodule Ecto.QueryTest do
   describe "bindings" do
     test "are not required by macros" do
       _ = from(p in "posts") |> limit(1)
-      _ = from(p in "posts") |> order_by([asc: :title])
+      _ = from(p in "posts") |> order_by(asc: :title)
       _ = from(p in "posts") |> where(title: "foo")
       _ = from(p in "posts") |> having(title: "foo")
       _ = from(p in "posts") |> offset(1)
@@ -185,9 +186,10 @@ defmodule Ecto.QueryTest do
 
     test "must be a list of variables" do
       assert_raise Ecto.Query.CompileError,
-                   "binding list should contain only variables or `{as, var}` tuples, got: 0", fn ->
-        quote_and_eval select(%Query{}, [0], 1)
-      end
+                   "binding list should contain only variables or `{as, var}` tuples, got: 0",
+                   fn ->
+                     quote_and_eval(select(%Query{}, [0], 1))
+                   end
     end
 
     test "ignore unbound _ var" do
@@ -239,17 +241,18 @@ defmodule Ecto.QueryTest do
   describe "trailing bindings (...)" do
     test "match on last bindings" do
       query = "posts" |> join(:inner, [], "comments") |> join(:inner, [], "votes")
+
       assert select(query, [..., v], v).select.expr ==
-             {:&, [], [2]}
+               {:&, [], [2]}
 
       assert select(query, [p, ..., v], {p, v}).select.expr ==
-             {:{}, [], [{:&, [], [0]}, {:&, [], [2]}]}
+               {:{}, [], [{:&, [], [0]}, {:&, [], [2]}]}
 
       assert select(query, [p, c, v, ...], v).select.expr ==
-             {:&, [], [2]}
+               {:&, [], [2]}
 
       assert select(query, [..., c, v], {c, v}).select.expr ==
-             {:{}, [], [{:&, [], [1]}, {:&, [], [2]}]}
+               {:{}, [], [{:&, [], [1]}, {:&, [], [2]}]}
     end
 
     test "match on last bindings with multiple constructs" do
@@ -271,20 +274,23 @@ defmodule Ecto.QueryTest do
         |> join(:inner, [..., c], v in "votes", on: c.id == v.id)
 
       assert hd(tl(query.joins)).on.expr ==
-             {:==, [], [
-              {{:., [], [{:&, [], [1]}, :id]}, [], []},
-              {{:., [], [{:&, [], [2]}, :id]}, [], []}
-             ]}
+               {:==, [],
+                [
+                  {{:., [], [{:&, [], [1]}, :id]}, [], []},
+                  {{:., [], [{:&, [], [2]}, :id]}, [], []}
+                ]}
     end
 
     test "match on last bindings on keyword query" do
       posts = "posts"
       query = from [..., p] in posts, join: c in "comments", on: p.id == c.id
+
       assert hd(query.joins).on.expr ==
-             {:==, [], [
-              {{:., [], [{:&, [], [0]}, :id]}, [], []},
-              {{:., [], [{:&, [], [1]}, :id]}, [], []}
-             ]}
+               {:==, [],
+                [
+                  {{:., [], [{:&, [], [0]}, :id]}, [], []},
+                  {{:., [], [{:&, [], [1]}, :id]}, [], []}
+                ]}
     end
 
     test "dynamic in :on takes new binding when ... is used" do
@@ -292,7 +298,7 @@ defmodule Ecto.QueryTest do
       query = from p in "posts", join: c in "comments", on: ^join_on
 
       assert inspect(query) ==
-        ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", on: c1.text == \"Test Comment\">]
+               ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", on: c1.text == \"Test Comment\">]
     end
   end
 
@@ -301,8 +307,12 @@ defmodule Ecto.QueryTest do
       query =
         from(p in "posts",
           join: b in "blogs",
-          join: c in "comments", as: :comment,
-          join: l in "links", on: l.valid, as: :link)
+          join: c in "comments",
+          as: :comment,
+          join: l in "links",
+          on: l.valid,
+          as: :link
+        )
 
       assert %{comment: 2, link: 3} == query.aliases
     end
@@ -323,7 +333,7 @@ defmodule Ecto.QueryTest do
     end
 
     test "assigns a name to a subquery source" do
-      posts_query = from p in "posts"
+      posts_query = from(p in "posts")
       query = from p in subquery(posts_query), as: :post
 
       assert %{post: 0} == query.aliases
@@ -332,6 +342,7 @@ defmodule Ecto.QueryTest do
 
     test "assign to source fails when non-atom name passed" do
       message = ~r"`as` must be a compile time atom, got: `\"post\"`"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         quote_and_eval(from(p in "posts", as: "post"))
       end
@@ -345,6 +356,7 @@ defmodule Ecto.QueryTest do
 
     test "crashes on duplicate as for keyword query" do
       message = ~r"`as` keyword was given more than once"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         quote_and_eval(from(p in "posts", join: b in "blogs", as: :foo, as: :bar))
       end
@@ -352,13 +364,17 @@ defmodule Ecto.QueryTest do
 
     test "crashes on assigning the same name twice at compile time" do
       message = ~r"alias `:foo` already exists"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
-        quote_and_eval(from(p in "posts", join: b in "blogs", as: :foo, join: c in "comments", as: :foo))
+        quote_and_eval(
+          from(p in "posts", join: b in "blogs", as: :foo, join: c in "comments", as: :foo)
+        )
       end
     end
 
     test "crashes on assigning the same name twice at runtime" do
       message = ~r"alias `:foo` already exists"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         query = "posts"
         from(p in query, join: b in "blogs", as: :foo, join: c in "comments", as: :foo)
@@ -367,6 +383,7 @@ defmodule Ecto.QueryTest do
 
     test "crashes on assigning the same name twice when aliasing source" do
       message = ~r"alias `:foo` already exists"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         query = from p in "posts", join: b in "blogs", as: :foo
         from(p in query, as: :foo)
@@ -375,6 +392,7 @@ defmodule Ecto.QueryTest do
 
     test "crashes on assigning the name to source when it already has one" do
       message = ~r"can't apply alias `:foo`, binding in `from` is already aliased to `:post`"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         query = from p in "posts", as: :post
         from(p in query, as: :foo)
@@ -388,7 +406,7 @@ defmodule Ecto.QueryTest do
         |> where([comment: c], c.id == 0)
 
       assert inspect(query) ==
-        ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", as: :comment, on: true, where: c1.id == 0>]
+               ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", as: :comment, on: true, where: c1.id == 0>]
     end
 
     test "match on binding by name for source" do
@@ -397,7 +415,7 @@ defmodule Ecto.QueryTest do
         |> where([post: p], p.id == 0)
 
       assert inspect(query) ==
-        ~s[#Ecto.Query<from p0 in \"posts\", as: :post, where: p0.id == 0>]
+               ~s[#Ecto.Query<from p0 in \"posts\", as: :post, where: p0.id == 0>]
     end
 
     test "match on binding by name for source and join" do
@@ -408,7 +426,7 @@ defmodule Ecto.QueryTest do
         |> update([comment: c], set: [id: c.id + 1])
 
       assert inspect(query) ==
-        ~s{#Ecto.Query<from p0 in "posts", as: :post, join: c1 in "comments", as: :comment, on: true, update: [set: [id: c1.id + 1]]>}
+               ~s{#Ecto.Query<from p0 in "posts", as: :post, join: c1 in "comments", as: :comment, on: true, update: [set: [id: c1.id + 1]]>}
     end
 
     test "match on binding by name with ... in the middle" do
@@ -419,7 +437,7 @@ defmodule Ecto.QueryTest do
         |> where([p, ..., authors: a], a.id == 0)
 
       assert inspect(query) ==
-        ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", on: true, join: a2 in \"authors\", as: :authors, on: true, where: a2.id == 0>]
+               ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", on: true, join: a2 in \"authors\", as: :authors, on: true, where: a2.id == 0>]
     end
 
     test "crashes on non-existing binding" do
@@ -432,12 +450,13 @@ defmodule Ecto.QueryTest do
 
     test "crashes on bind not in tail of the list" do
       message = ~r"tuples must be at the end of the binding list"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
-      quote_and_eval(
-        "posts"
-        |> join(:inner, [p], c in "comments", as: :comment)
-        |> where([{:comment, c}, p], c.id == 0)
-      )
+        quote_and_eval(
+          "posts"
+          |> join(:inner, [p], c in "comments", as: :comment)
+          |> where([{:comment, c}, p], c.id == 0)
+        )
       end
     end
 
@@ -450,7 +469,7 @@ defmodule Ecto.QueryTest do
         |> where([{^assoc, c}], c.id == 0)
 
       assert inspect(query) ==
-        ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", as: :comment, on: true, where: c1.id == 0>]
+               ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", as: :comment, on: true, where: c1.id == 0>]
     end
 
     test "dynamic in :on takes new binding when alias is used" do
@@ -458,7 +477,7 @@ defmodule Ecto.QueryTest do
       query = from p in "posts", join: c in "comments", as: :comment, on: ^join_on
 
       assert inspect(query) ==
-        ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", as: :comment, on: c1.text == \"Test Comment\">]
+               ~s[#Ecto.Query<from p0 in \"posts\", join: c1 in \"comments\", as: :comment, on: c1.text == \"Test Comment\">]
     end
   end
 
@@ -497,6 +516,7 @@ defmodule Ecto.QueryTest do
       posts = from "posts", prefix: "hello"
 
       message = "can't apply prefix `\"world\"`, `from` is already prefixed to `\"hello\"`"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         from posts, prefix: "world"
       end
@@ -551,21 +571,23 @@ defmodule Ecto.QueryTest do
     test "are supported through from/2" do
       # queries need to be on the same line or == wont work
       assert from(p in "posts", select: 1 < 2) == from(p in "posts", []) |> select([p], 1 < 2)
-      assert from(p in "posts", where: 1 < 2)  == from(p in "posts", []) |> where([p], 1 < 2)
+      assert from(p in "posts", where: 1 < 2) == from(p in "posts", []) |> where([p], 1 < 2)
 
       query = "posts"
-      assert (query |> select([p], p.title)) == from(p in query, select: p.title)
+      assert query |> select([p], p.title) == from(p in query, select: p.title)
     end
 
     test "are built at compile time with binaries" do
       quoted =
         quote do
           from(p in "posts",
-               join: b in "blogs",
-               join: c in "comments", on: c.text == "",
-               limit: 0,
-               where: p.id == 0 and b.id == 0 and c.id == 0,
-               select: p)
+            join: b in "blogs",
+            join: c in "comments",
+            on: c.text == "",
+            limit: 0,
+            where: p.id == 0 and b.id == 0 and c.id == 0,
+            select: p
+          )
         end
 
       assert {:%{}, _, list} = Macro.expand(quoted, __ENV__)
@@ -576,11 +598,13 @@ defmodule Ecto.QueryTest do
       quoted =
         quote do
           from(p in Post,
-               join: b in Blog,
-               join: c in Comment, on: c.text == "",
-               limit: 0,
-               where: p.id == 0 and b.id == 0 and c.id == 0,
-               select: p)
+            join: b in Blog,
+            join: c in Comment,
+            on: c.text == "",
+            limit: 0,
+            where: p.id == 0 and b.id == 0 and c.id == 0,
+            select: p
+          )
         end
 
       assert {:%{}, _, list} = Macro.expand(quoted, __ENV__)
@@ -592,6 +616,7 @@ defmodule Ecto.QueryTest do
       from(p in "posts", join: c in assoc(p, :comments), select: p)
 
       message = ~r"`on` keyword must immediately follow a join"
+
       assert_raise Ecto.Query.CompileError, message, fn ->
         quote_and_eval(from(c in "comments", on: c.text == "", select: c))
       end
@@ -709,13 +734,13 @@ defmodule Ecto.QueryTest do
     test "removes join qualifiers" do
       base = %Ecto.Query{}
 
-      inner_query         = from p in "posts", inner_join: b in "blogs"
-      cross_query         = from p in "posts", cross_join: b in "blogs"
-      left_query          = from p in "posts", left_join: b in "blogs"
-      right_query         = from p in "posts", right_join: b in "blogs"
-      full_query          = from p in "posts", full_join: b in "blogs"
+      inner_query = from p in "posts", inner_join: b in "blogs"
+      cross_query = from p in "posts", cross_join: b in "blogs"
+      left_query = from p in "posts", left_join: b in "blogs"
+      right_query = from p in "posts", right_join: b in "blogs"
+      full_query = from p in "posts", full_join: b in "blogs"
       inner_lateral_query = from p in "posts", inner_lateral_join: b in "blogs"
-      left_lateral_query  = from p in "posts", left_lateral_join: b in "blogs"
+      left_lateral_query = from p in "posts", left_lateral_join: b in "blogs"
 
       refute inner_query.joins == base.joins
       refute cross_query.joins == base.joins
@@ -749,7 +774,8 @@ defmodule Ecto.QueryTest do
 
     test "removes join qualifiers with named bindings" do
       query =
-        from p in "posts", as: :base,
+        from p in "posts",
+          as: :base,
           inner_join: bi in "blogs",
           as: :blogs_i,
           cross_join: bc in "blogs",
@@ -820,102 +846,150 @@ defmodule Ecto.QueryTest do
     test "can be used to merge two dynamics" do
       left = dynamic([posts], posts.is_public == true)
       right = dynamic([posts], posts.is_draft == false)
-      
-      assert inspect(dynamic(^left and ^right)) == 
-        inspect(dynamic([posts], posts.is_public == true and posts.is_draft == false))
-      
-      assert inspect(dynamic(^left or ^right)) == 
-        inspect(dynamic([posts], posts.is_public == true or posts.is_draft == false))
+
+      assert inspect(dynamic(^left and ^right)) ==
+               inspect(dynamic([posts], posts.is_public == true and posts.is_draft == false))
+
+      assert inspect(dynamic(^left or ^right)) ==
+               inspect(dynamic([posts], posts.is_public == true or posts.is_draft == false))
     end
-      
+
     test "can be used to merge dynamics with subquery" do
-      subquery = 
-        from c in "comments", 
-          where: c.commented_by == ^Ecto.UUID.generate(), 
+      subquery =
+        from c in "comments",
+          where: c.commented_by == ^Ecto.UUID.generate(),
           select: c.post_id
-      
+
       dynamic = dynamic([posts], posts.is_public == true)
       dynamic_with_subquery = dynamic([posts], posts.id in subquery(subquery))
-      
-      assert inspect(dynamic(^dynamic and ^dynamic_with_subquery)) == 
-        inspect(dynamic([posts], posts.is_public == true and posts.id in subquery(subquery)))
-      
-      assert inspect(dynamic(^dynamic_with_subquery or ^dynamic)) == 
-        inspect(dynamic([posts], posts.id in subquery(subquery) or posts.is_public == true))
+
+      assert inspect(dynamic(^dynamic and ^dynamic_with_subquery)) ==
+               inspect(
+                 dynamic([posts], posts.is_public == true and posts.id in subquery(subquery))
+               )
+
+      assert inspect(dynamic(^dynamic_with_subquery or ^dynamic)) ==
+               inspect(
+                 dynamic([posts], posts.id in subquery(subquery) or posts.is_public == true)
+               )
     end
-    
+
     test "can be used to merge two dynamics with named bindings" do
       left = dynamic([post: post], post.is_public == true)
       right = dynamic([post: post], post.is_draft == false)
-      
+
       query = from p in "post", as: :post
-      
+
       assert inspect(where(query, ^dynamic(^left and ^right))) ==
-        inspect(where(query, [post: post], post.is_public == true and post.is_draft == false))
+               inspect(
+                 where(query, [post: post], post.is_public == true and post.is_draft == false)
+               )
     end
-    
+
     test "can be used to merge two dynamics with subquery that reuse named binding" do
-      subquery = 
-        from c in "comments", 
-          where: c.commented_by == ^Ecto.UUID.generate(), 
+      subquery =
+        from c in "comments",
+          where: c.commented_by == ^Ecto.UUID.generate(),
           select: c.post_id
 
       dynamic = dynamic([post: post], post.is_public == ^true)
       dynamic_with_subquery = dynamic([post: post], post.id in subquery(subquery))
       dynamic_not_in = dynamic([post: post], post.foo not in ^[1, 2, 3])
-      
+
       query = from p in "post", as: :post
-      
+
       assert inspect(where(query, ^dynamic(^dynamic and ^dynamic_with_subquery))) ==
-        inspect(where(query, [post: post], post.is_public == ^true and post.id in subquery(subquery)))
-      
+               inspect(
+                 where(
+                   query,
+                   [post: post],
+                   post.is_public == ^true and post.id in subquery(subquery)
+                 )
+               )
+
       assert inspect(where(query, ^dynamic(^dynamic_with_subquery or ^dynamic))) ==
-        inspect(where(query, [post: post], post.id in subquery(subquery) or post.is_public == ^true))
-      
-      assert inspect(where(query, ^dynamic(^dynamic_with_subquery and ^dynamic and ^dynamic_not_in))) ==
-        inspect(where(query, [post: post], post.id in subquery(subquery) and post.is_public == ^true and post.foo not in ^[1, 2, 3]))
+               inspect(
+                 where(
+                   query,
+                   [post: post],
+                   post.id in subquery(subquery) or post.is_public == ^true
+                 )
+               )
+
+      assert inspect(
+               where(query, ^dynamic(^dynamic_with_subquery and ^dynamic and ^dynamic_not_in))
+             ) ==
+               inspect(
+                 where(
+                   query,
+                   [post: post],
+                   post.id in subquery(subquery) and post.is_public == ^true and
+                     post.foo not in ^[1, 2, 3]
+                 )
+               )
     end
-    
+
     test "merges with precedence" do
       left = dynamic([posts], posts.is_public == true)
       right = dynamic([posts], posts.is_draft == false)
-      
-      assert inspect(dynamic(^left or ^left and ^right)) == 
-        inspect(dynamic([posts], posts.is_public == true or (posts.is_public == true and posts.is_draft == false)))
-      
-      assert inspect(dynamic(^left and ^left or ^right)) == 
-        inspect(dynamic([posts], (posts.is_public == true and posts.is_public == true) or posts.is_draft == false))
+
+      assert inspect(dynamic(^left or (^left and ^right))) ==
+               inspect(
+                 dynamic(
+                   [posts],
+                   posts.is_public == true or
+                     (posts.is_public == true and posts.is_draft == false)
+                 )
+               )
+
+      assert inspect(dynamic((^left and ^left) or ^right)) ==
+               inspect(
+                 dynamic(
+                   [posts],
+                   (posts.is_public == true and posts.is_public == true) or
+                     posts.is_draft == false
+                 )
+               )
     end
   end
-  
+
   describe "fragment/1" do
     test "raises at runtime when interpolation is not a keyword list" do
-      assert_raise ArgumentError, ~r/fragment\(...\) does not allow strings to be interpolated/s, fn ->
-        clause = ["1 = ?"]
-        from p in "posts", where: fragment(^clause)
-      end
+      assert_raise ArgumentError,
+                   ~r/fragment\(...\) does not allow strings to be interpolated/s,
+                   fn ->
+                     clause = ["1 = ?"]
+                     from p in "posts", where: fragment(^clause)
+                   end
     end
 
     test "raises at runtime when interpolation is a binary string" do
-      assert_raise ArgumentError, ~r/fragment\(...\) does not allow strings to be interpolated/, fn ->
-        clause = "1 = ?"
-        from p in "posts", where: fragment(^clause)
-      end
+      assert_raise ArgumentError,
+                   ~r/fragment\(...\) does not allow strings to be interpolated/,
+                   fn ->
+                     clause = "1 = ?"
+                     from p in "posts", where: fragment(^clause)
+                   end
     end
 
     test "keeps UTF-8 encoding" do
       assert inspect(from p in "posts", where: fragment("héllò")) ==
-             ~s[#Ecto.Query<from p0 in \"posts\", where: fragment("héllò")>]
+               ~s[#Ecto.Query<from p0 in \"posts\", where: fragment("héllò")>]
     end
   end
 
   describe "has_named_binding?/1" do
     test "returns true if query has a named binding" do
       query =
-        from(p in "posts", as: :posts,
+        from(p in "posts",
+          as: :posts,
           join: b in "blogs",
-          join: c in "comments", as: :comment,
-          join: l in "links", on: l.valid, as: :link)
+          join: c in "comments",
+          as: :comment,
+          join: l in "links",
+          on: l.valid,
+          as: :link
+        )
 
       assert has_named_binding?(query, :posts)
       assert has_named_binding?(query, :comment)
@@ -945,8 +1019,9 @@ defmodule Ecto.QueryTest do
       order_bys = [asc: :inserted_at, desc: :id]
       reversed_order_bys = [desc: :inserted_at, asc: :id]
       q = from(p in "posts")
+
       assert inspect(reverse_order(order_by(q, ^order_bys))) ==
-             inspect(order_by(q, ^reversed_order_bys))
+               inspect(order_by(q, ^reversed_order_bys))
     end
 
     test "reverses by primary key with no order" do

--- a/test/ecto/repo/autogenerate_test.exs
+++ b/test/ecto/repo/autogenerate_test.exs
@@ -117,6 +117,7 @@ defmodule Ecto.Repo.AutogenerateTest do
     def load(id, _, %{prefix: prefix}), do: {:ok, prefix <> @separator <> to_string(id)}
 
     def dump(nil, _, _), do: {:ok, nil}
+
     def dump(data, _, %{prefix: _prefix}),
       do: {:ok, data |> String.split(@separator) |> List.last() |> Integer.parse()}
   end
@@ -193,15 +194,19 @@ defmodule Ecto.Repo.AutogenerateTest do
   end
 
   test "does not update updated_at when the associated record did not change" do
-    company = TestRepo.insert!(%Company{offices: [%Office{id: 1, name: "1"}, %Office{id: 2, name: "2"}]})
+    company =
+      TestRepo.insert!(%Company{offices: [%Office{id: 1, name: "1"}, %Office{id: 2, name: "2"}]})
+
     [office_one, office_two] = company.offices
 
     changes = %{offices: [%{id: 1, name: "updated"}, %{id: 2, name: "2"}]}
+
     updated_company =
       company
       |> Ecto.Changeset.cast(changes, [])
       |> Ecto.Changeset.cast_assoc(:offices)
       |> TestRepo.update!()
+
     [updated_office_one, updated_office_two] = updated_company.offices
     assert updated_office_one.updated_at != office_one.updated_at
     assert updated_office_two.updated_at == office_two.updated_at
@@ -209,8 +214,7 @@ defmodule Ecto.Repo.AutogenerateTest do
 
   test "does not set inserted_at and updated_at values if they were previously set" do
     naive_datetime = ~N[2000-01-01 00:00:00]
-    default = TestRepo.insert!(%Company{inserted_at: naive_datetime,
-                                        updated_at: naive_datetime})
+    default = TestRepo.insert!(%Company{inserted_at: naive_datetime, updated_at: naive_datetime})
     assert default.inserted_at == naive_datetime
     assert default.updated_at == naive_datetime
 
@@ -226,7 +230,7 @@ defmodule Ecto.Repo.AutogenerateTest do
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {0, 0}} = default.updated_on
     assert default.created_on == default.updated_on
 
-    default = TestRepo.update!(%Manager{id: 1} |> Ecto.Changeset.change, force: true)
+    default = TestRepo.update!(%Manager{id: 1} |> Ecto.Changeset.change(), force: true)
     refute default.created_on
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {0, 0}} = default.updated_on
   end
@@ -237,7 +241,7 @@ defmodule Ecto.Repo.AutogenerateTest do
     assert %NaiveDateTime{microsecond: {0, 0}} = default.updated_at
     assert default.inserted_at == default.updated_at
 
-    default = TestRepo.update!(%NaiveMod{id: 1} |> Ecto.Changeset.change, force: true)
+    default = TestRepo.update!(%NaiveMod{id: 1} |> Ecto.Changeset.change(), force: true)
     refute default.inserted_at
     assert %NaiveDateTime{microsecond: {0, 0}} = default.updated_at
   end
@@ -248,7 +252,7 @@ defmodule Ecto.Repo.AutogenerateTest do
     assert %NaiveDateTime{microsecond: {_, 6}} = default.updated_at
     assert default.inserted_at == default.updated_at
 
-    default = TestRepo.update!(%NaiveUsecMod{id: 1} |> Ecto.Changeset.change, force: true)
+    default = TestRepo.update!(%NaiveUsecMod{id: 1} |> Ecto.Changeset.change(), force: true)
     refute default.inserted_at
     assert %NaiveDateTime{microsecond: {_, 6}} = default.updated_at
   end
@@ -259,7 +263,7 @@ defmodule Ecto.Repo.AutogenerateTest do
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {0, 0}} = default.updated_at
     assert default.inserted_at == default.updated_at
 
-    default = TestRepo.update!(%UtcMod{id: 1} |> Ecto.Changeset.change, force: true)
+    default = TestRepo.update!(%UtcMod{id: 1} |> Ecto.Changeset.change(), force: true)
     refute default.inserted_at
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {0, 0}} = default.updated_at
   end
@@ -270,7 +274,7 @@ defmodule Ecto.Repo.AutogenerateTest do
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {_, 6}} = default.updated_at
     assert default.inserted_at == default.updated_at
 
-    default = TestRepo.update!(%UtcUsecMod{id: 1} |> Ecto.Changeset.change, force: true)
+    default = TestRepo.update!(%UtcUsecMod{id: 1} |> Ecto.Changeset.change(), force: true)
     refute default.inserted_at
     assert %DateTime{time_zone: "Etc/UTC", microsecond: {_, 6}} = default.updated_at
   end

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -40,8 +40,9 @@ defmodule Ecto.Repo.BelongsToTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.insert!(changeset)
     assoc = schema.assoc
     assert assoc.id
@@ -56,8 +57,9 @@ defmodule Ecto.Repo.BelongsToTest do
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.insert!(changeset)
     assoc = schema.assoc
     assert assoc.__meta__.prefix == "prefix"
@@ -80,12 +82,16 @@ defmodule Ecto.Repo.BelongsToTest do
   test "raises on action mismatch on insert" do
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz"})
+
     changeset = put_in(changeset.changes.assoc.action, :delete)
-    assert_raise ArgumentError, ~r"got action :delete in changeset for associated .* while inserting", fn ->
-      TestRepo.insert!(changeset)
-    end
+
+    assert_raise ArgumentError,
+                 ~r"got action :delete in changeset for associated .* while inserting",
+                 fn ->
+                   TestRepo.insert!(changeset)
+                 end
   end
 
   test "checks dual changes on insert" do
@@ -94,6 +100,7 @@ defmodule Ecto.Repo.BelongsToTest do
       %MySchema{}
       |> Ecto.Changeset.change(assoc_id: 13)
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz", id: 13})
+
     TestRepo.insert!(changeset)
 
     # values are different
@@ -101,6 +108,7 @@ defmodule Ecto.Repo.BelongsToTest do
       %MySchema{}
       |> Ecto.Changeset.change(assoc_id: 13)
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz"})
+
     assert_raise ArgumentError, ~r"there is already a change setting its foreign key", fn ->
       TestRepo.insert!(changeset)
     end
@@ -109,10 +117,12 @@ defmodule Ecto.Repo.BelongsToTest do
   test "returns untouched changeset on invalid children on insert" do
     assoc = %MyAssoc{x: "xyz"}
     assoc_changeset = %{Ecto.Changeset.change(assoc) | valid?: false}
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     assert {:error, changeset} = TestRepo.insert(%{changeset | valid?: true})
     assert_received {:rollback, ^changeset}
     refute changeset.valid?
@@ -123,9 +133,10 @@ defmodule Ecto.Repo.BelongsToTest do
 
     changeset =
       put_in(%MySchema{}.__meta__.context, {:invalid, [unique: "my_schema_foo_index"]})
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert_received {:rollback, ^changeset}
     assert changeset.data.__meta__.state == :built
@@ -138,13 +149,14 @@ defmodule Ecto.Repo.BelongsToTest do
   test "returns untouched changeset on child constraint mismatch on insert" do
     assoc_changeset =
       put_in(%MyAssoc{}.__meta__.context, {:invalid, [unique: "my_assoc_foo_index"]})
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.unique_constraint(:foo)
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert changeset.data.__meta__.state == :built
     assert %Ecto.Association.NotLoaded{} = changeset.data.assoc
@@ -162,12 +174,14 @@ defmodule Ecto.Repo.BelongsToTest do
   test "handles valid nested assocs on insert" do
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc)
+
     schema = TestRepo.insert!(changeset)
     assert schema.assoc.sub_assoc.id
     assert schema.assoc_id == schema.assoc.id
@@ -181,13 +195,15 @@ defmodule Ecto.Repo.BelongsToTest do
   test "handles valid nested assocs on insert preserving parent schema prefix" do
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc)
+
     schema = TestRepo.insert!(changeset)
 
     assert schema.assoc.sub_assoc.__meta__.prefix == "prefix"
@@ -195,14 +211,17 @@ defmodule Ecto.Repo.BelongsToTest do
 
   test "handles invalid nested assocs on insert" do
     sub_assoc_change = %{Ecto.Changeset.change(%SubAssoc{y: "xyz"}) | valid?: false}
+
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, sub_assoc_change)
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc)
+
     assert {:error, changeset} = TestRepo.insert(%{changeset | valid?: true})
     refute Map.has_key?(changeset.changes, :id)
     refute Map.has_key?(changeset.changes, :assoc_id)
@@ -232,8 +251,9 @@ defmodule Ecto.Repo.BelongsToTest do
 
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.id
@@ -242,14 +262,15 @@ defmodule Ecto.Repo.BelongsToTest do
     assert assoc.updated_at
   end
 
-    test "inserting assocs on update preserving parent schema prefix" do
+  test "inserting assocs on update preserving parent schema prefix" do
     sample = %MyAssoc{x: "xyz"}
 
     changeset =
       %MySchema{id: 1}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.__meta__.prefix == "prefix"
@@ -263,27 +284,35 @@ defmodule Ecto.Repo.BelongsToTest do
       %MySchema{id: 1, assoc: sample}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "abc"})
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.id != 10
     assert assoc.x == "abc"
     assert assoc.id == schema.assoc_id
     assert assoc.updated_at
-    assert_received {:update, _} # Parent
-    assert_received {:insert, _} # New assoc
-    assert_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    assert_received {:insert, _}
+    # Old assoc
+    assert_received {:delete, _}
 
     # Replacing assoc with nil
     changeset =
       %MySchema{id: 1, assoc: sample}
       |> Ecto.Changeset.change(x: "2")
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     schema = TestRepo.update!(changeset)
     refute schema.assoc
     refute schema.assoc_id
-    assert_received {:update, _} # Parent
-    refute_received {:insert, _} # New assoc
-    assert_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    refute_received {:insert, _}
+    # Old assoc
+    assert_received {:delete, _}
   end
 
   test "replacing assocs on update (on_replace: :nilify)" do
@@ -294,27 +323,35 @@ defmodule Ecto.Repo.BelongsToTest do
       %MySchema{id: 1, nilify_assoc: sample}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:nilify_assoc, %MyAssoc{x: "abc"})
+
     schema = TestRepo.update!(changeset)
     assoc = schema.nilify_assoc
     assert assoc.id != 10
     assert assoc.x == "abc"
     assert assoc.id == schema.nilify_assoc_id
     assert assoc.updated_at
-    assert_received {:update, _} # Parent
-    assert_received {:insert, _} # New assoc
-    refute_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    assert_received {:insert, _}
+    # Old assoc
+    refute_received {:delete, _}
 
     # Replacing assoc with nil
     changeset =
       %MySchema{id: 1, nilify_assoc: sample}
       |> Ecto.Changeset.change(x: "2")
       |> Ecto.Changeset.put_assoc(:nilify_assoc, nil)
+
     schema = TestRepo.update!(changeset)
     refute schema.nilify_assoc
     refute schema.nilify_assoc_id
-    assert_received {:update, _} # Parent
-    refute_received {:insert, _} # New assoc
-    refute_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    refute_received {:insert, _}
+    # Old assoc
+    refute_received {:delete, _}
   end
 
   test "changing assocs on update raises if there is no id" do
@@ -323,8 +360,9 @@ defmodule Ecto.Repo.BelongsToTest do
 
     changeset =
       %MySchema{id: 1, assoc: sample}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample_changeset)
+
     assert_raise Ecto.NoPrimaryKeyValueError, fn ->
       TestRepo.update!(changeset)
     end
@@ -332,21 +370,24 @@ defmodule Ecto.Repo.BelongsToTest do
 
   test "changing assocs on update" do
     sample = %MyAssoc{x: "xyz", id: 13, my_schema: 1, sub_assoc: nil}
-    sample = put_meta sample, state: :loaded
+    sample = put_meta(sample, state: :loaded)
 
     # Changing the assoc
     sample_changeset = Ecto.Changeset.change(sample, x: "abc")
+
     changeset =
       %MySchema{id: 1, assoc: sample}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample_changeset)
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.id == 13
     assert assoc.x == "abc"
     refute assoc.inserted_at
     assert assoc.updated_at
-    refute_received {:delete, _} # Same assoc should not emit delete
+    # Same assoc should not emit delete
+    refute_received {:delete, _}
   end
 
   test "removing assocs on update raises if there is no id" do
@@ -355,8 +396,9 @@ defmodule Ecto.Repo.BelongsToTest do
     # Raises if there's no id
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     assert_raise Ecto.NoPrimaryKeyValueError, fn ->
       TestRepo.update!(changeset)
     end
@@ -368,6 +410,7 @@ defmodule Ecto.Repo.BelongsToTest do
       %MySchema{id: 1}
       |> Ecto.Changeset.change(assoc_id: 13)
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz", id: 13})
+
     TestRepo.update!(changeset)
 
     # values are different
@@ -375,6 +418,7 @@ defmodule Ecto.Repo.BelongsToTest do
       %MySchema{id: 1}
       |> Ecto.Changeset.change(assoc_id: 13)
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz"})
+
     assert_raise ArgumentError, ~r"there is already a change setting its foreign key", fn ->
       TestRepo.update!(changeset)
     end
@@ -385,8 +429,9 @@ defmodule Ecto.Repo.BelongsToTest do
 
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     schema = TestRepo.update!(changeset)
     assert schema.assoc == nil
   end
@@ -397,8 +442,9 @@ defmodule Ecto.Repo.BelongsToTest do
     changeset =
       %MySchema{id: 1, assoc: assoc}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     TestRepo.update!(changeset)
     assert_received {:delete, %{prefix: "prefix", source: "my_assoc"}}
   end
@@ -406,10 +452,12 @@ defmodule Ecto.Repo.BelongsToTest do
   test "returns untouched changeset on invalid children on update" do
     assoc = %MyAssoc{x: "xyz"}
     assoc_changeset = %{Ecto.Changeset.change(assoc) | valid?: false}
+
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     assert {:error, changeset} = TestRepo.update(%{changeset | valid?: true})
     assert_received {:rollback, ^changeset}
     refute changeset.valid?
@@ -417,11 +465,13 @@ defmodule Ecto.Repo.BelongsToTest do
 
   test "returns untouched changeset on constraint mismatch on update" do
     my_schema = %MySchema{id: 1, assoc: nil}
+
     changeset =
       put_in(my_schema.__meta__.context, {:invalid, [unique: "my_schema_foo_index"]})
       |> Ecto.Changeset.change(x: "foo")
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz"})
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.update(changeset)
     assert_received {:rollback, ^changeset}
     refute changeset.data.assoc
@@ -432,14 +482,17 @@ defmodule Ecto.Repo.BelongsToTest do
 
   test "handles valid nested assocs on update" do
     assoc = %MyAssoc{id: 1, x: "xyz"}
+
     assoc_changeset =
       assoc
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     schema = TestRepo.update!(changeset)
     assert schema.assoc.sub_assoc.id
 
@@ -453,14 +506,15 @@ defmodule Ecto.Repo.BelongsToTest do
     sub_assoc_changeset = %{Ecto.Changeset.change(sub_assoc) | valid?: false}
 
     assoc = %MyAssoc{id: 1, x: "xyz"}
+
     assoc_changeset =
       assoc
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, sub_assoc_changeset)
 
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
 
     assert {:error, changeset} = TestRepo.update(%{changeset | valid?: true})

--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -55,8 +55,9 @@ defmodule Ecto.Repo.EmbeddedTest do
   test "handles embeds on insert" do
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, %MyEmbed{x: "xyz"})
+
     schema = TestRepo.insert!(changeset)
     embed = schema.embed
     assert embed.id
@@ -66,8 +67,9 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embeds, [%MyEmbed{x: "xyz"}])
+
     schema = TestRepo.insert!(changeset)
     [embed] = schema.embeds
     assert embed.id
@@ -103,6 +105,7 @@ defmodule Ecto.Repo.EmbeddedTest do
       |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, %MyEmbed{x: "xyz"})
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert changeset.data.__meta__.state == :built
     refute changeset.data.embed
@@ -119,7 +122,7 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, invalid_assoc)
       |> Ecto.Changeset.put_embed(:embed, %MyEmbed{x: "xyz"})
 
@@ -132,10 +135,12 @@ defmodule Ecto.Repo.EmbeddedTest do
       %MyEmbed{x: "xyz"}
       |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:sub_embed, %SubEmbed{y: "xyz"})
+
     changeset =
       %MySchema{}
       |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, embed)
+
     schema = TestRepo.insert!(changeset)
     assert schema.embed.sub_embed.y == "xyz"
   end
@@ -151,12 +156,16 @@ defmodule Ecto.Repo.EmbeddedTest do
   end
 
   test "duplicate pk on insert" do
-    embeds = [%MyEmbed{x: "xyz", id: @uuid} |> Ecto.Changeset.change,
-              %MyEmbed{x: "abc", id: @uuid} |> Ecto.Changeset.change]
+    embeds = [
+      %MyEmbed{x: "xyz", id: @uuid} |> Ecto.Changeset.change(),
+      %MyEmbed{x: "abc", id: @uuid} |> Ecto.Changeset.change()
+    ]
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embeds, embeds)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     refute changeset.valid?
     errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _} -> msg end)
@@ -181,8 +190,9 @@ defmodule Ecto.Repo.EmbeddedTest do
   test "inserting embeds on update" do
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, %MyEmbed{x: "xyz"})
+
     schema = TestRepo.update!(changeset)
     embed = schema.embed
     assert embed.id
@@ -191,8 +201,9 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embeds, [%MyEmbed{x: "xyz"}])
+
     schema = TestRepo.update!(changeset)
     [embed] = schema.embeds
     assert embed.id
@@ -205,10 +216,12 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     # Replacing embed with a new one
     new_embed = %MyEmbed{x: "abc"}
+
     changeset =
       %MySchema{id: 1, embed: embed}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, new_embed)
+
     schema = TestRepo.update!(changeset)
     embed = schema.embed
     assert embed.id != @uuid
@@ -219,8 +232,9 @@ defmodule Ecto.Repo.EmbeddedTest do
     # Replacing embed with nil
     changeset =
       %MySchema{id: 1, embed: embed}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, nil)
+
     schema = TestRepo.update!(changeset)
     refute schema.embed
   end
@@ -230,10 +244,12 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     # Raises if there's no id
     embed_changeset = Ecto.Changeset.change(embed, x: "abc")
+
     changeset =
       %MySchema{id: 1, embed: embed}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, embed_changeset)
+
     assert_raise Ecto.NoPrimaryKeyValueError, fn ->
       TestRepo.update!(changeset)
     end
@@ -245,8 +261,9 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     changeset =
       %MySchema{id: 1, embed: sample}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, sample_changeset)
+
     schema = TestRepo.update!(changeset)
     embed = schema.embed
     assert embed.id == @uuid
@@ -256,8 +273,9 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     changeset =
       %MySchema{id: 1, embeds: [sample]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embeds, [sample_changeset])
+
     schema = TestRepo.update!(changeset)
     [embed] = schema.embeds
     assert embed.id == @uuid
@@ -274,14 +292,20 @@ defmodule Ecto.Repo.EmbeddedTest do
       %MySchema{id: 1, embed: embed}
       |> Ecto.Changeset.change(x: "abc")
       |> Ecto.Changeset.put_embed(:embed, no_changes)
+
     schema = TestRepo.update!(changeset)
     refute schema.embed.updated_at
 
-    changes = Ecto.Changeset.change(%MyEmbed{x: "xyz", id: "30313233-3435-3637-3839-616263646567"}, x: "abc")
+    changes =
+      Ecto.Changeset.change(%MyEmbed{x: "xyz", id: "30313233-3435-3637-3839-616263646567"},
+        x: "abc"
+      )
+
     changeset =
       %MySchema{id: 1, embeds: [embed]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embeds, [no_changes, changes])
+
     schema = TestRepo.update!(changeset)
     refute hd(schema.embeds).updated_at
   end
@@ -291,15 +315,17 @@ defmodule Ecto.Repo.EmbeddedTest do
 
     changeset =
       %MySchema{id: 1, embed: embed}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, nil)
+
     schema = TestRepo.update!(changeset)
     assert schema.embed == nil
 
     changeset =
       %MySchema{id: 1, embeds: [embed]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embeds, [])
+
     schema = TestRepo.update!(changeset)
     assert schema.embeds == []
   end
@@ -308,11 +334,13 @@ defmodule Ecto.Repo.EmbeddedTest do
     embed = %MyEmbed{x: "xyz"}
 
     my_schema = %MySchema{id: 1, embed: nil}
+
     changeset =
       put_in(my_schema.__meta__.context, {:invalid, [unique: "my_schema_foo_index"]})
       |> Ecto.Changeset.change(x: "foo")
       |> Ecto.Changeset.put_embed(:embed, embed)
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.update(changeset)
     refute changeset.data.embed
     assert changeset.changes.embed
@@ -322,14 +350,17 @@ defmodule Ecto.Repo.EmbeddedTest do
 
   test "handles nested embeds on update" do
     embed = %MyEmbed{id: @uuid, x: "xyz"}
+
     embed_changeset =
       embed
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:sub_embed, %SubEmbed{y: "xyz"})
+
     changeset =
       %MySchema{id: 1, embed: embed}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_embed(:embed, embed_changeset)
+
     schema = TestRepo.update!(changeset)
     assert schema.embed.sub_embed.y == "xyz"
   end

--- a/test/ecto/repo/has_assoc_test.exs
+++ b/test/ecto/repo/has_assoc_test.exs
@@ -51,8 +51,9 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.insert!(changeset)
     assoc = schema.assoc
     assert assoc.id
@@ -62,8 +63,9 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.insert!(changeset)
     [assoc] = schema.assocs
     assert assoc.id
@@ -78,8 +80,9 @@ defmodule Ecto.Repo.HasAssocTest do
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.insert!(changeset)
     assoc = schema.assoc
 
@@ -88,8 +91,9 @@ defmodule Ecto.Repo.HasAssocTest do
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.insert!(changeset)
     [assoc] = schema.assocs
 
@@ -120,21 +124,27 @@ defmodule Ecto.Repo.HasAssocTest do
   test "raises on action mismatch on insert" do
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz"})
+
     changeset = put_in(changeset.changes.assoc.action, :delete)
-    assert_raise ArgumentError, ~r"got action :delete in changeset for associated .* while inserting", fn ->
-      TestRepo.insert!(changeset)
-    end
+
+    assert_raise ArgumentError,
+                 ~r"got action :delete in changeset for associated .* while inserting",
+                 fn ->
+                   TestRepo.insert!(changeset)
+                 end
   end
 
   test "returns untouched changeset on invalid children on insert" do
     assoc = %MyAssoc{x: "xyz"}
     assoc_changeset = %{Ecto.Changeset.change(assoc) | valid?: false}
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     assert {:error, changeset} = TestRepo.insert(%{changeset | valid?: true})
     assert_received {:rollback, ^changeset}
     refute changeset.valid?
@@ -145,9 +155,10 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       put_in(%MySchema{}.__meta__.context, {:invalid, [unique: "my_schema_foo_index"]})
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert_received {:rollback, ^changeset}
     assert changeset.data.__meta__.state == :built
@@ -160,13 +171,14 @@ defmodule Ecto.Repo.HasAssocTest do
   test "returns untouched changeset on child constraint mismatch on insert" do
     assoc_changeset =
       put_in(%MyAssoc{}.__meta__.context, {:invalid, [unique: "my_assoc_foo_index"]})
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.unique_constraint(:foo)
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert changeset.data.__meta__.state == :built
     assert %Ecto.Association.NotLoaded{} = changeset.data.assoc
@@ -184,12 +196,14 @@ defmodule Ecto.Repo.HasAssocTest do
   test "handles valid nested assocs on insert" do
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc)
+
     schema = TestRepo.insert!(changeset)
     assert schema.assoc.sub_assoc.id
 
@@ -201,27 +215,32 @@ defmodule Ecto.Repo.HasAssocTest do
   test "handles valid nested assocs on insert preserving parent schema prefix" do
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc)
+
     schema = TestRepo.insert!(changeset)
     assert schema.__meta__.prefix == "prefix"
   end
 
   test "handles invalid nested assocs on insert" do
     sub_assoc_change = %{Ecto.Changeset.change(%SubAssoc{y: "xyz"}) | valid?: false}
+
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, sub_assoc_change)
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc)
+
     assert {:error, changeset} = TestRepo.insert(%{changeset | valid?: true})
     refute Map.has_key?(changeset.changes, :id)
     refute changeset.changes.assoc.changes.my_schema_id
@@ -238,12 +257,16 @@ defmodule Ecto.Repo.HasAssocTest do
   end
 
   test "duplicate pk on insert" do
-    assocs = [%MyAssoc{x: "xyz", id: 1} |> Ecto.Changeset.change,
-              %MyAssoc{x: "abc", id: 1} |> Ecto.Changeset.change]
+    assocs = [
+      %MyAssoc{x: "xyz", id: 1} |> Ecto.Changeset.change(),
+      %MyAssoc{x: "abc", id: 1} |> Ecto.Changeset.change()
+    ]
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, assocs)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     refute changeset.valid?
     errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _} -> msg end)
@@ -268,8 +291,9 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.id
@@ -279,8 +303,9 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.id
@@ -295,8 +320,9 @@ defmodule Ecto.Repo.HasAssocTest do
     changeset =
       %MySchema{id: 1}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample)
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.__meta__.prefix == "prefix"
@@ -304,8 +330,9 @@ defmodule Ecto.Repo.HasAssocTest do
     changeset =
       %MySchema{id: 1}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.__meta__.prefix == "prefix"
@@ -318,10 +345,13 @@ defmodule Ecto.Repo.HasAssocTest do
       %MySchema{id: 1, delete_assoc: sample}
       |> Ecto.Changeset.cast(%{x: "abc", delete_assoc: %{delete: true, id: 10}}, [:x])
       |> Ecto.Changeset.cast_assoc(:delete_assoc)
+
     schema = TestRepo.update!(changeset)
     refute schema.delete_assoc
-    assert_received {:update, _} # Parent
-    assert_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # Old assoc
+    assert_received {:delete, _}
   end
 
   test "updating assocs with action: :delete" do
@@ -331,10 +361,13 @@ defmodule Ecto.Repo.HasAssocTest do
       %MySchema{id: 1, delete_assocs: [sample]}
       |> Ecto.Changeset.cast(%{x: "abc", delete_assocs: [%{delete: true, id: 10}]}, [:x])
       |> Ecto.Changeset.cast_assoc(:delete_assocs)
+
     schema = TestRepo.update!(changeset)
     assert schema.delete_assocs == []
-    assert_received {:update, _} # Parent
-    assert_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # Old assoc
+    assert_received {:delete, _}
   end
 
   test "replacing assocs on update on_replace: :delete" do
@@ -345,26 +378,34 @@ defmodule Ecto.Repo.HasAssocTest do
       %MySchema{id: 1, assoc: sample}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "abc"})
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.id != 10
     assert assoc.x == "abc"
     assert assoc.my_schema_id == schema.id
     assert assoc.updated_at
-    assert_received {:update, _} # Parent
-    assert_received {:insert, _} # New assoc
-    assert_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    assert_received {:insert, _}
+    # Old assoc
+    assert_received {:delete, _}
 
     # Replacing assoc with nil
     changeset =
       %MySchema{id: 1, assoc: sample}
       |> Ecto.Changeset.change(x: "2")
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     schema = TestRepo.update!(changeset)
     refute schema.assoc
-    assert_received {:update, _} # Parent
-    refute_received {:insert, _} # New assoc
-    assert_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    refute_received {:insert, _}
+    # Old assoc
+    assert_received {:delete, _}
   end
 
   test "replacing assocs on update on_replace: :nilify" do
@@ -375,26 +416,34 @@ defmodule Ecto.Repo.HasAssocTest do
       %MySchema{id: 1, nilify_assoc: sample}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:nilify_assoc, %MyAssoc{x: "abc"})
+
     schema = TestRepo.update!(changeset)
     assoc = schema.nilify_assoc
     assert assoc.id != 10
     assert assoc.x == "abc"
     assert assoc.my_schema_id == schema.id
     assert assoc.updated_at
-    assert_received {:update, _} # Parent
-    assert_received {:insert, _} # New assoc
-    assert_received {:update, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    assert_received {:insert, _}
+    # Old assoc
+    assert_received {:update, _}
 
     # Replacing assoc with nil
     changeset =
       %MySchema{id: 1, nilify_assoc: sample}
       |> Ecto.Changeset.change(x: "2")
       |> Ecto.Changeset.put_assoc(:nilify_assoc, nil)
+
     schema = TestRepo.update!(changeset)
     refute schema.nilify_assoc
-    assert_received {:update, _} # Parent
-    refute_received {:insert, _} # New assoc
-    assert_received {:update, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    refute_received {:insert, _}
+    # Old assoc
+    assert_received {:update, _}
   end
 
   test "changing assocs on update raises if there is no id" do
@@ -403,8 +452,9 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       %MySchema{id: 1, assoc: sample}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample_changeset)
+
     assert_raise Ecto.NoPrimaryKeyValueError, fn ->
       TestRepo.update!(changeset)
     end
@@ -412,33 +462,38 @@ defmodule Ecto.Repo.HasAssocTest do
 
   test "changing assocs on update" do
     sample = %MyAssoc{x: "xyz", id: 13, my_schema: 1, sub_assoc: nil}
-    sample = put_meta sample, state: :loaded
+    sample = put_meta(sample, state: :loaded)
 
     # Changing the assoc
     sample_changeset = Ecto.Changeset.change(sample, x: "abc")
+
     changeset =
       %MySchema{id: 1, assoc: sample}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, sample_changeset)
+
     schema = TestRepo.update!(changeset)
     assoc = schema.assoc
     assert assoc.id == 13
     assert assoc.x == "abc"
     refute assoc.inserted_at
     assert assoc.updated_at
-    refute_received {:delete, _} # Same assoc should not emit delete
+    # Same assoc should not emit delete
+    refute_received {:delete, _}
 
     changeset =
       %MySchema{id: 1, assocs: [sample]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample_changeset])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.id == 13
     assert assoc.x == "abc"
     refute assoc.inserted_at
     assert assoc.updated_at
-    refute_received {:delete, _} # Same assoc should not emit delete
+    # Same assoc should not emit delete
+    refute_received {:delete, _}
   end
 
   test "removing assocs on update raises if there is no id" do
@@ -447,8 +502,9 @@ defmodule Ecto.Repo.HasAssocTest do
     # Raises if there's no id
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     assert_raise Ecto.NoPrimaryKeyValueError, fn ->
       TestRepo.update!(changeset)
     end
@@ -459,15 +515,17 @@ defmodule Ecto.Repo.HasAssocTest do
 
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     schema = TestRepo.update!(changeset)
     assert schema.assoc == nil
 
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [])
+
     schema = TestRepo.update!(changeset)
     assert schema.assocs == []
   end
@@ -478,16 +536,18 @@ defmodule Ecto.Repo.HasAssocTest do
     changeset =
       %MySchema{id: 1, assoc: assoc}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, nil)
+
     TestRepo.update!(changeset)
     assert_received {:delete, %{prefix: "prefix", source: "my_assoc"}}
 
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [])
+
     TestRepo.update!(changeset)
     assert_received {:delete, %{prefix: "prefix", source: "my_assoc"}}
   end
@@ -495,10 +555,12 @@ defmodule Ecto.Repo.HasAssocTest do
   test "returns untouched changeset on invalid children on update" do
     assoc = %MyAssoc{x: "xyz"}
     assoc_changeset = %{Ecto.Changeset.change(assoc) | valid?: false}
+
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     assert {:error, changeset} = TestRepo.update(%{changeset | valid?: true})
     assert_received {:rollback, ^changeset}
     refute changeset.valid?
@@ -506,11 +568,13 @@ defmodule Ecto.Repo.HasAssocTest do
 
   test "returns untouched changeset on constraint mismatch on update" do
     my_schema = %MySchema{id: 1, assoc: nil}
+
     changeset =
       put_in(my_schema.__meta__.context, {:invalid, [unique: "my_schema_foo_index"]})
       |> Ecto.Changeset.change(x: "foo")
       |> Ecto.Changeset.put_assoc(:assoc, %MyAssoc{x: "xyz"})
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.update(changeset)
     assert_received {:rollback, ^changeset}
     refute changeset.data.assoc
@@ -521,14 +585,17 @@ defmodule Ecto.Repo.HasAssocTest do
 
   test "handles valid nested assocs on update" do
     assoc = %MyAssoc{id: 1, x: "xyz"}
+
     assoc_changeset =
       assoc
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
+
     schema = TestRepo.update!(changeset)
     assert schema.assoc.sub_assoc.id
 
@@ -542,14 +609,15 @@ defmodule Ecto.Repo.HasAssocTest do
     sub_assoc_changeset = %{Ecto.Changeset.change(sub_assoc) | valid?: false}
 
     assoc = %MyAssoc{id: 1, x: "xyz"}
+
     assoc_changeset =
       assoc
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, sub_assoc_changeset)
 
     changeset =
       %MySchema{id: 1, assoc: assoc}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assoc, assoc_changeset)
 
     assert {:error, changeset} = TestRepo.update(%{changeset | valid?: true})

--- a/test/ecto/repo/many_to_many_test.exs
+++ b/test/ecto/repo/many_to_many_test.exs
@@ -41,8 +41,14 @@ defmodule Ecto.Repo.ManyToManyTest do
       field :x, :string
       field :y, :binary
       many_to_many :assocs, MyAssoc, join_through: "schemas_assocs", on_replace: :delete
-      many_to_many :schema_assocs, MyAssoc, join_through: MySchemaAssoc, join_defaults: [public: true]
-      many_to_many :mfa_schema_assocs, MyAssoc, join_through: MySchemaAssoc, join_defaults: {__MODULE__, :send_to_self, [:extra]}
+
+      many_to_many :schema_assocs, MyAssoc,
+        join_through: MySchemaAssoc,
+        join_defaults: [public: true]
+
+      many_to_many :mfa_schema_assocs, MyAssoc,
+        join_through: MySchemaAssoc,
+        join_defaults: {__MODULE__, :send_to_self, [:extra]}
     end
 
     def send_to_self(struct, owner, extra) do
@@ -56,15 +62,18 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.insert!(changeset)
     [assoc] = schema.assocs
     assert assoc.id
     assert assoc.x == "xyz"
     assert assoc.inserted_at
     assert_received {:insert, _}
-    assert_received {:insert_all, %{source: "schemas_assocs"}, [[my_assoc_id: 1, my_schema_id: 1]]}
+
+    assert_received {:insert_all, %{source: "schemas_assocs"},
+                     [[my_assoc_id: 1, my_schema_id: 1]]}
   end
 
   test "handles assocs on insert preserving parent schema prefix" do
@@ -73,8 +82,9 @@ defmodule Ecto.Repo.ManyToManyTest do
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.insert!(changeset)
     [assoc] = schema.assocs
     assert assoc.__meta__.prefix == "prefix"
@@ -85,7 +95,7 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:schema_assocs, [sample])
 
     schema = TestRepo.insert!(changeset)
@@ -108,7 +118,7 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{x: "abc"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:mfa_schema_assocs, [sample])
 
     schema = TestRepo.insert!(changeset)
@@ -135,7 +145,9 @@ defmodule Ecto.Repo.ManyToManyTest do
     assert assoc.x == "xyz"
     assert assoc.inserted_at
     assert_received {:insert, _}
-    assert_received {:insert_all, %{source: "schemas_assocs"}, [[my_assoc_id: 1, my_schema_id: 1]]}
+
+    assert_received {:insert_all, %{source: "schemas_assocs"},
+                     [[my_assoc_id: 1, my_schema_id: 1]]}
   end
 
   test "handles invalid assocs from struct on insert" do
@@ -148,12 +160,14 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
 
-    assert_raise ArgumentError, ~r"got action :delete in changeset for associated .* while inserting", fn ->
-      TestRepo.insert!(changeset)
-    end
+    assert_raise ArgumentError,
+                 ~r"got action :delete in changeset for associated .* while inserting",
+                 fn ->
+                   TestRepo.insert!(changeset)
+                 end
   end
 
   test "returns untouched changeset on invalid children on insert" do
@@ -161,7 +175,7 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
 
     assert {:error, changeset} = TestRepo.insert(%{changeset | valid?: true})
@@ -174,9 +188,10 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       put_in(%MySchema{}.__meta__.context, {:invalid, [unique: "my_schema_foo_index"]})
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert_received {:rollback, ^changeset}
     assert changeset.data.__meta__.state == :built
@@ -189,13 +204,14 @@ defmodule Ecto.Repo.ManyToManyTest do
   test "returns untouched changeset on child constraint mismatch on insert" do
     assoc =
       put_in(%MyAssoc{}.__meta__.context, {:invalid, [unique: "my_assoc_foo_index"]})
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.unique_constraint(:foo)
 
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
+
     assert {:error, changeset} = TestRepo.insert(changeset)
     assert changeset.data.__meta__.state == :built
     assert %Ecto.Association.NotLoaded{} = changeset.data.assocs
@@ -214,45 +230,54 @@ defmodule Ecto.Repo.ManyToManyTest do
   test "handles valid nested assocs on insert" do
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
+
     schema = TestRepo.insert!(changeset)
     assert hd(schema.assocs).sub_assoc.id
 
     # Just one transaction was used
     assert_received {:transaction, _}
     refute_received {:rollback, _}
-    assert_received {:insert_all, %{source: "schemas_assocs"}, [[my_assoc_id: 1, my_schema_id: 1]]}
+
+    assert_received {:insert_all, %{source: "schemas_assocs"},
+                     [[my_assoc_id: 1, my_schema_id: 1]]}
   end
 
   test "handles valid nested assocs on insert preserving parent schema prefix" do
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
+
     schema = TestRepo.insert!(changeset)
     assert hd(schema.assocs).sub_assoc.__meta__.prefix == "prefix"
   end
 
   test "handles invalid nested assocs on insert" do
     sub_assoc_change = %{Ecto.Changeset.change(%SubAssoc{y: "xyz"}) | valid?: false}
+
     assoc =
       %MyAssoc{x: "xyz"}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, sub_assoc_change)
+
     changeset =
       %MySchema{}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc])
+
     assert {:error, changeset} = TestRepo.insert(%{changeset | valid?: true})
     refute Map.has_key?(changeset.changes, :id)
     refute changeset.valid?
@@ -285,13 +310,16 @@ defmodule Ecto.Repo.ManyToManyTest do
       %MySchema{id: 3}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.id
     assert assoc.x == "xyz"
     assert assoc.updated_at
     assert_received {:update, _}
-    assert_received {:insert_all, %{source: "schemas_assocs"}, [[my_assoc_id: 1, my_schema_id: 3]]}
+
+    assert_received {:insert_all, %{source: "schemas_assocs"},
+                     [[my_assoc_id: 1, my_schema_id: 3]]}
   end
 
   test "inserting assocs on update preserving parent schema prefix" do
@@ -302,6 +330,7 @@ defmodule Ecto.Repo.ManyToManyTest do
       |> Ecto.put_meta(prefix: "prefix")
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:assocs, [sample])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.__meta__.prefix == "prefix"
@@ -314,6 +343,7 @@ defmodule Ecto.Repo.ManyToManyTest do
       %MySchema{id: 3}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:schema_assocs, [sample])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.schema_assocs
     assert assoc.id
@@ -331,15 +361,22 @@ defmodule Ecto.Repo.ManyToManyTest do
       %MySchema{id: 3, assocs: [sample]}
       |> Ecto.Changeset.change(x: "1")
       |> Ecto.Changeset.put_assoc(:assocs, [%MyAssoc{x: "abc"}])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.id != 10
     assert assoc.x == "abc"
     assert assoc.updated_at
-    assert_received {:update, _} # Parent
-    assert_received {:insert, _} # New assoc
-    refute_received {:delete, _} # Old assoc
-    assert_received {:insert_all, %{source: "schemas_assocs"}, [[my_assoc_id: 1, my_schema_id: 3]]}
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    assert_received {:insert, _}
+    # Old assoc
+    refute_received {:delete, _}
+
+    assert_received {:insert_all, %{source: "schemas_assocs"},
+                     [[my_assoc_id: 1, my_schema_id: 3]]}
+
     assert_received {:delete_all, %{from: %{source: {"schemas_assocs", _}}}}
 
     # Replacing assoc with nil
@@ -347,11 +384,15 @@ defmodule Ecto.Repo.ManyToManyTest do
       %MySchema{id: 1, assocs: [sample]}
       |> Ecto.Changeset.change(x: "2")
       |> Ecto.Changeset.put_assoc(:assocs, [])
+
     schema = TestRepo.update!(changeset)
     assert schema.assocs == []
-    assert_received {:update, _} # Parent
-    refute_received {:insert, _} # New assoc
-    refute_received {:delete, _} # Old assoc
+    # Parent
+    assert_received {:update, _}
+    # New assoc
+    refute_received {:insert, _}
+    # Old assoc
+    refute_received {:delete, _}
     refute_received {:insert_all, _, _}
     assert_received {:delete_all, _}
   end
@@ -362,8 +403,9 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{id: 1, assocs: [sample]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample_changeset])
+
     assert_raise Ecto.NoPrimaryKeyValueError, fn ->
       TestRepo.update!(changeset)
     end
@@ -371,35 +413,39 @@ defmodule Ecto.Repo.ManyToManyTest do
 
   test "changing assocs on update" do
     sample = %MyAssoc{x: "xyz", id: 13, sub_assoc: nil}
-    sample = put_meta sample, state: :loaded
+    sample = put_meta(sample, state: :loaded)
 
     # Changing the assoc
     sample_changeset = Ecto.Changeset.change(sample, x: "abc")
+
     changeset =
       %MySchema{id: 1, assocs: [sample]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample_changeset])
+
     schema = TestRepo.update!(changeset)
     [assoc] = schema.assocs
     assert assoc.id == 13
     assert assoc.x == "abc"
     refute assoc.inserted_at
     assert assoc.updated_at
-    refute_received :delete # Same assoc should not emit delete
+    # Same assoc should not emit delete
+    refute_received :delete
     refute_received {:delete_all, _}
     refute_received {:insert_all, _, _}
   end
 
   test "adding struct assocs on update" do
     sample = %MyAssoc{x: "xyz", id: 13, sub_assoc: nil}
-    sample = put_meta sample, state: :loaded
+    sample = put_meta(sample, state: :loaded)
     latest = %MyAssoc{x: "abc", id: 11, sub_assoc: nil}
 
     # Changing the assoc
     changeset =
       %MySchema{id: 1, assocs: [sample]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample, latest])
+
     schema = TestRepo.update!(changeset)
     [sample, latest] = schema.assocs
 
@@ -416,15 +462,16 @@ defmodule Ecto.Repo.ManyToManyTest do
 
   test "adding mixed changeset and struct assocs on update" do
     sample = %MyAssoc{x: "xyz", id: 13, sub_assoc: nil}
-    sample = put_meta sample, state: :loaded
+    sample = put_meta(sample, state: :loaded)
     sample = Ecto.Changeset.change(sample, x: "XYZ")
     latest = %MyAssoc{x: "abc", id: 11, sub_assoc: nil}
 
     # Changing the assoc
     changeset =
       %MySchema{id: 1, assocs: [sample]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [sample, latest])
+
     schema = TestRepo.update!(changeset)
     [sample, latest] = schema.assocs
 
@@ -445,9 +492,10 @@ defmodule Ecto.Repo.ManyToManyTest do
     # Raises if there's no id
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [])
-    assert_raise RuntimeError,  ~r/could not delete join entry because `id` is nil/, fn ->
+
+    assert_raise RuntimeError, ~r/could not delete join entry because `id` is nil/, fn ->
       TestRepo.update!(changeset)
     end
   end
@@ -457,8 +505,9 @@ defmodule Ecto.Repo.ManyToManyTest do
 
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [])
+
     schema = TestRepo.update!(changeset)
     assert schema.assocs == []
     assert_received {:delete_all, %{prefix: nil, from: %{source: {"schemas_assocs", _}}}}
@@ -470,8 +519,9 @@ defmodule Ecto.Repo.ManyToManyTest do
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
       |> Ecto.put_meta(prefix: "prefix")
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [])
+
     TestRepo.update!(changeset)
     assert_received {:delete_all, %{prefix: "prefix", from: %{source: {"schemas_assocs", _}}}}
   end
@@ -479,10 +529,12 @@ defmodule Ecto.Repo.ManyToManyTest do
   test "returns untouched changeset on invalid children on update" do
     assoc = %MyAssoc{x: "xyz"}
     assoc_changeset = %{Ecto.Changeset.change(assoc) | valid?: false}
+
     changeset =
       %MySchema{id: 1}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc_changeset])
+
     assert {:error, changeset} = TestRepo.update(%{changeset | valid?: true})
     assert_received {:rollback, ^changeset}
     refute changeset.valid?
@@ -496,6 +548,7 @@ defmodule Ecto.Repo.ManyToManyTest do
       |> Ecto.Changeset.change(x: "foo")
       |> Ecto.Changeset.put_assoc(:assocs, [%MyAssoc{x: "xyz"}])
       |> Ecto.Changeset.unique_constraint(:foo)
+
     assert {:error, changeset} = TestRepo.update(changeset)
     assert_received {:rollback, ^changeset}
     assert changeset.data.assocs == []
@@ -507,14 +560,17 @@ defmodule Ecto.Repo.ManyToManyTest do
 
   test "handles valid nested assocs on update" do
     assoc = %MyAssoc{id: 1, x: "xyz"}
+
     assoc_changeset =
       assoc
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, %SubAssoc{y: "xyz"})
+
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc_changeset])
+
     schema = TestRepo.update!(changeset)
     assert hd(schema.assocs).sub_assoc.id
 
@@ -529,14 +585,15 @@ defmodule Ecto.Repo.ManyToManyTest do
     sub_assoc_changeset = %{Ecto.Changeset.change(sub_assoc) | valid?: false}
 
     assoc = %MyAssoc{id: 1, x: "xyz"}
+
     assoc_changeset =
       assoc
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:sub_assoc, sub_assoc_changeset)
 
     changeset =
       %MySchema{id: 1, assocs: [assoc]}
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:assocs, [assoc_changeset])
 
     assert {:error, changeset} = TestRepo.update(%{changeset | valid?: true})

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -12,14 +12,22 @@ defmodule Ecto.Repo.SupervisorTest do
   end
 
   test "invokes the init/2 callback on start", context do
-    {:ok, _} = Ecto.TestRepo.start_link(parent: self(), name: context.test, query_cache_owner: false)
+    {:ok, _} =
+      Ecto.TestRepo.start_link(parent: self(), name: context.test, query_cache_owner: false)
+
     assert_receive {Ecto.TestRepo, :supervisor, _}
   end
 
   test "invokes the init/2 callback on config" do
     assert Ecto.TestRepo.config() |> normalize() ==
-           [database: "hello", hostname: "local", otp_app: :ecto, password: "pass",
-            user: "invalid", username: "user"]
+             [
+               database: "hello",
+               hostname: "local",
+               otp_app: :ecto,
+               password: "pass",
+               user: "invalid",
+               username: "user"
+             ]
   end
 
   def handle_event(event, measurements, metadata, %{pid: pid}) do
@@ -46,16 +54,25 @@ defmodule Ecto.Repo.SupervisorTest do
   test "reads otp app configuration" do
     put_env(database: "hello")
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [])
+
     assert normalize(config) ==
-           [database: "hello", otp_app: :ecto]
+             [database: "hello", otp_app: :ecto]
   end
 
   test "merges url into configuration" do
     put_env(database: "hello", url: "ecto://eric:hunter2@host:12345/mydb")
-    {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [extra: "extra"])
+    {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, extra: "extra")
+
     assert normalize(config) ==
-           [database: "mydb", extra: "extra", hostname: "host",
-            otp_app: :ecto, password: "hunter2", port: 12345, username: "eric"]
+             [
+               database: "mydb",
+               extra: "extra",
+               hostname: "host",
+               otp_app: :ecto,
+               password: "hunter2",
+               port: 12345,
+               username: "eric"
+             ]
   end
 
   if Version.match?(System.version(), ">= 1.10.0") do
@@ -69,13 +86,15 @@ defmodule Ecto.Repo.SupervisorTest do
   test "is no-op for nil or empty URL" do
     put_env(database: "hello", url: nil)
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [])
+
     assert normalize(config) ==
-           [database: "hello", otp_app: :ecto]
+             [database: "hello", otp_app: :ecto]
 
     put_env(database: "hello", url: "")
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [])
+
     assert normalize(config) ==
-           [database: "hello", otp_app: :ecto]
+             [database: "hello", otp_app: :ecto]
   end
 
   test "works without an environment" do
@@ -105,7 +124,11 @@ defmodule Ecto.Repo.SupervisorTest do
   end
 
   test "parse_url query string" do
-    encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&timeout=1000&pool_size=42&currentSchema=my_schema")
+    encoded_url =
+      URI.encode(
+        "ecto://eric:it+й@host:12345/mydb?ssl=true&timeout=1000&pool_size=42&currentSchema=my_schema"
+      )
+
     url = parse_url(encoded_url)
     assert {:password, "it+й"} in url
     assert {:username, "eric"} in url
@@ -154,9 +177,11 @@ defmodule Ecto.Repo.SupervisorTest do
     end
 
     for key <- ["timeout", "pool_size"] do
-      assert_raise Ecto.InvalidURLError, ~r"can not parse value `not_an_int` for parameter `#{key}` as an integer", fn ->
-        parse_url("ecto://eric:it+й@host:12345/mydb?#{key}=not_an_int")
-      end
+      assert_raise Ecto.InvalidURLError,
+                   ~r"can not parse value `not_an_int` for parameter `#{key}` as an integer",
+                   fn ->
+                     parse_url("ecto://eric:it+й@host:12345/mydb?#{key}=not_an_int")
+                   end
     end
   end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -144,69 +144,60 @@ defmodule Ecto.RepoTest do
 
   test "defines child_spec/1" do
     assert TestRepo.child_spec([]) == %{
-      id: TestRepo,
-      start: {TestRepo, :start_link, [[]]},
-      type: :supervisor
-    }
+             id: TestRepo,
+             start: {TestRepo, :start_link, [[]]},
+             type: :supervisor
+           }
   end
 
   test "load/2" do
     # string fields
-    assert %MySchema{x: "abc"} =
-           TestRepo.load(MySchema, %{"x" => "abc"})
+    assert %MySchema{x: "abc"} = TestRepo.load(MySchema, %{"x" => "abc"})
 
     # atom fields
-    assert %MySchema{x: "abc"} =
-           TestRepo.load(MySchema, %{x: "abc"})
+    assert %MySchema{x: "abc"} = TestRepo.load(MySchema, %{x: "abc"})
 
     # keyword list
-    assert %MySchema{x: "abc"} =
-           TestRepo.load(MySchema, [x: "abc"])
+    assert %MySchema{x: "abc"} = TestRepo.load(MySchema, x: "abc")
 
     # atom fields and values
-    assert %MySchema{x: "abc"} =
-           TestRepo.load(MySchema, {[:x], ["abc"]})
+    assert %MySchema{x: "abc"} = TestRepo.load(MySchema, {[:x], ["abc"]})
 
     # string fields and values
-    assert %MySchema{x: "abc"} =
-           TestRepo.load(MySchema, {["x"], ["abc"]})
+    assert %MySchema{x: "abc"} = TestRepo.load(MySchema, {["x"], ["abc"]})
 
     # default value
-    assert %MySchema{x: "abc", z: "z"} =
-           TestRepo.load(MySchema, %{x: "abc"})
+    assert %MySchema{x: "abc", z: "z"} = TestRepo.load(MySchema, %{x: "abc"})
 
     # source field
-    assert %MySchema{y: "abc"} =
-           TestRepo.load(MySchema, %{yyy: "abc"})
+    assert %MySchema{y: "abc"} = TestRepo.load(MySchema, %{yyy: "abc"})
 
     # array field
-    assert %MySchema{array: ["one", "two"]} =
-           TestRepo.load(MySchema, %{array: ["one", "two"]})
+    assert %MySchema{array: ["one", "two"]} = TestRepo.load(MySchema, %{array: ["one", "two"]})
 
     # map field with atoms
-    assert %MySchema{map: %{color: "red"}} =
-           TestRepo.load(MySchema, %{map: %{color: "red"}})
+    assert %MySchema{map: %{color: "red"}} = TestRepo.load(MySchema, %{map: %{color: "red"}})
 
     # map field with strings
     assert %MySchema{map: %{"color" => "red"}} =
-           TestRepo.load(MySchema, %{map: %{"color" => "red"}})
+             TestRepo.load(MySchema, %{map: %{"color" => "red"}})
 
     # nil
-    assert %MySchema{x: nil} =
-           TestRepo.load(MySchema, %{x: nil})
+    assert %MySchema{x: nil} = TestRepo.load(MySchema, %{x: nil})
 
     # invalid field is ignored
-    assert %MySchema{} =
-           TestRepo.load(MySchema, %{bad: "bad"})
+    assert %MySchema{} = TestRepo.load(MySchema, %{bad: "bad"})
 
     # invalid value
-    assert_raise ArgumentError, "cannot load `0` as type :string for field `x` in schema Ecto.RepoTest.MySchema", fn ->
-      TestRepo.load(MySchema, %{x: 0})
-    end
+    assert_raise ArgumentError,
+                 "cannot load `0` as type :string for field `x` in schema Ecto.RepoTest.MySchema",
+                 fn ->
+                   TestRepo.load(MySchema, %{x: 0})
+                 end
 
     # schemaless
     assert TestRepo.load(%{x: :string}, %{x: "abc", bad: "bad"}) ==
-           %{x: "abc"}
+             %{x: "abc"}
   end
 
   describe "get" do
@@ -214,16 +205,19 @@ defmodule Ecto.RepoTest do
       TestRepo.get(MySchema, 123)
 
       message = "cannot perform Ecto.Repo.get/2 because the given value is nil"
+
       assert_raise ArgumentError, message, fn ->
         TestRepo.get(MySchema, nil)
       end
 
       message = ~r"value `:atom` in `where` cannot be cast to type :id in query"
+
       assert_raise Ecto.Query.CastError, message, fn ->
         TestRepo.get(MySchema, :atom)
       end
 
       message = ~r"expected a from expression with a schema in query"
+
       assert_raise Ecto.QueryError, message, fn ->
         TestRepo.get(%Ecto.Query{}, :atom)
       end
@@ -236,6 +230,7 @@ defmodule Ecto.RepoTest do
       TestRepo.get_by(MySchema, %{id: 123})
 
       message = ~r"value `:atom` in `where` cannot be cast to type :id in query"
+
       assert_raise Ecto.Query.CastError, message, fn ->
         TestRepo.get_by(MySchema, id: :atom)
       end
@@ -245,6 +240,7 @@ defmodule Ecto.RepoTest do
   describe "reload" do
     test "raises when input structs do not have valid primary keys" do
       message = "Ecto.Repo.reload/2 expects existent structs, found a `nil` primary key"
+
       assert_raise ArgumentError, message, fn ->
         TestRepo.reload(%MySchema{})
       end
@@ -252,6 +248,7 @@ defmodule Ecto.RepoTest do
 
     test "raises when input is not a struct or a list of structs" do
       message = ~r"expected a struct or a list of structs,"
+
       assert_raise ArgumentError, message, fn ->
         TestRepo.reload(%{my_key: 1})
       end
@@ -263,6 +260,7 @@ defmodule Ecto.RepoTest do
 
     test "raises when schema doesn't have a primary key" do
       message = ~r"to have exactly one primary key"
+
       assert_raise ArgumentError, message, fn ->
         TestRepo.reload(%MySchemaNoPK{})
       end
@@ -270,6 +268,7 @@ defmodule Ecto.RepoTest do
 
     test "raises when receives multiple struct types" do
       message = ~r"expected an homogenous list"
+
       assert_raise ArgumentError, message, fn ->
         TestRepo.reload([%MySchemaWithAssoc{id: 1}, %MySchema{id: 2}])
       end
@@ -320,23 +319,33 @@ defmodule Ecto.RepoTest do
     test "aggregates on the given field" do
       TestRepo.aggregate(MySchema, :min, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: min(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: min(m0.id)>"
 
       TestRepo.aggregate(MySchema, :max, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: max(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: max(m0.id)>"
 
       TestRepo.aggregate(MySchema, :sum, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: sum(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: sum(m0.id)>"
 
       TestRepo.aggregate(MySchema, :avg, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: avg(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: avg(m0.id)>"
 
       TestRepo.aggregate(MySchema, :count, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
 
       TestRepo.aggregate(MySchema, :count)
       assert_received {:all, query}
@@ -352,28 +361,35 @@ defmodule Ecto.RepoTest do
     test "removes any preload from query" do
       from(MySchemaWithAssoc, preload: :parent) |> TestRepo.aggregate(:count, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchemaWithAssoc, select: count(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchemaWithAssoc, select: count(m0.id)>"
     end
 
     test "removes order by from query without distinct/limit/offset/combinations" do
       from(MySchema, order_by: :id) |> TestRepo.aggregate(:count, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
     end
 
     test "overrides any select" do
       from(MySchema, select: true) |> TestRepo.aggregate(:count, :id)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, select: count(m0.id)>"
     end
 
     test "uses subqueries with distinct/limit/offset" do
       from(MySchema, limit: 5) |> TestRepo.aggregate(:count, :id)
       assert_received {:all, query}
+
       assert inspect(query) ==
                "#Ecto.Query<from m0 in subquery(from m0 in Ecto.RepoTest.MySchema,\n" <>
-                "  limit: 5,\n" <>
-                "  select: %{id: m0.id}), select: count(m0.id)>"
+                 "  limit: 5,\n" <>
+                 "  select: %{id: m0.id}), select: count(m0.id)>"
     end
 
     test "uses subqueries with combinations" do
@@ -398,39 +414,53 @@ defmodule Ecto.RepoTest do
     test "selects 1 and sets limit to 1" do
       TestRepo.exists?(MySchema)
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
 
-      from(MySchema, select: [:id], limit: 10) |> TestRepo.exists?
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
+
+      from(MySchema, select: [:id], limit: 10) |> TestRepo.exists?()
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
     end
 
     test "removes any preload from query" do
-      from(MySchemaWithAssoc, preload: :parent) |> TestRepo.exists?
+      from(MySchemaWithAssoc, preload: :parent) |> TestRepo.exists?()
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchemaWithAssoc, limit: 1, select: 1>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchemaWithAssoc, limit: 1, select: 1>"
     end
 
     test "removes distinct from query" do
-      from(MySchema, select: [:id], distinct: true) |> TestRepo.exists?
+      from(MySchema, select: [:id], distinct: true) |> TestRepo.exists?()
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
     end
 
     test "removes order by from query without distinct/limit/offset" do
-      from(MySchema, order_by: :id) |> TestRepo.exists?
+      from(MySchema, order_by: :id) |> TestRepo.exists?()
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
     end
 
     test "overrides any select" do
-      from(MySchema, select: true) |> TestRepo.exists?
+      from(MySchema, select: true) |> TestRepo.exists?()
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
 
-      from(MySchema, union: ^from(MySchema, select: true)) |> TestRepo.exists?
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
+
+      from(MySchema, union: ^from(MySchema, select: true)) |> TestRepo.exists?()
       assert_received {:all, query}
-      assert inspect(query) == "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, union: (from m0 in Ecto.RepoTest.MySchema,\n  select: 1), limit: 1, select: 1>"
+
+      assert inspect(query) ==
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, union: (from m0 in Ecto.RepoTest.MySchema,\n  select: 1), limit: 1, select: 1>"
     end
   end
 
@@ -502,10 +532,13 @@ defmodule Ecto.RepoTest do
       ])
 
       assert_received {:insert_all, %{source: "my_schema"}, rows}
-      assert [[x: "x1", yyy: "y1"],
-              [x: {%Ecto.Query{} = query2, [^value]}, z: "z2"],
-              [x: {%Ecto.Query{} = query3, [^value]}, z: "z3"],
-              [yyy: {%Ecto.Query{} = query4y, [^value]}, z: {%Ecto.Query{} = query4x, [^value]}]] = rows
+
+      assert [
+               [x: "x1", yyy: "y1"],
+               [x: {%Ecto.Query{} = query2, [^value]}, z: "z2"],
+               [x: {%Ecto.Query{} = query3, [^value]}, z: "z3"],
+               [yyy: {%Ecto.Query{} = query4y, [^value]}, z: {%Ecto.Query{} = query4x, [^value]}]
+             ] = rows
 
       assert [%{expr: {:==, _, [_, {:^, [], [2]}]}}] = query2.wheres
       assert [%{expr: {:==, _, [_, {:^, [], [4]}]}}] = query3.wheres
@@ -518,12 +551,13 @@ defmodule Ecto.RepoTest do
 
       threshold = "ten"
 
-      query = from s in MySchema,
-        where: s.x > ^threshold,
-        select: %{
-          foo: s.x,
-          bar: fragment("concat(?, ?, ?)", ^"one", ^"two", s.z)
-        }
+      query =
+        from s in MySchema,
+          where: s.x > ^threshold,
+          select: %{
+            foo: s.x,
+            bar: fragment("concat(?, ?, ?)", ^"one", ^"two", s.z)
+          }
 
       TestRepo.insert_all(MySchema, query)
 
@@ -536,16 +570,19 @@ defmodule Ecto.RepoTest do
       assert_raise ArgumentError, fn ->
         TestRepo.insert_all(MySchema, from(s in MySchema))
       end
+
       assert_raise ArgumentError, fn ->
-        source = from s in MySchema,
-          select: s.x
+        source =
+          from s in MySchema,
+            select: s.x
+
         TestRepo.insert_all(MySchema, source)
       end
     end
 
     test "raises when on associations" do
       assert_raise ArgumentError, fn ->
-        TestRepo.insert_all MySchema, [%{another: nil}]
+        TestRepo.insert_all(MySchema, [%{another: nil}])
       end
     end
 
@@ -605,7 +642,7 @@ defmodule Ecto.RepoTest do
     end
 
     test "Repo.insert_all raises when placeholder key is used for different types" do
-      placeholders = %{uuid_key: Ecto.UUID.generate}
+      placeholders = %{uuid_key: Ecto.UUID.generate()}
       ph_key = {:placeholder, :uuid_key}
       entries = [%{bid: ph_key, string: ph_key}]
 
@@ -633,7 +670,7 @@ defmodule Ecto.RepoTest do
       TestRepo.update_all(query, [])
 
       assert_raise Ecto.QueryError, fn ->
-        TestRepo.update_all from(e in MySchema, order_by: e.x), set: [x: "321"]
+        TestRepo.update_all(from(e in MySchema, order_by: e.x), set: [x: "321"])
       end
     end
   end
@@ -647,7 +684,7 @@ defmodule Ecto.RepoTest do
       TestRepo.delete_all(query)
 
       assert_raise Ecto.QueryError, fn ->
-        TestRepo.delete_all from(e in MySchema, order_by: e.x)
+        TestRepo.delete_all(from(e in MySchema, order_by: e.x))
       end
     end
   end
@@ -657,7 +694,7 @@ defmodule Ecto.RepoTest do
       schema = %MySchemaNoPK{x: "abc"}
 
       assert_raise Ecto.NoPrimaryKeyFieldError, fn ->
-        TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
+        TestRepo.update!(schema |> Ecto.Changeset.change(), force: true)
       end
 
       assert_raise Ecto.NoPrimaryKeyFieldError, fn ->
@@ -669,7 +706,7 @@ defmodule Ecto.RepoTest do
       schema = %MySchema{id: 1, x: "abc"}
       TestRepo.get(MySchema, 123)
       TestRepo.get_by(MySchema, x: "abc")
-      TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
+      TestRepo.update!(schema |> Ecto.Changeset.change(), force: true)
       TestRepo.delete!(schema)
     end
 
@@ -677,7 +714,7 @@ defmodule Ecto.RepoTest do
       schema = %MySchema{x: "abc"}
 
       assert_raise Ecto.NoPrimaryKeyValueError, fn ->
-        TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
+        TestRepo.update!(schema |> Ecto.Changeset.change(), force: true)
       end
 
       assert_raise Ecto.NoPrimaryKeyValueError, fn ->
@@ -693,7 +730,7 @@ defmodule Ecto.RepoTest do
 
     test "works with custom source schema" do
       schema = %MySchema{id: 1, x: "abc"} |> put_meta(source: "custom_schema")
-      TestRepo.update!(schema |> Ecto.Changeset.change, force: true)
+      TestRepo.update!(schema |> Ecto.Changeset.change(), force: true)
       TestRepo.delete!(schema)
 
       to_insert = %MySchema{x: "abc"} |> put_meta(source: "custom_schema")
@@ -739,7 +776,7 @@ defmodule Ecto.RepoTest do
 
     test "insert, update, insert_or_update and delete filters out unknown field" do
       valid = Ecto.Changeset.change(%MySchema{id: 1})
-      valid = put_in valid.changes[:unknown], "foo"
+      valid = put_in(valid.changes[:unknown], "foo")
 
       assert {:ok, %MySchema{} = inserted} = TestRepo.insert(valid)
       refute Map.has_key?(inserted, :unknown)
@@ -776,16 +813,16 @@ defmodule Ecto.RepoTest do
       my_schema = put_in(my_schema.__meta__.context, {:error, :stale})
       stale = Ecto.Changeset.cast(my_schema, %{x: "foo"}, [:x])
 
-      assert {:error, changeset} = TestRepo.insert(stale, [stale_error_field: :id])
+      assert {:error, changeset} = TestRepo.insert(stale, stale_error_field: :id)
       assert changeset.errors == [id: {"is stale", [stale: true]}]
 
-      assert {:error, changeset} = TestRepo.update(stale, [stale_error_field: :id])
+      assert {:error, changeset} = TestRepo.update(stale, stale_error_field: :id)
       assert changeset.errors == [id: {"is stale", [stale: true]}]
 
-      assert {:error, changeset} = TestRepo.delete(stale, [stale_error_field: :id])
+      assert {:error, changeset} = TestRepo.delete(stale, stale_error_field: :id)
       assert changeset.errors == [id: {"is stale", [stale: true]}]
 
-      assert_raise Ecto.StaleEntryError, fn -> TestRepo.insert(stale, [stale_error_field: "id"]) end
+      assert_raise Ecto.StaleEntryError, fn -> TestRepo.insert(stale, stale_error_field: "id") end
     end
 
     test "insert, update, and delete adds custom stale error message" do
@@ -867,7 +904,7 @@ defmodule Ecto.RepoTest do
       valid =
         %MySchema{id: 1}
         |> Ecto.Changeset.cast(%{x: "foo"}, [:x])
-        |> Map.put(:repo_opts, [prefix: "public"])
+        |> Map.put(:repo_opts, prefix: "public")
 
       assert {:ok, schema} = TestRepo.insert(valid)
       assert schema.__meta__.prefix == "public"
@@ -883,7 +920,7 @@ defmodule Ecto.RepoTest do
       valid =
         %MySchema{id: 1}
         |> Ecto.Changeset.cast(%{x: "foo"}, [:x])
-        |> Map.put(:repo_opts, [prefix: "public"])
+        |> Map.put(:repo_opts, prefix: "public")
 
       assert {:ok, schema} = TestRepo.insert(valid, prefix: "private")
       assert schema.__meta__.prefix == "private"
@@ -988,7 +1025,7 @@ defmodule Ecto.RepoTest do
         |> Ecto.Changeset.cast(%{parent: %{n: 1}}, [])
         |> Ecto.Changeset.cast_assoc(:parent)
 
-      valid = put_in(valid.changes.parent.repo_opts, [prefix: "public"])
+      valid = put_in(valid.changes.parent.repo_opts, prefix: "public")
 
       assert {:ok, schema} = TestRepo.insert(valid, prefix: "other")
       assert schema.parent.__meta__.prefix == "other"
@@ -1015,9 +1052,11 @@ defmodule Ecto.RepoTest do
       assert {:error, ^update} = TestRepo.update(ignore, prefix: "prefix")
       assert {:error, ^delete} = TestRepo.delete(ignore, prefix: "prefix")
 
-      assert_raise ArgumentError, ~r"a valid changeset with action :ignore was given to Ecto.TestRepo.insert/2", fn ->
-        TestRepo.insert(%{ignore | valid?: true})
-      end
+      assert_raise ArgumentError,
+                   ~r"a valid changeset with action :ignore was given to Ecto.TestRepo.insert/2",
+                   fn ->
+                     TestRepo.insert(%{ignore | valid?: true})
+                   end
     end
 
     test "insert!, update!, insert_or_update! and delete!" do
@@ -1032,24 +1071,28 @@ defmodule Ecto.RepoTest do
       invalid = %Ecto.Changeset{valid?: false, data: %MySchema{}, types: %{}}
 
       assert_raise Ecto.InvalidChangesetError,
-                   ~r"could not perform insert because changeset is invalid", fn ->
-        TestRepo.insert!(invalid)
-      end
+                   ~r"could not perform insert because changeset is invalid",
+                   fn ->
+                     TestRepo.insert!(invalid)
+                   end
 
       assert_raise Ecto.InvalidChangesetError,
-                   ~r"could not perform update because changeset is invalid", fn ->
-        TestRepo.update!(invalid)
-      end
+                   ~r"could not perform update because changeset is invalid",
+                   fn ->
+                     TestRepo.update!(invalid)
+                   end
 
       assert_raise Ecto.InvalidChangesetError,
-                   ~r"could not perform insert because changeset is invalid", fn ->
-        TestRepo.insert_or_update!(invalid)
-      end
+                   ~r"could not perform insert because changeset is invalid",
+                   fn ->
+                     TestRepo.insert_or_update!(invalid)
+                   end
 
       assert_raise Ecto.InvalidChangesetError,
-                   ~r"could not perform delete because changeset is invalid", fn ->
-        TestRepo.delete!(invalid)
-      end
+                   ~r"could not perform delete because changeset is invalid",
+                   fn ->
+                     TestRepo.delete!(invalid)
+                   end
     end
 
     test "insert!, update! and delete! fail on changeset without data" do
@@ -1071,53 +1114,63 @@ defmodule Ecto.RepoTest do
     test "insert!, update!, insert_or_update! and delete! fail on changeset with wrong action" do
       invalid = %Ecto.Changeset{valid?: true, data: %MySchema{id: 123}, action: :other}
 
-      assert_raise ArgumentError, "a changeset with action :other was given to Ecto.TestRepo.insert/2", fn ->
-        TestRepo.insert!(invalid)
-      end
+      assert_raise ArgumentError,
+                   "a changeset with action :other was given to Ecto.TestRepo.insert/2",
+                   fn ->
+                     TestRepo.insert!(invalid)
+                   end
 
-      assert_raise ArgumentError, "a changeset with action :other was given to Ecto.TestRepo.update/2", fn ->
-        TestRepo.update!(invalid)
-      end
+      assert_raise ArgumentError,
+                   "a changeset with action :other was given to Ecto.TestRepo.update/2",
+                   fn ->
+                     TestRepo.update!(invalid)
+                   end
 
-      assert_raise ArgumentError, "a changeset with action :other was given to Ecto.TestRepo.insert/2", fn ->
-        TestRepo.insert_or_update!(invalid)
-      end
+      assert_raise ArgumentError,
+                   "a changeset with action :other was given to Ecto.TestRepo.insert/2",
+                   fn ->
+                     TestRepo.insert_or_update!(invalid)
+                   end
 
-      assert_raise ArgumentError, "a changeset with action :other was given to Ecto.TestRepo.delete/2", fn ->
-        TestRepo.delete!(invalid)
-      end
+      assert_raise ArgumentError,
+                   "a changeset with action :other was given to Ecto.TestRepo.delete/2",
+                   fn ->
+                     TestRepo.delete!(invalid)
+                   end
     end
 
     test "insert_or_update uses the correct action" do
-      built  = Ecto.Changeset.cast(%MySchema{y: "built"}, %{}, [])
+      built = Ecto.Changeset.cast(%MySchema{y: "built"}, %{}, [])
+
       loaded =
         %MySchema{y: "loaded"}
-        |> TestRepo.insert!
+        |> TestRepo.insert!()
         |> Ecto.Changeset.cast(%{y: "updated"}, [:y])
+
       assert_received {:insert, _}
 
-      TestRepo.insert_or_update built
+      TestRepo.insert_or_update(built)
       assert_received {:insert, _}
 
-      TestRepo.insert_or_update loaded
+      TestRepo.insert_or_update(loaded)
       assert_received {:update, _}
     end
 
     test "insert_or_update fails on invalid states" do
       deleted =
         %MySchema{y: "deleted"}
-        |> TestRepo.insert!
-        |> TestRepo.delete!
+        |> TestRepo.insert!()
+        |> TestRepo.delete!()
         |> Ecto.Changeset.cast(%{y: "updated"}, [:y])
 
       assert_raise ArgumentError, ~r/the changeset has an invalid state/, fn ->
-        TestRepo.insert_or_update deleted
+        TestRepo.insert_or_update(deleted)
       end
     end
 
     test "insert_or_update fails when being passed a struct" do
       assert_raise ArgumentError, ~r/giving a struct to .* is not supported/, fn ->
-        TestRepo.insert_or_update %MySchema{}
+        TestRepo.insert_or_update(%MySchema{})
       end
     end
   end
@@ -1155,14 +1208,14 @@ defmodule Ecto.RepoTest do
       %MySchema{id: 1}
       |> Ecto.Changeset.cast(%{x: "one"}, [:x])
       |> Ecto.Changeset.prepare_changes(fn %{repo: repo} = changeset ->
-            Process.put(:ecto_repo, repo)
-            Process.put(:ecto_counter, 1)
-            changeset
-          end)
+        Process.put(:ecto_repo, repo)
+        Process.put(:ecto_counter, 1)
+        changeset
+      end)
       |> Ecto.Changeset.prepare_changes(fn changeset ->
-            Process.put(:ecto_counter, 2)
-            changeset
-          end)
+        Process.put(:ecto_counter, 2)
+        changeset
+      end)
     end
 
     test "does not run transaction without prepare" do
@@ -1318,40 +1371,48 @@ defmodule Ecto.RepoTest do
   describe "changeset constraints" do
     test "are mapped to repo constraint violations" do
       my_schema = %MySchema{id: 1}
+
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "custom_foo_index"]})
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index")
+
       assert {:error, changeset} = TestRepo.insert(changeset)
       refute changeset.valid?
     end
 
     test "are mapped to repo constraint violation using suffix match" do
       my_schema = %MySchema{id: 1}
+
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index", match: :suffix)
+
       assert {:error, changeset} = TestRepo.insert(changeset)
       refute changeset.valid?
     end
 
     test "are mapped to repo constraint violation using prefix match" do
       my_schema = %MySchema{id: 1}
+
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo, name: "foo_table_custom_foo", match: :prefix)
+
       assert {:error, changeset} = TestRepo.insert(changeset)
       refute changeset.valid?
     end
 
     test "may fail to map to repo constraint violation on name" do
       my_schema = %MySchema{id: 1}
+
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index")
+
       assert_raise Ecto.ConstraintError, fn ->
         TestRepo.insert(changeset)
       end
@@ -1359,10 +1420,15 @@ defmodule Ecto.RepoTest do
 
     test "may fail to map to repo constraint violation on index type" do
       my_schema = %MySchema{id: 1}
+
       changeset =
-        put_in(my_schema.__meta__.context, {:invalid, [invalid_constraint_type: "my_schema_foo_index"]})
+        put_in(
+          my_schema.__meta__.context,
+          {:invalid, [invalid_constraint_type: "my_schema_foo_index"]}
+        )
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo)
+
       assert_raise Ecto.ConstraintError, fn ->
         TestRepo.insert(changeset)
       end
@@ -1430,14 +1496,16 @@ defmodule Ecto.RepoTest do
     end
 
     test "raises on non-empty conflict_target with on_conflict raise" do
-      assert_raise ArgumentError, ":conflict_target option is forbidden when :on_conflict is :raise", fn ->
-        TestRepo.insert(%MySchema{id: 1}, on_conflict: :raise, conflict_target: [:id])
-      end
+      assert_raise ArgumentError,
+                   ":conflict_target option is forbidden when :on_conflict is :raise",
+                   fn ->
+                     TestRepo.insert(%MySchema{id: 1}, on_conflict: :raise, conflict_target: [:id])
+                   end
     end
 
     test "raises on query mismatch" do
       assert_raise ArgumentError, ~r"cannot run on_conflict: query", fn ->
-        query = from p in "posts"
+        query = from(p in "posts")
         TestRepo.insert(%MySchema{id: 1}, on_conflict: query)
       end
     end
@@ -1494,12 +1562,12 @@ defmodule Ecto.RepoTest do
     defmodule NoTransactionAdapter do
       @behaviour Ecto.Adapter
       defmacro __before_compile__(_opts), do: :ok
-      def dumpers(_, _), do: raise "not implemented"
-      def loaders(_, _), do: raise "not implemented"
-      def init(_), do: raise "not implemented"
-      def checkout(_, _, _), do: raise "not implemented"
-      def checked_out?(_), do: raise "not implemented"
-      def ensure_all_started(_, _), do: raise "not implemented"
+      def dumpers(_, _), do: raise("not implemented")
+      def loaders(_, _), do: raise("not implemented")
+      def init(_), do: raise("not implemented")
+      def checkout(_, _, _), do: raise("not implemented")
+      def checked_out?(_), do: raise("not implemented")
+      def ensure_all_started(_, _), do: raise("not implemented")
     end
 
     defmodule NoTransactionRepo do
@@ -1522,7 +1590,7 @@ defmodule Ecto.RepoTest do
     end
 
     test "puts the dynamic repo in pdict" do
-      assert is_pid TestRepo.get_dynamic_repo()
+      assert is_pid(TestRepo.get_dynamic_repo())
 
       assert Task.async(fn -> TestRepo.get_dynamic_repo() end) |> Task.await() ==
                TestRepo
@@ -1590,38 +1658,38 @@ defmodule Ecto.RepoTest do
     test "all" do
       query = from p in MyParent, select: p
 
-      PrepareRepo.all(query, [hello: :world])
+      PrepareRepo.all(query, hello: :world)
       assert_received {:all, ^query, [hello: :world]}
       assert_received {:all, %{prefix: "rewritten"}}
 
-      PrepareRepo.one(query, [hello: :world])
+      PrepareRepo.one(query, hello: :world)
       assert_received {:all, ^query, [hello: :world]}
       assert_received {:all, %{prefix: "rewritten"}}
     end
 
     test "update_all" do
       query = from p in MyParent, update: [set: [n: 1]]
-      PrepareRepo.update_all(query, [], [hello: :world])
+      PrepareRepo.update_all(query, [], hello: :world)
       assert_received {:update_all, ^query, [hello: :world]}
       assert_received {:update_all, %{prefix: "rewritten"}}
     end
 
     test "delete_all" do
-      query = from p in MyParent
-      PrepareRepo.delete_all(query, [hello: :world])
+      query = from(p in MyParent)
+      PrepareRepo.delete_all(query, hello: :world)
       assert_received {:delete_all, ^query, [hello: :world]}
       assert_received {:delete_all, %{prefix: "rewritten"}}
     end
 
     test "stream" do
       query = from p in MyParent, select: p
-      PrepareRepo.stream(query, [hello: :world]) |> Enum.to_list()
+      PrepareRepo.stream(query, hello: :world) |> Enum.to_list()
       assert_received {:stream, ^query, [hello: :world]}
       assert_received {:stream, %{prefix: "rewritten"}}
     end
 
     test "preload" do
-      PrepareRepo.preload(%MySchemaWithAssoc{parent_id: 1}, :parent, [hello: :world])
+      PrepareRepo.preload(%MySchemaWithAssoc{parent_id: 1}, :parent, hello: :world)
       assert_received {:all, query, [hello: :world]}
       assert query.from.source == {"my_parent", Ecto.RepoTest.MyParent}
     end
@@ -1645,7 +1713,7 @@ defmodule Ecto.RepoTest do
   describe "all_running" do
     test "lists all running repositories" do
       assert Ecto.TestRepo in Ecto.Repo.all_running()
-      pid = start_supervised! {Ecto.TestRepo, name: nil}
+      pid = start_supervised!({Ecto.TestRepo, name: nil})
       assert pid in Ecto.Repo.all_running()
     end
   end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../integration_test/support/types.exs", __DIR__
+Code.require_file("../../integration_test/support/types.exs", __DIR__)
 
 defmodule Ecto.SchemaTest do
   use ExUnit.Case, async: true
@@ -7,10 +7,10 @@ defmodule Ecto.SchemaTest do
     use Ecto.Schema
 
     schema "my schema" do
-      field :name,  :string, default: "eric", autogenerate: {String, :upcase, ["eric"]}
+      field :name, :string, default: "eric", autogenerate: {String, :upcase, ["eric"]}
       field :email, :string, uniq: true, read_after_writes: true
       field :password, :string, redact: true
-      field :temp,  :any, default: "temp", virtual: true, redact: true
+      field :temp, :any, default: "temp", virtual: true, redact: true
       field :count, :decimal, read_after_writes: true, source: :cnt
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
@@ -21,42 +21,75 @@ defmodule Ecto.SchemaTest do
   end
 
   test "schema metadata" do
-    assert Schema.__schema__(:source)             == "my schema"
-    assert Schema.__schema__(:prefix)             == nil
-    assert Schema.__schema__(:fields)             == [:id, :name, :email, :password, :count, :array, :uuid, :query_excluded_field, :comment_id]
-    assert Schema.__schema__(:query_fields)       == [:id, :name, :email, :password, :count, :array, :uuid, :comment_id]
-    assert Schema.__schema__(:read_after_writes)  == [:email, :count]
-    assert Schema.__schema__(:primary_key)        == [:id]
-    assert Schema.__schema__(:autogenerate_id)    == {:id, :id, :id}
+    assert Schema.__schema__(:source) == "my schema"
+    assert Schema.__schema__(:prefix) == nil
+
+    assert Schema.__schema__(:fields) == [
+             :id,
+             :name,
+             :email,
+             :password,
+             :count,
+             :array,
+             :uuid,
+             :query_excluded_field,
+             :comment_id
+           ]
+
+    assert Schema.__schema__(:query_fields) == [
+             :id,
+             :name,
+             :email,
+             :password,
+             :count,
+             :array,
+             :uuid,
+             :comment_id
+           ]
+
+    assert Schema.__schema__(:read_after_writes) == [:email, :count]
+    assert Schema.__schema__(:primary_key) == [:id]
+    assert Schema.__schema__(:autogenerate_id) == {:id, :id, :id}
   end
 
   test "types metadata" do
-    assert Schema.__schema__(:type, :id)         == :id
-    assert Schema.__schema__(:type, :name)       == :string
-    assert Schema.__schema__(:type, :email)      == :string
-    assert Schema.__schema__(:type, :array)      == {:array, :string}
+    assert Schema.__schema__(:type, :id) == :id
+    assert Schema.__schema__(:type, :name) == :string
+    assert Schema.__schema__(:type, :email) == :string
+    assert Schema.__schema__(:type, :array) == {:array, :string}
     assert Schema.__schema__(:type, :comment_id) == :id
   end
 
   test "sources metadata" do
-    assert Schema.__schema__(:field_source, :id)         == :id
-    assert Schema.__schema__(:field_source, :name)       == :name
-    assert Schema.__schema__(:field_source, :email)      == :email
-    assert Schema.__schema__(:field_source, :array)      == :array
+    assert Schema.__schema__(:field_source, :id) == :id
+    assert Schema.__schema__(:field_source, :name) == :name
+    assert Schema.__schema__(:field_source, :email) == :email
+    assert Schema.__schema__(:field_source, :array) == :array
     assert Schema.__schema__(:field_source, :comment_id) == :comment_id
-    assert Schema.__schema__(:field_source, :count)      == :cnt
-    assert Schema.__schema__(:field_source, :xyz)        == nil
+    assert Schema.__schema__(:field_source, :count) == :cnt
+    assert Schema.__schema__(:field_source, :xyz) == nil
   end
 
   test "changeset metadata" do
     assert Schema.__changeset__() |> Map.drop([:comment, :permalink]) ==
-           %{name: :string, email: :string, password: :string, count: :decimal, array: {:array, :string},
-             comment_id: :id, temp: :any, id: :id, uuid: Ecto.UUID, query_excluded_field: :string}
+             %{
+               name: :string,
+               email: :string,
+               password: :string,
+               count: :decimal,
+               array: {:array, :string},
+               comment_id: :id,
+               temp: :any,
+               id: :id,
+               uuid: Ecto.UUID,
+               query_excluded_field: :string
+             }
   end
 
   test "autogenerate metadata (private)" do
     assert Schema.__schema__(:autogenerate) ==
-           [{[:name], {String, :upcase, ["eric"]}}, {[:uuid], {Ecto.UUID, :autogenerate, []}}]
+             [{[:name], {String, :upcase, ["eric"]}}, {[:uuid], {Ecto.UUID, :autogenerate, []}}]
+
     assert Schema.__schema__(:autoupdate) == []
   end
 
@@ -110,7 +143,7 @@ defmodule Ecto.SchemaTest do
     schema = %Schema{}
     assert inspect(schema.__meta__) == "#Ecto.Schema.Metadata<:built, \"my schema\">"
 
-    schema = Ecto.put_meta %Schema{}, context: <<0>>
+    schema = Ecto.put_meta(%Schema{}, context: <<0>>)
     assert inspect(schema.__meta__) == "#Ecto.Schema.Metadata<:built, \"my schema\", <<0>>>"
   end
 
@@ -147,7 +180,7 @@ defmodule Ecto.SchemaTest do
 
     @primary_key {:perm, CustomPermalink, autogenerate: true}
     @foreign_key_type :string
-    @field_source_mapper &(&1 |> Atom.to_string |> String.upcase |> String.to_atom())
+    @field_source_mapper &(&1 |> Atom.to_string() |> String.upcase() |> String.to_atom())
 
     schema "users" do
       field :name
@@ -181,16 +214,16 @@ defmodule Ecto.SchemaTest do
     use Ecto.Schema
 
     embedded_schema do
-      field :name,  :string, default: "eric"
+      field :name, :string, default: "eric"
       field :password, :string, redact: true
     end
   end
 
   test "embedded schema" do
-    assert EmbeddedSchema.__schema__(:source)          == nil
-    assert EmbeddedSchema.__schema__(:prefix)          == nil
-    assert EmbeddedSchema.__schema__(:fields)          == [:id, :name, :password]
-    assert EmbeddedSchema.__schema__(:primary_key)     == [:id]
+    assert EmbeddedSchema.__schema__(:source) == nil
+    assert EmbeddedSchema.__schema__(:prefix) == nil
+    assert EmbeddedSchema.__schema__(:fields) == [:id, :name, :password]
+    assert EmbeddedSchema.__schema__(:primary_key) == [:id]
     assert EmbeddedSchema.__schema__(:autogenerate_id) == {:id, :id, :binary_id}
   end
 
@@ -216,9 +249,9 @@ defmodule Ecto.SchemaTest do
   end
 
   test "custom embedded schema" do
-    assert CustomEmbeddedSchema.__schema__(:source)      == nil
-    assert CustomEmbeddedSchema.__schema__(:prefix)      == nil
-    assert CustomEmbeddedSchema.__schema__(:fields)      == [:name]
+    assert CustomEmbeddedSchema.__schema__(:source) == nil
+    assert CustomEmbeddedSchema.__schema__(:prefix) == nil
+    assert CustomEmbeddedSchema.__schema__(:fields) == [:name]
     assert CustomEmbeddedSchema.__schema__(:primary_key) == []
   end
 
@@ -229,6 +262,7 @@ defmodule Ecto.SchemaTest do
       embeds_one :one, One, primary_key: false do
         field :x
       end
+
       embeds_many :many, Many do
         field :y
       end
@@ -237,10 +271,12 @@ defmodule Ecto.SchemaTest do
 
   test "inline embedded schema" do
     assert %Ecto.Embedded{related: InlineEmbeddedSchema.One} =
-      InlineEmbeddedSchema.__schema__(:embed, :one)
+             InlineEmbeddedSchema.__schema__(:embed, :one)
+
     assert %Ecto.Embedded{related: InlineEmbeddedSchema.Many} =
-      InlineEmbeddedSchema.__schema__(:embed, :many)
-    assert InlineEmbeddedSchema.One.__schema__(:fields)  == [:x]
+             InlineEmbeddedSchema.__schema__(:embed, :many)
+
+    assert InlineEmbeddedSchema.One.__schema__(:fields) == [:x]
     assert InlineEmbeddedSchema.Many.__schema__(:fields) == [:id, :y]
   end
 
@@ -254,9 +290,10 @@ defmodule Ecto.SchemaTest do
 
   test "timestamps autogenerate metadata (private)" do
     assert TimestampsAutoGen.__schema__(:autogenerate) ==
-           [{[:inserted_at, :updated_at], {:m, :f, [:a]}}]
+             [{[:inserted_at, :updated_at], {:m, :f, [:a]}}]
+
     assert TimestampsAutoGen.__schema__(:autoupdate) ==
-           [{[:updated_at], {:m, :f, [:a]}}]
+             [{[:updated_at], {:m, :f, [:a]}}]
   end
 
   defmodule TimestampsCustom do
@@ -397,15 +434,17 @@ defmodule Ecto.SchemaTest do
   end
 
   test "default of invalid type" do
-    assert_raise ArgumentError, ~s/value "1" is invalid for type :integer, can't set default/, fn ->
-      defmodule SchemaInvalidDefault do
-        use Ecto.Schema
+    assert_raise ArgumentError,
+                 ~s/value "1" is invalid for type :integer, can't set default/,
+                 fn ->
+                   defmodule SchemaInvalidDefault do
+                     use Ecto.Schema
 
-        schema "invalid_default" do
-          field :count, :integer, default: "1"
-        end
-      end
-    end
+                     schema "invalid_default" do
+                       field :count, :integer, default: "1"
+                     end
+                   end
+                 end
 
     assert_raise ArgumentError, ~s/value 1 is invalid for type :string, can't set default/, fn ->
       defmodule SchemaInvalidDefault do
@@ -439,15 +478,17 @@ defmodule Ecto.SchemaTest do
       end
     end
 
-    assert_raise ArgumentError, ~r/schema Ecto.SchemaTest.Schema is not a valid type for field :name/, fn ->
-      defmodule SchemaInvalidFieldType do
-        use Ecto.Schema
+    assert_raise ArgumentError,
+                 ~r/schema Ecto.SchemaTest.Schema is not a valid type for field :name/,
+                 fn ->
+                   defmodule SchemaInvalidFieldType do
+                     use Ecto.Schema
 
-        schema "invalidtype" do
-          field :name, Schema
-        end
-      end
-    end
+                     schema "invalidtype" do
+                       field :name, Schema
+                     end
+                   end
+                 end
 
     assert_raise ArgumentError, "invalid or unknown type :jsonb for field :name", fn ->
       defmodule SchemaInvalidFieldType do
@@ -485,38 +526,41 @@ defmodule Ecto.SchemaTest do
 
   test "fail invalid autogenerate" do
     assert_raise ArgumentError,
-                 "field :x does not support :autogenerate because it uses a primitive type :string", fn ->
-      defmodule AutogenerateFail do
-        use Ecto.Schema
+                 "field :x does not support :autogenerate because it uses a primitive type :string",
+                 fn ->
+                   defmodule AutogenerateFail do
+                     use Ecto.Schema
 
-        schema "hello" do
-          field :x, :string, autogenerate: true
-        end
-      end
-    end
+                     schema "hello" do
+                       field :x, :string, autogenerate: true
+                     end
+                   end
+                 end
 
     assert_raise ArgumentError,
                  "only primary keys allow :autogenerate for type :id, " <>
-                 "field :x is not a primary key", fn ->
-      defmodule AutogenerateFail do
-        use Ecto.Schema
+                   "field :x is not a primary key",
+                 fn ->
+                   defmodule AutogenerateFail do
+                     use Ecto.Schema
 
-        schema "hello" do
-          field :x, :id, autogenerate: true
-        end
-      end
-    end
+                     schema "hello" do
+                       field :x, :id, autogenerate: true
+                     end
+                   end
+                 end
 
     assert_raise ArgumentError,
-                 "cannot mark the same field as autogenerate and read_after_writes", fn ->
-      defmodule AutogenerateFail do
-        use Ecto.Schema
+                 "cannot mark the same field as autogenerate and read_after_writes",
+                 fn ->
+                   defmodule AutogenerateFail do
+                     use Ecto.Schema
 
-        schema "hello" do
-          field :x, Ecto.UUID, autogenerate: true, read_after_writes: true
-        end
-      end
-    end
+                     schema "hello" do
+                       field :x, Ecto.UUID, autogenerate: true, read_after_writes: true
+                     end
+                   end
+                 end
   end
 
   ## Associations
@@ -541,7 +585,10 @@ defmodule Ecto.SchemaTest do
       has_many :emails, {"users_emails", Email}, on_replace: :delete
       has_one :profile, {"users_profiles", Profile}
       belongs_to :summary, {"post_summary", Summary}
-      belongs_to :reference, SchemaWithParameterizedPrimaryKey, type: ParameterizedPrefixedString, prefix: "ref"
+
+      belongs_to :reference, SchemaWithParameterizedPrimaryKey,
+        type: ParameterizedPrefixedString,
+        prefix: "ref"
     end
   end
 
@@ -551,125 +598,190 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_many association" do
-    struct =
-      %Ecto.Association.Has{field: :posts, owner: AssocSchema, cardinality: :many, on_delete: :nothing,
-                            related: Post, owner_key: :id, related_key: :assoc_schema_id, queryable: Post,
-                            on_replace: :raise}
+    struct = %Ecto.Association.Has{
+      field: :posts,
+      owner: AssocSchema,
+      cardinality: :many,
+      on_delete: :nothing,
+      related: Post,
+      owner_key: :id,
+      related_key: :assoc_schema_id,
+      queryable: Post,
+      on_replace: :raise
+    }
 
     assert AssocSchema.__schema__(:association, :posts) == struct
     assert AssocSchema.__changeset__().posts == {:assoc, struct}
 
-    posts = (%AssocSchema{}).posts
+    posts = %AssocSchema{}.posts
     assert %Ecto.Association.NotLoaded{} = posts
     assert inspect(posts) == "#Ecto.Association.NotLoaded<association :posts is not loaded>"
   end
 
   test "has_many association via {source schema}" do
-    struct =
-      %Ecto.Association.Has{field: :emails, owner: AssocSchema, cardinality: :many, on_delete: :nothing,
-                            related: Email, owner_key: :id, related_key: :assoc_schema_id,
-                            queryable: {"users_emails", Email}, on_replace: :delete}
+    struct = %Ecto.Association.Has{
+      field: :emails,
+      owner: AssocSchema,
+      cardinality: :many,
+      on_delete: :nothing,
+      related: Email,
+      owner_key: :id,
+      related_key: :assoc_schema_id,
+      queryable: {"users_emails", Email},
+      on_replace: :delete
+    }
 
     assert AssocSchema.__schema__(:association, :emails) == struct
     assert AssocSchema.__changeset__().emails == {:assoc, struct}
 
-    posts = (%AssocSchema{}).posts
+    posts = %AssocSchema{}.posts
     assert %Ecto.Association.NotLoaded{__cardinality__: :many} = posts
     assert inspect(posts) == "#Ecto.Association.NotLoaded<association :posts is not loaded>"
   end
 
   test "has_many through association" do
     assert AssocSchema.__schema__(:association, :comment_authors) ==
-           %Ecto.Association.HasThrough{field: :comment_authors, owner: AssocSchema, cardinality: :many,
-                                         through: [:comment, :authors], owner_key: :comment_id}
+             %Ecto.Association.HasThrough{
+               field: :comment_authors,
+               owner: AssocSchema,
+               cardinality: :many,
+               through: [:comment, :authors],
+               owner_key: :comment_id
+             }
 
     refute Map.has_key?(AssocSchema.__changeset__(), :comment_authors)
 
-    authors = (%AssocSchema{}).comment_authors
+    authors = %AssocSchema{}.comment_authors
     assert %Ecto.Association.NotLoaded{} = authors
-    assert inspect(authors) == "#Ecto.Association.NotLoaded<association :comment_authors is not loaded>"
+
+    assert inspect(authors) ==
+             "#Ecto.Association.NotLoaded<association :comment_authors is not loaded>"
   end
 
   test "has_one association" do
-    struct =
-      %Ecto.Association.Has{field: :author, owner: AssocSchema, cardinality: :one, on_delete: :nothing,
-                            related: User, owner_key: :id, related_key: :assoc_schema_id, queryable: User,
-                            on_replace: :raise}
+    struct = %Ecto.Association.Has{
+      field: :author,
+      owner: AssocSchema,
+      cardinality: :one,
+      on_delete: :nothing,
+      related: User,
+      owner_key: :id,
+      related_key: :assoc_schema_id,
+      queryable: User,
+      on_replace: :raise
+    }
 
     assert AssocSchema.__schema__(:association, :author) == struct
     assert AssocSchema.__changeset__().author == {:assoc, struct}
 
-    author = (%AssocSchema{}).author
+    author = %AssocSchema{}.author
     assert %Ecto.Association.NotLoaded{} = author
     assert inspect(author) == "#Ecto.Association.NotLoaded<association :author is not loaded>"
   end
 
   test "has_one association via {source, schema}" do
-    struct =
-      %Ecto.Association.Has{field: :profile, owner: AssocSchema, cardinality: :one, on_delete: :nothing,
-                            related: Profile, owner_key: :id, related_key: :assoc_schema_id,
-                            queryable: {"users_profiles", Profile}, on_replace: :raise}
+    struct = %Ecto.Association.Has{
+      field: :profile,
+      owner: AssocSchema,
+      cardinality: :one,
+      on_delete: :nothing,
+      related: Profile,
+      owner_key: :id,
+      related_key: :assoc_schema_id,
+      queryable: {"users_profiles", Profile},
+      on_replace: :raise
+    }
 
     assert AssocSchema.__schema__(:association, :profile) == struct
     assert AssocSchema.__changeset__().profile == {:assoc, struct}
 
-    author = (%AssocSchema{}).author
+    author = %AssocSchema{}.author
     assert %Ecto.Association.NotLoaded{__cardinality__: :one} = author
     assert inspect(author) == "#Ecto.Association.NotLoaded<association :author is not loaded>"
   end
 
   test "has_one through association" do
     assert AssocSchema.__schema__(:association, :comment_main_author) ==
-           %Ecto.Association.HasThrough{field: :comment_main_author, owner: AssocSchema, cardinality: :one,
-                                         through: [:comment, :main_author], owner_key: :comment_id}
+             %Ecto.Association.HasThrough{
+               field: :comment_main_author,
+               owner: AssocSchema,
+               cardinality: :one,
+               through: [:comment, :main_author],
+               owner_key: :comment_id
+             }
 
     refute Map.has_key?(AssocSchema.__changeset__(), :comment_main_author)
 
-    author = (%AssocSchema{}).comment_main_author
+    author = %AssocSchema{}.comment_main_author
     assert %Ecto.Association.NotLoaded{} = author
-    assert inspect(author) == "#Ecto.Association.NotLoaded<association :comment_main_author is not loaded>"
+
+    assert inspect(author) ==
+             "#Ecto.Association.NotLoaded<association :comment_main_author is not loaded>"
   end
 
   test "belongs_to association" do
-    struct =
-      %Ecto.Association.BelongsTo{field: :comment, owner: AssocSchema, cardinality: :one,
-       related: Comment, owner_key: :comment_id, related_key: :id, queryable: Comment,
-       on_replace: :raise, defaults: []}
+    struct = %Ecto.Association.BelongsTo{
+      field: :comment,
+      owner: AssocSchema,
+      cardinality: :one,
+      related: Comment,
+      owner_key: :comment_id,
+      related_key: :id,
+      queryable: Comment,
+      on_replace: :raise,
+      defaults: []
+    }
 
     assert AssocSchema.__schema__(:association, :comment) == struct
     assert AssocSchema.__changeset__().comment == {:assoc, struct}
 
-    comment = (%AssocSchema{}).comment
+    comment = %AssocSchema{}.comment
     assert %Ecto.Association.NotLoaded{} = comment
     assert inspect(comment) == "#Ecto.Association.NotLoaded<association :comment is not loaded>"
   end
 
   test "belongs_to association via {source, schema}" do
-    struct =
-      %Ecto.Association.BelongsTo{field: :summary, owner: AssocSchema, cardinality: :one,
-       related: Summary, owner_key: :summary_id, related_key: :id,
-       queryable: {"post_summary", Summary}, on_replace: :raise, defaults: []}
+    struct = %Ecto.Association.BelongsTo{
+      field: :summary,
+      owner: AssocSchema,
+      cardinality: :one,
+      related: Summary,
+      owner_key: :summary_id,
+      related_key: :id,
+      queryable: {"post_summary", Summary},
+      on_replace: :raise,
+      defaults: []
+    }
 
     assert AssocSchema.__schema__(:association, :summary) == struct
     assert AssocSchema.__changeset__().summary == {:assoc, struct}
 
-    comment = (%AssocSchema{}).comment
+    comment = %AssocSchema{}.comment
     assert %Ecto.Association.NotLoaded{} = comment
     assert inspect(comment) == "#Ecto.Association.NotLoaded<association :comment is not loaded>"
   end
 
   test "belongs_to association via Ecto.ParameterizedType" do
-    struct =
-      %Ecto.Association.BelongsTo{field: :reference, owner: AssocSchema, cardinality: :one,
-       related: SchemaWithParameterizedPrimaryKey, owner_key: :reference_id, related_key: :id, queryable: SchemaWithParameterizedPrimaryKey,
-       on_replace: :raise, defaults: []}
+    struct = %Ecto.Association.BelongsTo{
+      field: :reference,
+      owner: AssocSchema,
+      cardinality: :one,
+      related: SchemaWithParameterizedPrimaryKey,
+      owner_key: :reference_id,
+      related_key: :id,
+      queryable: SchemaWithParameterizedPrimaryKey,
+      on_replace: :raise,
+      defaults: []
+    }
 
     assert AssocSchema.__schema__(:association, :reference) == struct
     assert AssocSchema.__changeset__().reference == {:assoc, struct}
 
-    reference = (%AssocSchema{}).reference
+    reference = %AssocSchema{}.reference
     assert %Ecto.Association.NotLoaded{} = reference
-    assert inspect(reference) == "#Ecto.Association.NotLoaded<association :reference is not loaded>"
+
+    assert inspect(reference) ==
+             "#Ecto.Association.NotLoaded<association :reference is not loaded>"
   end
 
   defmodule CustomAssocSchema do
@@ -754,6 +866,7 @@ defmodule Ecto.SchemaTest do
 
   test "has_* references option has to match a field on schema" do
     message = ~r"schema does not have the field :pk used by association :posts"
+
     assert_raise ArgumentError, message, fn ->
       defmodule PkAssocMisMatch do
         use Ecto.Schema
@@ -767,6 +880,7 @@ defmodule Ecto.SchemaTest do
 
   test "has_* expects a queryable" do
     message = ~r"association :posts queryable must be a schema or a {source, schema}. got: 123"
+
     assert_raise ArgumentError, message, fn ->
       defmodule QueryableMisMatch do
         use Ecto.Schema
@@ -802,6 +916,7 @@ defmodule Ecto.SchemaTest do
 
   test "has_* through has to match an association on schema" do
     message = ~r"schema does not have the association :whatever used by association :posts"
+
     assert_raise ArgumentError, message, fn ->
       defmodule PkAssocMisMatch do
         use Ecto.Schema
@@ -814,7 +929,9 @@ defmodule Ecto.SchemaTest do
   end
 
   test "has_* through with schema" do
-    message = ~r"When using the :through option, the schema should not be passed as second argument"
+    message =
+      ~r"When using the :through option, the schema should not be passed as second argument"
+
     assert_raise ArgumentError, message, fn ->
       defmodule ThroughMatch do
         use Ecto.Schema
@@ -829,6 +946,7 @@ defmodule Ecto.SchemaTest do
   test "belongs_to raises helpful error with redundant foreign key name" do
     name = :author
     message = ~r"foreign_key :#{name} must be distinct from corresponding association name"
+
     assert_raise ArgumentError, message, fn ->
       defmodule SchemaBadForeignKey do
         use Ecto.Schema
@@ -854,6 +972,7 @@ defmodule Ecto.SchemaTest do
       end
     end
     """
+
     message = "schema already defined for DoubleSchema on line 4"
 
     assert_raise RuntimeError, message, fn ->
@@ -901,7 +1020,9 @@ defmodule Ecto.SchemaTest do
 
   describe "preload_order option" do
     test "invalid option" do
-      message = "expected `:preload_order` for :posts to be a keyword list or a list of atoms/fields, got: `:title`"
+      message =
+        "expected `:preload_order` for :posts to be a keyword list or a list of atoms/fields, got: `:title`"
+
       assert_raise ArgumentError, message, fn ->
         defmodule ThroughMatch do
           use Ecto.Schema
@@ -914,8 +1035,10 @@ defmodule Ecto.SchemaTest do
     end
 
     test "invalid direction" do
-      message = "expected `:preload_order` for :posts to be a keyword list or a list of atoms/fields, " <>
-                  "got: `[invalid_direction: :title]`, `:invalid_direction` is not a valid direction"
+      message =
+        "expected `:preload_order` for :posts to be a keyword list or a list of atoms/fields, " <>
+          "got: `[invalid_direction: :title]`, `:invalid_direction` is not a valid direction"
+
       assert_raise ArgumentError, message, fn ->
         defmodule ThroughMatch do
           use Ecto.Schema
@@ -928,8 +1051,10 @@ defmodule Ecto.SchemaTest do
     end
 
     test "invalid item" do
-      message = "expected `:preload_order` for :posts to be a keyword list or a list of atoms/fields, " <>
-                  "got: `[\"text\"]`, `\"text\"` is not valid"
+      message =
+        "expected `:preload_order` for :posts to be a keyword list or a list of atoms/fields, " <>
+          "got: `[\"text\"]`, `\"text\"` is not valid"
+
       assert_raise ArgumentError, message, fn ->
         defmodule ThroughMatch do
           use Ecto.Schema

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -3,10 +3,10 @@ defmodule Ecto.TypeTest do
 
   defmodule Custom do
     use Ecto.Type
-    def type,      do: :custom
-    def load(_),   do: {:ok, :load}
-    def dump(_),   do: {:ok, :dump}
-    def cast(_),   do: {:ok, :cast}
+    def type, do: :custom
+    def load(_), do: {:ok, :load}
+    def dump(_), do: {:ok, :dump}
+    def cast(_), do: {:ok, :cast}
     def equal?(true, _), do: true
     def equal?(_, _), do: false
     def embed_as(_), do: :dump
@@ -14,10 +14,10 @@ defmodule Ecto.TypeTest do
 
   defmodule CustomAny do
     use Ecto.Type
-    def type,      do: :any
-    def load(_),   do: {:ok, :load}
-    def dump(_),   do: {:ok, :dump}
-    def cast(_),   do: {:ok, :cast}
+    def type, do: :any
+    def load(_), do: {:ok, :load}
+    def dump(_), do: {:ok, :dump}
+    def cast(_), do: {:ok, :cast}
   end
 
   defmodule Schema do
@@ -89,9 +89,14 @@ defmodule Ecto.TypeTest do
     assert dump({:map, :integer}, %{"a" => 1, "b" => nil}) == {:ok, %{"a" => 1, "b" => nil}}
     assert cast({:map, :integer}, %{"a" => "1", "b" => nil}) == {:ok, %{"a" => 1, "b" => nil}}
 
-    assert load({:map, {:array, :integer}}, %{"a" => [0, 0], "b" => [1, 1]}) == {:ok, %{"a" => [0, 0], "b" => [1, 1]}}
-    assert dump({:map, {:array, :integer}}, %{"a" => [0, 0], "b" => [1, 1]}) == {:ok, %{"a" => [0, 0], "b" => [1, 1]}}
-    assert cast({:map, {:array, :integer}}, %{"a" => [0, 0], "b" => [1, 1]}) == {:ok, %{"a" => [0, 0], "b" => [1, 1]}}
+    assert load({:map, {:array, :integer}}, %{"a" => [0, 0], "b" => [1, 1]}) ==
+             {:ok, %{"a" => [0, 0], "b" => [1, 1]}}
+
+    assert dump({:map, {:array, :integer}}, %{"a" => [0, 0], "b" => [1, 1]}) ==
+             {:ok, %{"a" => [0, 0], "b" => [1, 1]}}
+
+    assert cast({:map, {:array, :integer}}, %{"a" => [0, 0], "b" => [1, 1]}) ==
+             {:ok, %{"a" => [0, 0], "b" => [1, 1]}}
 
     assert load({:map, :integer}, %{"a" => ""}) == :error
     assert dump({:map, :integer}, %{"a" => ""}) == :error
@@ -151,8 +156,11 @@ defmodule Ecto.TypeTest do
     assert dump({:map, Custom}, 1) == :error
     assert cast({:map, Custom}, 1) == :error
 
-    assert load({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) == {:ok, %{"a" => :used}}
-    assert dump({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) == {:ok, %{"a" => :used}}
+    assert load({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) ==
+             {:ok, %{"a" => :used}}
+
+    assert dump({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) ==
+             {:ok, %{"a" => :used}}
   end
 
   test "dump with custom function" do
@@ -233,17 +241,18 @@ defmodule Ecto.TypeTest do
     @uuid_binary <<191, 224, 136, 140, 92, 89, 75, 179, 173, 253, 113, 240, 184, 93, 61, 183>>
 
     test "one" do
-      embed = %Ecto.Embedded{field: :embed, cardinality: :one,
-                             owner: __MODULE__, related: Schema}
-      type  = {:parameterized, Ecto.Embedded, embed}
+      embed = %Ecto.Embedded{field: :embed, cardinality: :one, owner: __MODULE__, related: Schema}
+      type = {:parameterized, Ecto.Embedded, embed}
 
       assert {:ok, %Schema{id: @uuid_string, a: 1, c: 0}} =
-             adapter_load(Ecto.TestAdapter, type, %{"id" => @uuid_binary, "abc" => 1})
+               adapter_load(Ecto.TestAdapter, type, %{"id" => @uuid_binary, "abc" => 1})
+
       assert {:ok, nil} == adapter_load(Ecto.TestAdapter, type, nil)
       assert :error == adapter_load(Ecto.TestAdapter, type, 1)
 
       assert {:ok, %{abc: 1, c: 0, id: @uuid_binary}} ==
-             adapter_dump(Ecto.TestAdapter, type, %Schema{id: @uuid_string, a: 1})
+               adapter_dump(Ecto.TestAdapter, type, %Schema{id: @uuid_string, a: 1})
+
       assert {:ok, nil} = adapter_dump(Ecto.TestAdapter, type, nil)
       assert :error = adapter_dump(Ecto.TestAdapter, type, 1)
 
@@ -253,17 +262,24 @@ defmodule Ecto.TypeTest do
     end
 
     test "many" do
-      embed = %Ecto.Embedded{field: :embed, cardinality: :many,
-                             owner: __MODULE__, related: Schema}
-      type  = {:parameterized, Ecto.Embedded, embed}
+      embed = %Ecto.Embedded{
+        field: :embed,
+        cardinality: :many,
+        owner: __MODULE__,
+        related: Schema
+      }
+
+      type = {:parameterized, Ecto.Embedded, embed}
 
       assert {:ok, [%Schema{id: @uuid_string, a: 1, c: 0}]} =
-             adapter_load(Ecto.TestAdapter, type, [%{"id" => @uuid_binary, "abc" => 1}])
+               adapter_load(Ecto.TestAdapter, type, [%{"id" => @uuid_binary, "abc" => 1}])
+
       assert {:ok, []} == adapter_load(Ecto.TestAdapter, type, nil)
       assert :error == adapter_load(Ecto.TestAdapter, type, 1)
 
       assert {:ok, [%{id: @uuid_binary, abc: 1, c: 0}]} ==
-             adapter_dump(Ecto.TestAdapter, type, [%Schema{id: @uuid_string, a: 1}])
+               adapter_dump(Ecto.TestAdapter, type, [%Schema{id: @uuid_string, a: 1}])
+
       assert {:ok, nil} = adapter_dump(Ecto.TestAdapter, type, nil)
       assert :error = adapter_dump(Ecto.TestAdapter, type, 1)
 
@@ -291,32 +307,43 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.cast(:date, "1900-02-29") == :error
 
       assert Ecto.Type.cast(:date, %{"year" => "2015", "month" => "12", "day" => "31"}) ==
-             {:ok, @date}
+               {:ok, @date}
+
       assert Ecto.Type.cast(:date, %{year: 2015, month: 12, day: 31}) ==
-             {:ok, @date}
+               {:ok, @date}
+
       assert Ecto.Type.cast(:date, %{"year" => "", "month" => "", "day" => ""}) ==
-             {:ok, nil}
+               {:ok, nil}
+
       assert Ecto.Type.cast(:date, %{year: nil, month: nil, day: nil}) ==
-             {:ok, nil}
+               {:ok, nil}
+
       assert Ecto.Type.cast(:date, %{"year" => "2015", "month" => "", "day" => "31"}) ==
-             :error
+               :error
+
       assert Ecto.Type.cast(:date, %{"year" => "2015", "month" => nil, "day" => "31"}) ==
-             :error
+               :error
+
       assert Ecto.Type.cast(:date, %{"year" => "2015", "month" => nil}) ==
-             :error
+               :error
+
       assert Ecto.Type.cast(:date, %{"year" => "", "month" => "01", "day" => "30"}) ==
-             :error
+               :error
+
       assert Ecto.Type.cast(:date, %{"year" => nil, "month" => "01", "day" => "30"}) ==
-             :error
+               :error
 
       assert Ecto.Type.cast(:date, DateTime.from_unix!(10)) ==
-             {:ok, @date_unix_epoch}
+               {:ok, @date_unix_epoch}
+
       assert Ecto.Type.cast(:date, ~N[1970-01-01 12:23:34]) ==
-             {:ok, @date_unix_epoch}
+               {:ok, @date_unix_epoch}
+
       assert Ecto.Type.cast(:date, @date) ==
-             {:ok, @date}
+               {:ok, @date}
+
       assert Ecto.Type.cast(:date, ~T[12:23:34]) ==
-             :error
+               :error
 
       assert Ecto.Type.cast(:date, "2015-12-31T00:00:00") == {:ok, @date}
       assert Ecto.Type.cast(:date, "2015-12-31 00:00:00") == {:ok, @date}
@@ -325,13 +352,13 @@ defmodule Ecto.TypeTest do
     test "dump" do
       assert Ecto.Type.dump(:date, @date) == {:ok, @date}
       assert Ecto.Type.dump(:date, @leap_date) == {:ok, @leap_date}
-      assert Ecto.Type.dump(:date, @date_unix_epoch) ==  {:ok, @date_unix_epoch}
+      assert Ecto.Type.dump(:date, @date_unix_epoch) == {:ok, @date_unix_epoch}
     end
 
     test "load" do
       assert Ecto.Type.load(:date, @date) == {:ok, @date}
       assert Ecto.Type.load(:date, @leap_date) == {:ok, @leap_date}
-      assert Ecto.Type.load(:date, @date_unix_epoch) ==  {:ok, @date_unix_epoch}
+      assert Ecto.Type.load(:date, @date_unix_epoch) == {:ok, @date_unix_epoch}
     end
   end
 
@@ -344,7 +371,7 @@ defmodule Ecto.TypeTest do
     test "cast" do
       assert Ecto.Type.cast(:time, @time) == {:ok, @time}
       assert Ecto.Type.cast(:time, @time_usec) == {:ok, @time}
-      assert Ecto.Type.cast(:time, @time_zero) ==  {:ok, @time_zero}
+      assert Ecto.Type.cast(:time, @time_zero) == {:ok, @time_zero}
 
       assert Ecto.Type.cast(:time, "23:50") == {:ok, @time_zero}
       assert Ecto.Type.cast(:time, "23:50:07") == {:ok, @time}
@@ -363,35 +390,50 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.cast(:time, "00:00:00.A00") == :error
 
       assert Ecto.Type.cast(:time, %{"hour" => "23", "minute" => "50", "second" => "07"}) ==
-             {:ok, @time}
+               {:ok, @time}
+
       assert Ecto.Type.cast(:time, %{hour: 23, minute: 50, second: 07}) ==
-             {:ok, @time}
+               {:ok, @time}
+
       assert Ecto.Type.cast(:time, %{"hour" => "", "minute" => ""}) ==
-             {:ok, nil}
+               {:ok, nil}
+
       assert Ecto.Type.cast(:time, %{hour: nil, minute: nil}) ==
-             {:ok, nil}
+               {:ok, nil}
+
       assert Ecto.Type.cast(:time, %{"hour" => "23", "minute" => "50"}) ==
-             {:ok, @time_zero}
+               {:ok, @time_zero}
+
       assert Ecto.Type.cast(:time, %{hour: 23, minute: 50}) ==
-             {:ok, @time_zero}
+               {:ok, @time_zero}
+
       assert Ecto.Type.cast(:time, %{hour: 23, minute: 50, second: 07, microsecond: 30_000}) ==
-             {:ok, @time}
-      assert Ecto.Type.cast(:time, %{"hour" => 23, "minute" => 50, "second" => 07, "microsecond" => 30_000}) ==
-             {:ok, @time}
+               {:ok, @time}
+
+      assert Ecto.Type.cast(:time, %{
+               "hour" => 23,
+               "minute" => 50,
+               "second" => 07,
+               "microsecond" => 30_000
+             }) ==
+               {:ok, @time}
+
       assert Ecto.Type.cast(:time, %{"hour" => "", "minute" => "50"}) ==
-             :error
+               :error
+
       assert Ecto.Type.cast(:time, %{hour: 23, minute: nil}) ==
-             :error
+               :error
 
       assert Ecto.Type.cast(:time, ~N[2016-11-11 23:30:10]) ==
-             {:ok, ~T[23:30:10]}
+               {:ok, ~T[23:30:10]}
+
       assert Ecto.Type.cast(:time, ~D[2016-11-11]) ==
-             :error
+               :error
     end
 
     test "dump" do
       assert Ecto.Type.dump(:time, @time) == {:ok, @time}
-      assert Ecto.Type.dump(:time, @time_zero) ==  {:ok, @time_zero}
+      assert Ecto.Type.dump(:time, @time_zero) == {:ok, @time_zero}
 
       assert_raise ArgumentError, ~r":time expects microseconds to be empty", fn ->
         Ecto.Type.dump(:time, @time_usec)
@@ -401,14 +443,14 @@ defmodule Ecto.TypeTest do
     test "load" do
       assert Ecto.Type.load(:time, @time) == {:ok, @time}
       assert Ecto.Type.load(:time, @time_usec) == {:ok, @time}
-      assert Ecto.Type.load(:time, @time_zero) ==  {:ok, @time_zero}
+      assert Ecto.Type.load(:time, @time_zero) == {:ok, @time_zero}
     end
   end
 
   describe "time_usec" do
     test "cast from Time" do
       assert Ecto.Type.cast(:time_usec, @time_usec) == {:ok, @time_usec}
-      assert Ecto.Type.cast(:time_usec, @time_zero) ==  {:ok, @time_zero_usec}
+      assert Ecto.Type.cast(:time_usec, @time_zero) == {:ok, @time_zero_usec}
     end
 
     test "cast from binary" do
@@ -427,14 +469,30 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast from map" do
-      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50", "second" => "00"}) == {:ok, @time_zero_usec}
-      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 0}) == {:ok, @time_zero_usec}
+      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50", "second" => "00"}) ==
+               {:ok, @time_zero_usec}
+
+      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 0}) ==
+               {:ok, @time_zero_usec}
+
       assert Ecto.Type.cast(:time_usec, %{"hour" => "", "minute" => ""}) == {:ok, nil}
       assert Ecto.Type.cast(:time_usec, %{hour: nil, minute: nil}) == {:ok, nil}
-      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50"}) == {:ok, @time_zero_usec}
+
+      assert Ecto.Type.cast(:time_usec, %{"hour" => "23", "minute" => "50"}) ==
+               {:ok, @time_zero_usec}
+
       assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50}) == {:ok, @time_zero_usec}
-      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 07, microsecond: 30_000}) == {:ok, @time_usec}
-      assert Ecto.Type.cast(:time_usec, %{"hour" => 23, "minute" => 50, "second" => 07, "microsecond" => 30_000}) == {:ok, @time_usec}
+
+      assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: 50, second: 07, microsecond: 30_000}) ==
+               {:ok, @time_usec}
+
+      assert Ecto.Type.cast(:time_usec, %{
+               "hour" => 23,
+               "minute" => 50,
+               "second" => 07,
+               "microsecond" => 30_000
+             }) == {:ok, @time_usec}
+
       assert Ecto.Type.cast(:time_usec, %{"hour" => "", "minute" => "50"}) == :error
       assert Ecto.Type.cast(:time_usec, %{hour: 23, minute: nil}) == :error
     end
@@ -462,7 +520,7 @@ defmodule Ecto.TypeTest do
 
     test "load" do
       assert Ecto.Type.load(:time_usec, @time_usec) == {:ok, @time_usec}
-      assert Ecto.Type.load(:time_usec, @time_zero) ==  {:ok, @time_zero_usec}
+      assert Ecto.Type.load(:time_usec, @time_zero) == {:ok, @time_zero_usec}
     end
   end
 
@@ -492,59 +550,142 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.cast(:naive_datetime, "2015-01-23 23:50.123") == :error
       assert Ecto.Type.cast(:naive_datetime, "2015-01-23 23:50Z") == :error
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                               "hour" => "23", "minute" => "50", "second" => "07"}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "23",
+               "minute" => "50",
+               "second" => "07"
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 07
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => "", "month" => "", "day" => "",
-                                               "hour" => "", "minute" => ""}) ==
-             {:ok, nil}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => "",
+               "month" => "",
+               "day" => "",
+               "hour" => "",
+               "minute" => ""
+             }) ==
+               {:ok, nil}
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: nil, month: nil, day: nil, hour: nil, minute: nil}) ==
-             {:ok, nil}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: nil,
+               month: nil,
+               day: nil,
+               hour: nil,
+               minute: nil
+             }) ==
+               {:ok, nil}
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                               "hour" => "23", "minute" => "50"}) ==
-             {:ok, @datetime_zero}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "23",
+               "minute" => "50"
+             }) ==
+               {:ok, @datetime_zero}
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: 50}) ==
-             {:ok, @datetime_zero}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: 23,
+               minute: 50
+             }) ==
+               {:ok, @datetime_zero}
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: 2015, month: 1, day: 23, hour: 23,
-                                               minute: 50, second: 07, microsecond: 8_000}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 07,
+               microsecond: 8_000
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => 2015, "month" => 1, "day" => 23,
-                                               "hour" => 23, "minute" => 50, "second" => 07,
-                                               "microsecond" => 8_000}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => 2015,
+               "month" => 1,
+               "day" => 23,
+               "hour" => 23,
+               "minute" => 50,
+               "second" => 07,
+               "microsecond" => 8_000
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                               "hour" => "", "minute" => "50"}) ==
-             :error
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "",
+               "minute" => "50"
+             }) ==
+               :error
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: nil}) ==
-             :error
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: 23,
+               minute: nil
+             }) ==
+               :error
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => "", "month" => "", "day" => "",
-                                               "hour" => "23", "minute" => "50", "second" => "07"}) ==
-             :error
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => "",
+               "month" => "",
+               "day" => "",
+               "hour" => "23",
+               "minute" => "50",
+               "second" => "07"
+             }) ==
+               :error
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: nil, month: nil, day: nil, hour: 23, minute: 50, second: 07}) ==
-             :error
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: nil,
+               month: nil,
+               day: nil,
+               hour: 23,
+               minute: 50,
+               second: 07
+             }) ==
+               :error
 
-      assert Ecto.Type.cast(:naive_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                               "hour" => "", "minute" => ""}) ==
-             :error
+      assert Ecto.Type.cast(:naive_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "",
+               "minute" => ""
+             }) ==
+               :error
 
-      assert Ecto.Type.cast(:naive_datetime, %{year: 2015, month: 1, day: 23, hour: nil, minute: nil}) ==
-             :error
+      assert Ecto.Type.cast(:naive_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: nil,
+               minute: nil
+             }) ==
+               :error
 
       assert Ecto.Type.cast(:naive_datetime, DateTime.from_unix!(10, :second)) ==
-             {:ok, ~N[1970-01-01 00:00:10]}
+               {:ok, ~N[1970-01-01 00:00:10]}
 
       assert Ecto.Type.cast(:naive_datetime, @time) == :error
       assert Ecto.Type.cast(:naive_datetime, 1) == :error
@@ -578,13 +719,16 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.load(:naive_datetime, @datetime_leapyear) == {:ok, @datetime_leapyear}
 
       assert Ecto.Type.load(:naive_datetime, DateTime.from_naive!(@datetime, "Etc/UTC")) ==
-             {:ok, @datetime}
+               {:ok, @datetime}
+
       assert Ecto.Type.load(:naive_datetime, DateTime.from_naive!(@datetime_zero, "Etc/UTC")) ==
-             {:ok, @datetime_zero}
+               {:ok, @datetime_zero}
+
       assert Ecto.Type.load(:naive_datetime, DateTime.from_naive!(@datetime_usec, "Etc/UTC")) ==
-             {:ok, @datetime}
+               {:ok, @datetime}
+
       assert Ecto.Type.load(:naive_datetime, DateTime.from_naive!(@datetime_leapyear, "Etc/UTC")) ==
-             {:ok, @datetime_leapyear}
+               {:ok, @datetime_leapyear}
     end
   end
 
@@ -592,22 +736,43 @@ defmodule Ecto.TypeTest do
     test "cast from NaiveDateTime" do
       assert Ecto.Type.cast(:naive_datetime_usec, @datetime_zero) == {:ok, @datetime_zero_usec}
       assert Ecto.Type.cast(:naive_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, @datetime_leapyear) == {:ok, @datetime_leapyear_usec}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, @datetime_leapyear) ==
+               {:ok, @datetime_leapyear_usec}
     end
 
     test "cast from binary" do
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23 23:50:00") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:00") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:00Z") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2000-02-29T23:50:07") == {:ok, @datetime_leapyear_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07.008000") == {:ok, @datetime_usec}
-      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07.008000Z") == {:ok, @datetime_usec}
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23 23:50:00") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:00") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:00Z") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, "2000-02-29T23:50:07") ==
+               {:ok, @datetime_leapyear_usec}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07.008000") ==
+               {:ok, @datetime_usec}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23T23:50:07.008000Z") ==
+               {:ok, @datetime_usec}
 
       assert Ecto.Type.cast(:naive_datetime_usec, "2015-01-23P23:50:07") == :error
     end
 
     test "cast from map" do
-      term = %{"year" => "2015", "month" => "1", "day" => "23", "hour" => "23", "minute" => "50", "second" => "00"}
+      term = %{
+        "year" => "2015",
+        "month" => "1",
+        "day" => "23",
+        "hour" => "23",
+        "minute" => "50",
+        "second" => "00"
+      }
+
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 0}
@@ -625,19 +790,38 @@ defmodule Ecto.TypeTest do
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50}
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
-      term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07, microsecond: 8_000}
+      term = %{
+        year: 2015,
+        month: 1,
+        day: 23,
+        hour: 23,
+        minute: 50,
+        second: 07,
+        microsecond: 8_000
+      }
+
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_usec}
 
       term = %{
-        "year" => 2015, "month" => 1, "day" => 23,
-        "hour" => 23, "minute" => 50, "second" => 07, "microsecond" => 8_000
+        "year" => 2015,
+        "month" => 1,
+        "day" => 23,
+        "hour" => 23,
+        "minute" => 50,
+        "second" => 07,
+        "microsecond" => 8_000
       }
+
       assert Ecto.Type.cast(:naive_datetime_usec, term) == {:ok, @datetime_usec}
 
       term = %{
-        "year" => "2015", "month" => "1", "day" => "23",
-        "hour" => "", "minute" => "50"
+        "year" => "2015",
+        "month" => "1",
+        "day" => "23",
+        "hour" => "",
+        "minute" => "50"
       }
+
       assert Ecto.Type.cast(:naive_datetime_usec, term) == :error
 
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: nil}
@@ -645,7 +829,8 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast from DateTime" do
-      assert Ecto.Type.cast(:naive_datetime_usec, DateTime.from_unix!(10, :second)) == {:ok, ~N[1970-01-01 00:00:10.000000]}
+      assert Ecto.Type.cast(:naive_datetime_usec, DateTime.from_unix!(10, :second)) ==
+               {:ok, ~N[1970-01-01 00:00:10.000000]}
     end
 
     test "cast from Time" do
@@ -658,7 +843,9 @@ defmodule Ecto.TypeTest do
 
     test "dump" do
       assert Ecto.Type.dump(:naive_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.dump(:naive_datetime_usec, @datetime_leapyear_usec) == {:ok, @datetime_leapyear_usec}
+
+      assert Ecto.Type.dump(:naive_datetime_usec, @datetime_leapyear_usec) ==
+               {:ok, @datetime_leapyear_usec}
 
       assert_raise ArgumentError, ~r":naive_datetime_usec expects microsecond precision", fn ->
         Ecto.Type.dump(:naive_datetime_usec, @datetime)
@@ -667,14 +854,16 @@ defmodule Ecto.TypeTest do
 
     test "load" do
       assert Ecto.Type.load(:naive_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.load(:naive_datetime_usec, @datetime_leapyear_usec) == {:ok, @datetime_leapyear_usec}
+
+      assert Ecto.Type.load(:naive_datetime_usec, @datetime_leapyear_usec) ==
+               {:ok, @datetime_leapyear_usec}
     end
   end
 
-  @datetime DateTime.from_unix!(1422057007, :second)
-  @datetime_zero DateTime.from_unix!(1422057000, :second)
-  @datetime_zero_usec DateTime.from_unix!(1422057000000000, :microsecond)
-  @datetime_usec DateTime.from_unix!(1422057007008000, :microsecond)
+  @datetime DateTime.from_unix!(1_422_057_007, :second)
+  @datetime_zero DateTime.from_unix!(1_422_057_000, :second)
+  @datetime_zero_usec DateTime.from_unix!(1_422_057_000_000_000, :microsecond)
+  @datetime_usec DateTime.from_unix!(1_422_057_007_008_000, :microsecond)
   @datetime_usec_tz %DateTime{
     calendar: Calendar.ISO,
     day: 24,
@@ -689,8 +878,8 @@ defmodule Ecto.TypeTest do
     year: 2015,
     zone_abbr: "CET"
   }
-  @datetime_leapyear DateTime.from_unix!(951868207, :second)
-  @datetime_leapyear_usec DateTime.from_unix!(951868207008000, :microsecond)
+  @datetime_leapyear DateTime.from_unix!(951_868_207, :second)
+  @datetime_leapyear_usec DateTime.from_unix!(951_868_207_008_000, :microsecond)
 
   describe "utc_datetime" do
     test "cast" do
@@ -713,48 +902,105 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.cast(:utc_datetime, "2015-01-23 23:50.123") == :error
       assert Ecto.Type.cast(:utc_datetime, "2015-01-23 23:50Z") == :error
 
-      assert Ecto.Type.cast(:utc_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                             "hour" => "23", "minute" => "50", "second" => "07"}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "23",
+               "minute" => "50",
+               "second" => "07"
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:utc_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 07
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:utc_datetime, %DateTime{calendar: Calendar.ISO, year: 2015, month: 1, day: 24,
-                                                     hour: 9, minute: 50, second: 7, microsecond: {0, 0},
-                                                     std_offset: 0, utc_offset: 36000,
-                                                     time_zone: "Etc/GMT-10", zone_abbr: "+10"}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:utc_datetime, %DateTime{
+               calendar: Calendar.ISO,
+               year: 2015,
+               month: 1,
+               day: 24,
+               hour: 9,
+               minute: 50,
+               second: 7,
+               microsecond: {0, 0},
+               std_offset: 0,
+               utc_offset: 36000,
+               time_zone: "Etc/GMT-10",
+               zone_abbr: "+10"
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:utc_datetime, %{"year" => "", "month" => "", "day" => "",
-                                             "hour" => "", "minute" => ""}) ==
-             {:ok, nil}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               "year" => "",
+               "month" => "",
+               "day" => "",
+               "hour" => "",
+               "minute" => ""
+             }) ==
+               {:ok, nil}
 
-      assert Ecto.Type.cast(:utc_datetime, %{year: nil, month: nil, day: nil, hour: nil, minute: nil}) ==
-             {:ok, nil}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               year: nil,
+               month: nil,
+               day: nil,
+               hour: nil,
+               minute: nil
+             }) ==
+               {:ok, nil}
 
-      assert Ecto.Type.cast(:utc_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                             "hour" => "23", "minute" => "50"}) ==
-             {:ok, @datetime_zero}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "23",
+               "minute" => "50"
+             }) ==
+               {:ok, @datetime_zero}
 
       assert Ecto.Type.cast(:utc_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: 50}) ==
-             {:ok, @datetime_zero}
+               {:ok, @datetime_zero}
 
-      assert Ecto.Type.cast(:utc_datetime, %{year: 2015, month: 1, day: 23, hour: 23,
-                                               minute: 50, second: 07, microsecond: 8_000}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               year: 2015,
+               month: 1,
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 07,
+               microsecond: 8_000
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:utc_datetime, %{"year" => 2015, "month" => 1, "day" => 23,
-                                             "hour" => 23, "minute" => 50, "second" => 07,
-                                             "microsecond" => 8_000}) ==
-             {:ok, @datetime}
+      assert Ecto.Type.cast(:utc_datetime, %{
+               "year" => 2015,
+               "month" => 1,
+               "day" => 23,
+               "hour" => 23,
+               "minute" => 50,
+               "second" => 07,
+               "microsecond" => 8_000
+             }) ==
+               {:ok, @datetime}
 
-      assert Ecto.Type.cast(:utc_datetime, %{"year" => "2015", "month" => "1", "day" => "23",
-                                             "hour" => "", "minute" => "50"}) ==
-             :error
+      assert Ecto.Type.cast(:utc_datetime, %{
+               "year" => "2015",
+               "month" => "1",
+               "day" => "23",
+               "hour" => "",
+               "minute" => "50"
+             }) ==
+               :error
 
       assert Ecto.Type.cast(:utc_datetime, %{year: 2015, month: 1, day: 23, hour: 23, minute: nil}) ==
-             :error
+               :error
 
       assert Ecto.Type.cast(:utc_datetime, ~T[12:23:34]) == :error
       assert Ecto.Type.cast(:utc_datetime, 1) == :error
@@ -772,9 +1018,14 @@ defmodule Ecto.TypeTest do
     end
 
     test "dump" do
-      assert Ecto.Type.dump(:utc_datetime, @datetime) == DateTime.from_naive(~N[2015-01-23 23:50:07], "Etc/UTC")
-      assert Ecto.Type.dump(:utc_datetime, @datetime_zero) == DateTime.from_naive(~N[2015-01-23 23:50:00], "Etc/UTC")
-      assert Ecto.Type.dump(:utc_datetime, @datetime_leapyear) == DateTime.from_naive(~N[2000-02-29 23:50:07], "Etc/UTC")
+      assert Ecto.Type.dump(:utc_datetime, @datetime) ==
+               DateTime.from_naive(~N[2015-01-23 23:50:07], "Etc/UTC")
+
+      assert Ecto.Type.dump(:utc_datetime, @datetime_zero) ==
+               DateTime.from_naive(~N[2015-01-23 23:50:00], "Etc/UTC")
+
+      assert Ecto.Type.dump(:utc_datetime, @datetime_leapyear) ==
+               DateTime.from_naive(~N[2000-02-29 23:50:07], "Etc/UTC")
 
       assert_raise ArgumentError, ~r":utc_datetime expects microseconds to be empty", fn ->
         Ecto.Type.dump(:utc_datetime, @datetime_usec)
@@ -801,42 +1052,80 @@ defmodule Ecto.TypeTest do
     end
 
     test "cast from binary" do
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23 23:50:00") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:00") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:00Z") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-24T09:50:00+10:00") == {:ok, @datetime_zero_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:07.008000") == {:ok, @datetime_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:07.008000Z") == {:ok, @datetime_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T17:50:07.008000-06:00") == {:ok, @datetime_usec}
-      assert Ecto.Type.cast(:utc_datetime_usec, "2000-02-29T23:50:07.008") == {:ok, @datetime_leapyear_usec}
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23 23:50:00") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:00") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:00Z") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-24T09:50:00+10:00") ==
+               {:ok, @datetime_zero_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:07.008000") ==
+               {:ok, @datetime_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T23:50:07.008000Z") ==
+               {:ok, @datetime_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23T17:50:07.008000-06:00") ==
+               {:ok, @datetime_usec}
+
+      assert Ecto.Type.cast(:utc_datetime_usec, "2000-02-29T23:50:07.008") ==
+               {:ok, @datetime_leapyear_usec}
 
       assert Ecto.Type.cast(:utc_datetime_usec, "2015-01-23P23:50:07") == :error
     end
 
     test "cast from map" do
       term = %{
-        "year" => "2015", "month" => "1", "day" => "23",
-        "hour" => "23", "minute" => "50", "second" => "00"
+        "year" => "2015",
+        "month" => "1",
+        "day" => "23",
+        "hour" => "23",
+        "minute" => "50",
+        "second" => "00"
       }
+
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 0}
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %DateTime{
-        calendar: Calendar.ISO, year: 2015, month: 1, day: 24,
-        hour: 9, minute: 50, second: 0, microsecond: {0, 0},
-        std_offset: 0, utc_offset: 36000,
-        time_zone: "Etc/GMT-10", zone_abbr: "+10"
+        calendar: Calendar.ISO,
+        year: 2015,
+        month: 1,
+        day: 24,
+        hour: 9,
+        minute: 50,
+        second: 0,
+        microsecond: {0, 0},
+        std_offset: 0,
+        utc_offset: 36000,
+        time_zone: "Etc/GMT-10",
+        zone_abbr: "+10"
       }
+
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
       term = %DateTime{
-        calendar: Calendar.ISO, year: 2015, month: 1, day: 24,
-        hour: 9, minute: 50, second: 7, microsecond: {8000, 6},
-        std_offset: 0, utc_offset: 36000,
-        time_zone: "Etc/GMT-10", zone_abbr: "+10"
+        calendar: Calendar.ISO,
+        year: 2015,
+        month: 1,
+        day: 24,
+        hour: 9,
+        minute: 50,
+        second: 7,
+        microsecond: {8000, 6},
+        std_offset: 0,
+        utc_offset: 36000,
+        time_zone: "Etc/GMT-10",
+        zone_abbr: "+10"
       }
+
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_usec}
 
       term = %{"year" => "", "month" => "", "day" => "", "hour" => "", "minute" => ""}
@@ -851,13 +1140,28 @@ defmodule Ecto.TypeTest do
       term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50}
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_zero_usec}
 
-      term = %{year: 2015, month: 1, day: 23, hour: 23, minute: 50, second: 07, microsecond: 8_000}
+      term = %{
+        year: 2015,
+        month: 1,
+        day: 23,
+        hour: 23,
+        minute: 50,
+        second: 07,
+        microsecond: 8_000
+      }
+
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_usec}
 
       term = %{
-        "year" => 2015, "month" => 1, "day" => 23,
-        "hour" => 23, "minute" => 50, "second" => 07, "microsecond" => 8_000
+        "year" => 2015,
+        "month" => 1,
+        "day" => 23,
+        "hour" => 23,
+        "minute" => 50,
+        "second" => 07,
+        "microsecond" => 8_000
       }
+
       assert Ecto.Type.cast(:utc_datetime_usec, term) == {:ok, @datetime_usec}
 
       term = %{"year" => "2015", "month" => "1", "day" => "23", "hour" => "", "minute" => "50"}
@@ -876,7 +1180,8 @@ defmodule Ecto.TypeTest do
     end
 
     test "dump" do
-      assert Ecto.Type.dump(:utc_datetime_usec, @datetime_usec) == DateTime.from_naive(~N[2015-01-23 23:50:07.008000], "Etc/UTC")
+      assert Ecto.Type.dump(:utc_datetime_usec, @datetime_usec) ==
+               DateTime.from_naive(~N[2015-01-23 23:50:07.008000], "Etc/UTC")
 
       assert_raise ArgumentError, ~r":utc_datetime_usec expects microsecond precision", fn ->
         Ecto.Type.dump(:utc_datetime_usec, @datetime)
@@ -885,9 +1190,16 @@ defmodule Ecto.TypeTest do
 
     test "load" do
       assert Ecto.Type.load(:utc_datetime_usec, @datetime_usec) == {:ok, @datetime_usec}
-      assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:07.008000]) == {:ok, @datetime_usec}
-      assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07.008000]) == {:ok, @datetime_leapyear_usec}
-      assert Ecto.Type.load(:utc_datetime_usec, @datetime_leapyear_usec) == {:ok, @datetime_leapyear_usec}
+
+      assert Ecto.Type.load(:utc_datetime_usec, ~N[2015-01-23 23:50:07.008000]) ==
+               {:ok, @datetime_usec}
+
+      assert Ecto.Type.load(:utc_datetime_usec, ~N[2000-02-29 23:50:07.008000]) ==
+               {:ok, @datetime_leapyear_usec}
+
+      assert Ecto.Type.load(:utc_datetime_usec, @datetime_leapyear_usec) ==
+               {:ok, @datetime_leapyear_usec}
+
       assert Ecto.Type.load(:utc_datetime_usec, @datetime_zero) == {:ok, @datetime_zero_usec}
       assert Ecto.Type.load(:utc_datetime_usec, ~D[2018-01-01]) == :error
     end
@@ -919,15 +1231,53 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.equal?(:time_usec, ~T[09:00:00], ~T[09:00:00.000000])
       refute Ecto.Type.equal?(:time_usec, ~T[09:00:00], ~T[09:00:00.999999])
 
-      assert Ecto.Type.equal?(:naive_datetime, ~N[2018-01-01 09:00:00], ~N[2018-01-01 09:00:00.000000])
-      refute Ecto.Type.equal?(:naive_datetime, ~N[2018-01-01 09:00:00], ~N[2018-01-01 09:00:00.999999])
-      assert Ecto.Type.equal?(:naive_datetime_usec, ~N[2018-01-01 09:00:00], ~N[2018-01-01 09:00:00.000000])
-      refute Ecto.Type.equal?(:naive_datetime_usec, ~N[2018-01-01 09:00:00], ~N[2018-01-01 09:00:00.999999])
+      assert Ecto.Type.equal?(
+               :naive_datetime,
+               ~N[2018-01-01 09:00:00],
+               ~N[2018-01-01 09:00:00.000000]
+             )
 
-      assert Ecto.Type.equal?(:utc_datetime, utc("2018-01-01 09:00:00"), utc("2018-01-01 09:00:00.000000"))
-      refute Ecto.Type.equal?(:utc_datetime, utc("2018-01-01 09:00:00"), utc("2018-01-01 09:00:00.999999"))
-      assert Ecto.Type.equal?(:utc_datetime_usec, utc("2018-01-01 09:00:00"), utc("2018-01-01 09:00:00.000000"))
-      refute Ecto.Type.equal?(:utc_datetime_usec, utc("2018-01-01 09:00:00"), utc("2018-01-01 09:00:00.999999"))
+      refute Ecto.Type.equal?(
+               :naive_datetime,
+               ~N[2018-01-01 09:00:00],
+               ~N[2018-01-01 09:00:00.999999]
+             )
+
+      assert Ecto.Type.equal?(
+               :naive_datetime_usec,
+               ~N[2018-01-01 09:00:00],
+               ~N[2018-01-01 09:00:00.000000]
+             )
+
+      refute Ecto.Type.equal?(
+               :naive_datetime_usec,
+               ~N[2018-01-01 09:00:00],
+               ~N[2018-01-01 09:00:00.999999]
+             )
+
+      assert Ecto.Type.equal?(
+               :utc_datetime,
+               utc("2018-01-01 09:00:00"),
+               utc("2018-01-01 09:00:00.000000")
+             )
+
+      refute Ecto.Type.equal?(
+               :utc_datetime,
+               utc("2018-01-01 09:00:00"),
+               utc("2018-01-01 09:00:00.999999")
+             )
+
+      assert Ecto.Type.equal?(
+               :utc_datetime_usec,
+               utc("2018-01-01 09:00:00"),
+               utc("2018-01-01 09:00:00.000000")
+             )
+
+      refute Ecto.Type.equal?(
+               :utc_datetime_usec,
+               utc("2018-01-01 09:00:00"),
+               utc("2018-01-01 09:00:00.999999")
+             )
     end
 
     test "composite semantical comparison" do

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -6,8 +6,8 @@ defmodule Ecto.UUIDTest do
   @test_uuid_invalid_characters "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   @test_uuid_invalid_format "xxxxxxxx-xxxx"
   @test_uuid_null "00000000-0000-0000-0000-000000000000"
-  @test_uuid_binary <<0x60, 0x1D, 0x74, 0xE4, 0xA8, 0xD3, 0x4B, 0x6E,
-                      0x83, 0x65, 0xED, 0xDB, 0x4C, 0x89, 0x33, 0x27>>
+  @test_uuid_binary <<0x60, 0x1D, 0x74, 0xE4, 0xA8, 0xD3, 0x4B, 0x6E, 0x83, 0x65, 0xED, 0xDB,
+                      0x4C, 0x89, 0x33, 0x27>>
 
   test "cast" do
     assert Ecto.UUID.cast(@test_uuid) == {:ok, @test_uuid}
@@ -20,6 +20,7 @@ defmodule Ecto.UUIDTest do
 
   test "cast!" do
     assert Ecto.UUID.cast!(@test_uuid) == @test_uuid
+
     assert_raise Ecto.CastError, "cannot cast nil to Ecto.UUID", fn ->
       assert Ecto.UUID.cast!(nil)
     end
@@ -28,6 +29,7 @@ defmodule Ecto.UUIDTest do
   test "load" do
     assert Ecto.UUID.load(@test_uuid_binary) == {:ok, @test_uuid}
     assert Ecto.UUID.load("") == :error
+
     assert_raise ArgumentError, ~r"trying to load string UUID as Ecto.UUID:", fn ->
       Ecto.UUID.load(@test_uuid)
     end
@@ -59,6 +61,6 @@ defmodule Ecto.UUIDTest do
   end
 
   test "generate" do
-    assert << _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96 >> = Ecto.UUID.generate()
+    assert <<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = Ecto.UUID.generate()
   end
 end

--- a/test/mix/tasks/ecto.create_drop_test.exs
+++ b/test/mix/tasks/ecto.create_drop_test.exs
@@ -10,27 +10,27 @@ defmodule Mix.Tasks.Ecto.CreateDropTest do
     @behaviour Ecto.Adapter.Storage
 
     defmacro __before_compile__(_), do: :ok
-    def dumpers(_, _), do: raise "not implemented"
-    def loaders(_, _), do: raise "not implemented"
-    def init(_), do: raise "not implemented"
-    def checkout(_, _, _), do: raise "not implemented"
-    def checked_out?(_), do: raise "not implemented"
-    def ensure_all_started(_, _), do: raise "not implemented"
+    def dumpers(_, _), do: raise("not implemented")
+    def loaders(_, _), do: raise("not implemented")
+    def init(_), do: raise("not implemented")
+    def checkout(_, _, _), do: raise("not implemented")
+    def checked_out?(_), do: raise("not implemented")
+    def ensure_all_started(_, _), do: raise("not implemented")
 
-    def storage_up(_), do: Process.get(:storage_up) || raise "no storage_up"
-    def storage_down(_), do: Process.get(:storage_down) || raise "no storage_down"
-    def storage_status(_), do: raise "no storage_status"
+    def storage_up(_), do: Process.get(:storage_up) || raise("no storage_up")
+    def storage_down(_), do: Process.get(:storage_down) || raise("no storage_down")
+    def storage_status(_), do: raise("no storage_status")
   end
 
   defmodule NoStorageAdapter do
     @behaviour Ecto.Adapter
     defmacro __before_compile__(_), do: :ok
-    def dumpers(_, _), do: raise "not implemented"
-    def loaders(_, _), do: raise "not implemented"
-    def init(_), do: raise "not implemented"
-    def checkout(_, _, _), do: raise "not implemented"
-    def checked_out?(_), do: raise "not implemented"
-    def ensure_all_started(_, _), do: raise "not implemented"
+    def dumpers(_, _), do: raise("not implemented")
+    def loaders(_, _), do: raise("not implemented")
+    def init(_), do: raise("not implemented")
+    def checkout(_, _, _), do: raise("not implemented")
+    def checked_out?(_), do: raise("not implemented")
+    def ensure_all_started(_, _), do: raise("not implemented")
   end
 
   # Mocked repos
@@ -52,32 +52,39 @@ defmodule Mix.Tasks.Ecto.CreateDropTest do
 
   test "runs the adapter storage_up" do
     Process.put(:storage_up, :ok)
-    Create.run ["-r", to_string(Repo)]
-    assert_received {:mix_shell, :info, ["The database for Mix.Tasks.Ecto.CreateDropTest.Repo has been created"]}
+    Create.run(["-r", to_string(Repo)])
+
+    assert_received {:mix_shell, :info,
+                     ["The database for Mix.Tasks.Ecto.CreateDropTest.Repo has been created"]}
   end
 
   test "runs the adapter storage_up with --quiet" do
     Process.put(:storage_up, :ok)
-    Create.run ["-r", to_string(Repo), "--quiet"]
+    Create.run(["-r", to_string(Repo), "--quiet"])
     refute_received {:mix_shell, :info, [_]}
   end
 
   test "informs the user when the repo is already up" do
     Process.put(:storage_up, {:error, :already_up})
-    Create.run ["-r", to_string(Repo)]
-    assert_received {:mix_shell, :info, ["The database for Mix.Tasks.Ecto.CreateDropTest.Repo has already been created"]}
+    Create.run(["-r", to_string(Repo)])
+
+    assert_received {:mix_shell, :info,
+                     [
+                       "The database for Mix.Tasks.Ecto.CreateDropTest.Repo has already been created"
+                     ]}
   end
 
   test "raises an error when storage_up gives an unknown feedback" do
     Process.put(:storage_up, {:error, :confused})
+
     assert_raise Mix.Error, fn ->
-      Create.run ["-r", to_string(Repo)]
+      Create.run(["-r", to_string(Repo)])
     end
   end
 
   test "raises an error on storage_up when the adapter doesn't define a storage" do
     assert_raise Mix.Error, ~r/to implement Ecto.Adapter.Storage/, fn ->
-      Create.run ["-r", to_string(NoStorageRepo)]
+      Create.run(["-r", to_string(NoStorageRepo)])
     end
   end
 
@@ -85,37 +92,45 @@ defmodule Mix.Tasks.Ecto.CreateDropTest do
 
   test "runs the adapter storage_down" do
     Process.put(:storage_down, :ok)
-    Drop.run ["-r", to_string(Repo)]
-    assert_received {:mix_shell, :info, ["The database for Mix.Tasks.Ecto.CreateDropTest.Repo has been dropped"]}
+    Drop.run(["-r", to_string(Repo)])
+
+    assert_received {:mix_shell, :info,
+                     ["The database for Mix.Tasks.Ecto.CreateDropTest.Repo has been dropped"]}
   end
 
   test "runs the adapter storage_down with --quiet" do
     Process.put(:storage_down, :ok)
-    Drop.run ["-r", to_string(Repo), "--quiet"]
+    Drop.run(["-r", to_string(Repo), "--quiet"])
     refute_received {:mix_shell, :info, [_]}
   end
 
   test "informs the user when the repo is already down" do
     Process.put(:storage_down, {:error, :already_down})
-    Drop.run ["-r", to_string(Repo)]
-    assert_received {:mix_shell, :info, ["The database for Mix.Tasks.Ecto.CreateDropTest.Repo has already been dropped"]}
+    Drop.run(["-r", to_string(Repo)])
+
+    assert_received {:mix_shell, :info,
+                     [
+                       "The database for Mix.Tasks.Ecto.CreateDropTest.Repo has already been dropped"
+                     ]}
   end
 
   test "raises an error when storage_down gives an unknown feedback" do
     Process.put(:storage_down, {:error, {:error, :confused}})
+
     assert_raise Mix.Error, ~r/couldn't be dropped: {:error, :confused}/, fn ->
-      Drop.run ["-r", to_string(Repo)]
+      Drop.run(["-r", to_string(Repo)])
     end
 
     Process.put(:storage_down, {:error, "unknown"})
+
     assert_raise Mix.Error, ~r/couldn't be dropped: unknown/, fn ->
-      Drop.run ["-r", to_string(Repo)]
+      Drop.run(["-r", to_string(Repo)])
     end
   end
 
   test "raises an error on storage_down when the adapter doesn't define a storage" do
     assert_raise Mix.Error, ~r/to implement Ecto.Adapter.Storage/, fn ->
-      Drop.run ["-r", to_string(NoStorageRepo)]
+      Drop.run(["-r", to_string(NoStorageRepo)])
     end
   end
 end

--- a/test/mix/tasks/ecto.gen.repo_test.exs
+++ b/test/mix/tasks/ecto.gen.repo_test.exs
@@ -5,29 +5,29 @@ defmodule Mix.Tasks.Ecto.Gen.RepoTest do
 
   test "raises when no repo given" do
     msg = "ecto.gen.repo expects the repository to be given as -r MyApp.Repo"
-    assert_raise Mix.Error, msg, fn -> run [] end
+    assert_raise Mix.Error, msg, fn -> run([]) end
   end
 
   test "raises when multiple repos given" do
     msg = "ecto.gen.repo expects a single repository to be given"
-    assert_raise Mix.Error, msg, fn -> run ["-r", "Foo.Repo", "--repo", "Bar.Repo"] end
+    assert_raise Mix.Error, msg, fn -> run(["-r", "Foo.Repo", "--repo", "Bar.Repo"]) end
   end
 
   test "generates a new repo" do
-    in_tmp "new_repo", fn ->
-      run ["-r", "Repo"]
+    in_tmp("new_repo", fn ->
+      run(["-r", "Repo"])
 
-      assert_file "lib/repo.ex", """
+      assert_file("lib/repo.ex", """
       defmodule Repo do
         use Ecto.Repo,
           otp_app: :ecto,
           adapter: Ecto.Adapters.Postgres
       end
-      """
+      """)
 
       first_line = if Code.ensure_loaded?(Config), do: "import Config", else: "use Mix.Config"
 
-      assert_file "config/config.exs", """
+      assert_file("config/config.exs", """
       #{first_line}
 
       config :ecto, Repo,
@@ -35,22 +35,23 @@ defmodule Mix.Tasks.Ecto.Gen.RepoTest do
         username: "user",
         password: "pass",
         hostname: "localhost"
-      """
-    end
+      """)
+    end)
   end
 
   test "generates a new repo with existing config file" do
-    in_tmp "existing_config", fn ->
-      File.mkdir_p! "config"
-      File.write! "config/config.exs", """
+    in_tmp("existing_config", fn ->
+      File.mkdir_p!("config")
+
+      File.write!("config/config.exs", """
       # Hello
       use Mix.Config
       # World
-      """
+      """)
 
-      run ["-r", "Repo"]
+      run(["-r", "Repo"])
 
-      assert_file "config/config.exs", """
+      assert_file("config/config.exs", """
       # Hello
       use Mix.Config
 
@@ -60,15 +61,15 @@ defmodule Mix.Tasks.Ecto.Gen.RepoTest do
         password: "pass",
         hostname: "localhost"
       # World
-      """
-    end
+      """)
+    end)
   end
 
   test "generates a new namespaced repo" do
-    in_tmp "namespaced", fn ->
-      run ["-r", "My.AppRepo"]
-      assert_file "lib/my/app_repo.ex", "defmodule My.AppRepo do"
-    end
+    in_tmp("namespaced", fn ->
+      run(["-r", "My.AppRepo"])
+      assert_file("lib/my/app_repo.ex", "defmodule My.AppRepo do")
+    end)
   end
 
   @tmp_path Path.expand("../../../tmp", __DIR__)

--- a/test/mix/tasks/ecto_test.exs
+++ b/test/mix/tasks/ecto_test.exs
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.EctoTest do
   use ExUnit.Case
 
   test "provide a list of available Ecto Mix tasks" do
-    Mix.Tasks.Ecto.run []
+    Mix.Tasks.Ecto.run([])
     assert_received {:mix_shell, :info, ["Ecto v" <> _]}
     assert_received {:mix_shell, :info, ["mix ecto.create" <> _]}
     assert_received {:mix_shell, :info, ["mix ecto.drop" <> _]}
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.EctoTest do
 
   test "expects no arguments" do
     assert_raise Mix.Error, fn ->
-      Mix.Tasks.Ecto.run ["invalid"]
+      Mix.Tasks.Ecto.run(["invalid"])
     end
   end
 end

--- a/test/support/eval_helpers.exs
+++ b/test/support/eval_helpers.exs
@@ -5,6 +5,7 @@ defmodule Support.EvalHelpers do
   """
   defmacro quote_and_eval(quoted, binding \\ []) do
     quoted = Macro.escape(quoted)
+
     quote do
       Code.eval_quoted(unquote(quoted), unquote(binding), __ENV__)
     end

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -11,9 +11,9 @@ defmodule Ecto.TestAdapter do
   end
 
   def init(opts) do
-    :ecto   = opts[:otp_app]
-    "user"  = opts[:username]
-    "pass"  = opts[:password]
+    :ecto = opts[:otp_app]
+    "user" = opts[:username]
+    "pass" = opts[:password]
     "hello" = opts[:database]
     "local" = opts[:hostname]
 
@@ -21,7 +21,7 @@ defmodule Ecto.TestAdapter do
   end
 
   def checkout(mod, _opts, fun) do
-    send self(), {:checkout, fun}
+    send(self(), {:checkout, fun})
     Process.put({mod, :checked_out?}, true)
 
     try do
@@ -52,18 +52,18 @@ defmodule Ecto.TestAdapter do
   def prepare(operation, query), do: {:nocache, {operation, query}}
 
   def execute(_, _, {:nocache, {:all, query}}, _, _) do
-    send self(), {:all, query}
+    send(self(), {:all, query})
     Process.get(:test_repo_all_results) || results_for_all_query(query)
   end
 
   def execute(_, _meta, {:nocache, {op, query}}, _params, _opts) do
-    send self(), {op, query}
+    send(self(), {op, query})
     {1, nil}
   end
 
   def stream(_, _meta, {:nocache, {:all, query}}, _params, _opts) do
     Stream.map([:execute], fn :execute ->
-      send self(), {:stream, query}
+      send(self(), {:stream, query})
       results_for_all_query(query)
     end)
   end
@@ -128,7 +128,8 @@ defmodule Ecto.TestAdapter do
   def transaction(mod, _opts, fun) do
     # Makes transactions "trackable" in tests
     Process.put({mod, :in_transaction?}, true)
-    send self(), {:transaction, fun}
+    send(self(), {:transaction, fun})
+
     try do
       {:ok, fun.()}
     catch
@@ -144,12 +145,12 @@ defmodule Ecto.TestAdapter do
   end
 
   def rollback(_, value) do
-    send self(), {:rollback, value}
-    throw {:ecto_rollback, value}
+    send(self(), {:rollback, value})
+    throw({:ecto_rollback, value})
   end
 end
 
-Application.put_env(:ecto, Ecto.TestRepo, [user: "invalid"])
+Application.put_env(:ecto, Ecto.TestRepo, user: "invalid")
 
 defmodule Ecto.TestRepo do
   use Ecto.Repo, otp_app: :ecto, adapter: Ecto.TestAdapter


### PR DESCRIPTION
## What?
- Applies `mix format mix.exs "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}"` to the repo
- Adds a formatting check to `Earthfile` which will be executed in CI

## Why?
Because formatting matters :) 