### PR TITLE
Improve aborted transaction docs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1858,10 +1858,10 @@ defmodule Ecto.Repo do
 
   We have two options to deal with such scenarios:
   
-  If you are using Postgres and don't want to change the semantics of your code, 
-  you can also use the savepoints feature by passing the `:mode` option like this: 
-  `repo.insert(changeset, mode: :savepoint)`. In case of an exception, this will make 
-  the transaction rollback to the savepoint and prevent the transaction from failing.
+  If don't want to change the semantics of your code,  you can also use the savepoints 
+  feature by passing the `:mode` option like this: `repo.insert(changeset, mode: :savepoint)`. 
+  In case of an exception, this will make the transaction rollback to the savepoint and prevent 
+  the transaction from failing.
 
   Another alternative is to handle this operation outside of the transaction. 
   For example, you can choose to perform an explicit `repo.rollback` call in the 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1860,7 +1860,7 @@ defmodule Ecto.Repo do
   
   If don't want to change the semantics of your code,  you can also use the savepoints 
   feature by passing the `:mode` option like this: `repo.insert(changeset, mode: :savepoint)`. 
-  In case of an exception, this will make the transaction rollback to the savepoint and prevent 
+  In case of an exception, the transaction will rollback to the savepoint and prevent 
   the transaction from failing.
 
   Another alternative is to handle this operation outside of the transaction. 


### PR DESCRIPTION
I overlooked the savepoints feature in https://github.com/elixir-ecto/ecto/pull/3946 and found that it's actually an SQL standard. It seems it's currently supported by all our default adapters, so we shouldn't make the case that it's specific to Postgres.

BTW, Postgrex has this option documented here https://hexdocs.pm/postgrex/Postgrex.html#transaction/3, but I had to look up the source code to find that MyXQL and TDS also support the savepoints feature. Should we document this as part of Ecto `Repo.transaction/2` as well?