### PR TITLE
ensure type is fetched for field in validate inclusion, subset, and exclusion

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2005,7 +2005,10 @@ defmodule Ecto.Changeset do
   @spec validate_inclusion(t, atom, Enum.t, Keyword.t) :: t
   def validate_inclusion(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:inclusion, data}, fn _, value ->
-      type = Map.fetch!(changeset.types, field)
+      type =
+        changeset.types
+        |> Map.fetch!(field)
+        |> Ecto.Type.type()
 
       if Ecto.Type.include?(type, value, data),
         do: [],
@@ -2033,7 +2036,10 @@ defmodule Ecto.Changeset do
   @spec validate_subset(t, atom, Enum.t, Keyword.t) :: t
   def validate_subset(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:subset, data}, fn _, value ->
-      {:array, element_type} = Map.fetch!(changeset.types, field)
+      {:array, element_type} =
+        changeset.types
+        |> Map.fetch!(field)
+        |> Ecto.Type.type()
 
       case Enum.any?(value, fn element -> not Ecto.Type.include?(element_type, element, data) end) do
         true -> [{field, {message(opts, "has an invalid entry"), [validation: :subset, enum: data]}}]
@@ -2057,7 +2063,10 @@ defmodule Ecto.Changeset do
   @spec validate_exclusion(t, atom, Enum.t, Keyword.t) :: t
   def validate_exclusion(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:exclusion, data}, fn _, value ->
-      type = Map.fetch!(changeset.types, field)
+      type =
+        changeset.types
+        |> Map.fetch!(field)
+        |> Ecto.Type.type()
 
       if Ecto.Type.include?(type, value, data), do:
         [{field, {message(opts, "is reserved"), [validation: :exclusion, enum: data]}}], else: []


### PR DESCRIPTION
This PR fixes an error when custom field types are used when calling validations for inclusion, subset, and exclusion.

Previously, a mismatch error would be raised (at least for validate_subset) as the module implementing the type behaviour would be returned rather than the type it defines.