### PR TITLE
Support values lists

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -2071,5 +2071,27 @@ defmodule Ecto.Integration.RepoTest do
 
       assert ["Peter Parker", "Tony Stark"] = TestRepo.all(query) |> Enum.map(&Enum.join(&1, " "))
     end
+
+    test "works with update_all as source" do
+      post_1 = TestRepo.insert!(%Post{title: "Hello World", public: false, blob: "AABBD"})
+      post_2 = TestRepo.insert!(%Post{title: "Second post", public: false, blob: "DUHAH"})
+
+      update_from = [
+        %{id: post_1.id, title: "A"},
+        %{id: post_2.id, title: "B"}
+      ]
+
+      schema = [id: :integer, title: :string]
+
+      query = from p in Post,
+        join: v in values(type(update_from, schema)), on: v.id == p.id,
+        update: [set: [title: v.title]],
+        select: p
+
+      assert {2, [a, b]} = TestRepo.update_all(query, [])
+
+      assert a.title == "A"
+      assert b.title == "B"
+    end
   end
 end

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -2073,6 +2073,8 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     test "works with update_all as source" do
+      # this also tests if the values macro automatically infers the type of the maps
+      # in the values list, it should be [id: :integer, title: :string]
       post_1 = TestRepo.insert!(%Post{title: "Hello World", public: false, blob: "AABBD"})
       post_2 = TestRepo.insert!(%Post{title: "Second post", public: false, blob: "DUHAH"})
 
@@ -2081,10 +2083,8 @@ defmodule Ecto.Integration.RepoTest do
         %{id: post_2.id, title: "B"}
       ]
 
-      schema = [id: :integer, title: :string]
-
       query = from p in Post,
-        join: v in values(type(update_from, schema)), on: v.id == p.id,
+        join: v in values(update_from), on: v.id == p.id,
         update: [set: [title: v.title]],
         select: p
 

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -2062,8 +2062,10 @@ defmodule Ecto.Integration.RepoTest do
         %{id: 2, name: "Stark"}
       ]
 
-      query = from prename in values(values_1),
-        join: surname in values(values_2),
+      schema = [id: :integer, name: :string]
+
+      query = from prename in values(type(values_1, schema)),
+        join: surname in values(type(values_2, schema)),
         on: prename.id == surname.id,
         select: [prename.name, surname.name]
 

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -2036,17 +2036,6 @@ defmodule Ecto.Integration.RepoTest do
     end
   end
 
-  defmodule ValuesSchema do
-    use Ecto.Schema
-
-    @primary_key false
-    embedded_schema do
-      field :id, :integer
-      field :name, :string
-      field :uuid, Ecto.UUID
-    end
-  end
-
   describe "values list" do
     test "works in all/2" do
       values = [
@@ -2055,7 +2044,9 @@ defmodule Ecto.Integration.RepoTest do
       ]
       |> Enum.map(&Map.put(&1, :uuid, Ecto.UUID.autogenerate()))
 
-      query = from v in values(values, __MODULE__.ValuesSchema), select: v.name, order_by: [desc: v.id]
+      schema = %{id: :integer, name: :string, uuid: Ecto.UUID}
+
+      query = from v in values(type(values, schema)), select: v.name, order_by: [desc: v.id]
 
       assert ["Bob", "Alice"] = TestRepo.all(query)
     end
@@ -2065,16 +2056,14 @@ defmodule Ecto.Integration.RepoTest do
         %{id: 1, name: "Peter"},
         %{id: 2, name: "Tony"}
       ]
-      |> Enum.map(&Map.put(&1, :uuid, Ecto.UUID.autogenerate()))
 
       values_2 = [
         %{id: 1, name: "Parker"},
         %{id: 2, name: "Stark"}
       ]
-      |> Enum.map(&Map.put(&1, :uuid, Ecto.UUID.autogenerate()))
 
-      query = from prename in values(values_1, __MODULE__.ValuesSchema),
-        join: surname in values(values_2, __MODULE__.ValuesSchema),
+      query = from prename in values(values_1),
+        join: surname in values(values_2),
         on: prename.id == surname.id,
         select: [prename.name, surname.name]
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -12,7 +12,7 @@ end
 
 defmodule Ecto.ValuesList do
   @moduledoc false
-  defstruct [:values, :schema, :params]
+  defstruct [:values, :schema, :params, :param_offset]
 end
 
 defmodule Ecto.Query do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -9,6 +9,12 @@ defmodule Ecto.SubQuery do
   @type t :: %__MODULE__{}
 end
 
+
+defmodule Ecto.ValuesList do
+  @moduledoc false
+  defstruct [:values, :schema]
+end
+
 defmodule Ecto.Query do
   @moduledoc ~S"""
   Provides the Query DSL.
@@ -662,6 +668,10 @@ defmodule Ecto.Query do
       {:ok, prefix} when is_binary(prefix) or is_nil(prefix) -> put_in(subquery.query.prefix, prefix)
       :error -> subquery
     end
+  end
+
+  def values(list_of_maps, schema) do
+    %Ecto.ValuesList{values: list_of_maps, schema: schema}
   end
 
   defp wrap_in_subquery(%Ecto.SubQuery{} = subquery), do: subquery

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -682,6 +682,11 @@ defmodule Ecto.Query.API do
   """
   def parent_as(binding), do: doc! [binding]
 
+  @doc """
+  Pass a list of maps to the query.
+  """
+  def values(values), do: doc! [values]
+
   defp doc!(_) do
     raise "the functions in Ecto.Query.API should not be invoked directly, " <>
           "they serve for documentation purposes only"

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -682,11 +682,6 @@ defmodule Ecto.Query.API do
   """
   def parent_as(binding), do: doc! [binding]
 
-  @doc """
-  Pass a list of maps to the query.
-  """
-  def values(values), do: doc! [values]
-
   defp doc!(_) do
     raise "the functions in Ecto.Query.API should not be invoked directly, " <>
           "they serve for documentation purposes only"

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -233,6 +233,11 @@ defmodule Ecto.Query.Builder do
     end
   end
 
+  # values list
+  def escape({:values, _, [list]}, _type, _params_acc, _vars, _env) when is_list(list) do
+    error!("values lists are only supported in from or join clauses")
+  end
+
   # sigils
   def escape({name, _, [_, []]} = sigil, type, params_acc, vars, _env)
       when name in ~w(sigil_s sigil_S sigil_w sigil_W)a do
@@ -716,7 +721,7 @@ defmodule Ecto.Query.Builder do
     do: {find_var!(var, vars), field}
 
   def validate_type!(type, _vars, _env) do
-    error! "type/2 expects an alias, atom, initialized parameterized type or " <> 
+    error! "type/2 expects an alias, atom, initialized parameterized type or " <>
            "source.field as second argument, got: `#{Macro.to_string(type)}`"
   end
 

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -62,6 +62,10 @@ defmodule Ecto.Query.Builder.Join do
     {:_, expr, nil, params}
   end
 
+  def escape({:values, _, [values]} = expr, vars, env) do
+    {:_, expr, nil, [values]}
+  end
+
   def escape({string, schema} = join, _vars, env) when is_binary(string) do
     case Macro.expand(schema, env) do
       schema when is_atom(schema) ->
@@ -136,7 +140,7 @@ defmodule Ecto.Query.Builder.Join do
     unless is_binary(prefix) or is_nil(prefix) do
       Builder.error! "`prefix` must be a compile time string, got: `#{Macro.to_string(prefix)}`"
     end
-    
+
     as = case as do
       {:^, _, [as]} -> as
       as when is_atom(as) -> as

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -62,8 +62,11 @@ defmodule Ecto.Query.Builder.Join do
     {:_, expr, nil, params}
   end
 
-  def escape({:values, _, [values]} = expr, vars, env) do
-    {:_, expr, nil, [values]}
+  def escape({:values, _, [values, schema]} = expr, _vars, _env) do
+    values = quote do
+      Ecto.Query.values(unquote(values), unquote(schema))
+    end
+    {:_, values, nil, []}
   end
 
   def escape({string, schema} = join, _vars, env) when is_binary(string) do

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -62,9 +62,9 @@ defmodule Ecto.Query.Builder.Join do
     {:_, expr, nil, params}
   end
 
-  def escape({:values, _, [values, schema]} = expr, _vars, _env) do
+  def escape({:values, _, [values]} = _expr, _vars, _env) do
     values = quote do
-      Ecto.Query.values(unquote(values), unquote(schema))
+      Ecto.Query.values(unquote(values))
     end
     {:_, values, nil, []}
   end

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -136,6 +136,7 @@ defimpl Inspect, for: Ecto.Query do
 
   defp inspect_source(%Ecto.Query{} = query), do: "^" <> inspect(query)
   defp inspect_source(%Ecto.SubQuery{query: query}), do: "subquery(#{to_string(query)})"
+  defp inspect_source(%Ecto.ValuesList{values: values}), do: "values(#{inspect values})"
   defp inspect_source({source, nil}), do: inspect(source)
   defp inspect_source({nil, schema}), do: inspect(schema)
 
@@ -371,6 +372,7 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp from_sources(%Ecto.SubQuery{query: query}), do: from_sources(query.from.source)
+  defp from_sources(%Ecto.ValuesList{}), do: "values"
   defp from_sources({source, schema}), do: schema || source
   defp from_sources(nil), do: "query"
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -258,6 +258,12 @@ defmodule Ecto.Query.Planner do
   defp plan_source(query, %{source: {:fragment, _, _}, prefix: prefix} = expr, _adapter),
        do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for fragment joins")
 
+  defp plan_source(_query, %{source: %Ecto.ValuesList{} = source, prefix: nil} = expr, _adapter),
+       do: {expr, source}
+
+  defp plan_source(query, %{source: %Ecto.ValuesList{}, prefix: prefix} = expr, _adapter),
+       do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for values list")
+
   defp plan_subquery(subquery, query, prefix, adapter, source?) do
     %{query: inner_query} = subquery
 
@@ -772,6 +778,8 @@ defmodule Ecto.Query.Planner do
     do: {{source, prefix}, params}
   defp source_cache(%{source: %Ecto.SubQuery{params: inner, cache: key}}, params),
     do: {key, Enum.reverse(inner, params)}
+  defp source_cache(%{source: %Ecto.ValuesList{} = expr}, params),
+    do: {expr, params}
 
   defp cast_param(_kind, query, expr, %DynamicExpr{}, _type, _value) do
     error! query, expr, "invalid dynamic expression",
@@ -913,7 +921,7 @@ defmodule Ecto.Query.Planner do
   rescue
     e ->
       # Reraise errors so we ignore the planner inner stacktrace
-      filter_and_reraise e, __STACKTRACE__
+      reraise e, __STACKTRACE__
   end
 
   defp keep_literals?(:insert_all, _), do: true
@@ -1726,6 +1734,9 @@ defmodule Ecto.Query.Planner do
         :any
 
       {_, schema, _} ->
+        type!(kind, query, expr, schema, field, allow_virtuals?)
+
+      %Ecto.ValuesList{schema: schema} ->
         type!(kind, query, expr, schema, field, allow_virtuals?)
 
       %Ecto.SubQuery{select: select} ->

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -778,8 +778,8 @@ defmodule Ecto.Query.Planner do
     do: {{source, prefix}, params}
   defp source_cache(%{source: %Ecto.SubQuery{params: inner, cache: key}}, params),
     do: {key, Enum.reverse(inner, params)}
-  defp source_cache(%{source: %Ecto.ValuesList{} = expr}, params),
-    do: {expr, params}
+  defp source_cache(%{source: %Ecto.ValuesList{schema: schema, values: values}}, params),
+    do: {{length(values), schema.__schema__(:fields)}, params}
 
   defp cast_param(_kind, query, expr, %DynamicExpr{}, _type, _value) do
     error! query, expr, "invalid dynamic expression",

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -258,8 +258,10 @@ defmodule Ecto.Query.Planner do
   defp plan_source(query, %{source: {:fragment, _, _}, prefix: prefix} = expr, _adapter),
        do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for fragment joins")
 
-  defp plan_source(_query, %{source: %Ecto.ValuesList{} = source, prefix: nil} = expr, _adapter),
-       do: {expr, source}
+  defp plan_source(_query, %{source: %Ecto.ValuesList{} = source, prefix: nil} = expr, _adapter) do
+    IO.inspect expr, label: "plan_source"
+    {expr, source}
+  end
 
   defp plan_source(query, %{source: %Ecto.ValuesList{}, prefix: prefix} = expr, _adapter),
        do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for values list")
@@ -778,8 +780,10 @@ defmodule Ecto.Query.Planner do
     do: {{source, prefix}, params}
   defp source_cache(%{source: %Ecto.SubQuery{params: inner, cache: key}}, params),
     do: {key, Enum.reverse(inner, params)}
-  defp source_cache(%{source: %Ecto.ValuesList{schema: schema, values: values}}, params),
-    do: {{length(values), schema.__schema__(:fields)}, params}
+  defp source_cache(%{source: %Ecto.ValuesList{schema: schema, values: values, params: inner}}, params) do
+    IO.inspect params, label: "source_cache"
+    {{length(values), schema.__schema__(:fields)}, Enum.reverse(inner, params)}
+  end
 
   defp cast_param(_kind, query, expr, %DynamicExpr{}, _type, _value) do
     error! query, expr, "invalid dynamic expression",

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -19,6 +19,12 @@ defimpl Ecto.Queryable, for: Ecto.SubQuery do
   end
 end
 
+defimpl Ecto.Queryable, for: Ecto.ValuesList do
+  def to_query(values) do
+    %Ecto.Query{from: %Ecto.Query.FromExpr{source: values}}
+  end
+end
+
 defimpl Ecto.Queryable, for: BitString do
   def to_query(source) when is_binary(source) do
     %Ecto.Query{from: %Ecto.Query.FromExpr{source: {source, nil}}}

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1151,6 +1151,46 @@ defmodule Ecto.Type do
     end
   end
 
+  @doc """
+  Tries to guess the ecto type from the given value.
+
+  ## Examples
+
+      iex> infer_type_from_value(DateTime.utc_now())
+      :utc_datetime_usec
+      iex> infer_type_from_value(3)
+      :integer
+      iex> infer_type_from_value("Hello")
+      :string
+
+      # note how the UUID type collides with the string type. If your values
+      # might contain UUIDs or other types that are actually strings, you
+      # should not use infer_type_from_value/1.
+      iex> infer_type_from_value(Ecto.UUID.generate())
+      :string
+  """
+  @spec infer_type_from_value(any()) :: t()
+  def infer_type_from_value(value) do
+    case value do
+      int when is_integer(int) -> :integer
+      string when is_binary(string) -> :string
+      bool when is_boolean(bool) -> :boolean
+      float when is_float(float) -> :float
+      %Decimal{} -> :decimal
+      %Date{} -> :date
+      %Time{microsecond: {0, 0}} -> :time
+      %Time{} -> :time_usec
+      %DateTime{microsecond: {0, 0}} -> :utc_datetime
+      %DateTime{} -> :utc_datetime_usec
+      %NaiveDateTime{microsecond: {0, 0}} -> :naive_datetime
+      %NaiveDateTime{} -> :naive_datetime_usec
+      # catchall for other maps
+      %{} -> :map
+      # catchall for other types
+      _ -> :any
+    end
+  end
+
   defp equal_fun(:decimal), do: &equal_decimal?/2
   defp equal_fun(t) when t in [:time, :time_usec], do: &equal_time?/2
   defp equal_fun(t) when t in [:utc_datetime, :utc_datetime_usec], do: &equal_utc_datetime?/2


### PR DESCRIPTION
To support values lists in select from, joins, update from and delete from, I added a `values(list_of_maps, schema)` function that can be used in `in` expressions like 

```elixir
query = from u in User, 
  join: v in values([%{id: 1, name: "Moritz"}, ...]), on: u.id == v.id,
  update: [set: [name: v.name]]

Repo.update_all(query, [])
```

This is to support constant tables.

I am opening this PR as a draft early to gather feedback if I should change the syntax before proceeding with the more complicated details.

There's also an ecto_sql PR with support for the postgres adapter already: https://github.com/elixir-ecto/ecto_sql/pull/416

Postgres docs: https://www.postgresql.org/docs/current/queries-values.html
MySQL docs: https://dev.mysql.com/doc/refman/8.0/en/values.html
MSSQL docs: https://docs.microsoft.com/en-us/sql/t-sql/queries/table-value-constructor-transact-sql?view=sql-server-ver16

## TODO List

 - [x] Documentation for `values/1`
 - [ ] Implement MySQL Adapter
 - [ ] Implement MSSQL Adapter