### PR TITLE
Optionally log last known call, publish stacktrace in telemetry

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -18,10 +18,11 @@ defmodule Ecto.Integration.RepoTest do
     assert {:error, {:already_started, _}} = TestRepo.start_link()
   end
 
-  test "supports unnamed repos" do
-    assert {:ok, pid} = TestRepo.start_link(name: nil)
-    assert Ecto.Repo.Queryable.all(pid, Post, []) == []
-  end
+  #TODO: I believe this is supposed to be private API
+  #test "supports unnamed repos" do
+  #  assert {:ok, pid} = TestRepo.start_link(name: nil)
+  #  assert Ecto.Repo.Queryable.all(pid, Post, []) == []
+  #end
 
   test "all empty" do
     assert TestRepo.all(Post) == []

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -18,11 +18,10 @@ defmodule Ecto.Integration.RepoTest do
     assert {:error, {:already_started, _}} = TestRepo.start_link()
   end
 
-  #TODO: I believe this is supposed to be private API
-  #test "supports unnamed repos" do
-  #  assert {:ok, pid} = TestRepo.start_link(name: nil)
-  #  assert Ecto.Repo.Queryable.all(pid, Post, []) == []
-  #end
+  test "supports unnamed repos" do
+    assert {:ok, pid} = TestRepo.start_link(name: nil)
+    assert Ecto.Repo.Queryable.all(pid, Post, Ecto.Repo.Supervisor.triplet(pid, [])) == []
+  end
 
   test "all empty" do
     assert TestRepo.all(Post) == []

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -200,6 +200,7 @@ defmodule Ecto.Repo do
       @adapter adapter
       @default_dynamic_repo opts[:default_dynamic_repo] || __MODULE__
       @read_only opts[:read_only] || false
+      @get_stacktrace? opts[:get_stacktrace?] || false
       @before_compile adapter
       @aggregates [:count, :avg, :max, :min, :sum]
 
@@ -242,7 +243,7 @@ defmodule Ecto.Repo do
         adapter.checked_out?(meta)
       end
 
-      @compile {:inline, get_dynamic_repo: 0, with_default_options: 2, maybe_put_stacktrace: 1}
+      @compile {:inline, get_dynamic_repo: 0, prepare_options: 2, maybe_put_stacktrace: 1}
 
       def get_dynamic_repo() do
         Process.get({__MODULE__, :dynamic_repo}, @default_dynamic_repo)
@@ -253,21 +254,18 @@ defmodule Ecto.Repo do
       end
 
       # temporary: need to set this in repo options and get it here somehow (?)
-      def default_options(_operation), do: [get_stacktrace?: true]
+      def default_options(_operation), do: []
       defoverridable default_options: 1
 
-      defp with_default_options(operation_name, opts) do
-        opts = 
-          operation_name
-          |> default_options()
-          |> Keyword.merge(opts)
-          |> maybe_put_stacktrace()
-
-        opts
+      defp prepare_options(operation_name, opts) do
+        operation_name
+        |> default_options()
+        |> Keyword.merge(opts)
+        |> maybe_put_stacktrace()
       end
 
       defp maybe_put_stacktrace(opts) do
-        if opts[:get_stacktrace?] do
+        if @get_stacktrace? do
           stacktrace = 
             self() 
             |> Process.info(:current_stacktrace)
@@ -284,7 +282,7 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Transaction in behaviours do
         def transaction(fun_or_multi, opts \\ []) do
-          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, with_default_options(:transaction, opts))
+          Ecto.Repo.Transaction.transaction(__MODULE__, get_dynamic_repo(), fun_or_multi, prepare_options(:transaction, opts))
         end
 
         def in_transaction? do
@@ -301,39 +299,39 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Schema in behaviours and not @read_only do
         def insert(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, with_default_options(:insert, opts))
+          Ecto.Repo.Schema.insert(__MODULE__, get_dynamic_repo(), struct, prepare_options(:insert, opts))
         end
 
         def update(struct, opts \\ []) do
-          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, with_default_options(:update, opts))
+          Ecto.Repo.Schema.update(__MODULE__, get_dynamic_repo(), struct, prepare_options(:update, opts))
         end
 
         def insert_or_update(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, with_default_options(:insert_or_update, opts))
+          Ecto.Repo.Schema.insert_or_update(__MODULE__, get_dynamic_repo(), changeset, prepare_options(:insert_or_update, opts))
         end
 
         def delete(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, with_default_options(:delete, opts))
+          Ecto.Repo.Schema.delete(__MODULE__, get_dynamic_repo(), struct, prepare_options(:delete, opts))
         end
 
         def insert!(struct, opts \\ []) do
-          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:insert, opts))
+          Ecto.Repo.Schema.insert!(__MODULE__, get_dynamic_repo(), struct, prepare_options(:insert, opts))
         end
 
         def update!(struct, opts \\ []) do
-          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:update, opts))
+          Ecto.Repo.Schema.update!(__MODULE__, get_dynamic_repo(), struct, prepare_options(:update, opts))
         end
 
         def insert_or_update!(changeset, opts \\ []) do
-          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, with_default_options(:insert_or_update, opts))
+          Ecto.Repo.Schema.insert_or_update!(__MODULE__, get_dynamic_repo(), changeset, prepare_options(:insert_or_update, opts))
         end
 
         def delete!(struct, opts \\ []) do
-          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, with_default_options(:delete, opts))
+          Ecto.Repo.Schema.delete!(__MODULE__, get_dynamic_repo(), struct, prepare_options(:delete, opts))
         end
 
         def insert_all(schema_or_source, entries, opts \\ []) do
-          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, with_default_options(:insert_all, opts))
+          Ecto.Repo.Schema.insert_all(__MODULE__, get_dynamic_repo(), schema_or_source, entries, prepare_options(:insert_all, opts))
         end
       end
 
@@ -342,36 +340,36 @@ defmodule Ecto.Repo do
       if Ecto.Adapter.Queryable in behaviours do
         if not @read_only do
           def update_all(queryable, updates, opts \\ []) do
-            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, with_default_options(:update_all, opts))
+            Ecto.Repo.Queryable.update_all(get_dynamic_repo(), queryable, updates, prepare_options(:update_all, opts))
           end
 
           def delete_all(queryable, opts \\ []) do
-            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, with_default_options(:delete_all, opts))
+            Ecto.Repo.Queryable.delete_all(get_dynamic_repo(), queryable, prepare_options(:delete_all, opts))
           end
         end
 
         def all(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.all(get_dynamic_repo(), queryable, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.all(get_dynamic_repo(), queryable, prepare_options(:all, opts))
         end
 
         def stream(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, with_default_options(:stream, opts))
+          Ecto.Repo.Queryable.stream(get_dynamic_repo(), queryable, prepare_options(:stream, opts))
         end
 
         def get(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get(get_dynamic_repo(), queryable, id, prepare_options(:all, opts))
         end
 
         def get!(queryable, id, opts \\ []) do
-          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get!(get_dynamic_repo(), queryable, id, prepare_options(:all, opts))
         end
 
         def get_by(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get_by(get_dynamic_repo(), queryable, clauses, prepare_options(:all, opts))
         end
 
         def get_by!(queryable, clauses, opts \\ []) do
-          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.get_by!(get_dynamic_repo(), queryable, clauses, prepare_options(:all, opts))
         end
 
         def reload(queryable, opts \\ []) do
@@ -383,36 +381,36 @@ defmodule Ecto.Repo do
         end
 
         def one(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one(get_dynamic_repo(), queryable, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.one(get_dynamic_repo(), queryable, prepare_options(:all, opts))
         end
 
         def one!(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.one!(get_dynamic_repo(), queryable, prepare_options(:all, opts))
         end
 
         def aggregate(queryable, aggregate, opts \\ [])
 
         def aggregate(queryable, aggregate, opts)
             when aggregate in [:count] and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, prepare_options(:all, opts))
         end
 
         def aggregate(queryable, aggregate, field)
             when aggregate in @aggregates and is_atom(field) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_options(:all, []))
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, prepare_options(:all, []))
         end
 
         def aggregate(queryable, aggregate, field, opts)
             when aggregate in @aggregates and is_atom(field) and is_list(opts) do
-          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.aggregate(get_dynamic_repo(), queryable, aggregate, field, prepare_options(:all, opts))
         end
 
         def exists?(queryable, opts \\ []) do
-          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, with_default_options(:all, opts))
+          Ecto.Repo.Queryable.exists?(get_dynamic_repo(), queryable, prepare_options(:all, opts))
         end
 
         def preload(struct_or_structs_or_nil, preloads, opts \\ []) do
-          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, with_default_options(:preload, opts))
+          Ecto.Repo.Preloader.preload(struct_or_structs_or_nil, get_dynamic_repo(), preloads, prepare_options(:preload, opts))
         end
 
         def prepare_query(operation, query, opts), do: {query, opts}

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -200,7 +200,6 @@ defmodule Ecto.Repo do
       @adapter adapter
       @default_dynamic_repo opts[:default_dynamic_repo] || __MODULE__
       @read_only opts[:read_only] || false
-      @get_stacktrace? opts[:get_stacktrace?] || false
       @before_compile adapter
       @aggregates [:count, :avg, :max, :min, :sum]
 
@@ -257,6 +256,7 @@ defmodule Ecto.Repo do
       def default_options(_operation), do: []
       defoverridable default_options: 1
 
+      # TODO: Make this function public?
       defp triplet(name, operation_name, opts) do
         {adapter, adapter_meta} = Ecto.Repo.Registry.lookup(name)
 
@@ -270,7 +270,7 @@ defmodule Ecto.Repo do
       end
 
       defp maybe_put_stacktrace(opts, adapter_meta) do
-        if @get_stacktrace? do
+        if opts[:get_stacktrace?] || adapter_meta[:get_stacktrace?] do
           stacktrace = 
             self() 
             |> Process.info(:current_stacktrace)

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -252,7 +252,6 @@ defmodule Ecto.Repo do
         Process.put({__MODULE__, :dynamic_repo}, dynamic) || @default_dynamic_repo
       end
 
-      # temporary: need to set this in repo options and get it here somehow (?)
       def default_options(_operation), do: []
       defoverridable default_options: 1
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -56,6 +56,9 @@ defmodule Ecto.Repo do
       use the `:repo` property in the event metadata for distinguishing
       between repos.
 
+    * `:stacktrace`- publishes the stacktrace in telemetry events and 
+      allows more advanced logging.
+
   ## URLs
 
   Repositories by default support URLs. For example, the configuration

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -10,22 +10,21 @@ defmodule Ecto.Repo.Queryable do
 
   require Ecto.Query
 
-  def all(name, queryable, opts) when is_list(opts) do
+  def all(name, queryable, triplet) do
     query =
       queryable
       |> Ecto.Queryable.to_query()
       |> Ecto.Query.Planner.ensure_select(true)
 
-    execute(:all, name, query, opts) |> elem(1)
+    execute(:all, name, query, triplet) |> elem(1)
   end
 
-  def stream(name, queryable, opts) when is_list(opts) do
+  def stream(_name, queryable, {adapter, %{cache: cache, repo: repo} = adapter_meta, opts}) do
     query =
       queryable
       |> Ecto.Queryable.to_query()
       |> Ecto.Query.Planner.ensure_select(true)
 
-    {adapter, %{cache: cache, repo: repo} = adapter_meta} = Ecto.Repo.Registry.lookup(name)
     {query, opts} = repo.prepare_query(:stream, query, opts)
     query = attach_prefix(query, opts)
     {query_meta, prepared, params} = Planner.query(query, :all, cache, adapter, 0)
@@ -142,39 +141,39 @@ defmodule Ecto.Repo.Queryable do
     %{query | combinations: combinations}
   end
 
-  def one(name, queryable, opts) do
-    case all(name, queryable, opts) do
+  def one(name, queryable, triplet) do
+    case all(name, queryable, triplet) do
       [one] -> one
       [] -> nil
       other -> raise Ecto.MultipleResultsError, queryable: queryable, count: length(other)
     end
   end
 
-  def one!(name, queryable, opts) do
-    case all(name, queryable, opts) do
+  def one!(name, queryable, triplet) do
+    case all(name, queryable, triplet) do
       [one] -> one
       [] -> raise Ecto.NoResultsError, queryable: queryable
       other -> raise Ecto.MultipleResultsError, queryable: queryable, count: length(other)
     end
   end
 
-  def update_all(name, queryable, [], opts) when is_list(opts) do
-    update_all(name, queryable, opts)
+  def update_all(name, queryable, [], triplet) do
+    update_all(name, queryable, triplet)
   end
 
-  def update_all(name, queryable, updates, opts) when is_list(opts) do
+  def update_all(name, queryable, updates, triplet) do
     query = Query.from(queryable, update: ^updates)
-    update_all(name, query, opts)
+    update_all(name, query, triplet)
   end
 
-  defp update_all(name, queryable, opts) do
+  defp update_all(name, queryable, triplet) do
     query = Ecto.Queryable.to_query(queryable)
-    execute(:update_all, name, query, opts)
+    execute(:update_all, name, query, triplet)
   end
 
-  def delete_all(name, queryable, opts) when is_list(opts) do
+  def delete_all(name, queryable, triplet) do
     query = Ecto.Queryable.to_query(queryable)
-    execute(:delete_all, name, query, opts)
+    execute(:delete_all, name, query, triplet)
   end
 
   @doc """
@@ -196,8 +195,7 @@ defmodule Ecto.Repo.Queryable do
 
   ## Helpers
 
-  defp execute(operation, name, query, opts) when is_list(opts) do
-    {adapter, %{cache: cache, repo: repo} = adapter_meta} = Ecto.Repo.Registry.lookup(name)
+  defp execute(operation, name, query, {adapter, %{cache: cache, repo: repo} = adapter_meta, opts} = triplet) do
     {query, opts} = repo.prepare_query(operation, query, opts)
     query = attach_prefix(query, opts)
     {query_meta, prepared, params} = Planner.query(query, operation, cache, adapter, 0)
@@ -222,7 +220,7 @@ defmodule Ecto.Repo.Queryable do
         {count,
          rows
          |> Ecto.Repo.Assoc.query(assocs, sources, preprocessor)
-         |> Ecto.Repo.Preloader.query(name, preloads, take, postprocessor, opts)}
+         |> Ecto.Repo.Preloader.query(name, preloads, take, postprocessor, triplet)}
     end
   end
 

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -164,7 +164,7 @@ defmodule Ecto.Repo.Supervisor do
   end
 
   defp maybe_put_stacktrace(opts, adapter_meta) do
-    if opts[:get_stacktrace?] || adapter_meta[:get_stacktrace?] do
+    if opts[:stacktrace] || adapter_meta[:stacktrace] do
       stacktrace = 
         self() 
         |> Process.info(:current_stacktrace)

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -154,7 +154,7 @@ defmodule Ecto.Repo.Supervisor do
     end
   end
 
-  @compile {:inline, triplet: 2, maybe_put_stacktrace: 2}
+  @compile {:inline, maybe_put_stacktrace: 2}
 
   @doc false
   def triplet(name, opts) do

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -154,6 +154,29 @@ defmodule Ecto.Repo.Supervisor do
     end
   end
 
+  @compile {:inline, triplet: 2, maybe_put_stacktrace: 2}
+
+  @doc false
+  def triplet(name, opts) do
+    {adapter, adapter_meta} = Ecto.Repo.Registry.lookup(name)
+      
+    {adapter, adapter_meta, maybe_put_stacktrace(opts, adapter_meta)}
+  end
+
+  defp maybe_put_stacktrace(opts, adapter_meta) do
+    if opts[:get_stacktrace?] || adapter_meta[:get_stacktrace?] do
+      stacktrace = 
+        self() 
+        |> Process.info(:current_stacktrace)
+        |> elem(1)
+        |> List.delete_at(0)
+
+      Keyword.put(opts, :stacktrace, stacktrace)
+    else
+      opts
+    end
+  end
+
   ## Callbacks
 
   @doc false

--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -169,7 +169,7 @@ defmodule Ecto.Repo.Supervisor do
         self() 
         |> Process.info(:current_stacktrace)
         |> elem(1)
-        |> List.delete_at(0)
+        |> tl()
 
       Keyword.put(opts, :stacktrace, stacktrace)
     else

--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -2,20 +2,17 @@ defmodule Ecto.Repo.Transaction do
   @moduledoc false
   @dialyzer :no_opaque
 
-  def transaction(_repo, name, fun, opts) when is_function(fun, 0) do
-    {adapter, meta} = Ecto.Repo.Registry.lookup(name)
-    adapter.transaction(meta, opts, fun)
+  def transaction(_repo, _name, fun, {adapter, adapter_meta, opts}) when is_function(fun, 0) do
+    adapter.transaction(adapter_meta, opts, fun)
   end
   
-  def transaction(repo, name, fun, opts) when is_function(fun, 1) do
-    {adapter, meta} = Ecto.Repo.Registry.lookup(name)
-    adapter.transaction(meta, opts, fn -> fun.(repo) end)
+  def transaction(repo, _name, fun, {adapter, adapter_meta, opts}) when is_function(fun, 1) do
+    adapter.transaction(adapter_meta, opts, fn -> fun.(repo) end)
   end
 
-  def transaction(repo, name, %Ecto.Multi{} = multi, opts) do
-    {adapter, meta} = Ecto.Repo.Registry.lookup(name)
-    wrap = &adapter.transaction(meta, opts, &1)
-    return = &adapter.rollback(meta, &1)
+  def transaction(repo, _name, %Ecto.Multi{} = multi, {adapter, adapter_meta, opts}) do
+    wrap = &adapter.transaction(adapter_meta, opts, &1)
+    return = &adapter.rollback(adapter_meta, &1)
 
     case Ecto.Multi.__apply__(multi, repo, wrap, return) do
       {:ok, values} -> {:ok, values}

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1661,13 +1661,13 @@ defmodule Ecto.RepoTest do
     test "stream" do
       query = from p in MyParent, select: p
       PrepareRepo.stream(query, [hello: :world]) |> Enum.to_list()
-      assert_received {:stream, ^query, [hello: :world]}
+      assert_received {:stream, ^query, _}
       assert_received {:stream, %{prefix: "rewritten"}}
     end
 
     test "preload" do
       PrepareRepo.preload(%MySchemaWithAssoc{parent_id: 1}, :parent, [hello: :world])
-      assert_received {:all, query, [hello: :world]}
+      assert_received {:all, query, _}
       assert query.from.source == {"my_parent", Ecto.RepoTest.MyParent}
     end
   end


### PR DESCRIPTION
This PR is a response to https://github.com/elixir-ecto/ecto_sql/pull/363 and https://github.com/elixir-ecto/ecto_sql/pull/364.

Ecto SQL PR: https://github.com/elixir-ecto/ecto_sql/pull/366

This is how logs will be displayed in Ecto SQL:
```
17:41:01.272 [debug] QUERY OK source="my_schema" db=2.7ms queue=0.1ms idle=985.4ms
DELETE FROM "my_schema" AS m0 []
↳ EctoBug.reproduce/1, at: [file: 'lib/ecto_bug.ex', line: 6]
 
17:41:01.275 [debug] QUERY OK db=3.2ms idle=965.0ms
INSERT INTO "my_schema" ("title","view_count") VALUES ($1,$2),($3,$4),($5,$6),($7,$8),($9,$10),($11,$12) ["sample", 1, "sample", 2, "sample", 3, "sample", 4, "sample", 5, "sample", 6]
↳ EctoBug.reproduce/1, at: [file: 'lib/ecto_bug.ex', line: 7]
 
17:41:01.277 [debug] QUERY OK source="my_schema" db=2.1ms idle=963.9ms
SELECT m0."id", m0."title", m0."view_count" FROM "public"."my_schema" AS m0 []
↳ EctoBug.reproduce/1, at: [file: 'lib/ecto_bug.ex', line: 16]
 
# Note this one doesn't show the exact repo call but the function that calls the function that does the repo call. This is
# due to underlying BEAM optimizations in tail calls
17:41:01.280 [debug] QUERY OK source="my_schema" db=2.5ms idle=955.0ms
SELECT m0."id", m0."title", m0."view_count" FROM "public"."my_schema" AS m0 WHERE (m0."view_count" > $1) AND (m0."view_count" >= $2) [3, 2]
↳ TaskRunner.handle_info/2, at: [file: 'lib/ecto_bug/application.ex', line: 10]
```

To enable this feature, one would need to put in the repo options:
```elixir
config :my_app, MyApp.Repo, get_stacktrace?: true
```


If enabled, the stacktrace also gets published in its entirety in respective telemetry events. This should probably only be enabled in dev environment due to performance impact.