### PR TITLE
Extending the Doc about executing the Multi.put(...)

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -615,14 +615,26 @@ defmodule Ecto.Multi do
   @doc """
   Adds a value to the changes so far under the given name.
 
-  The value put is out of the transaction.
+  If you would like to run arbitrary functions as part of your transaction, see `run/3` or `run/5`.
 
   ## Example
 
+  Adding a pre-received company as value to the changes
+
+      company = Repo.insert(Company)
+
       Ecto.Multi.new()
-      |> Ecto.Multi.put(:params, params)
-      |> Ecto.Multi.insert(:user, fn changes -> User.changeset(changes.params) end)
-      |> Ecto.Multi.insert(:person, fn changes -> Person.changeset(changes.user, changes.params) end)
+      |> Ecto.Multi.put(:company, company)
+      |> Ecto.Multi.insert(:user, fn changes -> User.changeset(changes.company) end)
+      |> Ecto.Multi.insert(:person, fn changes -> Person.changeset(changes.user, changes.company) end)
+      |> MyApp.Repo.transaction()
+
+  the same but in more shorter form
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.put(:company, Repo.insert(Company))
+      |> Ecto.Multi.insert(:user, fn changes -> User.changeset(changes.company) end)
+      |> Ecto.Multi.insert(:person, fn changes -> Person.changeset(changes.user, changes.company) end)
       |> MyApp.Repo.transaction()
   """
   @spec put(t, name, any) :: t

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -629,6 +629,16 @@ defmodule Ecto.Multi do
       |> Ecto.Multi.insert(:user, fn changes -> User.changeset(changes.company) end)
       |> Ecto.Multi.insert(:person, fn changes -> Person.changeset(changes.user, changes.company) end)
       |> MyApp.Repo.transaction()
+
+  In the example above there isn't a large benefit in putting the
+  `company` in the multi, because you could also access the
+  `company` variable directly inside the anonymous function.
+  
+  However, the benefit of `put/3` is when composing `Ecto.Multi`s.
+  If the insert operations above were defined in another module,
+  you could use `put(:company, company)` to inject changes that
+  will be accessed by other functions down the chain, removing
+  the need to pass both `multi` and `company` values around.
   """
   @spec put(t, name, any) :: t
   def put(multi, name, value) do

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -615,24 +615,17 @@ defmodule Ecto.Multi do
   @doc """
   Adds a value to the changes so far under the given name.
 
-  If you would like to run arbitrary functions as part of your transaction, see `run/3` or `run/5`.
+  The given `value` is added to the multi before the transaction starts.
+  If you would like to run arbitrary functions as part of your transaction,
+  see `run/3` or `run/5`.
 
   ## Example
 
-  Adding a pre-received company as value to the changes
-
-      company = Repo.insert(Company)
+  Imagine there is an existing company schema that you retrieved from
+  the database. You can insert it as a change in the multi using `put/3`:
 
       Ecto.Multi.new()
       |> Ecto.Multi.put(:company, company)
-      |> Ecto.Multi.insert(:user, fn changes -> User.changeset(changes.company) end)
-      |> Ecto.Multi.insert(:person, fn changes -> Person.changeset(changes.user, changes.company) end)
-      |> MyApp.Repo.transaction()
-
-  the same but in more shorter form
-
-      Ecto.Multi.new()
-      |> Ecto.Multi.put(:company, Repo.insert(Company))
       |> Ecto.Multi.insert(:user, fn changes -> User.changeset(changes.company) end)
       |> Ecto.Multi.insert(:person, fn changes -> Person.changeset(changes.user, changes.company) end)
       |> MyApp.Repo.transaction()

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -615,6 +615,8 @@ defmodule Ecto.Multi do
   @doc """
   Adds a value to the changes so far under the given name.
 
+  The value put is out of the transaction.
+
   ## Example
 
       Ecto.Multi.new()


### PR DESCRIPTION
Sometimes when we use Multi.put operation along with others Multi operations like insert, update, delete (etc) what will be executed in transaction we may automatically decide what Multi.put will be executed in transaction too. So, may be to add additional note to the Doc to catch additional Dev attention what Multi.put will be execute outside of transaction? 