### PR TITLE
allow kw and map updates from put_embed/4

### DIFF
--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -254,6 +254,22 @@ defmodule Ecto.Repo.EmbeddedTest do
     refute embed.inserted_at
     assert embed.updated_at
 
+    kw_changeset = Ecto.Changeset.put_embed(changeset, :embed, id: @uuid, x: "def")
+    schema = TestRepo.update!(kw_changeset)
+    embed = schema.embed
+    assert embed.id == @uuid
+    assert embed.x == "def"
+    refute embed.inserted_at
+    assert embed.updated_at
+
+    map_changeset = Ecto.Changeset.put_embed(changeset, :embed, %{id: @uuid, x: "def"})
+    schema = TestRepo.update!(map_changeset)
+    embed = schema.embed
+    assert embed.id == @uuid
+    assert embed.x == "def"
+    refute embed.inserted_at
+    assert embed.updated_at
+
     changeset =
       %MySchema{id: 1, embeds: [sample]}
       |> Ecto.Changeset.change


### PR DESCRIPTION
While investigating https://github.com/elixir-ecto/ecto/issues/3851 I found that using keyword lists and maps to update existing embedded structs with `put_embed/4` had some unexpected behaviour.

The issue is that the action for the resulting changeset is always `:insert`:

```elixir
defp action_from_changeset(_) do
   :insert # We don't care if it is insert/update for embeds (no meta)
end
```
But when you are updating an existing embedded struct with a primary key, the allowed actions are `:update` and `:delete`:

```elixir
defp allowed_actions(pk_values) do
    if Enum.all?(pk_values, &is_nil/1) do
      [:insert, :update, :delete]
    else
      [:update, :delete]
    end
end
```

So I think there is a need to differentiate between `:insert` and `:update` actions in this scenario. Otherwise `check_action!/2` will always raise.

The way it happens when not using kw lists/maps is that a `nil` current value forces an `:insert` action and anything else forces an `:update` action. I just extended this logic over to the kw list/map scenario.