### PR TITLE
Add Ecto.ConstraintError to Repo.delete/2 docs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1622,9 +1622,10 @@ defmodule Ecto.Repo do
 
   If the struct has no primary key, `Ecto.NoPrimaryKeyFieldError`
   will be raised. If the struct has been removed from db prior to
-  call, `Ecto.StaleEntryError` will be raised. If more than one 
-  database operation is required, they're automatically wrapped 
-  in a transaction.
+  call, `Ecto.StaleEntryError` will be raised. If removing the struct 
+  from the db will violate an existing constraint, `Ecto.ConstraintError` 
+  will be raised. If more than one database operation is required, 
+  they're automatically wrapped in a transaction.
 
   It returns `{:ok, struct}` if the struct has been successfully
   deleted or `{:error, changeset}` if there was a validation

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1621,7 +1621,7 @@ defmodule Ecto.Repo do
   Deletes a struct using its primary key.
 
   If the struct has no primary key, `Ecto.NoPrimaryKeyFieldError`
-  will be raised. If the struct has been removed prior to call,
+  will be raised. If the struct has been removed prior to the call,
   `Ecto.StaleEntryError` will be raised. If more than one database
   operation is required, they're automatically wrapped in a transaction.
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1629,7 +1629,9 @@ defmodule Ecto.Repo do
 
   It returns `{:ok, struct}` if the struct has been successfully
   deleted or `{:error, changeset}` if there was a validation
-  or a known constraint error.
+  or a known constraint error. To make Ecto aware of contraints be sure
+  to pass a changeset as the first arg with the relevant constraint 
+  applied (see Ecto.Changeset).
 
   ## Options
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1621,17 +1621,16 @@ defmodule Ecto.Repo do
   Deletes a struct using its primary key.
 
   If the struct has no primary key, `Ecto.NoPrimaryKeyFieldError`
-  will be raised. If the struct has been removed from db prior to
-  call, `Ecto.StaleEntryError` will be raised. If removing the struct 
-  will violate an existing constraint, `Ecto.ConstraintError` will be
-  raised. If more than one database operation is required, they're
-  automatically wrapped in a transaction.
+  will be raised. If the struct has been removed prior to call,
+  `Ecto.StaleEntryError` will be raised. If more than one database
+  operation is required, they're automatically wrapped in a transaction.
 
   It returns `{:ok, struct}` if the struct has been successfully
   deleted or `{:error, changeset}` if there was a validation
-  or a known constraint error. To make Ecto aware of contraints be sure
-  to pass a changeset as the first arg with the relevant constraint 
-  applied (see Ecto.Changeset).
+  or a known constraint error. By default, constraint errors will
+  raise the `Ecto.ConstraintError` exception, unless a changeset is
+  given as the first argument with the relevant constraints declared
+  in it (see `Ecto.Changeset`).
 
   ## Options
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1623,9 +1623,9 @@ defmodule Ecto.Repo do
   If the struct has no primary key, `Ecto.NoPrimaryKeyFieldError`
   will be raised. If the struct has been removed from db prior to
   call, `Ecto.StaleEntryError` will be raised. If removing the struct 
-  from the db will violate an existing constraint, `Ecto.ConstraintError` 
-  will be raised. If more than one database operation is required, 
-  they're automatically wrapped in a transaction.
+  will violate an existing constraint, `Ecto.ConstraintError` will be
+  raised. If more than one database operation is required, they're
+  automatically wrapped in a transaction.
 
   It returns `{:ok, struct}` if the struct has been successfully
   deleted or `{:error, changeset}` if there was a validation


### PR DESCRIPTION
Just ran into this and was a bit confused because I thought the docs implied an error tuple would be returned in the relevant case. I also tend to think referencing how to use a changeset with `no_assoc_constraint` here as well to avoid raising the error might be a good idea. If others agree I would be happy to add. But for now listing this error along with the others seems like the minimal positive change here.