### PR TITLE
Document omitting fields in select

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1267,6 +1267,11 @@ defmodule Ecto.Query do
 
   If you want a map with only the selected fields to be returned.
 
+  To select a struct but omit only given fields, you can
+  override them with `nil` or another default value:
+
+      from(city in City, select: %{city | geojson: nil})
+
   For more information, read the docs for `Ecto.Query.API.struct/2`
   and `Ecto.Query.API.map/2`.
 
@@ -1278,6 +1283,7 @@ defmodule Ecto.Query do
       City |> select([:name])
       City |> select([c], struct(c, [:name]))
       City |> select([c], map(c, [:name]))
+      City |> select([c], %{c | geojson: nil})
 
   ## Dynamic parts
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1270,7 +1270,7 @@ defmodule Ecto.Query do
   To select a struct but omit only given fields, you can
   override them with `nil` or another default value:
 
-      from(city in City, select: %{city | geojson: nil})
+      from(city in City, select: %{city | geojson: nil, text: "<redacted>"})
 
   For more information, read the docs for `Ecto.Query.API.struct/2`
   and `Ecto.Query.API.map/2`.
@@ -1283,7 +1283,7 @@ defmodule Ecto.Query do
       City |> select([:name])
       City |> select([c], struct(c, [:name]))
       City |> select([c], map(c, [:name]))
-      City |> select([c], %{c | geojson: nil})
+      City |> select([c], %{c | geojson: nil, text: "<redacted>"})
 
   ## Dynamic parts
 


### PR DESCRIPTION
In https://github.com/elixir-ecto/ecto/pull/3934, the `%{schema | my_field: nil}` syntax stopped retrieving the `my_field` from the DB, making it a viable way of achieving omitting fields (a feature discussed [here](https://groups.google.com/g/elixir-ecto/c/9lCaPISWebg)).

Should this be part of the documented public API?