### PR TITLE
Fix description of  again

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -148,7 +148,7 @@ defmodule Ecto.Repo do
     * `:queue_time` - the time spent waiting to check out a database connection
     * `:query_time` - the time spent executing the query
     * `:decode_time` - the time spent decoding the data received from the database
-    * `:total_time` - the sum of (`queue_time`, `query_time`, and `decode_time`) subtracted by `idle_time`
+    * `:total_time` - the sum of (`queue_time`, `query_time`, and `decode_time`)️
 
   All measurements are given in the `:native` time unit. You can read more
   about it in the docs for `System.convert_time_unit/3`.


### PR DESCRIPTION
Ooops

Here is some real data:
**idle_time**: 1890963
**queue_time**: 28
**query_time**: 37635616
**decode_time**: 1016
**total_time**: 37636661

So (28 + 37635616 + 1016) = 37636660 which looks like it is a rounding error off from the reported `total_time` of 37636661