### PR TITLE
Fix Ecto.Multi.insert_all/5 Dialyzer spec

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -490,15 +490,22 @@ defmodule Ecto.Multi do
       |> MyApp.Repo.transaction()
 
   """
-  @spec insert_all(t, name, schema_or_source, [map | Keyword.t] | fun([map | Keyword.t]), Keyword.t) :: t
-  def insert_all(multi, name, schema_or_source, entries_or_fun, opts \\ [])
+  @spec insert_all(
+          t,
+          name,
+          schema_or_source,
+          entries_or_query_or_fun :: [map | Keyword.t()] | fun([map | Keyword.t()]) | Ecto.Query.t(),
+          Keyword.t()
+        ) :: t
+  def insert_all(multi, name, schema_or_source, entries_or_query_or_fun, opts \\ [])
 
-  def insert_all(multi, name, schema_or_source, entries_fun, opts) when is_function(entries_fun, 1) and is_list(opts) do
+  def insert_all(multi, name, schema_or_source, entries_fun, opts)
+      when is_function(entries_fun, 1) and is_list(opts) do
     run(multi, name, operation_fun({:insert_all, schema_or_source, entries_fun}, opts))
   end
 
-  def insert_all(multi, name, schema_or_source, entries, opts) when is_list(opts) do
-    add_operation(multi, name, {:insert_all, schema_or_source, entries, opts})
+  def insert_all(multi, name, schema_or_source, entries_or_query, opts) when is_list(opts) do
+    add_operation(multi, name, {:insert_all, schema_or_source, entries_or_query, opts})
   end
 
   @doc """


### PR DESCRIPTION
Fixes Dialyzer Typespec for `Ecto.Multi.insert_all/5` when using a query.

The file seems to be unformatted. I applied formatting to the function that I corrected only.

## Code

```elixir
Ecto.Multi.insert_all(multi, :name, Acme.Schema, from(x in y, ...), [])
```

## Dialyzer Warning

```
The function call will not succeed.

Ecto.Multi.insert_all(
  _multi :: %Ecto.Multi{:names => MapSet.t(_), :operations => []},
  _name :: :name,
  Acme.Schema,
  %Ecto.Query{
    :aliases => _,
    :assocs => _,
    :combinations => _,
    :distinct => _,
    :from => _,
    :group_bys => _,
    :havings => _,
    :joins => _,
    :limit => _,
    :lock => _,
    :offset => _,
    :order_bys => _,
    :prefix => _,
    :preloads => _,
    :select => _,
    :sources => _,
    :updates => _,
    :wheres => _,
    :windows => _,
    :with_ctes => _
  }
)

will never return since the 4th arguments differ
from the success typing arguments:

(
  %Ecto.Multi{
    :names => MapSet.t(_),
    :operations => [{_, {_, _} | {_, _, _} | {_, _, _, _}}]
  },
  any(),
  atom() | binary() | {binary(), atom()},
  (map() -> [[{_, _}] | map()]) | [Keyword.t() | map()]
)
```