### PR TITLE
Support passing queries using subqueries to Repo.insert_all

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -935,7 +935,7 @@ defmodule Ecto.Query.Planner do
                    &validate_and_increment(&1, &2, &3, &4, operation, adapter))
   end
 
-  defp validate_and_increment(:from, query, %{source: %Ecto.SubQuery{}}, _counter, kind, _adapter) when kind != :all do
+  defp validate_and_increment(:from, query, %{source: %Ecto.SubQuery{}}, _counter, kind, _adapter) when kind not in ~w(all insert_all)a do
     error! query, "`#{kind}` does not allow subqueries in `from`"
   end
   defp validate_and_increment(:from, query, %{source: source} = expr, counter, _kind, adapter) do


### PR DESCRIPTION
This is a follow-up to PR https://github.com/elixir-ecto/ecto/pull/3574 to allow queries that utilize subqueries to be passed to Repo.insert_all.

Without this change, the following succeeds:

```ex
Repo.insert_all(
  "widgets",
  from(
    w in "widgets",
    select: %{name: w.name},
  )
)
```

But this fails:

```ex
Repo.insert_all(
  "widgets",
  from(
    w in subquery(from(w in "widgets", select: %{name: w.name})),
    select: %{name: w.name},
  )
)
```

With the following error:

```
** (Ecto.QueryError) `insert_all` does not allow subqueries in `from` in query:

from w0 in subquery(from w0 in "widgets",
  select: %{name: w0.name}),
  select: %{name: w0.name}

    (elixir 1.12.2) lib/enum.ex:2385: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto 3.8.0-dev) lib/ecto/adapter/queryable.ex:123: Ecto.Adapter.Queryable.plan_query/3
    (ecto 3.8.0-dev) lib/ecto/repo/schema.ex:121: Ecto.Repo.Schema.extract_header_and_fields/8
    (ecto 3.8.0-dev) lib/ecto/repo/schema.ex:48: Ecto.Repo.Schema.do_insert_all/7
```

With the change, the second example succeeds.