### PR TITLE
allow arbitrary parentheses in wheres

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -422,6 +422,11 @@ defmodule Ecto.Query.Builder do
     error! "Tuples can only be used in comparisons with literal tuples of the same size"
   end
 
+  # Unecessary parentheses around an expression
+  def escape({:__block__, _, [expr]}, type, params_acc, vars, env) do
+    escape(expr, type, params_acc, vars, env)
+  end
+
   # Other functions - no type casting
   def escape({name, _, args} = expr, type, params_acc, vars, env) when is_atom(name) and is_list(args) do
     case call_type(name, length(args)) do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -59,6 +59,10 @@ defmodule Ecto.QueryTest do
         from p in "posts", where: [id: ^id]
       end
     end
+
+    test "allows arbitrary parentheses in where" do
+      _ = from(p in "posts", where: (not is_nil(p.title)))
+    end
   end
 
   describe "from" do


### PR DESCRIPTION
hello! :wave:

I noticed when building a `dynamic/2` that where clauses don't seem to like arbitrary parentheses surrounding expressions like `not is_nil(..)`.

Most minimally with a `dynamic/2` (although the same happens in `where/3` and `from/2`):

```elixir
iex> dynamic([f], (not is_nil(f.foo)))
** (Ecto.Query.CompileError) `not(is_nil(f.foo))` is not a valid query expression.
# ..
```

You can work around this particular case a number of ways:

- drop those extra parentheses, they aren't necessary: `dynamic([f], not is_nil(f.foo))`
- use the parentheses as shown in the error message: `dynamic([f], not(is_nil(f.foo)))`
- replace `not` with `== false`: `dynamic([f], (is_nil(f.foo) == false))`

So ultimately this PR is probably not necessary, but I like having the option to have those extra parentheses. I found this behavior when writing out a `dynamic/2` with a few expressions pieced together with `and/2`s and `or/2`s, and I like to add some extra parentheses to be explicit and let the formatter clean up for me.

What do you think?
