### PR TITLE
Add updated_at timestamp assertion to "changing embeds on update" test

### DIFF
--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -240,7 +240,11 @@ defmodule Ecto.Repo.EmbeddedTest do
   end
 
   test "changing embeds on update" do
-    sample = %MyEmbed{x: "xyz", id: @uuid}
+    an_hour_ago =
+      DateTime.utc_now()
+      |> DateTime.add(-3600)
+      |> DateTime.to_naive()
+    sample = %MyEmbed{x: "xyz", id: @uuid, updated_at: an_hour_ago}
     sample_changeset = Ecto.Changeset.change(sample, x: "abc")
 
     changeset =
@@ -253,6 +257,7 @@ defmodule Ecto.Repo.EmbeddedTest do
     assert embed.x == "abc"
     refute embed.inserted_at
     assert embed.updated_at
+    assert NaiveDateTime.compare(embed.updated_at, an_hour_ago) == :gt
 
     kw_changeset = Ecto.Changeset.put_embed(changeset, :embed, id: @uuid, x: "def")
     schema = TestRepo.update!(kw_changeset)


### PR DESCRIPTION
We noticed some problems when updating from `ecto` version `2.2.12` to `3.7.2`.

Upon further investigation, we found out that the `updated_at` field is not updated with the current datetime when updating embeds on a schema.

I pulled the repo and added a quick assertion in the repo test and it seems to indicate that the field is indeed not updating correctly. It seems to me that the following test should succeed.

Thanks for the help