### PR TITLE
don't mutate metadata if nothing changes

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1382,6 +1382,9 @@ defmodule Ecto.Association.ManyToMany do
     repo.insert(changeset, opts)
   end
 
+  defp put_new_prefix(%{data: %{__meta__: %{prefix: prefix}}} = changeset, prefix),
+    do: update_in(changeset.data, &Ecto.put_meta(&1, prefix: prefix))
+
   defp put_new_prefix(%{data: %{__meta__: %{prefix: nil}}} = changeset, prefix),
     do: update_in(changeset.data, &Ecto.put_meta(&1, prefix: prefix))
 

--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1383,7 +1383,7 @@ defmodule Ecto.Association.ManyToMany do
   end
 
   defp put_new_prefix(%{data: %{__meta__: %{prefix: prefix}}} = changeset, prefix),
-    do: update_in(changeset.data, &Ecto.put_meta(&1, prefix: prefix))
+    do: changeset
 
   defp put_new_prefix(%{data: %{__meta__: %{prefix: nil}}} = changeset, prefix),
     do: update_in(changeset.data, &Ecto.put_meta(&1, prefix: prefix))

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -93,7 +93,7 @@ defmodule Ecto.TestAdapter do
     {1, nil}
   end
 
-  def insert(_, %{context: nil, prefix: prefix} = meta, fields, on_conflict, returning, opts) do
+  def insert(_, %{context: nil, prefix: prefix} = meta, fields, on_conflict, returning, _opts) do
     meta = Map.merge(meta, %{fields: fields, on_conflict: on_conflict, returning: returning, prefix: prefix})
     send(self(), {:insert, meta})
     {:ok, Enum.zip(returning, 1..length(returning))}


### PR DESCRIPTION
The previous PR (https://github.com/elixir-ecto/ecto/pull/3878) will mutate the metadata if both the join table and parent table have `nil` prefix.