### PR TITLE
add on_valid_changeset/2 to changeset

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -3129,6 +3129,20 @@ defmodule Ecto.Changeset do
     |> merge_keyword_keys(msg_func, changeset)
     |> merge_related_keys(changes, types, msg_func, &traverse_validations/2)
   end
+
+  @doc """
+  A helper that allows to apply function on a changeset only if it is valid.
+  Always returns the changeset
+  """
+  @spec on_valid_changeset(Ecto.Changeset.t, (Ecto.Changeset.t -> Ecto.Changeset.t)) ::  Ecto.Changeset.t
+  def on_valid_changeset(%Ecto.Changeset{} = changeset, fun)
+      when is_function(fun) do
+    if changeset.valid? do
+      %Ecto.Changeset{} = fun.(changeset)
+    else
+      changeset
+    end
+  end
 end
 
 defimpl Inspect, for: Ecto.Changeset do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -2141,6 +2141,39 @@ defmodule Ecto.ChangesetTest do
     }
   end
 
+  describe "on_valid_changeset" do
+    defmodule Schema do
+      use Ecto.Schema
+
+      embedded_schema do
+        field(:field_1, :string)
+      end
+    end
+
+    test "when changeset is valid" do
+      changeset = %Schema{} |> Ecto.Changeset.change()
+
+      assert changeset.valid?
+
+      changeset =
+        changeset |> on_valid_changeset(&Ecto.Changeset.put_change(&1, :field_1, "field_1"))
+
+      assert changeset.changes.field_1 == "field_1"
+    end
+
+    test "when changeset is not valid" do
+      changeset =
+        %Schema{}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(:field_1, "error")
+
+      changeset =
+        changeset |> on_valid_changeset(&Ecto.Changeset.put_change(&1, :field_1, "field_1"))
+
+      assert changeset.changes == %{}
+    end
+  end
+
   ## inspect
 
   defmodule RedactedSchema do


### PR DESCRIPTION
Sometimes we want to do an action on a changes only if it is valid.
This function comes to reduce loc like this:
```elixir
 defp foo(%Ecto.Changeset{valid?: false} = changeset),
    do: changeset

  defp foo(%Ecto.Changeset{valid?: true} = changeset), do:
   changeset |> put_change(:subject, "hello")

```