### PR TITLE
raise if association doesn't have a primary key

### DIFF
--- a/lib/ecto/repo/assoc.ex
+++ b/lib/ecto/repo/assoc.ex
@@ -111,7 +111,6 @@ defmodule Ecto.Repo.Assoc do
     end)
 
     {_source, schema, _prefix} = elem(sources, idx)
-    {schema.__schema__(:primary_key), %{}, initial_dict, acc}
 
     case schema.__schema__(:primary_key) do
       [] -> raise Ecto.NoPrimaryKeyFieldError, schema: schema

--- a/lib/ecto/repo/assoc.ex
+++ b/lib/ecto/repo/assoc.ex
@@ -112,5 +112,10 @@ defmodule Ecto.Repo.Assoc do
 
     {_source, schema, _prefix} = elem(sources, idx)
     {schema.__schema__(:primary_key), %{}, initial_dict, acc}
+
+    case schema.__schema__(:primary_key) do
+      [] -> raise Ecto.NoPrimaryKeyFieldError, schema: schema
+      pk -> {pk, %{}, initial_dict, acc}
+    end
   end
 end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -44,6 +44,7 @@ defmodule Ecto.RepoTest do
 
     schema "my_schema_child" do
       field :a, :string
+      belongs_to :my_schema, MySchemaNoPK, references: :n, foreign_key: :n
     end
 
     def changeset(struct, params) do
@@ -139,6 +140,8 @@ defmodule Ecto.RepoTest do
     @primary_key false
     schema "my_schema" do
       field :x, :string
+      field :n, :integer
+      has_one :child, MySchemaChild, references: :n, foreign_key: :n
     end
   end
 
@@ -1491,6 +1494,19 @@ defmodule Ecto.RepoTest do
   describe "preload" do
     test "returns nil if first argument of preload is nil" do
       assert TestRepo.preload(nil, []) == nil
+    end
+
+    test "raises if primary key is not defined" do
+      query =
+        from(p in MySchemaNoPK,
+          left_join: c in MySchemaChild,
+          on: p.n == p.n,
+          preload: [child: c]
+        )
+
+      assert_raise Ecto.NoPrimaryKeyFieldError, fn ->
+        TestRepo.all(query)
+      end
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/elixir-ecto/ecto/issues/3855

When an association doesn't have a primary key, the data structure used to track the relationships between associated structs doesn't work as expected because it relies on the primary key. This PR raises early if any of the associations are missing a primary key. 

The queries can still technically function correctly if the leaf association doesn't have a PK, but I'm assuming the desired behaviour is to raise for symmetry/consistency reasons. For instance, if the user switched the order of the query so that the leaf is the parent it would no longer work. But if I'm mistaken please let me know!