### PR TITLE
change the Mix tasks advice to be close Getting Started.md

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -68,7 +68,7 @@ defmodule Ecto do
 
       def start(_type, _args) do
         children = [
-          {MyApp.Repo, []}
+          MyApp.Repo,
         ]
 
         opts = [strategy: :one_for_one, name: MyApp.Supervisor]

--- a/lib/mix/tasks/ecto.gen.repo.ex
+++ b/lib/mix/tasks/ecto.gen.repo.ex
@@ -75,7 +75,10 @@ defmodule Mix.Tasks.Ecto.Gen.Repo do
     Don't forget to add your new repo to your supervision tree
     (typically in lib/#{app}/application.ex):
 
-        {#{inspect repo}, []}
+        def start(_type, _args) do
+          children = [
+            #{inspect repo},
+          ]
 
     And to add it to the list of Ecto repositories in your
     configuration files (so Ecto tasks work as expected):


### PR DESCRIPTION
Hi!

The Ecto is great!
Thanks a lot.

I have a proposal to improve the description.

https://github.com/elixir-ecto/ecto/blob/a017d4a0ced979fa8c610b9dcba0f760cc47f253/lib/mix/tasks/ecto.gen.repo.ex#L78

```
Don't forget to add your new repo to your supervision tree
(typically in lib/#{app}/application.ex):

    {#{inspect repo}, []}
```

I was wondering if you could improve the description in Getting Started.md ? 
Of course I see the current description is right.
So I don't mind if the pull request was rejected.

