### PR TITLE
Suggest alternatives to inexistent fields in queries

### DIFF
--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -28,7 +28,7 @@ defmodule Ecto.QueryError do
   def exception(opts) do
     message = Keyword.fetch!(opts, :message)
     query   = Keyword.fetch!(opts, :query)
-    hint    = Keyword.fetch(opts, :hint)
+    hint    = Keyword.get(opts, :hint)
 
     message = """
     #{message} in query:
@@ -48,9 +48,10 @@ defmodule Ecto.QueryError do
       end
 
     message =
-      case hint do
-        {:ok, text} -> message <> "\n" <> text <> "\n"
-        _ -> message
+      if hint do
+        message <> "\n" <> hint <> "\n"
+      else
+        message
       end
 
     %__MODULE__{message: message}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1737,31 +1737,31 @@ defmodule Ecto.Query.Planner do
         error! query, expr, "field `#{field}` in `#{kind}` is a virtual field in schema #{inspect schema}"
 
       true ->
-        suggestion_str =
-          case closest_suggestion(field, schema) do
-            nil ->
-              ""
-            suggestion ->
-             ", did you mean `#{suggestion}`?"
-          end
-
-        error! query, expr, "field `#{field}` in `#{kind}` does not exist in schema #{inspect schema}" <> suggestion_str
+        hint = closest_fields_hint(field, schema)
+        error! query, expr, "field `#{field}` in `#{kind}` does not exist in schema #{inspect schema}", hint
     end
   end
 
-  defp closest_suggestion(input, schema) do
+  defp closest_fields_hint(input, schema) do
     input_string = Atom.to_string(input)
 
     schema.__schema__(:fields)
-    |> Enum.map(fn field ->
-      {field, String.jaro_distance(input_string, Atom.to_string(field))}
-    end)
-    |> Enum.max(fn {_f1, s1}, {_f2, s2} -> s1 >= s2 end)
+    |> Enum.map(fn field -> {field, String.jaro_distance(input_string, Atom.to_string(field))} end)
+    |> Enum.filter(fn {_field, score} -> score >= 0.77 end)
+    |> Enum.sort(& elem(&1, 0) >= elem(&2, 0))
+    |> Enum.take(5)
+    |> Enum.map(&elem(&1, 0))
     |> case do
-      {field, score} when score >= 0.8 ->
-        field
-      _ ->
+      [] ->
         nil
+
+      [suggestion] ->
+        "Did you mean `#{suggestion}`?"
+
+      suggestions ->
+        Enum.reduce(suggestions, "Did you mean one of: \n", fn suggestion, acc ->
+          acc <> "\n      * `#{suggestion}`"
+        end)
     end
   end
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -981,11 +981,15 @@ defmodule Ecto.Query.PlannerTest do
       normalize(query)
     end
 
-    message = ~r"field `postd` in `select` does not exist in schema Ecto.Query.PlannerTest.Comment, did you mean `posted`?"
-    assert_raise Ecto.QueryError, message, fn ->
+    exception = assert_raise Ecto.QueryError, fn ->
       query = from(Comment, []) |> select([c], c.postd)
       normalize(query)
     end
+
+    assert exception.message =~ "field `postd` in `select` does not exist in schema"
+    assert exception.message =~ "Did you mean one of:"
+    assert exception.message =~ "* `posted`"
+    assert exception.message =~ "* `post_id`"
 
     message = ~r"field `temp` in `select` is a virtual field in schema Ecto.Query.PlannerTest.Comment"
     assert_raise Ecto.QueryError, message, fn ->

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -981,6 +981,12 @@ defmodule Ecto.Query.PlannerTest do
       normalize(query)
     end
 
+    message = ~r"field `postd` in `select` does not exist in schema Ecto.Query.PlannerTest.Comment, did you mean `posted`?"
+    assert_raise Ecto.QueryError, message, fn ->
+      query = from(Comment, []) |> select([c], c.postd)
+      normalize(query)
+    end
+
     message = ~r"field `temp` in `select` is a virtual field in schema Ecto.Query.PlannerTest.Comment"
     assert_raise Ecto.QueryError, message, fn ->
       query = from(Comment, []) |> select([c], c.temp)


### PR DESCRIPTION
Looks for similar fields and tries to suggest them when raising about
invalid query.