### PR TITLE
Update docs for unsafe_fragment of conflict target option

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1220,7 +1220,8 @@ defmodule Ecto.Repo do
       It may also be `{:unsafe_fragment, binary_fragment}` to pass any
       expression to the database without any sanitization, this is useful
       for partial index or index with expressions, such as
-      `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
+      `{:unsafe_fragment, "(coalesce(firstname, ""), coalesce(lastname, "")) WHERE middlename IS NULL"}` for
+      `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, "")) WHERE middlename IS NULL` SQL query.
 
     * `:placeholders` - A map with placeholders. This feature is not supported
       by all databases. See the "Placeholders" section for more information.
@@ -1377,7 +1378,8 @@ defmodule Ecto.Repo do
       It may also be `{:unsafe_fragment, binary_fragment}` to pass any
       expression to the database without any sanitization, this is useful
       for partial index or index with expressions, such as
-      `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, ""))`.
+      `{:unsafe_fragment, "(coalesce(firstname, ""), coalesce(lastname, "")) WHERE middlename IS NULL"}` for
+      `ON CONFLICT (coalesce(firstname, ""), coalesce(lastname, "")) WHERE middlename IS NULL` SQL query.
 
     * `:stale_error_field` - The field where stale errors will be added in
       the returning changeset. This option can be used to avoid raising


### PR DESCRIPTION
`{:unsafe_fragment, binary_fragment}` of `:conflict_target` option is necessary for upsert with partial index, but its docs don't have enough information.

I'm not good at English, so any suggestions for the comments are welcome.