### PR TITLE
Add additional example for keyword lists

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -975,6 +975,7 @@ defmodule Ecto.Repo do
 
       # Use a keyword list to preload nested associations as well
       posts = Repo.preload posts, [comments: [:replies, :likes], authors: []]
+      posts = Repo.preload posts, [comments: [:replies, :likes], :authors]
 
       # Use a keyword list to customize how associations are queried
       posts = Repo.preload posts, [comments: from(c in Comment, order_by: c.published_at)]


### PR DESCRIPTION
I've noticed on several codebases that there's always some confusion when trying to execute nested preloading. In my opinion it is because the order of examples that are given on 

```elixir
# preloading a single association, nothing new
posts = Repo.preload posts, :comments

# preloading several associations looks quite straight forward
posts = Repo.preload posts, [:comments, :authors]

# But here is where I've found confusion among developers. 
 posts = Repo.preload posts, [comments: [:replies, :likes], authors: []]
``` 

On the last example, the `:comments` nested preloads are just an extension of the previous example. Yet the `:authors` field does not require any nested preloading at all. Which in fact makes sense, because Ecto will not have to preload anything where there is an empty list, which is quite convenient for dynamic preloading. However when a given entity is considerably large, this example can give the impression that all of the fields on the same level of preloading where nested preloading took place, have the need to require an empty list. Such as:


```elixir
# This is what I usually encounter
 posts = Repo.preload posts, [comments: [replies: [:reactions], likes: []], authors: []]
``` 

As you can see the `:replies` field has now a nested preload, which based on the example I've been talking before gives that impression that `:likes` should have the empty list because another field from the same level of preloading actually had some nested preloading taking place. We could obviously have a smaller list, such as: 

```elixir
# This is what I would like to see on the codebase most likely
 posts = Repo.preload posts, [comments: [replies: [:reactions], :likes], :authors]
``` 








