### PR TITLE
Detect `empty_values` inside lists when casting.

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -577,7 +577,7 @@ defmodule Ecto.Changeset do
   defp cast_field(key, param_key, type, params, current, empty_values, defaults, valid?) do
     case params do
       %{^param_key => value} ->
-        value = if value in empty_values, do: Map.get(defaults, key), else: value
+        value = filter_empty_values(type, value, empty_values, defaults, key)
         case Ecto.Type.cast(type, value) do
           {:ok, value} ->
             if Ecto.Type.equal?(type, current, value) do
@@ -595,6 +595,13 @@ defmodule Ecto.Changeset do
 
       _ ->
         :missing
+    end
+  end
+
+  defp filter_empty_values(type, value, empty_values, defaults, key) do
+    case Ecto.Type.filter_empty_values(type, value, empty_values) do
+      :empty -> Map.get(defaults, key)
+      {:ok, value} -> value
     end
   end
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -867,9 +867,7 @@ defmodule Ecto.Type do
   @spec filter_empty_values(t, any, [any]) :: {:ok, any} | :empty
   def filter_empty_values({:array, type}, value, empty_values) when is_list(value) do
     value = for elem <- value,
-      result = filter_empty_values(type, elem, empty_values),
-      :empty != result,
-      {:ok, elem} = result,
+      {:ok, elem} <- [filter_empty_values(type, elem, empty_values)],
       do: elem
 
     {:ok, value}

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -863,6 +863,26 @@ defmodule Ecto.Type do
   defp same_date(%Date{} = term), do: {:ok, term}
   defp same_date(_), do: :error
 
+  @doc false
+  @spec filter_empty_values(t, any, [any]) :: {:ok, any} | :empty
+  def filter_empty_values({:array, type}, value, empty_values) when is_list(value) do
+    value = for elem <- value,
+      result = filter_empty_values(type, elem, empty_values),
+      :empty != result,
+      {:ok, elem} = result,
+      do: elem
+
+    {:ok, value}
+  end
+
+  def filter_empty_values(_type, value, empty_values) do
+    if value in empty_values do
+      :empty
+    else
+      {:ok, value}
+    end
+  end
+
   ## Adapter related
 
   @doc false

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -182,6 +182,14 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes == %{title: "", body: nil}
   end
 
+  test "cast/4: with nested empty values" do
+    params = %{"topics" => ["", "bar", ""]}
+    struct = %Post{topics: ["foo"]}
+
+    changeset = cast(struct, params, ~w(topics)a)
+    assert changeset.changes == %{topics: ["bar"]}
+  end
+
   test "cast/4: with custom empty values" do
     params = %{"title" => "empty", "body" => nil}
     struct = %Post{title: "foo", body: "bar"}


### PR DESCRIPTION
See https://elixirforum.com/t/phoenix-casting-multiple-checkboxes-to-array-ecto-enum/46252/6

This way, an HTML form with checkboxes having names ending with `[]` can have
a hidden input with empty value to ensure the presence of that parameter
if none of the checkboxes are checked.