### PR TITLE
Allow using type/2 with virtual fields

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -405,9 +405,11 @@ defmodule Ecto.Schema do
   * `__schema__(:primary_key)` - Returns a list of primary key fields (empty if there is none);
 
   * `__schema__(:fields)` - Returns a list of all non-virtual field names;
+  * `__schema__(:virtual_fields)` - Returns a list of all virtual field names;
   * `__schema__(:field_source, field)` - Returns the alias of the given field;
 
   * `__schema__(:type, field)` - Returns the type of the given non-virtual field;
+  * `__schema__(:virtual_type, field)` - Returns the type of the given virtual field;
 
   * `__schema__(:associations)` - Returns a list of all association field names;
   * `__schema__(:association, assoc)` - Returns the association reflection of the given assoc;

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -998,6 +998,11 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
+  test "normalize: allow virtual fields in type/2" do
+    query = from(Comment, []) |> select([c], type(fragment("1"), c.temp))
+    normalize(query)
+  end
+
   test "normalize: validate fields in left side of in expressions" do
     query = from(Post, []) |> where([p], p.id in [1, 2, 3])
     normalize(query)


### PR DESCRIPTION
This would close #3767, but I think some discussion must be done:

1. I'm adding `__schema__(:virtual_type, type)` to avoid breaking compatibility with existing places that may rely on `__schema__(:type, type)` not returning virtual fields types. Ecto's own codebase does that, and I think elsewhere it may happen, so its probably a bad idea to break this behaviour.
2. All information returned by `__schema__(:virtual_type, type)` and `__schema__(:virtual_fields)` is possible to get through `__changeset__`, yet its probably not fine to rely on this function from Planner.

If we agree on something I can create new tests and make improvements.