### PR TITLE
Fix regression in validating inclusion of custom types

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1090,6 +1090,13 @@ defmodule Ecto.ChangesetTest do
     assert changeset.valid?
   end
 
+  test "validate_subset/3 raises if field type is not array" do
+    assert_raise ArgumentError, "validate_subset/4 expects field type to be array, field `:title` has type `:string`", fn ->
+      changeset(%{"title" => "hello"})
+      |> validate_subset(:title, ["hello"])
+    end
+  end
+
   test "validate_exclusion/3" do
     changeset =
       changeset(%{"title" => "world"})


### PR DESCRIPTION
Reported here: https://github.com/elixir-ecto/ecto/pull/3742#issuecomment-948320014

This PR:
- reverts #3742
- adds a regression test for the introduced bug
- adds a note in `validate_subset` documentation about its usage