### PR TITLE
Fix apply/5 prefix parameter spec

### DIFF
--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -122,7 +122,7 @@ defmodule Ecto.Query.Builder.From do
   @doc """
   The callback applied by `build/2` to build the query.
   """
-  @spec apply(Ecto.Queryable.t(), non_neg_integer, atom, String.t | nil, [String.t]) :: Ecto.Query.t()
+  @spec apply(Ecto.Queryable.t(), non_neg_integer, atom, {:ok, String.t} | nil, [String.t]) :: Ecto.Query.t()
   def apply(query, binds, as, prefix, hints) do
     query =
       query


### PR DESCRIPTION
Related to #3811 

### Precheck

* Do not use the issues tracker for help or support requests (try Elixir Forum, Stack Overflow, IRC or mailing lists, etc).
* For proposing a new feature, please start a discussion on [elixir-ecto](https://groups.google.com/forum/#!forum/elixir-ecto).
* For bugs, do a quick search and make sure the bug has not yet been reported.
* Finally, be nice and have fun!

### Environment

* Elixir version (elixir -v): 1.13.1
* Database and version (PostgreSQL 9.4, MongoDB 3.2, etc.): PostgreSQL 11.5
* Ecto version (mix deps): 3.7.1
* Database adapter and version (mix deps): Postgrex 0.15.13
* Operating system: Manjaro

### Current behavior

Wrong spec perceived by Dialyzer while using `Ecto.Query.from/2` macro with `prefix` and runtime table name String as queryable.

For example:

```elixir
import Ecto.Query, only: [from: 2]

def my_function(table_name) do
  from(table_name, prefix: "my_prefix")
end
```

Produces:

```elixir
The call 'Elixir.Ecto.Query.Builder.From':apply
         (_table_name@1 :: <<_:64, _:_*8>>,
          0,
          'pre_invoice_reckon',
          {ok,
           <<105,110,118,111,105,99,101,95,119,111,114,107,101,114,115>>},
          []) breaks the contract 
          ('Elixir.Ecto.Queryable':t(),
          non_neg_integer(),
          atom(),
          'Elixir.String':t() | 'nil',
          ['Elixir.String':t()]) ->
             'Elixir.Ecto.Query':t()
```

### Expected behavior

From the Dialyzer error and the Ecto implementation, the spec should be changed from:

```elixir
@spec apply(Ecto.Queryable.t(), non_neg_integer, atom, String.t | nil, [String.t]) :: Ecto.Query.t()
```

to:

```elixir
@spec apply(Ecto.Queryable.t(), non_neg_integer, atom, {:ok, String.t} | nil, [String.t]) :: Ecto.Query.t()
```