### PR TITLE
properly escape parameterized types when inspecting query

### DIFF
--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -247,6 +247,10 @@ defimpl Inspect, for: Ecto.Query do
     value
   end
 
+  defp prewalk(%Ecto.Query.Tagged{value: value, tag: {:parameterized, type, opts}}) do
+    {:type, [], [value, {:{}, [], [:parameterized, type, opts]}]}
+  end
+
   defp prewalk(%Ecto.Query.Tagged{value: value, tag: tag}) do
     {:type, [], [value, tag]}
   end
@@ -324,6 +328,10 @@ defimpl Inspect, for: Ecto.Query do
       _ ->
         binding(names, ix)
     end
+  end
+
+  defp type_to_expr({:parameterized, type, opts}, _names, _part) do
+    {:{}, [], [:parameterized, type, opts]}
   end
 
   defp type_to_expr({ix, type}, names, part) when is_integer(ix) do

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -251,6 +251,10 @@ defimpl Inspect, for: Ecto.Query do
     {:type, [], [value, tag]}
   end
 
+  defp prewalk({:type, _, [value, {:parameterized, type, opts}]}) do
+    {:type, [], [value, {:{}, [], [:parameterized, type, opts]}]}
+  end
+
   defp prewalk(node) do
     node
   end


### PR DESCRIPTION
When constructing a query that does a typecast to a parameterized type, e.g `type(foo.bar, {:parameterized, Type, params})`, the query seems to function fine, but during inspect it raises errors. This PR addresses that by adding handlers in the appropriate places in the inspect logic.