### PR TITLE
Backwards compatibility on Changeset.validate_subset/3

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2043,13 +2043,14 @@ defmodule Ecto.Changeset do
   def validate_subset(changeset, field, data, opts \\ []) do
     validate_change changeset, field, {:subset, data}, fn _, value ->
       element_type =
-        case Map.fetch!(changeset.types, field) do
+        case Map.fetch!(changeset.types, field)do
           {:array, element_type} ->
             element_type
 
           type ->
-            raise ArgumentError,
-              "validate_subset/4 expects field type to be array, field `#{inspect(field)}` has type `#{inspect(type)}`"
+            # backwards compatibility: custom types use underlying type
+            {:array, element_type} = Ecto.Type.type(type)
+            element_type
         end
 
       case Enum.any?(value, fn element -> not Ecto.Type.include?(element_type, element, data) end) do


### PR DESCRIPTION
If the underlying type of a custom type is `{:array, internal_type}`, assume it is Enumerable of internal_type, doing a semantic comparison for internal_type. Closes issue #3768.