### PR TITLE
Allow coalesce in type/2

### DIFF
--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -112,7 +112,7 @@ defmodule Ecto.Integration.TypeTest do
   end
 
   test "tagged types" do
-    TestRepo.insert!(%Post{})
+    TestRepo.insert!(%Post{visits: 12})
 
     # Numbers
     assert [1]   = TestRepo.all(from Post, select: type(^"1", :integer))
@@ -132,6 +132,10 @@ defmodule Ecto.Integration.TypeTest do
     assert [4.0] = TestRepo.all(from Post, select: type(2.0 + ^"2", :float))
     assert [4]   = TestRepo.all(from p in Post, select: type(2 + ^"2", p.visits))
     assert [4.0] = TestRepo.all(from p in Post, select: type(2.0 + ^"2", p.intensity))
+
+    # Comparison expression
+    assert [12] = TestRepo.all(from p in Post, select: type(coalesce(p.visits, 0), :integer))
+    assert [1.0] = TestRepo.all(from p in Post, select: type(coalesce(p.intensity, 1.0), :float))
   end
 
   test "binary id type" do

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -641,6 +641,10 @@ defmodule Ecto.Query.API do
       from p in Post, select: type(avg(p.cost), :integer)
       from p in Post, select: type(filter(avg(p.cost), p.cost > 0), :integer)
 
+  Or to type comparison expression results:
+
+      from p in Post, select: type(coalesce(p.cost, 0), :integer)
+
   """
   def type(interpolated_value, type), do: doc! [interpolated_value, type]
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -95,6 +95,10 @@ defmodule Ecto.Query.Builder do
     escape_with_type(expr, type, params_acc, vars, env)
   end
 
+  def escape({:type, _, [{:coalesce, _, [_ | _]} = expr, type]}, _type, params_acc, vars, env) do
+    escape_with_type(expr, type, params_acc, vars, env)
+  end
+
   def escape({:type, _, [{:field, _, [_ | _]} = expr, type]}, _type, params_acc, vars, env) do
     escape_with_type(expr, type, params_acc, vars, env)
   end
@@ -124,10 +128,11 @@ defmodule Ecto.Query.Builder do
         the first argument of type/2 must be one of:
 
           * interpolations, such as ^value
-          * fields, such as p.foo or field(p)
+          * fields, such as p.foo or field(p, :foo)
           * fragments, such fragment("foo(?)", value)
           * an arithmetic expression (+, -, *, /)
           * an aggregation or window expression (avg, count, min, max, sum, over, filter)
+          * an conditional expression (coalesce)
           * access/json paths (p.column[0].field)
 
         Got: #{Macro.to_string(expr)}

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -132,7 +132,7 @@ defmodule Ecto.Query.Builder do
           * fragments, such fragment("foo(?)", value)
           * an arithmetic expression (+, -, *, /)
           * an aggregation or window expression (avg, count, min, max, sum, over, filter)
-          * an conditional expression (coalesce)
+          * a conditional expression (coalesce)
           * access/json paths (p.column[0].field)
 
         Got: #{Macro.to_string(expr)}


### PR DESCRIPTION
There don't seem to be (unit) tests around functions/expressions within type/2. I've confirmed it working on a local project.

For context see https://github.com/elixir-ecto/ecto/issues/2500