### PR TITLE
keep type for virtual fields in subquery

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -398,7 +398,7 @@ defmodule Ecto.Query.Planner do
         if valid_subquery_value?(value) do
           {key, value}
         else
-          error!(query, "atoms, maps, lists, tuples and sources are not allowed as map values in subquery, got: `#{Macro.to_string(expr)}`")
+          error!(query, "atoms, structs, maps, lists, tuples and sources are not allowed as map values in subquery, got: `#{Macro.to_string(expr)}`")
         end
     end)
   end
@@ -406,7 +406,7 @@ defmodule Ecto.Query.Planner do
   defp valid_subquery_value?({_, _}), do: false
   defp valid_subquery_value?(args) when is_list(args), do: false
   defp valid_subquery_value?({container, _, args})
-       when container in [:{}, :%{}, :&] and is_list(args), do: false
+       when container in [:{}, :%{}, :&, :%] and is_list(args), do: false
   defp valid_subquery_value?(nil), do: true
   defp valid_subquery_value?(arg) when is_atom(arg), do: is_boolean(arg)
   defp valid_subquery_value?(_), do: true

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -307,7 +307,12 @@ defmodule Ecto.Query.Planner do
   defp subquery_source(nil, types), do: {:map, types}
   defp subquery_source(name, types) when is_atom(name), do: {:struct, name, types}
   defp subquery_source({:source, schema, prefix, types}, only) do
-    types = Enum.map(only, fn {field, _} -> {field, Keyword.get(types, field, :any)} end)
+    types =
+      Enum.map(only, fn
+        {field, {:value, type}} -> {field, Keyword.get(types, field, type)}
+        {field, _} -> {field, Keyword.get(types, field, :any)}
+      end)
+
     {:source, schema, prefix, types}
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -307,12 +307,7 @@ defmodule Ecto.Query.Planner do
   defp subquery_source(nil, types), do: {:map, types}
   defp subquery_source(name, types) when is_atom(name), do: {:struct, name, types}
   defp subquery_source({:source, schema, prefix, types}, only) do
-    types =
-      Enum.map(only, fn
-        {field, {:value, type}} -> {field, Keyword.get(types, field, type)}
-        {field, _} -> {field, Keyword.get(types, field, :any)}
-      end)
-
+    types = Enum.map(only, fn {field, {:value, type}} -> {field, Keyword.get(types, field, type)} end)
     {:source, schema, prefix, types}
   end
 

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -99,7 +99,7 @@ defmodule Ecto.Query.SubqueryTest do
     end
 
     test "invalid values" do
-      message = "atoms, maps, lists, tuples and sources are not allowed as map values in subquery"
+      message = "atoms, structs, maps, lists, tuples and sources are not allowed as map values in subquery"
 
       assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
         query = select(Post, [p], %{t: p.title, l: :literal})
@@ -123,6 +123,11 @@ defmodule Ecto.Query.SubqueryTest do
 
       assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
         query = select(Post, [p], %{t: p.title, l: p})
+        plan(from(subquery(query), []))
+      end
+
+      assert_raise Ecto.SubQueryError, ~r/#{message}/, fn ->
+        query = select(Post, [p], %{t: p.title, l: %Post{}})
         plan(from(subquery(query), []))
       end
     end


### PR DESCRIPTION
This is addressing https://github.com/elixir-ecto/ecto/issues/3921.

The issue is that the virtual fields are not in the type list for the source/schema so their type is set to `:any`. Since the Postgres adapter is not using `timestamptz`, these fields are returned as NaiveDateTime.

I think there's another solution that would work by taking the virtual fields into account here: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query/planner.ex#L1583. But that would be a bigger change and would have to alter how `schema.__schema__(:dump)` is created. That's why I went this route first, but please let me know what you think! 