### PR TITLE
Handle atom list sigils in select

### DIFF
--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -34,7 +34,7 @@ defmodule Ecto.Query.Builder.Select do
   def escape(other, vars, env) do
     cond do
       take?(other) ->
-        {{:{}, [], [:&, [], [0]]}, {[], %{0 => {:any, other}}}}
+        {{:{}, [], [:&, [], [0]]}, {[], %{0 => {:any, Macro.expand(other, env)}}}}
 
       maybe_take?(other) ->
         Builder.error! """
@@ -154,6 +154,11 @@ defmodule Ecto.Query.Builder.Select do
       raise ArgumentError,
         "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect fields}`"
     end
+  end
+
+  # atom list sigils
+  defp take?({name, _, [_, modifiers]}) when name in ~w(sigil_w sigil_W)a do
+    ?a in modifiers
   end
 
   defp take?(fields) do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -59,6 +59,7 @@ defmodule Ecto.Query.Builder.SelectTest do
       fields = ~w[field]a
       assert select("q", [q], map(q, ~w[field]a)).select.take == %{0 => {:map, fields}}
       assert select("q", [q], struct(q, @fields)).select.take == %{0 => {:struct, fields}}
+      assert select("q", [q], ~w[field]a).select.take == %{0 => {:any, fields}}
     end
 
     test "raises on single atom" do


### PR DESCRIPTION
Related to #3800 and #2958.
Atom list sigils were being escaped as literals instead of going into select_expr.take. 