### PR TITLE
Support arbitrary scalar subqueries as query expressions

### DIFF
--- a/test/ecto/query/builder/filter_test.exs
+++ b/test/ecto/query/builder/filter_test.exs
@@ -104,6 +104,17 @@ defmodule Ecto.Query.Builder.FilterTest do
       assert_quantified_subquery.(any_query, :any)
     end
 
+    test "supports scalar subqueries anywhere in the expression" do
+      s = from(p in "posts", select: avg(p.rating))
+
+      %{wheres: [where]} = from(p in "posts", where: p.rating > subquery(s), select: p.id)
+
+      assert Macro.to_string(where.expr) ==
+             "&0.rating() > {:subquery, 0}"
+      assert where.params ==
+             [{:subquery, 0}]
+    end
+
     test "raises on invalid keywords" do
       assert_raise ArgumentError, fn ->
         where(from(p in "posts"), [p], ^[{1, 2}])

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1484,6 +1484,14 @@ defmodule Ecto.Query.PlannerTest do
         |> normalize()
 
       assert {:exists, _, [%Ecto.SubQuery{}]} = where.expr
+
+      avg_visits = from(p in Post, select: avg(p.visits))
+
+      %{wheres: [where]} =
+        from(p in Post, where: p.visits > subquery(avg_visits))
+        |> normalize()
+
+      assert {:>, _, [_, %Ecto.SubQuery{}]} = where.expr
     end
 
     test "raises a runtime error if more than 1 field is selected" do


### PR DESCRIPTION
[PostgreSQL allows scalar subqueries (subqueries that return one row and one column) anywhere in a value expression][1].

Add support for subqueries outside of other expressions like `in/2`, `any/1`, etc. I see this as a natural extension of [this PR that adds support for scalar subqueries in `Repo.insert_all`][2].

This appears to work in postgres with no modifications to `ecto_sql`, but I'm not sure how/if other database backends would be affected.

Here is an example query that previously errored but now works:

```ex
avg_amount =
  from(
    m in "measurements",
    select: avg(m.amount)
  )

from(
  m in "measurements",
  where: m.amount < subquery(avg_amount),
  select: m.amount
)
|> Repo.all()
```

This code previously failed to compile with the following error:

```
== Compilation error in file lib/ecto_app.ex ==
** (Ecto.Query.CompileError) `subquery(avg_amount)` is not a valid query expression.

* If you intended to call an Elixir function or introduce a value,
  you need to explicitly interpolate it with ^

* If you intended to call a database function, please check the documentation
  for Ecto.Query.API to see the supported database expressions

* If you intended to extend Ecto's query DSL, make sure that you have required
  the module or imported the relevant function. Note that you need macros to
  extend Ecto's querying capabilities
```

[1]: https://www.postgresql.org/docs/14/sql-expressions.html#SQL-SYNTAX-SCALAR-SUBQUERIES
[2]: https://github.com/elixir-ecto/ecto_sql/pull/39