### PR TITLE
Update on_replace options in has_many docs

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -770,8 +770,9 @@ defmodule Ecto.Schema do
 
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be
-      `:raise` (default), `:mark_as_invalid`, `:nilify`, or `:delete`.
-      See `Ecto.Changeset`'s section about ":on_replace" for more info.
+      `:raise` (default), `:mark_as_invalid`, `:nilify`, `:delete` or
+      `:delete_if_exists`. See `Ecto.Changeset`'s section about ":on_replace" for
+      more info.
 
     * `:defaults` - Default values to use when building the association.
       It may be a keyword list of options that override the association schema

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -771,7 +771,7 @@ defmodule Ecto.Schema do
     * `:on_replace` - The action taken on associations when the record is
       replaced when casting or manipulating parent changeset. May be
       `:raise` (default), `:mark_as_invalid`, `:nilify`, `:delete` or
-      `:delete_if_exists`. See `Ecto.Changeset`'s section about ":on_replace" for
+      `:delete_if_exists`. See `Ecto.Changeset`'s section about `:on_replace` for
       more info.
 
     * `:defaults` - Default values to use when building the association.


### PR DESCRIPTION
The `on_replace` option admits a new [`delete_if_exists`](https://hexdocs.pm/ecto/Ecto.Changeset.html#module-the-on_replace-option) value, which was not mentioned in the `has_many` docs.

You can always navigate to the `on_replace` option documentation, but the way that this is redacted makes you think that these 4 options are the only valid ones.