### PR TITLE
Mark no forced update in optimistic_lock as potentially breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,7 @@ v3.5 requires Elixir v1.8+.
 ### Bug fixes
 
   * [Ecto.Changeset] Ensure `:empty_values` in `cast/4` does not automatically propagate to following cast calls. If you want a given set of `:empty_values` to apply to all `cast/4` calls, change the value stored in `changeset.empty_values` instead
-  * [Ecto.Changeset] Do not force repository updates to happen when using `optimistic_lock`
+  * [Ecto.Changeset] **Potentially breaking change**: Do not force repository updates to happen when using `optimistic_lock`. The lock field will only be incremented if the record has other changes. If no changes, nothing happens.
   * [Ecto.Changeset] Do not automatically share empty values across `cast/3` calls
   * [Ecto.Query] Consider query prefix in cte/combination query cache
   * [Ecto.Query] Allow the entry to be marked as nil when using left join with subqueries


### PR DESCRIPTION
This change can break apps that depend on the old behavior for optimistic concurrency control.

The change, https://github.com/elixir-ecto/ecto/commit/b5d02d66881a1724dde5ea233c44852f010b73a1, in Ecto 3.5.0:

> [Ecto.Changeset] Do not force repository updates to happen when using optimistic_lock

...is listed under "Bug fixes". I suggest moving that to Breaking changes, or at least marking it as "Potentially breaking change".

We use a central "user" record for optimistic concurrency control involving other records related to the user. Until recently, we were running on Ecto 3.4.7, and we would run a transaction doing stuff related to the user (but which did not otherwise change the user's fields) and then run this code to make sure only one transaction would win:

```elixir
{:ok, user} <-
  user
  |> Changeset.optimistic_lock(:lock_version)
  |> Repo.update()
```

We recently upgraded to Ecto 3.7.1. Read through the changelog and did not see any (potentially) breaking changes. We found that the `optimistic_lock` change broke this workflow for us. So I suggest adding a note about it so others hopefully won't run into it.

Thanks! :)
