### PR TITLE
Support qualified macros in ecto queries

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -459,16 +459,9 @@ defmodule Ecto.Query.Builder do
   end
 
   # Raise nice error message for remote calls
-  def escape({{:., _, [mod, fun]}, _, args} = other, _type, _params_acc, _vars, _env)
+  def escape({{:., _, [_, fun]}, _, _} = other, type, params_acc, vars, env)
       when is_atom(fun) do
-    fun_arity = "#{fun}/#{length(args)}"
-
-    error! """
-    `#{Macro.to_string(other)}` is not a valid query expression. \
-    If you want to invoke #{Macro.to_string(mod)}.#{fun_arity} in \
-    a query, make sure that the module #{Macro.to_string(mod)} \
-    is required and that #{fun_arity} is a macro
-    """
+    try_expansion(other, type, params_acc, vars, env)
   end
 
   # For everything else we raise

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -236,7 +236,7 @@ defmodule Ecto.Query.BuilderTest do
     end
 
     assert_raise Ecto.Query.CompileError,
-                 ~r"make sure that the module Foo is required and that bar/1 is a macro",
+                 ~r"make sure that you have required\n  the module or imported the relevant function",
                  fn ->
       escape(quote(do: Foo.bar(x)), [x: 0], __ENV__) |> elem(0) |> Code.eval_quoted([], __ENV__)
     end

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -24,6 +24,7 @@ defmodule Ecto.QueryTest do
   import Support.EvalHelpers
   import Ecto.Query
   import Ecto.QueryTest.Macros
+  require Ecto.QueryTest.Macros, as: Macros
   alias Ecto.Query
 
   defmodule Schema do
@@ -35,6 +36,8 @@ defmodule Ecto.QueryTest do
   describe "query building" do
     test "allows macros" do
       test_data = "test"
+      query = from(p in "posts") |> where([q], Macros.macro_equal(q.title, ^test_data))
+      assert "&0.title() == ^0" == Macro.to_string(hd(query.wheres).expr)
       query = from(p in "posts") |> where([q], macro_equal(q.title, ^test_data))
       assert "&0.title() == ^0" == Macro.to_string(hd(query.wheres).expr)
     end
@@ -45,7 +48,9 @@ defmodule Ecto.QueryTest do
     end
 
     test "allows macro in where" do
+      _ = from(p in "posts", where: p.title == "C" or Macros.macrotest(p.title))
       _ = from(p in "posts", where: p.title == "C" or macrotest(p.title))
+      _ = from(p in "posts", where: p.title == "C" or Macros.deeper_macrotest(p.title))
       _ = from(p in "posts", where: p.title == "C" or deeper_macrotest(p.title))
     end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1,19 +1,7 @@
 Code.require_file "../support/eval_helpers.exs", __DIR__
 
-defmodule Ecto.QueryTest do
-  use ExUnit.Case, async: true
-
-  import Support.EvalHelpers
-  import Ecto.Query
-  alias Ecto.Query
-
-  defmodule Schema do
-    use Ecto.Schema
-    schema "schema" do
-    end
-  end
-
-  defmacrop macro_equal(column, value) do
+defmodule Ecto.QueryTest.Macros do
+  defmacro macro_equal(column, value) do
     quote do
       unquote(column) == unquote(value)
     end
@@ -23,6 +11,24 @@ defmodule Ecto.QueryTest do
     quote do
       %{"1" => unquote(key),
         "2" => unquote(key)}
+    end
+  end
+
+  defmacro macrotest(x), do: quote(do: is_nil(unquote(x)) or unquote(x) == "A")
+  defmacro deeper_macrotest(x), do: quote(do: macrotest(unquote(x)) or unquote(x) == "B")
+end
+
+defmodule Ecto.QueryTest do
+  use ExUnit.Case, async: true
+
+  import Support.EvalHelpers
+  import Ecto.Query
+  import Ecto.QueryTest.Macros
+  alias Ecto.Query
+
+  defmodule Schema do
+    use Ecto.Schema
+    schema "schema" do
     end
   end
 
@@ -38,8 +44,6 @@ defmodule Ecto.QueryTest do
       from(p in "posts", select: [macro_map(^key)])
     end
 
-    defmacrop macrotest(x), do: quote(do: is_nil(unquote(x)) or unquote(x) == "A")
-    defmacrop deeper_macrotest(x), do: quote(do: macrotest(unquote(x)) or unquote(x) == "B")
     test "allows macro in where" do
       _ = from(p in "posts", where: p.title == "C" or macrotest(p.title))
       _ = from(p in "posts", where: p.title == "C" or deeper_macrotest(p.title))


### PR DESCRIPTION
Previously, if you tried to use a qualified macro via `require`, you would get a compile error that tells you to make sure that you're using `require` correctly. As far as I can tell, there was no way to actually get qualified macros to work because Ecto never actually tries to expand them.

Without the code changes to `lib/ecto/query/builder.ex` but with the modifications to the tests in `test/ecto/query/builder_test.exs`, the test fails with the following error despite the `macro_equal/2` being a macro and the `Macros` module being required:

    == Compilation error in file test/ecto/query_test.exs ==
    ** (Ecto.Query.CompileError) `Macros.macro_equal(q.title, ^test_data)` is not a valid query expression. If you want to invoke Macros.macro_equal/2 in a query, make sure that the module Macros is required and that macro_equal/2 is a macro

        (ecto 3.8.0-dev) expanding macro: Ecto.Query.where/3
        test/ecto/query_test.exs:39: Ecto.QueryTest."test query building allows macros"/1
        (elixir 1.12.2) expanding macro: Kernel.|>/2
        test/ecto/query_test.exs:39: Ecto.QueryTest."test query building allows macros"/1

The code change makes this test pass by trying expansion when encountering a qualified macro rather than raising an error. If the expansion fails (invalid macro), it still raises an error with the same messaging that you would get if you had used an invalid unqualified macro. This messaging still suggests that you make sure that the module is required and that the function is a macro, so the impact to developer experience in this situation should be minimal.