### PR TITLE
Fix many-to-many on_delete options

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1303,7 +1303,7 @@ defmodule Ecto.Schema do
       The keys are inflected from the schema names.
 
     * `:on_delete` - The action taken on associations when the parent record
-      is deleted. May be `:nothing` (default) or `:delete_all`.
+      is deleted. May be `:nothing` (default) or `:delete`.
       Using this option is DISCOURAGED for most relational databases. Instead,
       in your migration, set `references(:parent_id, on_delete: :delete_all)`.
       Opposite to the migration option, this option cannot guarantee integrity


### PR DESCRIPTION
Seeing the following error when using `delete_all` as documented:

```
** (ArgumentError) invalid `:on_replace` option for :my_assoc. The only valid options are: `:raise`, `:mark_as_invalid`, `:delete`
```

Not sure if this change is the best path forward but it seemed like the easiest way to report the issue.