### PR TITLE
Fix Ecto.assoc prefix behaviour

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -500,8 +500,14 @@ defmodule Ecto do
       posts = Repo.all from p in Post, where: is_nil(p.published_at)
       Repo.all Ecto.assoc(posts, [:comments, :author])
 
+  ## Options
+
+    * `:prefix` - the prefix to fetch preloads from. By default, queries
+      will use the same prefix as the first member in the given collection.
+      This option allows the prefix to be changed.
+
   """
-  def assoc(struct_or_structs, assocs) do
+  def assoc(struct_or_structs, assocs, opts \\ []) do
     [assoc | assocs] = List.wrap(assocs)
 
     structs =
@@ -511,7 +517,9 @@ defmodule Ecto do
         struct_or_structs -> List.wrap(struct_or_structs)
       end
 
-    schema = hd(structs).__struct__
+    sample = hd(structs)
+    prefix = assoc_prefix(sample, opts)
+    schema = sample.__struct__
     refl = %{owner_key: owner_key} = Ecto.Association.association_from_schema!(schema, assoc)
 
     values =
@@ -523,10 +531,24 @@ defmodule Ecto do
     case assocs do
       [] ->
         %module{} = refl
-        module.assoc_query(refl, nil, values)
+        %{module.assoc_query(refl, nil, values) | prefix: prefix}
 
       assocs ->
-        Ecto.Association.filter_through_chain(schema, [assoc | assocs], values)
+        %{Ecto.Association.filter_through_chain(schema, [assoc | assocs], values) | prefix: prefix}
+    end
+  end
+
+  defp assoc_prefix(sample, opts) do
+    case Keyword.fetch(opts, :prefix) do
+      {:ok, prefix} ->
+        prefix
+
+      :error ->
+        case sample do
+          %{__meta__: %{prefix: prefix}} -> prefix
+          # Must be an embedded schema
+          _ -> nil
+        end
     end
   end
 

--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -503,7 +503,7 @@ defmodule Ecto do
   ## Options
 
     * `:prefix` - the prefix to fetch preloads from. By default, queries
-      will use the same prefix as the first member in the given collection.
+      will use the same prefix as the first struct in the given collection.
       This option allows the prefix to be changed.
 
   """

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -959,7 +959,7 @@ defmodule Ecto.Repo do
       only be performed when we have more than one preload and the
       repository is not in a transaction. Defaults to `true`.
     * `:prefix` - the prefix to fetch preloads from. By default, queries
-      will use the same prefix as the first member in the given collection.
+      will use the same prefix as the first struct in the given collection.
       This option allows the prefix to be changed.
 
   See the ["Shared options"](#module-shared-options) section at the module

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -959,8 +959,8 @@ defmodule Ecto.Repo do
       only be performed when we have more than one preload and the
       repository is not in a transaction. Defaults to `true`.
     * `:prefix` - the prefix to fetch preloads from. By default, queries
-      will use the same prefix as the one in the given collection. This
-      option allows the prefix to be changed.
+      will use the same prefix as the first member in the given collection.
+      This option allows the prefix to be changed.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -46,6 +46,8 @@ defmodule EctoTest do
       |> Ecto.assoc(:no_prefix_assoc)
       |> normalize_with_params()
 
+    assert query.sources == {{"no_prefix_assoc", EctoTest.NoPrefixAssoc, "owner_prefix"}}
+
     # Multiple structs
     [%PrefixSchema{id: 1}, %PrefixSchema{id: 2}]
     |> Ecto.assoc(:no_prefix_assoc)

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -1,0 +1,109 @@
+defmodule EctoTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Query.Planner
+
+  defmodule PrefixSchema do
+    use Ecto.Schema
+
+    @schema_prefix "owner_prefix"
+    schema "prefix_schema" do
+      has_one :no_prefix_assoc, EctoTest.NoPrefixAssoc
+      has_one :prefix_assoc, EctoTest.PrefixAssoc
+    end
+  end
+
+  defmodule NoPrefixAssoc do
+    use Ecto.Schema
+
+    schema "no_prefix_assoc" do
+      belongs_to :prefix_schema, EctoTest.PrefixSchema
+      has_one :no_prefix_nested_assoc, EctoTest.NoPrefixNestedAssoc
+    end
+  end
+
+  defmodule PrefixAssoc do
+    use Ecto.Schema
+
+    @schema_prefix "assoc_prefix"
+    schema "prefix_assoc" do
+      belongs_to :prefix_schema, EctoTest.PrefixSchema
+    end
+  end
+
+  defmodule NoPrefixNestedAssoc do
+    use Ecto.Schema
+
+    schema "no_prefix_nested_assoc" do
+      belongs_to :no_prefix_nested_assoc, EctoTest.NoPrefixAssoc
+    end
+  end
+
+  test "Ecto.assoc/3: struct prefix is assigned to assoc with no prefix" do
+    # One struct
+    {query, _, _} =
+      %PrefixSchema{id: 1}
+      |> Ecto.assoc(:no_prefix_assoc)
+      |> normalize_with_params()
+
+    # Multiple structs
+    [%PrefixSchema{id: 1}, %PrefixSchema{id: 2}]
+    |> Ecto.assoc(:no_prefix_assoc)
+    |> normalize_with_params()
+
+    assert query.sources == {{"no_prefix_assoc", EctoTest.NoPrefixAssoc, "owner_prefix"}}
+  end
+
+  test "Ecto.assoc/3: struct prefix is not assigned to assoc that already has a prefix" do
+    # One struct
+    {query, _, _} =
+      %PrefixSchema{id: 1}
+      |> Ecto.assoc(:prefix_assoc)
+      |> normalize_with_params()
+
+    assert query.sources == {{"prefix_assoc", EctoTest.PrefixAssoc, "assoc_prefix"}}
+
+    # Multiple structs
+    {query, _, _} =
+      [%PrefixSchema{id: 1}, %PrefixSchema{id: 2}]
+      |> Ecto.assoc(:prefix_assoc)
+      |> normalize_with_params()
+
+    assert query.sources == {{"prefix_assoc", EctoTest.PrefixAssoc, "assoc_prefix"}}
+  end
+
+  test "Ecto.assoc/3: struct prefix is assigned to chain of assocs with no prefixes" do
+    {query, _, _} =
+      %PrefixSchema{id: 1}
+      |> Ecto.assoc([:no_prefix_assoc, :no_prefix_nested_assoc])
+      |> normalize_with_params()
+
+    assert query.sources ==
+             {{"no_prefix_nested_assoc", EctoTest.NoPrefixNestedAssoc, "owner_prefix"},
+              {"no_prefix_assoc", EctoTest.NoPrefixAssoc, "owner_prefix"}}
+  end
+
+  test "Ecto.assoc/3: prefix option is assigned to assoc instead of struct's prefix" do
+    {query, _, _} =
+      %PrefixSchema{id: 1}
+      |> Ecto.assoc(:no_prefix_assoc, prefix: "prefix_opt")
+      |> normalize_with_params()
+
+    assert query.sources == {{"no_prefix_assoc", EctoTest.NoPrefixAssoc, "prefix_opt"}}
+  end
+
+  defp plan(query, operation) do
+    Planner.plan(query, operation, Ecto.TestAdapter)
+  end
+
+  defp normalize_with_params(query, operation \\ :all) do
+    {query, params, _key} = plan(query, operation)
+
+    {query, select} =
+      query
+      |> Planner.ensure_select(operation == :all)
+      |> Planner.normalize(operation, Ecto.TestAdapter, 0)
+
+    {query, params, select}
+  end
+end

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -41,44 +41,45 @@ defmodule EctoTest do
 
   test "Ecto.assoc/3: struct prefix is assigned to assoc with no prefix" do
     # One struct
-    {query, _, _} =
+    query =
       %PrefixSchema{id: 1}
       |> Ecto.assoc(:no_prefix_assoc)
-      |> normalize_with_params()
+      |> normalize()
 
     assert query.sources == {{"no_prefix_assoc", EctoTest.NoPrefixAssoc, "owner_prefix"}}
 
     # Multiple structs
-    [%PrefixSchema{id: 1}, %PrefixSchema{id: 2}]
-    |> Ecto.assoc(:no_prefix_assoc)
-    |> normalize_with_params()
+    query =
+      [%PrefixSchema{id: 1}, %PrefixSchema{id: 2}]
+      |> Ecto.assoc(:no_prefix_assoc)
+      |> normalize()
 
     assert query.sources == {{"no_prefix_assoc", EctoTest.NoPrefixAssoc, "owner_prefix"}}
   end
 
   test "Ecto.assoc/3: struct prefix is not assigned to assoc that already has a prefix" do
     # One struct
-    {query, _, _} =
+    query =
       %PrefixSchema{id: 1}
       |> Ecto.assoc(:prefix_assoc)
-      |> normalize_with_params()
+      |> normalize()
 
     assert query.sources == {{"prefix_assoc", EctoTest.PrefixAssoc, "assoc_prefix"}}
 
     # Multiple structs
-    {query, _, _} =
+    query =
       [%PrefixSchema{id: 1}, %PrefixSchema{id: 2}]
       |> Ecto.assoc(:prefix_assoc)
-      |> normalize_with_params()
+      |> normalize()
 
     assert query.sources == {{"prefix_assoc", EctoTest.PrefixAssoc, "assoc_prefix"}}
   end
 
   test "Ecto.assoc/3: struct prefix is assigned to chain of assocs with no prefixes" do
-    {query, _, _} =
+    query =
       %PrefixSchema{id: 1}
       |> Ecto.assoc([:no_prefix_assoc, :no_prefix_nested_assoc])
-      |> normalize_with_params()
+      |> normalize()
 
     assert query.sources ==
              {{"no_prefix_nested_assoc", EctoTest.NoPrefixNestedAssoc, "owner_prefix"},
@@ -86,10 +87,10 @@ defmodule EctoTest do
   end
 
   test "Ecto.assoc/3: prefix option is assigned to assoc instead of struct's prefix" do
-    {query, _, _} =
+    query =
       %PrefixSchema{id: 1}
       |> Ecto.assoc(:no_prefix_assoc, prefix: "prefix_opt")
-      |> normalize_with_params()
+      |> normalize()
 
     assert query.sources == {{"no_prefix_assoc", EctoTest.NoPrefixAssoc, "prefix_opt"}}
   end
@@ -98,14 +99,14 @@ defmodule EctoTest do
     Planner.plan(query, operation, Ecto.TestAdapter)
   end
 
-  defp normalize_with_params(query, operation \\ :all) do
-    {query, params, _key} = plan(query, operation)
+  defp normalize(query, operation \\ :all) do
+    {query, _params, _key} = plan(query, operation)
 
-    {query, select} =
+    {query, _select} =
       query
       |> Planner.ensure_select(operation == :all)
       |> Planner.normalize(operation, Ecto.TestAdapter, 0)
 
-    {query, params, select}
+    query
   end
 end


### PR DESCRIPTION
Resolves https://github.com/elixir-ecto/ecto/issues/3871.

The preload behaviour is to pick the `:prefix` option and if that doesn't exist fall back to the first struct's prefix. It is set at the query level so that it's not overriding any `schema_prefix` attributes.

The relevant preload code is:

- https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/preloader.ex#L63
- ~~https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/preloader.ex#L63~~ https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/preloader.ex#L208