### PR TITLE
Fix doc typo and typespec

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1592,7 +1592,7 @@ defmodule Ecto.Query do
       Customer |> select([c], c.city) |> union(^supplier_query)
 
       # Ordered result
-      customer_query = Customer |> |> select([c], c.city) |> order_by(fragment("city"))
+      customer_query = Customer |> select([c], c.city) |> order_by(fragment("city"))
       supplier_query = Supplier |> select([s], s.city)
       union(customer_query, ^supplier_query)
 
@@ -1633,7 +1633,7 @@ defmodule Ecto.Query do
       Customer |> select([c], c.city) |> union_all(^supplier_query)
 
       # Ordered result
-      customer_query = Customer |> |> select([c], c.city) |> order_by(fragment("city"))
+      customer_query = Customer |> select([c], c.city) |> order_by(fragment("city"))
       supplier_query = Supplier |> select([s], s.city)
       union_all(customer_query, ^supplier_query)
   """
@@ -1679,7 +1679,7 @@ defmodule Ecto.Query do
       Customer |> select([c], c.city) |> except(^supplier_query)
 
       # Ordered result
-      customer_query = Customer |> |> select([c], c.city) |> order_by(fragment("city"))
+      customer_query = Customer |> select([c], c.city) |> order_by(fragment("city"))
       supplier_query = Supplier |> select([s], s.city)
       except(customer_query, ^supplier_query)
   """
@@ -1720,7 +1720,7 @@ defmodule Ecto.Query do
       Customer |> select([c], c.city) |> except_all(^supplier_query)
 
       # Ordered result
-      customer_query = Customer |> |> select([c], c.city) |> order_by(fragment("city"))
+      customer_query = Customer |> select([c], c.city) |> order_by(fragment("city"))
       supplier_query = Supplier |> select([s], s.city)
       except_all(customer_query, ^supplier_query)
   """
@@ -1766,7 +1766,7 @@ defmodule Ecto.Query do
       Customer |> select([c], c.city) |> intersect(^supplier_query)
 
       # Ordered result
-      customer_query = Customer |> |> select([c], c.city) |> order_by(fragment("city"))
+      customer_query = Customer |> select([c], c.city) |> order_by(fragment("city"))
       supplier_query = Supplier |> select([s], s.city)
       intersect(customer_query, ^supplier_query)
   """
@@ -1807,7 +1807,7 @@ defmodule Ecto.Query do
       Customer |> select([c], c.city) |> intersect_all(^supplier_query)
 
       # Ordered result
-      customer_query = Customer |> |> select([c], c.city) |> order_by(fragment("city"))
+      customer_query = Customer |> select([c], c.city) |> order_by(fragment("city"))
       supplier_query = Supplier |> select([s], s.city)
       intersect_all(customer_query, ^supplier_query)
   """

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -23,7 +23,7 @@ defmodule Ecto.Query.Builder.Select do
       {{:{}, [], [:&, [], [0]]}, {[], %{take: %{}, subqueries: []}}}
 
   """
-  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{}}}
+  @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{take: map, subqueries: list}}}
   def escape(atom, _vars, _env)
       when is_atom(atom) and not is_boolean(atom) and atom != nil do
     Builder.error! """


### PR DESCRIPTION
When reading the code, I noticed some typo in the doc (double pipe `|> |>`) and an invalid typespec.