### PR TITLE
Raise on atom literals in subqueries

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -398,7 +398,7 @@ defmodule Ecto.Query.Planner do
         if valid_subquery_value?(value) do
           {key, value}
         else
-          error!(query, "maps, lists, tuples and sources are not allowed as map values in subquery, got: `#{Macro.to_string(expr)}`")
+          error!(query, "atoms, maps, lists, tuples and sources are not allowed as map values in subquery, got: `#{Macro.to_string(expr)}`")
         end
     end)
   end
@@ -407,6 +407,8 @@ defmodule Ecto.Query.Planner do
   defp valid_subquery_value?(args) when is_list(args), do: false
   defp valid_subquery_value?({container, _, args})
        when container in [:{}, :%{}, :&] and is_list(args), do: false
+  defp valid_subquery_value?(nil), do: true
+  defp valid_subquery_value?(arg) when is_atom(arg), do: false
   defp valid_subquery_value?(_), do: true
 
   defp plan_joins(query, sources, offset, adapter) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -408,7 +408,7 @@ defmodule Ecto.Query.Planner do
   defp valid_subquery_value?({container, _, args})
        when container in [:{}, :%{}, :&] and is_list(args), do: false
   defp valid_subquery_value?(nil), do: true
-  defp valid_subquery_value?(arg) when is_atom(arg), do: false
+  defp valid_subquery_value?(arg) when is_atom(arg), do: is_boolean(arg)
   defp valid_subquery_value?(_), do: true
 
   defp plan_joins(query, sources, offset, adapter) do

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -96,6 +96,35 @@ defmodule Ecto.Query.SubqueryTest do
       assert [{:t, _}, {:l, "literal"}] = query.from.source.query.select.fields
     end
 
+    test "invalid values" do
+      message = "atoms, maps, lists, tuples and sources are not allowed as map values in subquery"
+
+      assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
+        query = select(Post, [p], %{t: p.title, l: :literal})
+        plan(from(subquery(query), []))
+      end
+
+      assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
+        query = select(Post, [p], %{t: p.title, l: []})
+        plan(from(subquery(query), []))
+      end
+
+      assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
+        query = select(Post, [p], %{t: p.title, l: %{}})
+        plan(from(subquery(query), []))
+      end
+
+      assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
+        query = select(Post, [p], %{t: p.title, l: {1, 2, 3}})
+        plan(from(subquery(query), []))
+      end
+
+      assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
+        query = select(Post, [p], %{t: p.title, l: p})
+        plan(from(subquery(query), []))
+      end
+    end
+
     test "with map updates in select can be used with assoc" do
       query =
         Post


### PR DESCRIPTION
Resolves https://github.com/elixir-ecto/ecto/issues/3870

This is my first attempt at changing the planner, so please approve with caution :).

The issue seems to be that the planner wasn't ignoring atom literals when collecting `query.select.fields` for a subquery, causing it to show up in the sql statement.