### PR TITLE
Warn when validate_required/3 called on has_many

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1798,7 +1798,7 @@ defmodule Ecto.Changeset do
   data given to the `changeset` is not empty.
 
   Do not use this function to validate associations that are required,
-  instead pass the `:required` option to `cast_assoc/3`.
+  instead pass the `:required` option to `cast_assoc/3` or `cast_embed/3`.
 
   Opposite to other validations, calling this function does not store
   the validation under the `changeset.validations` key. Instead, it

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -537,11 +537,9 @@ defmodule Ecto.Changeset.EmbeddedTest do
   ## Others
 
   test "validate_required/3 with has_many raises" do
-    import ExUnit.CaptureIO
-
     base_changeset = Changeset.change(%Author{})
 
-    assert capture_io(:stderr, fn ->
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
       changeset = Changeset.validate_required(base_changeset, :posts)
       assert changeset.valid?
     end) =~ ~r/attempting to validate embed_many field/

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -536,6 +536,17 @@ defmodule Ecto.Changeset.EmbeddedTest do
 
   ## Others
 
+  test "validate_required/3 with has_many raises" do
+    import ExUnit.CaptureIO
+
+    base_changeset = Changeset.change(%Author{})
+
+    assert capture_io(:stderr, fn ->
+      changeset = Changeset.validate_required(base_changeset, :posts)
+      assert changeset.valid?
+    end) =~ ~r/attempting to validate embed_many field/
+  end
+
   test "change embeds_one" do
     embed = Author.__schema__(:embed, :profile)
 

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -913,6 +913,17 @@ defmodule Ecto.Changeset.HasAssocTest do
 
   ## Other
 
+  test "validate_required/3 with has_many raises" do
+    import ExUnit.CaptureIO
+
+    base_changeset = Changeset.change(%Author{})
+
+    assert capture_io(:stderr, fn ->
+      changeset = Changeset.validate_required(base_changeset, :posts)
+      assert changeset.valid?
+    end) =~ ~r/attempting to validate has_many association :posts/
+  end
+
   test "put_assoc/4 with has_one" do
     base_changeset = Changeset.change(%Author{})
 


### PR DESCRIPTION
Calling `validate_required/3` on a `has_many`/`embeds_many` has no effect, add a warning to make it obvious.

Close #3861
