### PR TITLE
Fix named typed selection query

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -826,7 +826,7 @@ defmodule Ecto.Query.Builder do
       for {:named, key, name} <- vars do
         {key,
          quote do
-           Ecto.Query.Builder.count_alias!(query, unquote(name))
+           unquote(__MODULE__).count_alias!(query, unquote(name))
          end}
       end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1707,7 +1707,13 @@ defmodule Ecto.Query.Planner do
     type!(kind, query, expr, ix, field, allow_virtuals?)
   end
 
-  defp field_type!(kind, query, expr, {{{:., _, [_, :count_alias!]}, _, [_, name]}, field}, allow_virtuals?) do
+  defp field_type!(
+         kind,
+         query,
+         expr,
+         {{{:., _, [Ecto.Query.Builder, :count_alias!]}, _, [_, name]}, field},
+         allow_virtuals?
+       ) do
     ix = Ecto.Query.Builder.count_alias!(query, name)
     type!(kind, query, expr, ix, field, allow_virtuals?)
   end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1707,6 +1707,11 @@ defmodule Ecto.Query.Planner do
     type!(kind, query, expr, ix, field, allow_virtuals?)
   end
 
+  defp field_type!(kind, query, expr, {{{:., _, [_, :count_alias!]}, _, [_, name]}, field}, allow_virtuals?) do
+    ix = Ecto.Query.Builder.count_alias!(query, name)
+    type!(kind, query, expr, ix, field, allow_virtuals?)
+  end
+
   defp field_type!(_kind, _query, _expr, type, _) do
     type
   end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -391,6 +391,15 @@ defmodule Ecto.Query.InspectTest do
            ~s{from p0 in Inspect.Post, select: [:foo]}
   end
 
+  test "select bound name type after planner" do
+    query =
+     from(x in Post, as: :p)
+      |> select([p: p], type(p.visits, p.visits))
+      |> plan()
+
+    assert i(query) == ~s{from p0 in Inspect.Post, as: :p, select: type(p0.visits, :integer)}
+  end
+
   test "params" do
     assert i(from(x in Post, where: ^123 > ^(1 * 3))) ==
            ~s{from p0 in Inspect.Post, where: ^123 > ^3}


### PR DESCRIPTION
Calling type in a select expression with named bindings causes downstream errors as it seems the `Query.Builder.count_alias!/2` function is not being applied correctly.

Fixes #3899 