### PR TITLE
Allow custom error key in unique_constraint

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2646,6 +2646,10 @@ defmodule Ecto.Changeset do
       `:suffix` matches any repo constraint which `ends_with?` `:name`
        to this changeset constraint.
 
+    * `:error_key` - the key to which changeset error will be added when
+      check fails, defaults to the first field name of the given list of
+      fields.
+
   ## Complex constraints
 
   Because the constraint logic is in the database, we can leverage
@@ -2727,7 +2731,8 @@ defmodule Ecto.Changeset do
     constraint = opts[:name] || unique_index_name(changeset, fields)
     message    = message(opts, "has already been taken")
     match_type = Keyword.get(opts, :match, :exact)
-    add_constraint(changeset, :unique, to_string(constraint), match_type, first_field, message)
+    error_key  = Keyword.get(opts, :error_key, first_field)
+    add_constraint(changeset, :unique, to_string(constraint), match_type, error_key, message)
   end
 
   defp unique_index_name(changeset, fields) do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1825,6 +1825,12 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
            [%{type: :unique, field: :permalink, constraint: "posts_url_color_index", match: :exact,
               error_message: "has already been taken", error_type: :unique}]
+
+    changeset = change(%Post{}) |> unique_constraint([:permalink, :color], error_key: :color)
+
+    assert constraints(changeset) ==
+           [%{type: :unique, field: :color, constraint: "posts_url_color_index", match: :exact,
+              error_message: "has already been taken", error_type: :unique}]
   end
 
   test "foreign_key_constraint/3" do


### PR DESCRIPTION
`unsafe_validate_unique/3` allows a custom error key to which changeset error will be added when check fails.

This PR adds the same feature to `unique_constraint`.

It is useful when the composite key is `[:id, :slug]` for example, and the slug is duplicated. Saying to the user that the ID already exists does not make sense as most of the time the ID is auto generated and is not duplicated. With the PR we are able to set `:slug` as the error key.