### PR TITLE
Clarify the benefit of a composite type

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -30,7 +30,7 @@ defmodule Ecto.Enum do
   Composite types, such as `:array`, are also supported which allow selecting
   multiple values per record:
 
-      field :roles, {:array, Ecto.Enum}, values: [:Author, :Editor, :Admin]
+      field :roles, {:array, Ecto.Enum}, values: [:author, :editor, :admin]
 
   Overall, `:values` must be a list of atoms or a keyword list. Values will be
   cast to atoms safely and only if the atom exists in the list (otherwise an

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -27,7 +27,8 @@ defmodule Ecto.Enum do
   Some databases also support enum types, which you could use in combination
   with the above.
 
-  Composite types, such as `:array`, are also supported:
+  Composite types, such as `:array`, are also supported which allow selecting
+  multiple values per record:
 
       field :roles, {:array, Ecto.Enum}, values: [:Author, :Editor, :Admin]
 


### PR DESCRIPTION
When reading the docs about `Ecto.Enum` I wasn't exactly sure what the benefit of a composite type was so I wanted to add a little bit more to clarify.