### PR TITLE
Fragment escape

### DIFF
--- a/lib/ecto/adapter/queryable.ex
+++ b/lib/ecto/adapter/queryable.ex
@@ -96,6 +96,13 @@ defmodule Ecto.Adapter.Queryable do
               Enumerable.t
 
   @doc """
+  Returns a quoted identifier name suitable for
+  a specific database.
+
+  """
+  @callback quote_name(name :: String.t | atom()) :: String.t
+
+  @doc """
   Plans and prepares a query for the given repo, leveraging its query cache.
 
   This operation uses the query cache if one is available.

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -429,15 +429,15 @@ defmodule Ecto.Query.API do
   inspecting the Elixir query.  Other than that, it should be
   equivalent to a built-in Ecto query function.
 
-  ## Mutatinng the query string with escape!/1
+  ## Mutating the query string with escape!/1
 
   Ecto produces prepared queries and in most database adapter
   if passes parameters separately to the database. This has the
   strong benefit of guaranteeing that SQL injection attacks
   can't happen. But it also means that some interpolations
-  do not woek because the database itself does not accept
+  do not work because the database itself does not accept
   parameters for some types. Examples include table names,
-  coliumn names and collation names in Postgres.
+  column names and collation names in Postgres.
 
   The escape!/1 expression in a fragment supports interpolating
   a name into a query string. The arugment to escape!/1 is

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -351,6 +351,12 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:in, [], [left, right]]}, params_acc}
   end
 
+  def escape({:escape!, _, [arg]}, type, params_acc, vars, env) do
+    {arg, params_acc} = escape(arg, type, params_acc, vars, env)
+    expr = {:{}, [], [:escape!, [], [arg]]}
+    {expr, params_acc}
+  end
+
   def escape({:count, _, [arg, :distinct]}, type, params_acc, vars, env) do
     {arg, params_acc} = escape(arg, type, params_acc, vars, env)
     expr = {:{}, [], [:count, [], [arg, :distinct]]}
@@ -702,7 +708,7 @@ defmodule Ecto.Query.Builder do
     do: {find_var!(var, vars), field}
 
   def validate_type!(type, _vars, _env) do
-    error! "type/2 expects an alias, atom, initialized parameterized type or " <> 
+    error! "type/2 expects an alias, atom, initialized parameterized type or " <>
            "source.field as second argument, got: `#{Macro.to_string(type)}`"
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1929,8 +1929,8 @@ defmodule Ecto.Query.Planner do
           {[index | indexes], [make_raw_segment(params, index, adapter) | segments]}
         {:raw, _string} = raw, {indexes, segments} ->
           {indexes, [raw | segments]}
-        {:expr, _} = expr, {indexes, segments}  ->
-          {indexes, [expr | segments]}
+        other, {indexes, segments} ->
+          {indexes, [other | segments]}
       end)
 
     {indexes, Enum.reverse(segments)}
@@ -1946,11 +1946,8 @@ defmodule Ecto.Query.Planner do
     |> Enum.reverse()
   end
 
-  # TODO implement adapter.escape_string in the behaviour
-  # and the implementations
   defp make_raw_segment(_params, string, adapter) when is_binary(string) do
-    {:raw, "\"" <> string <> "\""}
-    # {:raw, adapter.escape_string(value)}
+    {:raw, adapter.quote_name(string)}
   end
 
   # Convert the result of the expression into a :raw

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -124,6 +124,10 @@ defmodule Ecto.TestAdapter do
     context
   end
 
+  def quote_name(name) do
+    [?<, name, ?>]
+  end
+
   ## Transactions
 
   def transaction(mod, _opts, fun) do


### PR DESCRIPTION
Adds support for `escape!/1` as a fragment expression.  This expression will:

1. Quote the query string using an adapter specific quote_name/1 function (this requires the companion pull request to echo_sql
2. Interpolate the result of the expression directly into the query string
2. Raise is the interpolated value includes the quoting character

This PR evolved from the [conversation](https://elixirforum.com/t/proposal-unsafe-interpolation-in-ecto/47922) on Elixir Forum.