### PR TITLE
Update example for cast/2

### DIFF
--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -40,7 +40,7 @@ defmodule Ecto.ParameterizedType do
 
         def cast(data, params) do
           ...
-          cast_data
+          {:ok, cast_data}
         end
 
         def load(data, _loader, params) do


### PR DESCRIPTION
The example was missing an `{:ok, ...}` tuple as the result of `cast/2`