### PR TITLE
Raise when schemaless struct is used in unsafe_validate_unique/4

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -616,7 +616,7 @@ defmodule Ecto.Integration.RepoTest do
     |> Ecto.Changeset.assoc_constraint(:post)
   end
 
-  test "unsafe_validate_unique/3" do
+  test "unsafe_validate_unique/4" do
     {:ok, inserted_post} = TestRepo.insert(%Post{title: "Greetings", visits: 13})
     new_post_changeset = Post.changeset(%Post{}, %{title: "Greetings", visits: 17})
 
@@ -632,7 +632,7 @@ defmodule Ecto.Integration.RepoTest do
     assert changeset.errors[:title] == nil # cannot conflict with itself
   end
 
-  test "unsafe_validate_unique/3 with composite keys" do
+  test "unsafe_validate_unique/4 with composite keys" do
     {:ok, inserted_post} = TestRepo.insert(%CompositePk{a: 123, b: 456, name: "UniqueName"})
 
     different_pk = CompositePk.changeset(%CompositePk{}, %{name: "UniqueName", a: 789, b: 321})

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1873,14 +1873,12 @@ defmodule Ecto.Changeset do
   """
   @spec unsafe_validate_unique(t, atom | [atom, ...], Ecto.Repo.t, Keyword.t) :: t
   def unsafe_validate_unique(%Changeset{} = changeset, fields, repo, opts \\ []) when is_list(opts) do
-    %{validations: validations, data: data} = changeset
+    {validations, schema} =
+      case changeset do
+        %{validations: validations, data: %schema{__meta__: %Metadata{}}} ->
+          {validations, schema}
 
-    schema =
-      case data do
-        %schema{__meta__: %Metadata{}} ->
-          schema
-
-        _ ->
+        %{data: data} ->
           raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets or embedded schemas, data received: #{inspect(data)}"
       end
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1872,16 +1872,16 @@ defmodule Ecto.Changeset do
   """
   @spec unsafe_validate_unique(t, atom | [atom, ...], Ecto.Repo.t, Keyword.t) :: t
   def unsafe_validate_unique(%Changeset{} = changeset, fields, repo, opts \\ []) when is_list(opts) do
-    %{data: data} = changeset
+    %{validations: validations, data: data} = changeset
 
     unless is_struct(data) and function_exported?(data.__struct__, :__schema__, 1) do
       raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets"
     end
 
-    {validations, schema} =
-      case changeset do
-        %{validations: validations, data: %schema{__meta__: _}} ->
-          {validations, schema}
+    schema =
+      case data do
+        %schema{__meta__: _} ->
+          schema
 
         _ ->
           raise ArgumentError, "unsafe_validate_unique/4 does not work with embedded schemas"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1871,8 +1871,8 @@ defmodule Ecto.Changeset do
 
   """
   @spec unsafe_validate_unique(t, atom | [atom, ...], Ecto.Repo.t, Keyword.t) :: t
-  def unsafe_validate_unique(changeset, fields, repo, opts \\ []) when is_list(opts) do
-    %Ecto.Changeset{data: data} = changeset
+  def unsafe_validate_unique(%Changeset{} = changeset, fields, repo, opts \\ []) when is_list(opts) do
+    %{data: data} = changeset
 
     unless is_struct(data) and function_exported?(data.__struct__, :__schema__, 1) do
       raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -39,7 +39,7 @@ defmodule Ecto.Changeset do
 
   Some validations may happen against the database but
   they are inherently unsafe. Those validations start with a `unsafe_`
-  prefix, such as `unsafe_validate_unique/3`.
+  prefix, such as `unsafe_validate_unique/4`.
 
   On the other hand, constraints rely on the database and are always safe.
   As a consequence, validations are always checked before constraints.
@@ -1877,6 +1877,10 @@ defmodule Ecto.Changeset do
     {validations, schema} =
       case changeset do
         %Ecto.Changeset{validations: validations, data: %schema{}} ->
+          unless function_exported?(schema, :__schema__, 1) do
+            raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets"
+          end
+
           {validations, schema}
         %Ecto.Changeset{} ->
           raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1872,8 +1872,6 @@ defmodule Ecto.Changeset do
   """
   @spec unsafe_validate_unique(t, atom | [atom, ...], Ecto.Repo.t, Keyword.t) :: t
   def unsafe_validate_unique(changeset, fields, repo, opts \\ []) when is_list(opts) do
-    fields = List.wrap(fields)
-    {repo_opts, opts} = Keyword.pop(opts, :repo_opts, [])
     %Ecto.Changeset{data: data} = changeset
 
     unless is_struct(data) and function_exported?(data.__struct__, :__schema__, 1) do
@@ -1889,6 +1887,7 @@ defmodule Ecto.Changeset do
           raise ArgumentError, "unsafe_validate_unique/4 does not work with embedded schemas"
       end
 
+    fields = List.wrap(fields)
     changeset = %{changeset | validations: [{hd(fields), {:unsafe_unique, fields: fields}} | validations]}
 
     where_clause = for field <- fields do
@@ -1907,6 +1906,8 @@ defmodule Ecto.Changeset do
     if unrelated_changes? || any_nil_values_for_fields? || any_prior_errors_for_fields? do
       changeset
     else
+      {repo_opts, opts} = Keyword.pop(opts, :repo_opts, [])
+
       query =
         Keyword.get(opts, :query, schema)
         |> maybe_exclude_itself(schema, changeset)

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1875,7 +1875,7 @@ defmodule Ecto.Changeset do
     %{validations: validations, data: data} = changeset
 
     unless is_struct(data) and function_exported?(data.__struct__, :__schema__, 1) do
-      raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets"
+      raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets, data received: #{inspect(data)}"
     end
 
     schema =
@@ -1883,8 +1883,8 @@ defmodule Ecto.Changeset do
         %schema{__meta__: _} ->
           schema
 
-        _ ->
-          raise ArgumentError, "unsafe_validate_unique/4 does not work with embedded schemas"
+        %embedded_schema{} ->
+          raise ArgumentError, "unsafe_validate_unique/4 does not work with embedded schemas, schema received: #{inspect(embedded_schema)}"
       end
 
     fields = List.wrap(fields)

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -279,6 +279,7 @@ defmodule Ecto.Changeset do
   require Ecto.Query
   alias __MODULE__
   alias Ecto.Changeset.Relation
+  alias Ecto.Schema.Metadata
 
   @empty_values [""]
 
@@ -1874,17 +1875,13 @@ defmodule Ecto.Changeset do
   def unsafe_validate_unique(%Changeset{} = changeset, fields, repo, opts \\ []) when is_list(opts) do
     %{validations: validations, data: data} = changeset
 
-    unless is_struct(data) and function_exported?(data.__struct__, :__schema__, 1) do
-      raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets, data received: #{inspect(data)}"
-    end
-
     schema =
       case data do
-        %schema{__meta__: _} ->
+        %schema{__meta__: %Metadata{}} ->
           schema
 
-        %embedded_schema{} ->
-          raise ArgumentError, "unsafe_validate_unique/4 does not work with embedded schemas, schema received: #{inspect(embedded_schema)}"
+        _ ->
+          raise ArgumentError, "unsafe_validate_unique/4 does not work with schemaless changesets or embedded schemas, data received: #{inspect(data)}"
       end
 
     fields = List.wrap(fields)

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1729,7 +1729,7 @@ defmodule Ecto.ChangesetTest do
       refute_receive [MockRepo, function: :exists?, query: %Ecto.Query{}, opts: []]
     end
 
-    test "does not allow schemaless queries" do
+    test "does not allow schemaless changesets" do
       types = %{title: :string, upvotes: :integer}
 
       # struct

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1750,6 +1750,16 @@ defmodule Ecto.ChangesetTest do
                      unsafe_validate_unique(changeset, [:title], TestRepo)
                    end
     end
+
+    test "does not allow embedded schemas" do
+      changeset = Ecto.Changeset.change(%SocialSource{})
+
+      assert_raise ArgumentError,
+                   ~s/unsafe_validate_unique\/4 does not work with embedded schemas/,
+                   fn ->
+                     unsafe_validate_unique(changeset, [:origin], TestRepo)
+                   end
+    end
   end
 
   ## Locks

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1736,7 +1736,7 @@ defmodule Ecto.ChangesetTest do
       changeset = Ecto.Changeset.cast({%NoSchemaPost{}, types}, %{title: "hi"}, Map.keys(types))
 
       msg =
-        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets, data received: %Ecto.ChangesetTest.NoSchemaPost{title: nil, upvotes: nil}/
+        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets or embedded schemas, data received: %Ecto.ChangesetTest.NoSchemaPost{title: nil, upvotes: nil}/
 
       assert_raise ArgumentError, msg, fn ->
         unsafe_validate_unique(changeset, [:title], TestRepo)
@@ -1746,7 +1746,7 @@ defmodule Ecto.ChangesetTest do
       changeset = Ecto.Changeset.cast({%{}, types}, %{title: "hi"}, Map.keys(types))
 
       msg =
-        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets, data received: %{}/
+        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets or embedded schemas, data received: %{}/
 
       assert_raise ArgumentError, msg, fn ->
         unsafe_validate_unique(changeset, [:title], TestRepo)
@@ -1757,7 +1757,7 @@ defmodule Ecto.ChangesetTest do
       changeset = Ecto.Changeset.change(%SocialSource{})
 
       msg =
-        ~s/unsafe_validate_unique\/4 does not work with embedded schemas, schema received: Ecto.ChangesetTest.SocialSource/
+        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets or embedded schemas, data received: %Ecto.ChangesetTest.SocialSource{origin: nil, url: nil}/
 
       assert_raise ArgumentError, msg, fn ->
         unsafe_validate_unique(changeset, [:origin], TestRepo)

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1728,6 +1728,28 @@ defmodule Ecto.ChangesetTest do
       # no overlap between changed fields and those required to be unique
       refute_receive [MockRepo, function: :exists?, query: %Ecto.Query{}, opts: []]
     end
+
+    test "does not allow schemaless queries" do
+      types = %{title: :string, upvotes: :integer}
+
+      # struct
+      changeset = Ecto.Changeset.cast({%NoSchemaPost{}, types}, %{title: "hi"}, Map.keys(types))
+
+      assert_raise ArgumentError,
+                   ~s/unsafe_validate_unique\/4 does not work with schemaless changesets/,
+                   fn ->
+                     unsafe_validate_unique(changeset, [:title], TestRepo)
+                   end
+
+      # map
+      changeset = Ecto.Changeset.cast({%{}, types}, %{title: "hi"}, Map.keys(types))
+
+      assert_raise ArgumentError,
+                   ~s/unsafe_validate_unique\/4 does not work with schemaless changesets/,
+                   fn ->
+                     unsafe_validate_unique(changeset, [:title], TestRepo)
+                   end
+    end
   end
 
   ## Locks

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1735,30 +1735,33 @@ defmodule Ecto.ChangesetTest do
       # struct
       changeset = Ecto.Changeset.cast({%NoSchemaPost{}, types}, %{title: "hi"}, Map.keys(types))
 
-      assert_raise ArgumentError,
-                   ~s/unsafe_validate_unique\/4 does not work with schemaless changesets/,
-                   fn ->
-                     unsafe_validate_unique(changeset, [:title], TestRepo)
-                   end
+      msg =
+        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets, data received: %Ecto.ChangesetTest.NoSchemaPost{title: nil, upvotes: nil}/
+
+      assert_raise ArgumentError, msg, fn ->
+        unsafe_validate_unique(changeset, [:title], TestRepo)
+      end
 
       # map
       changeset = Ecto.Changeset.cast({%{}, types}, %{title: "hi"}, Map.keys(types))
 
-      assert_raise ArgumentError,
-                   ~s/unsafe_validate_unique\/4 does not work with schemaless changesets/,
-                   fn ->
-                     unsafe_validate_unique(changeset, [:title], TestRepo)
-                   end
+      msg =
+        ~s/unsafe_validate_unique\/4 does not work with schemaless changesets, data received: %{}/
+
+      assert_raise ArgumentError, msg, fn ->
+        unsafe_validate_unique(changeset, [:title], TestRepo)
+      end
     end
 
     test "does not allow embedded schemas" do
       changeset = Ecto.Changeset.change(%SocialSource{})
 
-      assert_raise ArgumentError,
-                   ~s/unsafe_validate_unique\/4 does not work with embedded schemas/,
-                   fn ->
-                     unsafe_validate_unique(changeset, [:origin], TestRepo)
-                   end
+      msg =
+        ~s/unsafe_validate_unique\/4 does not work with embedded schemas, schema received: Ecto.ChangesetTest.SocialSource/
+
+      assert_raise ArgumentError, msg, fn ->
+        unsafe_validate_unique(changeset, [:origin], TestRepo)
+      end
     end
   end
 


### PR DESCRIPTION
I noticed this when looking over this PR: https://github.com/elixir-ecto/ecto/pull/3955.