### PR TITLE
Small dynamic binding fixes

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -852,6 +852,8 @@ defmodule Ecto.Query.Builder do
     do: {:pos, var, ix}
   defp escape_bind({{name, {var, _, context}}, _ix}) when is_atom(name) and is_atom(var) and is_atom(context),
     do: {:named, var, name}
+  defp escape_bind({{name, {{:^, _, _} = var, _, context}}, _ix}) when is_atom(name) and is_atom(context),
+    do: {:named, var, name}
   defp escape_bind({{{:^, _, [expr]}, {var, _, context}}, _ix}) when is_atom(var) and is_atom(context),
     do: {:named, var, expr}
   defp escape_bind({bind, _ix}),

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -136,6 +136,12 @@ defmodule Ecto.Query.Builder.Join do
     unless is_binary(prefix) or is_nil(prefix) do
       Builder.error! "`prefix` must be a compile time string, got: `#{Macro.to_string(prefix)}`"
     end
+    
+    as = case as do
+      {:^, _, [as]} -> as
+      as when is_atom(as) -> as
+      as -> Builder.error!("`as` must be a compile time atom or an interpolated value using ^, got: #{Macro.to_string(as)}")
+    end
 
     {query, binding} = Builder.escape_binding(query, binding, env)
     {join_bind, join_source, join_assoc, join_params} = escape(expr, binding, env)

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -1,7 +1,10 @@
+Code.require_file "../../../support/eval_helpers.exs", __DIR__
+
 defmodule Ecto.Query.Builder.JoinTest do
   use ExUnit.Case, async: true
 
   import Ecto.Query.Builder.Join
+  import Support.EvalHelpers
   doctest Ecto.Query.Builder.Join
 
   import Ecto.Query
@@ -75,6 +78,15 @@ defmodule Ecto.Query.Builder.JoinTest do
     subquery = "comments"
     join("posts", :left, [p], c in subquery(subquery), on: true)
     join("posts", :left, [p], c in subquery(subquery, prefix: "sample"), on: true)
+  end
+  
+  test "`as` accepts literal atoms and interpolated values, but not other literals" do
+    name = :comments
+    join("posts", :left, [p], c in assoc(p, :comments), as: :comments)
+    join("posts", :left, [p], c in assoc(p, :comments), as: ^name)
+    assert_raise Ecto.Query.CompileError, "`as` must be a compile time atom or an interpolated value using ^, got: 10", fn -> 
+      quote_and_eval(join("posts", :left, [p], c in assoc(p, :comments), as: 10))
+    end
   end
 
   test "raises on invalid qualifier" do


### PR DESCRIPTION
1. escape dynamic named bindings that appear in the bindings list:
  This allows you to do `from [{^as, row}] in query, ....`, whereas before the dynamic bindings only worked with `as(^binding)`. This can be cleaner if you need to reference the same binding multiple times.

2. require literal atom or interpolated value in `join` `as` just like we do in the `from` `as`
This was simply an oversight in the initial implementation, which resulted in queries looking like:

```elixir
from row in query,
  as: ^as,
  join: foo in assoc(row, :foo),
  as: other_as
```
which is clearly problematic.