### PR TITLE
insert_all query param count 

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1075,12 +1075,16 @@ defmodule Ecto.Integration.RepoTest do
     test "Repo.insert_all upserts and fills in placeholders with conditioned on_conflict query" do
       do_not_update_title = "don't touch me"
 
+      visits_value =
+        from p in Post, where: p.public == ^true and p.id > ^0, select: p.visits, limit: 1
+
       on_conflict =
         from p in Post, update: [set: [title: "updated"]], where: p.title != ^do_not_update_title
 
       placeholders = %{posted: Date.utc_today(), title: "title"}
 
       post1 = [
+        visits: visits_value,
         title: {:placeholder, :title},
         uuid: Ecto.UUID.generate(),
         posted: {:placeholder, :posted}

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1836,8 +1836,9 @@ defmodule Ecto.Integration.RepoTest do
 
     @tag :with_conflict_target
     test "on conflict query and conflict target" do
-      on_conflict = from Post, update: [set: [title: "second"]]
-      post = [title: "first", uuid: Ecto.UUID.generate()]
+      on_conflict = from p in Post, where: p.id > ^0, update: [set: [title: "second"]]
+      visits_value = from p in Post, where: p.public == ^true and p.id > ^0, select: p.visits, limit: 1
+      post = [title: "first", uuid: Ecto.UUID.generate(), visits: visits_value]
       assert TestRepo.insert_all(Post, [post], on_conflict: on_conflict, conflict_target: [:uuid]) ==
              {1, nil}
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -92,26 +92,31 @@ defmodule Ecto.Repo.Schema do
 
     placeholder_size = map_size(placeholder_dump)
 
-    counter = fn ->
-      Enum.reduce(
-        rows,
-        placeholder_size,
-        &(Enum.count(&1, fn {_, val} -> not match?({:placeholder, _}, val) end) + &2)
-      )
-    end
-
     placeholder_vals_list =
       placeholder_dump
       |> Enum.map(fn {_, {idx, _, value}} -> {idx, value} end)
       |> Enum.sort
       |> Enum.map(&elem(&1, 1))
 
-    if has_query? do
-      rows = plan_query_in_rows(rows, header, adapter)
-      {rows, header, placeholder_vals_list, counter}
-    else
-      {rows, header, placeholder_vals_list, counter}
+    {rows, row_query_param_count} =
+      if has_query? do
+        plan_query_in_rows(rows, header, adapter)
+      else
+        {rows, 0}
+      end
+
+    counter = fn ->
+      Enum.reduce(rows, placeholder_size + row_query_param_count, fn row, count ->
+        row_count =
+          Enum.count(row, fn {_, val} ->
+            not match?({:placeholder, _}, val) and not match?({%Ecto.Query{}, _}, val)
+          end)
+
+        count + row_count
+      end)
     end
+
+    {rows, header, placeholder_vals_list, counter}
   end
 
   defp extract_header_and_fields(repo, %Ecto.Query{} = query, _schema, _dumper, _autogen_id, _placeholder_map, adapter, opts) do
@@ -222,27 +227,29 @@ defmodule Ecto.Repo.Schema do
   end
 
   defp plan_query_in_rows(rows, header, adapter) do
-    {rows, _counter} =
-      Enum.map_reduce(rows, 0, fn fields, counter ->
-        Enum.flat_map_reduce(header, counter, fn key, counter ->
+    {rows, {_counter, query_param_counter}} =
+      Enum.map_reduce(rows, {0, 0}, fn fields, {counter, query_param_counter} ->
+        Enum.flat_map_reduce(header, {counter, query_param_counter}, fn key, {counter, query_param_counter} ->
           case :lists.keyfind(key, 1, fields) do
             {^key, %Ecto.Query{} = query} ->
               {query, params, _} = Ecto.Query.Planner.plan(query, :all, adapter)
               {_cast_params, dump_params} = Enum.unzip(params)
               {query, _} = Ecto.Query.Planner.normalize(query, :all, adapter, counter)
+              num_query_params = length(dump_params)
 
-              {[{key, {query, dump_params}}], counter + length(dump_params)}
+              {[{key, {query, dump_params}}],
+               {counter + num_query_params, query_param_counter + num_query_params}}
 
             {^key, value} ->
-              {[{key, value}], counter + 1}
+              {[{key, value}], {counter + 1, query_param_counter}}
 
             false ->
-              {[], counter}
+              {[], {counter, query_param_counter}}
           end
         end)
       end)
 
-    rows
+    {rows, query_param_counter}
   end
 
   defp autogenerate_id(nil, fields, header, _adapter) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -99,8 +99,8 @@ defmodule Ecto.Repo.Schema do
       |> Enum.map(&elem(&1, 1))
 
     if has_query? do
-      {rows, counter} = plan_query_in_rows(rows, header, adapter)
-      {rows, header, placeholder_vals_list, fn -> counter end}
+      {rows, value_param_count} = plan_query_in_rows(rows, header, adapter)
+      {rows, header, placeholder_vals_list, fn -> placeholder_size + value_param_count end}
     else
       counter = fn ->
         Enum.reduce(
@@ -222,24 +222,31 @@ defmodule Ecto.Repo.Schema do
   end
 
   defp plan_query_in_rows(rows, header, adapter) do
-    Enum.map_reduce(rows, 0, fn fields, counter ->
-      Enum.flat_map_reduce(header, counter, fn key, counter  ->
-        case :lists.keyfind(key, 1, fields) do
-          {^key, %Ecto.Query{} = query} ->
-            {query, params, _} = Ecto.Query.Planner.plan(query, :all, adapter)
-            {_cast_params, dump_params} = Enum.unzip(params)
-            {query, _} = Ecto.Query.Planner.normalize(query, :all, adapter, counter)
+    {rows, {_counter, value_param_counter}} =
+      Enum.map_reduce(rows, {0, 0}, fn fields, {counter, value_param_counter} ->
+        Enum.flat_map_reduce(header, {counter, value_param_counter}, fn key, {counter, value_param_counter}  ->
+          case :lists.keyfind(key, 1, fields) do
+            {^key, %Ecto.Query{} = query} ->
+              {query, params, _} = Ecto.Query.Planner.plan(query, :all, adapter)
+              {_cast_params, dump_params} = Enum.unzip(params)
+              {query, _} = Ecto.Query.Planner.normalize(query, :all, adapter, counter)
+              num_params = length(dump_params)
 
-            {[{key, {query, dump_params}}], counter + length(dump_params)}
+              {[{key, {query, dump_params}}], {counter + num_params, value_param_counter + num_params}}
 
-          {^key, value} ->
-            {[{key, value}], counter + 1}
+            {^key, {:placeholder, _} = value} ->
+              {[{key, value}], {counter + 1, value_param_counter}}
 
-          false ->
-            {[], counter}
-        end
+            {^key, value} ->
+              {[{key, value}], {counter + 1, value_param_counter + 1}}
+
+            false ->
+              {[], {counter, value_param_counter}}
+          end
+        end)
       end)
-    end)
+
+    {rows, value_param_counter}
   end
 
   defp autogenerate_id(nil, fields, header, _adapter) do


### PR DESCRIPTION
Previously `insert_all` counted each value query as 1 parameter which could cause errors like the one below if `on_conflict` is a query that has parameters:

> ```** (ArgumentError) parameters must be of length 4 for query %Postgrex.Query{cache: :statement, columns: nil, name: "ecto_insert_all_posts", param_formats: [:binary, :binary, :binary, :binary], param_oids: [1043, 2950, 16, 20], param_types: [Postgrex.Extensions.Raw, Postgrex.Extensions.UUID, Postgrex.Extensions.Bool, Postgrex.Extensions.Int8], ref: #Reference<0.958058084.406061059.69852>, result_formats: [], result_oids: nil, result_types: nil, statement: "INSERT INTO \"posts\" AS p0 (\"title\",\"uuid\",\"visits\") VALUES ($1,$2,(SELECT p0.\"visits\" FROM \"posts\" AS p0 WHERE ((p0.\"public\" = $3) AND (p0.\"id\" = $4)))) ON CONFLICT (\"uuid\") DO UPDATE SET \"title\" = 'second' WHERE (p0.\"id\" = $4)", types: {Postgrex.DefaultTypes, #Reference<0.958058084.406192129.71178>}}```

With this change it will now consider the number of parameters in each value query.