### PR TITLE
don't surface changes on embed updates

### DIFF
--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -199,7 +199,7 @@ defmodule Ecto.Embedded do
 
   defp to_struct(%Changeset{data: data} = changeset, action, %{related: schema}, adapter) do
     %{data: struct, changes: changes} = changeset =
-      Relation.surface_changes(changeset, data, schema.__schema__(:fields))
+      maybe_surface_changes(changeset, data, schema, action)
 
     embeds = prepare(changeset, schema.__schema__(:embeds), adapter, action)
 
@@ -208,6 +208,14 @@ defmodule Ecto.Embedded do
     |> autogenerate_id(struct, action, schema, adapter)
     |> autogenerate(action, schema)
     |> apply_embeds(struct)
+  end
+
+  defp maybe_surface_changes(changeset, data, schema, :insert) do
+    Relation.surface_changes(changeset, data, schema.__schema__(:fields))
+  end
+
+  defp maybe_surface_changes(changeset, _data, _schema, _action) do
+    changeset
   end
 
   defp run_prepare(changeset, repo) do

--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -320,6 +320,27 @@ defmodule Ecto.Repo.EmbeddedTest do
     assert schema.embeds == []
   end
 
+  test "updated_at is auto-updated" do
+    embed = %MyEmbed{x: "xyz", id: @uuid}
+    schema = TestRepo.insert!(%MySchema{id: 1, embed: embed})
+    inserted_at_orig = schema.embed.inserted_at
+    updated_at_orig = schema.embed.updated_at
+
+    embed_changeset = Ecto.Changeset.change(schema.embed, %{x: "abc"})
+
+    changeset =
+      schema
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_embed(:embed, embed_changeset)
+
+    schema = TestRepo.update!(changeset)
+    inserted_at_new = schema.embed.inserted_at
+    updated_at_new = schema.embed.updated_at
+
+    assert NaiveDateTime.compare(inserted_at_new, inserted_at_orig) == :eq
+    assert NaiveDateTime.compare(updated_at_new, updated_at_orig) == :gt
+  end
+
   test "returns untouched changeset on constraint mismatch on update" do
     embed = %MyEmbed{x: "xyz"}
 


### PR DESCRIPTION
Fixes https://github.com/elixir-ecto/ecto/pull/3859 and https://github.com/elixir-ecto/ecto/issues/3860

When preparing an embed for insert/update, it always calls `Relation.surface_changes`. When updating an embed, this causes the previously persisted `updated_at` value to be surfaced and auto-update doesn't generate a new one.

The proposal here is to only call `Relation.surface_changes` on `:insert`. I believe this is the intended use, because on `:insert` the fields of the underlying struct are considered to be new changes. But on `:update` I believe the underlying struct is taken to be the persisted data. This is also how it works for non-embedded schema.

I made a suggestion to create the autogenerated fields before calling `Relation.surface_changes` but I don't think this is correct anymore. On `:insert` it will cause any value the user supplied in the struct for an autogenerated field to be overwritten. 

