### PR TITLE
Improve docs about aborted transactions

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1838,10 +1838,10 @@ defmodule Ecto.Repo do
       Repo.transaction(fn repo ->
         case repo.insert(changeset) do
           {:ok, post} ->
-            repo.insert(%Success{})
+            repo.insert(%Status{value: "success"})
 
           {:error, changeset} ->
-            repo.insert(%Failure{})
+            repo.insert(%Status{value: "failure"})
         end
       end)
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1760,7 +1760,7 @@ defmodule Ecto.Repo do
         repo.insert!(%Post{})
       end)
 
-  If an exception occurs the transaction will be rolled back
+  If an Elixir exception occurs the transaction will be rolled back
   and the exception will bubble up from the transaction function.
   If no exception occurs, the transaction is committed when the
   function returns. A transaction can be explicitly rolled back
@@ -1856,12 +1856,7 @@ defmodule Ecto.Repo do
   no statement is sent to the database, an `:error` tuple is returned, and `repo.insert(%Failure{})` 
   operation will execute as usual. 
 
-  We have a few options to deal with such scenarios:
-  
-  The most obvious one would be to prevent the the database from raising using 
-  something like `repo.insert(post, on_conflict: :nothing)`. In this case, the 
-  operation will still fail at the database level, but since we are supressing the error, 
-  we will receive back a `:ok` tuple with an unsaved post: `%Post{id: nil}`.
+  We have two options to deal with such scenarios:
   
   If you are using Postgres and don't want to change the semantics of your code, 
   you can also use the savepoints feature by passing the `:mode` option like this: 


### PR DESCRIPTION
I made some changes to the initial docs by @josevalim trying to make language a little more accessible and easy to read by someone unfamiliar with some concepts.

- The first change reverts the "Elixir exception" part to avoid redundancy. This avoids introducing a perceived new concept since we talk about exceptions in other places always meaning elixir exceptions.
-  Updates the example so it mirrors the failure scenario making it clear that we want to execute some code after the first operation. The idea is to make sure users  understand that there's nothing special about the `{:error, changeset}` part.
- Changes the order of the explanation to prioritize what users might search after having this transaction error thrown at them.  I don't think we have to explain what happens with the success scenario, only the unexpected one (changeset valid + error from constraint). It's less of an effort since we are explaining just one thing.
- I tried to simplify some explanations to be more direct: "if x happens, y is the result", instead of: "when x happens, under y, z is the result".
- Add other options that might be useful to deal with this kind of problem besides just handling outside of the transaction (most of this was dug up from the forums in old posts and I think most people didn't even remember those are options).

PS.: I tried to pack some more information and make some stylistic changes to expand the concepts and streamline the language focusing on someone not well versed as the maintainers. More so, from the optics of someone just recently challenged by the docs and the overall technical language 🙈.