### PR TITLE
Builder: Fix escaping subqueries

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -179,7 +179,7 @@ defmodule Ecto.Query.Builder do
   end
 
   # subqueries
-  def escape({:subquery, _, _} = expr, _, {params, %{subqueries: subqueries} = acc}, _vars, _env) do
+  def escape({:subquery, _, [expr]}, _, {params, %{subqueries: subqueries} = acc}, _vars, _env) do
     subquery = quote(do: Ecto.Query.subquery(unquote(expr)))
     index = length(subqueries)
     # used both in ast and in parameters, as a placeholder.

--- a/test/ecto/query/builder/filter_test.exs
+++ b/test/ecto/query/builder/filter_test.exs
@@ -41,6 +41,16 @@ defmodule Ecto.Query.Builder.FilterTest do
         escape(:where, quote do [x: nil] end, 0, [], __ENV__)
       end
     end
+
+    test "works without Ecto.Query.subquery/1" do
+      import Ecto.Query, except: [subquery: 1]
+
+      s = from(p in "posts", select: 1)
+      %{wheres: [where]} = from(p in "posts", where: exists(s))
+
+      assert Macro.to_string(where.expr) ==
+             "exists({:subquery, 0})"
+    end
   end
 
   describe "at runtime" do


### PR DESCRIPTION
Fixes escaping of subqueries.

This broke in #3928 and was not properly reverted as part of the refactor in #3935 (see [comparison](https://github.com/elixir-ecto/ecto/compare/f1e7afd7e3d850cc5ced50cb90f21ceb768696eb..412e5f51f61f62b51a7506be1c29f2b55c9811be#diff-28c09a2701e1bdc727200dd4b3515822eb08c2d502ba20e7b132ae5926ce1e33L171-R188)).

`master` has been affected since #3928, but no releases.

I tested it using ecto `master` in another project. Not sure how to test it within `ecto`. Appreciate any leads! 🙏 