### PR TITLE
fix: set proper typespec for `Ecto.Query.Builder.From.apply`

### DIFF
--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -124,7 +124,7 @@ defmodule Ecto.Query.Builder.From do
   @doc """
   The callback applied by `build/2` to build the query.
   """
-  @spec apply(Ecto.Queryable.t(), non_neg_integer, atom, {:ok, String.t} | nil, [String.t]) :: Ecto.Query.t()
+  @spec apply(Ecto.Queryable.t(), non_neg_integer, term, {:ok, String.t} | nil, [String.t]) :: Ecto.Query.t()
   def apply(query, binds, as, prefix, hints) do
     query =
       query

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -124,7 +124,7 @@ defmodule Ecto.Query.Builder.From do
   @doc """
   The callback applied by `build/2` to build the query.
   """
-  @spec apply(Ecto.Queryable.t(), non_neg_integer, term, {:ok, String.t} | nil, [String.t]) :: Ecto.Query.t()
+  @spec apply(Ecto.Queryable.t(), non_neg_integer, Macro.t(), {:ok, String.t} | nil, [String.t]) :: Ecto.Query.t()
   def apply(query, binds, as, prefix, hints) do
     query =
       query


### PR DESCRIPTION
The typespec was incorrect given the new values allowed for the `as`. I could have done something like `atom | Macro.t()` or `atom | {:^, term, term}` or something, but that seemed like overkill to me. Happy to make the type more specific if necessary.