### PR TITLE
preserve parent prefix on join tables

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1382,9 +1382,6 @@ defmodule Ecto.Association.ManyToMany do
     repo.insert(changeset, opts)
   end
 
-  defp put_new_prefix(%{data: %{__meta__: %{prefix: prefix}}} = changeset, prefix),
-    do: changeset
-
   defp put_new_prefix(%{data: %{__meta__: %{prefix: nil}}} = changeset, prefix),
     do: update_in(changeset.data, &Ecto.put_meta(&1, prefix: prefix))
 

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -79,21 +79,22 @@ defmodule Ecto.TestAdapter do
 
   ## Schema
 
-  def insert_all(_, meta, header, rows, on_conflict, returning, placeholders, _opts) do
+  def insert_all(_, meta, header, rows, on_conflict, returning, placeholders, opts) do
     meta =
       Map.merge(meta, %{
         header: header,
         on_conflict: on_conflict,
         returning: returning,
-        placeholders: placeholders
+        placeholders: placeholders,
+        prefix: opts[:prefix]
       })
 
     send(self(), {:insert_all, meta, rows})
     {1, nil}
   end
 
-  def insert(_, %{context: nil} = meta, fields, on_conflict, returning, _opts) do
-    meta = Map.merge(meta, %{fields: fields, on_conflict: on_conflict, returning: returning})
+  def insert(_, %{context: nil, prefix: prefix} = meta, fields, on_conflict, returning, opts) do
+    meta = Map.merge(meta, %{fields: fields, on_conflict: on_conflict, returning: returning, prefix: prefix})
     send(self(), {:insert, meta})
     {:ok, Enum.zip(returning, 1..length(returning))}
   end


### PR DESCRIPTION
Resolves https://github.com/elixir-ecto/ecto/issues/3876.

The issue is that `Ecto.Association.insert_join` doesn't  take the parent prefix into consideration. There are a couple scenarios to handle:

1. The many_to_many association is defined by a source string. In this case `Repo.insert_all` is called with a list of maps and only considers `opts[:prefix]` when creating the sql statement. So I put the prefix in `opts`.
2. The many_to_many association is defined by a schema, in which case we have to consider the situation where the join table has its own prefix. So I check the metadata for the join table schema and only insert the parent prefix if it doesn't exist.