### PR TITLE
Builder: Unify passing argument {params, acc} to escape functions

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -57,7 +57,11 @@ defmodule Ecto.Query.Builder do
 
   If the subqueries field is available, subquery escaping must take place.
   """
-  @type acc :: %{optional(:subqueries) => list(Macro.t()), optional(any) => any}
+  @type acc :: %{
+          optional(:subqueries) => list(Macro.t()),
+          optional(:take) => %{non_neg_integer => Macro.t()},
+          optional(any) => any
+        }
 
   @doc """
   Smart escapes a query expression and extracts interpolated values in

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -175,13 +175,13 @@ defmodule Ecto.Query.Builder do
   end
 
   # subqueries
-  def escape({:subquery, _, _} = expr, _, {params, acc}, _vars, _env) do
+  def escape({:subquery, _, _} = expr, _, {params, %{subqueries: subqueries} = acc}, _vars, _env) do
     subquery = quote(do: Ecto.Query.subquery(unquote(expr)))
-    subqueries = Map.get(acc, :subqueries, [])
     index = length(subqueries)
     # used both in ast and in parameters, as a placeholder.
     expr = {:subquery, index}
-    {expr, {[expr | params], Map.put(acc, :subqueries, [subquery | subqueries])}}
+    acc = %{acc | subqueries: [subquery | subqueries]}
+    {expr, {[expr | params], acc}}
   end
 
   # interval
@@ -725,7 +725,7 @@ defmodule Ecto.Query.Builder do
     do: {find_var!(var, vars), field}
 
   def validate_type!(type, _vars, _env) do
-    error! "type/2 expects an alias, atom, initialized parameterized type or " <> 
+    error! "type/2 expects an alias, atom, initialized parameterized type or " <>
            "source.field as second argument, got: `#{Macro.to_string(type)}`"
   end
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -54,10 +54,10 @@ defmodule Ecto.Query.Builder do
 
   @typedoc """
   The accumulator during escape.
-  
-  If the subqueries field is available, it means subquery esscaping must take place.
+
+  If the subqueries field is available, subquery escaping must take place.
   """
-  @type acc :: %{optional(:subqueries) => list(Macro.t()), optional(any) => any} 
+  @type acc :: %{optional(:subqueries) => list(Macro.t()), optional(any) => any}
 
   @doc """
   Smart escapes a query expression and extracts interpolated values in
@@ -69,7 +69,7 @@ defmodule Ecto.Query.Builder do
   map.
   """
   @spec escape(Macro.t, quoted_type | {:in, quoted_type} | {:out, quoted_type}, {list, acc},
-               Keyword.t, Macro.Env.t | {Macro.Env.t, fun}) :: {Macro.t, {list, term}}
+               Keyword.t, Macro.Env.t | {Macro.Env.t, fun}) :: {Macro.t, {list, acc}}
   def escape(expr, type, params_acc, vars, env)
 
   # var.x - where var is bound

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -52,6 +52,13 @@ defmodule Ecto.Query.Builder do
   """
   @type quoted_type :: Ecto.Type.primitive | {non_neg_integer, atom | Macro.t}
 
+  @typedoc """
+  The accumulator during escape.
+  
+  If the subqueries field is available, it means subquery esscaping must take place.
+  """
+  @type acc :: %{optional(:subqueries) => list(Macro.t()), optional(any) => any} 
+
   @doc """
   Smart escapes a query expression and extracts interpolated values in
   a map.
@@ -61,7 +68,7 @@ defmodule Ecto.Query.Builder do
   with `^index` in the query where index is a number indexing into the
   map.
   """
-  @spec escape(Macro.t, quoted_type | {:in, quoted_type} | {:out, quoted_type}, {list, term},
+  @spec escape(Macro.t, quoted_type | {:in, quoted_type} | {:out, quoted_type}, {list, acc},
                Keyword.t, Macro.Env.t | {Macro.Env.t, fun}) :: {Macro.t, {list, term}}
   def escape(expr, type, params_acc, vars, env)
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -168,13 +168,13 @@ defmodule Ecto.Query.Builder do
   end
 
   # subqueries
-  def escape({:subquery, _, _} = expr, _, {params, {take, subqueries}}, _vars, _env) do
-    {expr, {params, subqueries}} = escape_subquery(expr, {params, subqueries})
-    {expr, {params, {take, subqueries}}}
-  end
-
-  def escape({:subquery, _, _} = expr, _, params_acc, _vars, _env) do
-    escape_subquery(expr, params_acc)
+  def escape({:subquery, _, _} = expr, _, {params, acc}, _vars, _env) do
+    subquery = quote(do: Ecto.Query.subquery(unquote(expr)))
+    subqueries = Map.get(acc, :subqueries, [])
+    index = length(subqueries)
+    # used both in ast and in parameters, as a placeholder.
+    expr = {:subquery, index}
+    {expr, {[expr | params], Map.put(acc, :subqueries, [subquery | subqueries])}}
   end
 
   # interval
@@ -532,14 +532,6 @@ defmodule Ecto.Query.Builder do
     frag
     |> split_fragment("")
     |> merge_fragments(args)
-  end
-
-  defp escape_subquery(expr, {params, subqueries}) do
-    subquery = quote(do: Ecto.Query.subquery(unquote(expr)))
-    index = length(subqueries)
-    # used both in ast and in parameters, as a placeholder.
-    expr = {:subquery, index}
-    {expr, {[expr | params], [subquery | subqueries]}}
   end
 
   defp escape_window_description([], params_acc, _vars, _env),

--- a/lib/ecto/query/builder/cte.ex
+++ b/lib/ecto/query/builder/cte.ex
@@ -46,7 +46,7 @@ defmodule Ecto.Query.Builder.CTE do
   end
 
   def build_cte(_name, {:fragment, _, _} = fragment, env) do
-    {expr, {params, :acc}} = Builder.escape(fragment, :any, {[], :acc}, [], env)
+    {expr, {params, _acc}} = Builder.escape(fragment, :any, {[], %{}}, [], env)
     params = Builder.escape_params(params)
 
     quote do

--- a/lib/ecto/query/builder/distinct.ex
+++ b/lib/ecto/query/builder/distinct.ex
@@ -8,13 +8,13 @@ defmodule Ecto.Query.Builder.Distinct do
   @doc """
   Escapes a list of quoted expressions.
 
-      iex> escape(quote do true end, {[], :acc}, [], __ENV__)
-      {true, {[], :acc}}
+      iex> escape(quote do true end, {[], %{}}, [], __ENV__)
+      {true, {[], %{}}}
 
-      iex> escape(quote do [x.x, 13] end, {[], :acc}, [x: 0], __ENV__)
+      iex> escape(quote do [x.x, 13] end, {[], %{}}, [x: 0], __ENV__)
       {[asc: {:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :x]]}, [], []]},
         asc: 13],
-       {[], :acc}}
+       {[], %{}}}
 
   """
   @spec escape(Macro.t, {list, term}, Keyword.t, Macro.Env.t) :: {Macro.t, {list, term}}
@@ -54,7 +54,7 @@ defmodule Ecto.Query.Builder.Distinct do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _}} = escape(expr, {[], :acc}, binding, env)
+    {expr, {params, _acc}} = escape(expr, {[], %{}}, binding, env)
     params = Builder.escape_params(params)
 
     distinct = quote do: %Ecto.Query.QueryExpr{

--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -11,8 +11,9 @@ defmodule Ecto.Query.Builder.Dynamic do
   @spec build([Macro.t], Macro.t, Macro.Env.t) :: Macro.t
   def build(binding, expr, env) do
     {query, vars} = Builder.escape_binding(quote(do: query), binding, env)
-    {expr, {params, subqueries}} = Builder.escape(expr, :any, {[], []}, vars, env)
+    {expr, {params, acc}} = Builder.escape(expr, :any, {[], %{}}, vars, env)
     params = Builder.escape_params(params)
+    subqueries = Map.get(acc, :subqueries, [])
 
     quote do
       %Ecto.Query.DynamicExpr{fun: fn query ->

--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -13,12 +13,11 @@ defmodule Ecto.Query.Builder.Dynamic do
     {query, vars} = Builder.escape_binding(quote(do: query), binding, env)
     {expr, {params, acc}} = Builder.escape(expr, :any, {[], %{subqueries: []}}, vars, env)
     params = Builder.escape_params(params)
-    subqueries = Map.fetch!(acc, :subqueries)
 
     quote do
       %Ecto.Query.DynamicExpr{fun: fn query ->
                                 _ = unquote(query)
-                                {unquote(expr), unquote(params), unquote(subqueries)}
+                                {unquote(expr), unquote(params), unquote(acc.subqueries)}
                               end,
                               binding: unquote(Macro.escape(binding)),
                               file: unquote(env.file),

--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -11,9 +11,9 @@ defmodule Ecto.Query.Builder.Dynamic do
   @spec build([Macro.t], Macro.t, Macro.Env.t) :: Macro.t
   def build(binding, expr, env) do
     {query, vars} = Builder.escape_binding(quote(do: query), binding, env)
-    {expr, {params, acc}} = Builder.escape(expr, :any, {[], %{}}, vars, env)
+    {expr, {params, acc}} = Builder.escape(expr, :any, {[], %{subqueries: []}}, vars, env)
     params = Builder.escape_params(params)
-    subqueries = Map.get(acc, :subqueries, [])
+    subqueries = Map.fetch!(acc, :subqueries)
 
     quote do
       %Ecto.Query.DynamicExpr{fun: fn query ->
@@ -60,7 +60,7 @@ defmodule Ecto.Query.Builder.Dynamic do
           {%Ecto.Query.DynamicExpr{binding: new_binding} = dynamic, _} ->
             binding = if length(new_binding) > length(binding), do: new_binding, else: binding
             expand(query, dynamic, {binding, params, subqueries, count})
-          
+
           param ->
             {{:^, meta, [count]}, {binding, [param | params], subqueries, count + 1}}
         end

--- a/lib/ecto/query/builder/filter.ex
+++ b/lib/ecto/query/builder/filter.ex
@@ -67,7 +67,7 @@ defmodule Ecto.Query.Builder.Filter do
     {expr, {params, acc}} = escape(kind, expr, 0, binding, env)
 
     params = Builder.escape_params(params)
-    subqueries = Enum.reverse(Map.get(acc, :subqueries, []))
+    subqueries = Enum.reverse(acc.subqueries)
 
     expr = quote do: %Ecto.Query.BooleanExpr{
                         expr: unquote(expr),

--- a/lib/ecto/query/builder/filter.ex
+++ b/lib/ecto/query/builder/filter.ex
@@ -18,12 +18,12 @@ defmodule Ecto.Query.Builder.Filter do
   """
   @spec escape(:where | :having | :on, Macro.t, non_neg_integer, Keyword.t, Macro.Env.t) :: {Macro.t, {list, list}}
   def escape(_kind, [], _binding, _vars, _env) do
-    {true, {[], []}}
+    {true, {[], %{subqueries: []}}}
   end
 
   def escape(kind, expr, binding, vars, env) when is_list(expr) do
     {parts, params_acc} =
-      Enum.map_reduce(expr, {[], %{}}, fn
+      Enum.map_reduce(expr, {[], %{subqueries: []}}, fn
         {field, nil}, _params_acc ->
           Builder.error! "nil given for `#{field}`. Comparison with nil is forbidden as it is unsafe. " <>
                          "Instead write a query with is_nil/1, for example: is_nil(s.#{field})"
@@ -33,7 +33,7 @@ defmodule Ecto.Query.Builder.Filter do
           {value, params_acc} = Builder.escape(value, {binding, field}, params_acc, vars, env)
           {{:{}, [], [:==, [], [to_escaped_field(binding, field), value]]}, params_acc}
 
-        _, _params_subqueries ->
+        _, _params_acc ->
           Builder.error! "expected a keyword list at compile time in #{kind}, " <>
                          "got: `#{Macro.to_string expr}`. If you would like to " <>
                          "pass a list dynamically, please interpolate the whole list with ^"
@@ -44,7 +44,7 @@ defmodule Ecto.Query.Builder.Filter do
   end
 
   def escape(_kind, expr, _binding, vars, env) do
-    Builder.escape(expr, :boolean, {[], %{}}, vars, env)
+    Builder.escape(expr, :boolean, {[], %{subqueries: []}}, vars, env)
   end
 
   @doc """

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -10,10 +10,10 @@ defmodule Ecto.Query.Builder.GroupBy do
 
   See `Ecto.Builder.escape/2`.
 
-      iex> escape(:group_by, quote do [x.x, 13] end, {[], :acc}, [x: 0], __ENV__)
+      iex> escape(:group_by, quote do [x.x, 13] end, {[], %{}}, [x: 0], __ENV__)
       {[{:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :x]]}, [], []]},
         13],
-       {[], :acc}}
+       {[], %{}}}
   """
   @spec escape(:group_by | :partition_by, Macro.t, {list, term}, Keyword.t, Macro.Env.t) ::
           {Macro.t, {list, term}}
@@ -93,7 +93,7 @@ defmodule Ecto.Query.Builder.GroupBy do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _}} = escape(:group_by, expr, {[], :acc}, binding, env)
+    {expr, {params, _acc}} = escape(:group_by, expr, {[], %{}}, binding, env)
     params = Builder.escape_params(params)
 
     group_by = quote do: %Ecto.Query.QueryExpr{

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -58,7 +58,7 @@ defmodule Ecto.Query.Builder.Join do
   end
 
   def escape({:fragment, _, [_ | _]} = expr, vars, env) do
-    {expr, {params, :acc}} = Builder.escape(expr, :any, {[], :acc}, vars, env)
+    {expr, {params, _acc}} = Builder.escape(expr, :any, {[], %{}}, vars, env)
     {:_, expr, nil, params}
   end
 

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -206,7 +206,10 @@ defmodule Ecto.Query.Builder.Join do
 
   def build_on(on, join, as, query, binding, count_bind, env) do
     case Ecto.Query.Builder.Filter.escape(:on, on, count_bind, binding, env) do
-      {on_expr, {on_params, []}}  ->
+      {_on_expr, {_on_params, %{subqueries: [_ | _]}}} ->
+        raise ArgumentError, "invalid expression for join `:on`, subqueries aren't supported"
+
+      {on_expr, {on_params, _acc}} ->
         on_params = Builder.escape_params(on_params)
 
         join =
@@ -223,9 +226,6 @@ defmodule Ecto.Query.Builder.Join do
           end
 
         Builder.apply_query(query, __MODULE__, [join, as, count_bind], env)
-
-      _pattern ->
-        raise ArgumentError, "invalid expression for join `:on`, subqueries aren't supported"
     end
   end
 

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -15,7 +15,7 @@ defmodule Ecto.Query.Builder.LimitOffset do
   @spec build(:limit | :offset, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
   def build(type, query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, :acc}} = Builder.escape(expr, :integer, {[], :acc}, binding, env)
+    {expr, {params, _acc}} = Builder.escape(expr, :integer, {[], %{}}, binding, env)
     params = Builder.escape_params(params)
 
     if contains_variable?(expr) do

--- a/lib/ecto/query/builder/lock.ex
+++ b/lib/ecto/query/builder/lock.ex
@@ -16,7 +16,7 @@ defmodule Ecto.Query.Builder.Lock do
   def escape(lock, _vars, _env) when is_binary(lock), do: lock
 
   def escape({:fragment, _, [_ | _]} = expr, vars, env) do
-    {expr, {params, :acc}} = Builder.escape(expr, :any, {[], :acc}, vars, env)
+    {expr, {params, _acc}} = Builder.escape(expr, :any, {[], %{}}, vars, env)
 
     if params != [] do
       Builder.error!("value interpolation is not allowed in :lock")

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -41,10 +41,10 @@ defmodule Ecto.Query.Builder.OrderBy do
 
   ## Examples
 
-      iex> escape(:order_by, quote do [x.x, desc: 13] end, {[], :acc}, [x: 0], __ENV__)
+      iex> escape(:order_by, quote do [x.x, desc: 13] end, {[], %{}}, [x: 0], __ENV__)
       {[asc: {:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :x]]}, [], []]},
         desc: 13],
-       {[], :acc}}
+       {[], %{}}}
 
   """
   @spec escape(:order_by | :distinct, Macro.t, {list, term}, Keyword.t, Macro.Env.t) ::
@@ -185,7 +185,7 @@ defmodule Ecto.Query.Builder.OrderBy do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _}} = escape(:order_by, expr, {[], :acc}, binding, env)
+    {expr, {params, _acc}} = escape(:order_by, expr, {[], %{}}, binding, env)
     params = Builder.escape_params(params)
 
     order_by = quote do: %Ecto.Query.QueryExpr{

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -48,7 +48,7 @@ defmodule Ecto.Query.Builder.Select do
     
       true ->
         {expr, {params, acc}} = escape(other, {[], %{subqueries: []}}, vars, env)
-        acc = Map.update!(acc, :subqueries, &Enum.reverse/1)
+        acc = %{acc | subqueries: Enum.reverse(acc.subqueries)}
         {expr, {params, acc}}
     end
   end
@@ -217,7 +217,6 @@ defmodule Ecto.Query.Builder.Select do
     {expr, {params, acc}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
     take = {:%{}, [], Map.to_list(Map.get(acc, :take, %{}))}
-    subqueries = Map.get(acc, :subqueries, [])
 
     select = quote do: %Ecto.Query.SelectExpr{
                          expr: unquote(expr),
@@ -225,7 +224,7 @@ defmodule Ecto.Query.Builder.Select do
                          file: unquote(env.file),
                          line: unquote(env.line),
                          take: unquote(take),
-                         subqueries: unquote(subqueries)}
+                         subqueries: unquote(acc.subqueries)}
 
     if kind == :select do
       Builder.apply_query(query, __MODULE__, [select], env)

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -14,13 +14,13 @@ defmodule Ecto.Query.Builder.Select do
   ## Examples
 
       iex> escape({1, 2}, [], __ENV__)
-      {{:{}, [], [:{}, [], [1, 2]]}, {[], {%{}, []}}}
+      {{:{}, [], [:{}, [], [1, 2]]}, {[], %{}}}
 
       iex> escape([1, 2], [], __ENV__)
-      {[1, 2], {[], {%{}, []}}}
+      {[1, 2], {[], %{}}}
 
       iex> escape(quote(do: x), [x: 0], __ENV__)
-      {{:{}, [], [:&, [], [0]]}, {[], {%{}, []}}}
+      {{:{}, [], [:&, [], [0]]}, {[], %{}}}
 
   """
   @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{}}}
@@ -34,7 +34,7 @@ defmodule Ecto.Query.Builder.Select do
   def escape(other, vars, env) do
     cond do
       take?(other) ->
-        {{:{}, [], [:&, [], [0]]}, {[], {%{0 => {:any, Macro.expand(other, env)}}, []}}}
+        {{:{}, [], [:&, [], [0]]}, {[], %{take: %{0 => {:any, Macro.expand(other, env)}}}}}
 
       maybe_take?(other) ->
         Builder.error! """
@@ -44,8 +44,15 @@ defmodule Ecto.Query.Builder.Select do
         """
     
       true ->
-        {expr, {params, {take, subqueries}}} = escape(other, {[], {%{}, []}}, vars, env)
-        {expr, {params, {take, Enum.reverse(subqueries)}}}
+        {expr, {params, acc}} = escape(other, {[], %{}}, vars, env)
+
+        acc =
+          case acc do
+            %{subqueries: subqueries} -> Map.put(acc, :subqueries, Enum.reverse(subqueries))
+            other -> other
+          end
+
+        {expr, {params, acc}}
     end
   end
 
@@ -99,12 +106,12 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   # map/struct(var, [:foo, :bar])
-  defp escape({tag, _, [{var, _, context}, fields]}, {params, {take, subqueries}}, vars, env)
+  defp escape({tag, _, [{var, _, context}, fields]}, {params, acc}, vars, env)
        when tag in [:map, :struct] and is_atom(var) and is_atom(context) do
     taken = escape_fields(fields, tag, env)
     expr = Builder.escape_var!(var, vars)
-    take = add_take(take, Builder.find_var!(var, vars), {tag, taken})
-    {expr, {params, {take, subqueries}}}
+    acc = add_take(acc, Builder.find_var!(var, vars), {tag, taken})
+    {expr, {params, acc}}
   end
 
   defp escape(expr, params_acc, vars, env) do
@@ -210,9 +217,10 @@ defmodule Ecto.Query.Builder.Select do
 
   def build(kind, query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, {take, subqueries}}} = escape(expr, binding, env)
+    {expr, {params, acc}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
-    take   = {:%{}, [], Map.to_list(take)}
+    take = {:%{}, [], Map.to_list(Map.get(acc, :take, %{}))}
+    subqueries = Map.get(acc, :subqueries, [])
 
     select = quote do: %Ecto.Query.SelectExpr{
                          expr: unquote(expr),
@@ -365,8 +373,10 @@ defmodule Ecto.Query.Builder.Select do
     Macro.to_string(other)
   end
 
-  defp add_take(take, key, value) do
-    Map.update(take, key, value, &merge_take_kind_and_fields(key, &1, value))
+  defp add_take(acc, key, value) do
+    Map.update(acc, :take, %{key => value}, fn take ->
+      Map.update(take, key, value, &merge_take_kind_and_fields(key, &1, value))
+    end)
   end
 
   defp merge_take(old_expr, %{} = old_take, %{} = new_take) do

--- a/lib/ecto/query/builder/update.ex
+++ b/lib/ecto/query/builder/update.ex
@@ -67,7 +67,7 @@ defmodule Ecto.Query.Builder.Update do
         {compile, [{k, v} | runtime], params}
       {k, v}, {compile, runtime, params} ->
         k = escape_field!(k)
-        {v, {params, :acc}} = Builder.escape(v, type_for_key(op, {0, k}), {params, :acc}, vars, env)
+        {v, {params, _acc}} = Builder.escape(v, type_for_key(op, {0, k}), {params, %{}}, vars, env)
         {[{k, v} | compile], runtime, params}
       _, _acc ->
         Builder.error! "malformed #{inspect op} in update `#{Macro.to_string(kw)}`, " <>

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -12,8 +12,8 @@ defmodule Ecto.Query.Builder.Windows do
 
   ## Examples
 
-      iex> escape(quote do [order_by: [desc: 13]] end, {[], :acc}, [x: 0], __ENV__)
-      {[order_by: [desc: 13]], [], {[], :acc}}
+      iex> escape(quote do [order_by: [desc: 13]] end, {[], %{}}, [x: 0], __ENV__)
+      {[order_by: [desc: 13]], [], {[], %{}}}
 
   """
   @spec escape([Macro.t], {list, term}, Keyword.t, Macro.Env.t | {Macro.Env.t, fun})
@@ -125,7 +125,7 @@ defmodule Ecto.Query.Builder.Windows do
   end
 
   defp escape_window(vars, {name, expr}, env) do
-    {compile_acc, runtime_acc, {params, _}} = escape(expr, {[], :acc}, vars, env)
+    {compile_acc, runtime_acc, {params, _acc}} = escape(expr, {[], %{}}, vars, env)
     {name, compile_acc, runtime_acc, Builder.escape_params(params)}
   end
 

--- a/test/ecto/query/builder/distinct_test.exs
+++ b/test/ecto/query/builder/distinct_test.exs
@@ -8,26 +8,26 @@ defmodule Ecto.Query.Builder.DistinctTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {true, {[], :acc}} ==
-             escape(true, {[], :acc}, [x: 0], __ENV__)
+      assert {true, {[], %{}}} ==
+             escape(true, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.y()] end), {[], :acc}} ==
-             escape(quote do x.y() end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.y()] end), {[], %{}}} ==
+             escape(quote do x.y() end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x(), asc: &1.y()] end), {[], :acc}} ==
-             escape(quote do [x.x(), y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x(), asc: &1.y()] end), {[], %{}}} ==
+             escape(quote do [x.x(), y.y()] end, {[], %{}}, [x: 0, y: 1], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], :acc}} ==
-             escape(quote do [x.x(), desc: y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], %{}}} ==
+             escape(quote do [x.x(), desc: y.y()] end, {[], %{}}, [x: 0, y: 1], __ENV__)
 
       import Kernel, except: [>: 2]
-      assert {Macro.escape(quote do [asc: 1 > 2] end), {[], :acc}} ==
-             escape(quote do 1 > 2 end, {[], :acc}, [], __ENV__)
+      assert {Macro.escape(quote do [asc: 1 > 2] end), {[], %{}}} ==
+             escape(quote do 1 > 2 end, {[], %{}}, [], __ENV__)
     end
 
     test "raises on unbound variables" do
       assert_raise Ecto.Query.CompileError, ~r"unbound variable `x` in query", fn ->
-        escape(quote do x.y end, {[], :acc}, [], __ENV__)
+        escape(quote do x.y end, {[], %{}}, [], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/filter_test.exs
+++ b/test/ecto/query/builder/filter_test.exs
@@ -15,10 +15,10 @@ defmodule Ecto.Query.Builder.FilterTest do
 
       assert escape(:where, quote do {x.x()} == {^"foo"} end, 0, [x: 0], __ENV__) ===
              {Macro.escape(quote do {&0.x()} == {^0} end),
-             {[{"foo", {0, :x}}], []}}
+             {[{"foo", {0, :x}}], %{}}}
 
       escaped = Macro.escape(quote do &0.x() == ^0 and &0.y() == ^1 end)
-      assert {^escaped, {params, []}} =
+      assert {^escaped, {params, %{}}} =
               escape(:where, quote do [x: ^"foo", y: ^"bar"] end, 0, [x: 0], __ENV__)
       assert [{{_, _, ["bar", :y]}, {0, :y}}, {{_, _, ["foo", :x]}, {0, :x}}] = params
     end

--- a/test/ecto/query/builder/filter_test.exs
+++ b/test/ecto/query/builder/filter_test.exs
@@ -11,11 +11,11 @@ defmodule Ecto.Query.Builder.FilterTest do
       import Kernel, except: [==: 2, and: 2]
 
       assert escape(:where, quote do [] end, 0, [x: 0], __ENV__) ===
-             {true, {[], []}}
+             {true, {[], %{subqueries: []}}}
 
       assert escape(:where, quote do {x.x()} == {^"foo"} end, 0, [x: 0], __ENV__) ===
              {Macro.escape(quote do {&0.x()} == {^0} end),
-             {[{"foo", {0, :x}}], %{}}}
+             {[{"foo", {0, :x}}], %{subqueries: []}}}
 
       escaped = Macro.escape(quote do &0.x() == ^0 and &0.y() == ^1 end)
       assert {^escaped, {params, %{}}} =

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -8,21 +8,21 @@ defmodule Ecto.Query.Builder.GroupByTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do [&0.y()] end), {[], :acc}} ==
-             escape(:group_by, quote do x.y() end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [&0.y()] end), {[], %{}}} ==
+             escape(:group_by, quote do x.y() end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [&0.x(), &1.y()] end), {[], :acc}} ==
-             escape(:group_by, quote do [x.x(), y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(quote do [&0.x(), &1.y()] end), {[], %{}}} ==
+             escape(:group_by, quote do [x.x(), y.y()] end, {[], %{}}, [x: 0, y: 1], __ENV__)
 
       import Kernel, except: [>: 2]
-      assert {Macro.escape(quote do [1 > 2] end), {[], :acc}} ==
-             escape(:group_by, quote do 1 > 2 end, {[], :acc}, [], __ENV__)
+      assert {Macro.escape(quote do [1 > 2] end), {[], %{}}} ==
+             escape(:group_by, quote do 1 > 2 end, {[], %{}}, [], __ENV__)
     end
 
     test "raises on unbound variables" do
       message = ~r"unbound variable `x` in query"
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:group_by, quote do x.y end, {[], :acc}, [], __ENV__)
+        escape(:group_by, quote do x.y end, {[], %{}}, [], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/order_by_test.exs
+++ b/test/ecto/query/builder/order_by_test.exs
@@ -8,45 +8,45 @@ defmodule Ecto.Query.Builder.OrderByTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do [asc: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do x.y() end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do x.y() end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x(), asc: &1.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [x.x(), y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x(), asc: &1.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do [x.x(), y.y()] end, {[], %{}}, [x: 0, y: 1], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [asc: x.x(), desc: y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do [asc: x.x(), desc: y.y()] end, {[], %{}}, [x: 0, y: 1], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [x.x(), desc: y.y()] end, {[], :acc}, [x: 0, y: 1], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x(), desc: &1.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do [x.x(), desc: y.y()] end, {[], %{}}, [x: 0, y: 1], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x()] end), {[], :acc}} ==
-             escape(:order_by, quote do :x end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x()] end), {[], %{}}} ==
+             escape(:order_by, quote do :x end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc: &0.x(), desc: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [:x, desc: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [asc: &0.x(), desc: &0.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do [:x, desc: :y] end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc_nulls_first: &0.x(), desc_nulls_first: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [asc_nulls_first: :x, desc_nulls_first: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [asc_nulls_first: &0.x(), desc_nulls_first: &0.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do [asc_nulls_first: :x, desc_nulls_first: :y] end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [asc_nulls_last: &0.x(), desc_nulls_last: &0.y()] end), {[], :acc}} ==
-             escape(:order_by, quote do [asc_nulls_last: :x, desc_nulls_last: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [asc_nulls_last: &0.x(), desc_nulls_last: &0.y()] end), {[], %{}}} ==
+             escape(:order_by, quote do [asc_nulls_last: :x, desc_nulls_last: :y] end, {[], %{}}, [x: 0], __ENV__)
 
       import Kernel, except: [>: 2]
-      assert {Macro.escape(quote do [asc: 1 > 2] end), {[], :acc}} ==
-             escape(:order_by, quote do 1 > 2 end, {[], :acc}, [], __ENV__)
+      assert {Macro.escape(quote do [asc: 1 > 2] end), {[], %{}}} ==
+             escape(:order_by, quote do 1 > 2 end, {[], %{}}, [], __ENV__)
     end
 
     test "raises on unbound variables" do
       assert_raise Ecto.Query.CompileError, ~r"unbound variable `x` in query", fn ->
-        escape(:order_by, quote do x.y end, {[], :acc}, [], __ENV__)
+        escape(:order_by, quote do x.y end, {[], %{}}, [], __ENV__)
       end
     end
 
     test "raises on unknown expression" do
       message = ~r":desc_nulls_first or interpolated value in `order_by`, got: `:test`"
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:order_by, quote do [test: x.y] end, {[], :acc}, [x: 0], __ENV__)
+        escape(:order_by, quote do [test: x.y] end, {[], %{}}, [x: 0], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -7,43 +7,43 @@ defmodule Ecto.Query.Builder.SelectTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do &0 end), {[], %{}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{subqueries: []}}} ==
              escape(quote do x end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0.y() end), {[], %{}}} ==
+      assert {Macro.escape(quote do &0.y() end), {[], %{subqueries: []}}} ==
              escape(quote do x.y() end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:any, [:foo, :bar, baz: :bat]}}}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:any, [:foo, :bar, baz: :bat]}}, subqueries: []}}} ==
              escape(quote do [:foo, :bar, baz: :bat] end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:struct, [:foo, :bar, baz: :bat]}}}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:struct, [:foo, :bar, baz: :bat]}}, subqueries: []}}} ==
              escape(quote do struct(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}, subqueries: []}}} ==
              escape(quote do map(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
 
-      assert {{:{}, [], [:{}, [], [0, 1, 2]]}, {[], %{}}} ==
+      assert {{:{}, [], [:{}, [], [0, 1, 2]]}, {[], %{subqueries: []}}} ==
              escape(quote do {0, 1, 2} end, [], __ENV__)
 
-      assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, {[], %{}}} ==
+      assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, {[], %{subqueries: []}}} ==
              escape(quote do %{a: a} end, [a: 0], __ENV__)
 
-      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, {[], %{}}} ==
+      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, {[], %{subqueries: []}}} ==
              escape(quote do %{a => b} end, [a: 0, b: 1], __ENV__)
 
-      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], {[], %{}}} ==
+      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], {[], %{subqueries: []}}} ==
              escape(quote do [x.y(), x.z()] end, [x: 0], __ENV__)
 
       assert {[{:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :y]]}, [], []]},
-               {:{}, [], [:^, [], [0]]}], {[{1, :any}], %{}}} ==
+               {:{}, [], [:^, [], [0]]}], {[{1, :any}], %{subqueries: []}}} ==
               escape(quote do [x.y(), ^1] end, [x: 0], __ENV__)
 
-      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {[], %{}}} ==
+      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {[], %{subqueries: []}}} ==
              escape(quote do %Foo{a: a} end, [a: 0], __ENV__)
     end
 
     test "on conflicting take" do
-      assert {_, {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}}}} =
+      assert {_, {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}, subqueries: []}}} =
              escape(quote do {map(x, [:foo, :bar]), map(x, [baz: :bat])} end, [x: 0], __ENV__)
 
       assert_raise Ecto.Query.CompileError,

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -7,43 +7,43 @@ defmodule Ecto.Query.Builder.SelectTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do &0 end), {[], {%{}, []}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{}}} ==
              escape(quote do x end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0.y() end), {[], {%{}, []}}} ==
+      assert {Macro.escape(quote do &0.y() end), {[], %{}}} ==
              escape(quote do x.y() end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], {%{0 => {:any, [:foo, :bar, baz: :bat]}}, []}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:any, [:foo, :bar, baz: :bat]}}}}} ==
              escape(quote do [:foo, :bar, baz: :bat] end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], {%{0 => {:struct, [:foo, :bar, baz: :bat]}}, []}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:struct, [:foo, :bar, baz: :bat]}}}}} ==
              escape(quote do struct(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], {%{0 => {:map, [:foo, :bar, baz: :bat]}}, []}}} ==
+      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}}}} ==
              escape(quote do map(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
 
-      assert {{:{}, [], [:{}, [], [0, 1, 2]]}, {[], {%{}, []}}} ==
+      assert {{:{}, [], [:{}, [], [0, 1, 2]]}, {[], %{}}} ==
              escape(quote do {0, 1, 2} end, [], __ENV__)
 
-      assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, {[], {%{}, []}}} ==
+      assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, {[], %{}}} ==
              escape(quote do %{a: a} end, [a: 0], __ENV__)
 
-      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, {[], {%{}, []}}} ==
+      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, {[], %{}}} ==
              escape(quote do %{a => b} end, [a: 0, b: 1], __ENV__)
 
-      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], {[], {%{}, []}}} ==
+      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], {[], %{}}} ==
              escape(quote do [x.y(), x.z()] end, [x: 0], __ENV__)
 
       assert {[{:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :y]]}, [], []]},
-               {:{}, [], [:^, [], [0]]}], {[{1, :any}], {%{}, []}}} ==
+               {:{}, [], [:^, [], [0]]}], {[{1, :any}], %{}}} ==
               escape(quote do [x.y(), ^1] end, [x: 0], __ENV__)
 
-      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {[], {%{}, []}}} ==
+      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {[], %{}}} ==
              escape(quote do %Foo{a: a} end, [a: 0], __ENV__)
     end
 
     test "on conflicting take" do
-      assert {_, {[], {%{0 => {:map, [:foo, :bar, baz: :bat]}}, []}}} =
+      assert {_, {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}}}} =
              escape(quote do {map(x, [:foo, :bar]), map(x, [baz: :bat])} end, [x: 0], __ENV__)
 
       assert_raise Ecto.Query.CompileError,

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -5,40 +5,47 @@ defmodule Ecto.Query.Builder.SelectTest do
   import Ecto.Query.Builder.Select
   doctest Ecto.Query.Builder.Select
 
+  defp params_acc(opts \\ []) do
+    params = opts[:params] || []
+    take = opts[:take] || %{}
+    subqueries = opts[:subqueries] || []
+    {params, %{take: take, subqueries: subqueries}}
+  end
+
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do &0 end), {[], %{subqueries: []}}} ==
+      assert {Macro.escape(quote do &0 end), params_acc()} ==
              escape(quote do x end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0.y() end), {[], %{subqueries: []}}} ==
+      assert {Macro.escape(quote do &0.y() end), params_acc()} ==
              escape(quote do x.y() end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:any, [:foo, :bar, baz: :bat]}}, subqueries: []}}} ==
+      assert {Macro.escape(quote do &0 end), params_acc(take: %{0 => {:any, [:foo, :bar, baz: :bat]}})} ==
              escape(quote do [:foo, :bar, baz: :bat] end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:struct, [:foo, :bar, baz: :bat]}}, subqueries: []}}} ==
+      assert {Macro.escape(quote do &0 end), params_acc(take: %{0 => {:struct, [:foo, :bar, baz: :bat]}})} ==
              escape(quote do struct(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do &0 end), {[], %{take: %{0 => {:map, [:foo, :bar, baz: :bat]}}, subqueries: []}}} ==
+      assert {Macro.escape(quote do &0 end), params_acc(take: %{0 => {:map, [:foo, :bar, baz: :bat]}})} ==
              escape(quote do map(x, [:foo, :bar, baz: :bat]) end, [x: 0], __ENV__)
 
-      assert {{:{}, [], [:{}, [], [0, 1, 2]]}, {[], %{subqueries: []}}} ==
+      assert {{:{}, [], [:{}, [], [0, 1, 2]]}, params_acc()} ==
              escape(quote do {0, 1, 2} end, [], __ENV__)
 
-      assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, {[], %{subqueries: []}}} ==
+      assert {{:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}, params_acc()} ==
              escape(quote do %{a: a} end, [a: 0], __ENV__)
 
-      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, {[], %{subqueries: []}}} ==
+      assert {{:{}, [], [:%{}, [], [{{:{}, [], [:&, [], [0]]}, {:{}, [], [:&, [], [1]]}}]]}, params_acc()} ==
              escape(quote do %{a => b} end, [a: 0, b: 1], __ENV__)
 
-      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], {[], %{subqueries: []}}} ==
+      assert {[Macro.escape(quote do &0.y() end), Macro.escape(quote do &0.z() end)], params_acc()} ==
              escape(quote do [x.y(), x.z()] end, [x: 0], __ENV__)
 
       assert {[{:{}, [], [{:{}, [], [:., [], [{:{}, [], [:&, [], [0]]}, :y]]}, [], []]},
-               {:{}, [], [:^, [], [0]]}], {[{1, :any}], %{subqueries: []}}} ==
+               {:{}, [], [:^, [], [0]]}], params_acc(params: [{1, :any}])} ==
               escape(quote do [x.y(), ^1] end, [x: 0], __ENV__)
 
-      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, {[], %{subqueries: []}}} ==
+      assert {{:{}, [], [:%, [], [Foo, {:{}, [], [:%{}, [], [a: {:{}, [], [:&, [], [0]]}]]}]]}, params_acc()} ==
              escape(quote do %Foo{a: a} end, [a: 0], __ENV__)
     end
 

--- a/test/ecto/query/builder/windows_test.exs
+++ b/test/ecto/query/builder/windows_test.exs
@@ -8,29 +8,29 @@ defmodule Ecto.Query.Builder.WindowsTest do
 
   describe "escape" do
     test "handles expressions and params" do
-      assert {Macro.escape(quote do [partition_by: [&0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [partition_by: x.y()] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [partition_by: [&0.y()]] end), [], {[], %{}}} ==
+             escape(quote do [partition_by: x.y()] end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [partition_by: [&0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [partition_by: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [partition_by: [&0.y()]] end), [], {[], %{}}} ==
+             escape(quote do [partition_by: :y] end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [order_by: [asc: &0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [order_by: x.y()] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [order_by: [asc: &0.y()]] end), [], {[], %{}}} ==
+             escape(quote do [order_by: x.y()] end, {[], %{}}, [x: 0], __ENV__)
 
-      assert {Macro.escape(quote do [order_by: [asc: &0.y()]] end), [], {[], :acc}} ==
-             escape(quote do [order_by: :y] end, {[], :acc}, [x: 0], __ENV__)
+      assert {Macro.escape(quote do [order_by: [asc: &0.y()]] end), [], {[], %{}}} ==
+             escape(quote do [order_by: :y] end, {[], %{}}, [x: 0], __ENV__)
     end
 
     test "supports frames" do
-      assert {Macro.escape(quote(do: [frame: fragment({:raw, "ROWS 3 PRECEDING EXCLUDE CURRENT ROW"})])), [], {[], :acc}} ==
-               escape(quote do [frame: fragment("ROWS 3 PRECEDING EXCLUDE CURRENT ROW")] end, {[], :acc}, [], __ENV__)
+      assert {Macro.escape(quote(do: [frame: fragment({:raw, "ROWS 3 PRECEDING EXCLUDE CURRENT ROW"})])), [], {[], %{}}} ==
+               escape(quote do [frame: fragment("ROWS 3 PRECEDING EXCLUDE CURRENT ROW")] end, {[], %{}}, [], __ENV__)
 
       assert {Macro.escape(quote(do: [frame: fragment({:raw, "ROWS "}, {:expr, ^0}, {:raw, " PRECEDING"})])),
-               [], {[{quote(do: start_frame), :any}], :acc}} ==
-               escape(quote do [frame: fragment("ROWS ? PRECEDING", ^start_frame)] end, {[], :acc}, [], __ENV__)
+               [], {[{quote(do: start_frame), :any}], %{}}} ==
+               escape(quote do [frame: fragment("ROWS ? PRECEDING", ^start_frame)] end, {[], %{}}, [], __ENV__)
 
       assert_raise Ecto.Query.CompileError, ~r"expected a dynamic or fragment in `:frame`", fn ->
-        escape(quote do [frame: [rows: -3, exclude: :current]] end, {[], :acc}, [], __ENV__)
+        escape(quote do [frame: [rows: -3, exclude: :current]] end, {[], %{}}, [], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -7,7 +7,7 @@ defmodule Ecto.Query.BuilderTest do
   doctest Ecto.Query.Builder
 
   defp escape(quoted, vars, env) do
-    {escaped, {params, :acc}} = escape(quoted, :any, {[], :acc}, vars, env)
+    {escaped, {params, _acc}} = escape(quoted, :any, {[], %{}}, vars, env)
     {escaped, params}
   end
 
@@ -256,7 +256,7 @@ defmodule Ecto.Query.BuilderTest do
   end
 
   defp params(quoted, type, vars \\ []) do
-    {_, {params, :acc}} = escape(quoted, type, {[], :acc}, vars, __ENV__)
+    {_, {params, _acc}} = escape(quoted, type, {[], %{}}, vars, __ENV__)
     params
   end
 


### PR DESCRIPTION
As suggested by @josevalim in https://github.com/elixir-ecto/ecto/pull/3928#issuecomment-1166486873:
> I think the correct fix would be to change `params_acc` to, instead of a `{list, term}`, it should be a tuple of shape `{list, map}`. The map can have the optional keys `:take` or `:subqueries`. This should be a more doable change because we don't need to change the shape of `params_acc` altogether, only of the second element, and the map shape makes it easier to know when take and subqueries are supported.
> 
> Would you like to send a PR to tidy this up? It would be very welcome! You can start by changing the code modified in this PR to pass a map instead of `{take, subquery}` and, if it works, we generalize for other operations. WDYT?

