### PR TITLE
Allow alias for selected value

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1538,8 +1538,27 @@ defmodule Ecto.Integration.RepoTest do
       assert [%Post{title: "1", counter: 2}] = TestRepo.all(subquery)
     end
 
-    @tag :select_alias
-    test "aliased selected values with order_by and group_by" do
+    @tag :selected_as_with_group_by
+    test "selected_as/2 with group_by" do
+      TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 3})
+      TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 2})
+      TestRepo.insert!(%Post{posted: ~D[2020-12-20], visits: nil})
+
+      query =
+        from p in Post,
+          select: %{
+            posted: selected_as(p.posted, :date),
+            min_visits: p.visits |> coalesce(0) |> min()
+          },
+          group_by: selected_as(:date),
+          order_by: p.posted
+
+      assert [%{posted: ~D[2020-12-20], min_visits: 0}, %{posted: ~D[2020-12-21], min_visits: 2}] =
+               TestRepo.all(query)
+    end
+
+    @tag :selected_as_with_order_by
+    test "selected_as/2 with order_by" do
       TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 3})
       TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 2})
       TestRepo.insert!(%Post{posted: ~D[2020-12-20], visits: nil})
@@ -1547,19 +1566,19 @@ defmodule Ecto.Integration.RepoTest do
       base_query =
         from p in Post,
           select: %{
-            posted: alias(p.posted, :date),
-            min_visits: p.visits |> coalesce(0) |> min() |> alias(:min_visits)
+            posted: p.posted,
+            min_visits: p.visits |> coalesce(0) |> min() |> selected_as(:min_visits)
           },
-          group_by: alias(:date)
+          group_by: p.posted
 
       # ascending order
-      results = base_query |> order_by(alias(:min_visits)) |> TestRepo.all()
+      results = base_query |> order_by(selected_as(:min_visits)) |> TestRepo.all()
 
       assert [%{posted: ~D[2020-12-20], min_visits: 0}, %{posted: ~D[2020-12-21], min_visits: 2}] =
                results
 
       # descending order
-      results = base_query |> order_by([desc: alias(:min_visits)]) |> TestRepo.all()
+      results = base_query |> order_by([desc: selected_as(:min_visits)]) |> TestRepo.all()
 
       assert [%{posted: ~D[2020-12-21], min_visits: 2}, %{posted: ~D[2020-12-20], min_visits: 0}] =
                results

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1538,7 +1538,7 @@ defmodule Ecto.Integration.RepoTest do
       assert [%Post{title: "1", counter: 2}] = TestRepo.all(subquery)
     end
 
-    @tag select_alias
+    @tag :select_alias
     test "aliased select value" do
       TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 3})
       TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 2})

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1548,14 +1548,14 @@ defmodule Ecto.Integration.RepoTest do
         from p in Post,
           select: %{
             posted: alias(p.posted, "posted"),
-            sum_visits: p.visits |> coalesce(0) |> sum() |> alias("sum_visits")
+            min_visits: p.visits |> coalesce(0) |> min() |> alias("min_visits")
           },
           group_by: fragment("posted"),
-          order_by: fragment("sum_visits")
+          order_by: fragment("min_visits")
 
       results = TestRepo.all(query)
 
-      assert [%{posted: ~D[2020-12-20], sum_visits: 0}, %{posted: ~D[2020-12-21], sum_visits: 5}] =
+      assert [%{posted: ~D[2020-12-20], min_visits: 0}, %{posted: ~D[2020-12-21], min_visits: 2}] =
                results
     end
   end

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -405,7 +405,7 @@ defmodule Ecto.Query do
 
   defmodule SelectExpr do
     @moduledoc false
-    defstruct [:expr, :file, :line, :fields, params: [], take: %{}, subqueries: []]
+    defstruct [:expr, :file, :line, :fields, params: [], take: %{}, subqueries: [], aliases: %{}]
   end
 
   defmodule JoinExpr do

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -11,8 +11,8 @@ defmodule Ecto.Query.API do
     * Null check functions: `is_nil/1`
     * Aggregates: `count/0`, `count/1`, `avg/1`, `sum/1`, `min/1`, `max/1`
     * Date/time intervals: `datetime_add/3`, `date_add/3`, `from_now/2`, `ago/2`
-    * Inside select: `struct/2`, `map/2`, `merge/2`, `alias/2` and literals (map, tuples, lists, etc)
-    * General: `fragment/1`, `field/2`, `type/2`, `as/1`, `parent_as/1`, `alias/1`
+    * Inside select: `struct/2`, `map/2`, `merge/2`, `selected_as/2` and literals (map, tuples, lists, etc)
+    * General: `fragment/1`, `field/2`, `type/2`, `as/1`, `parent_as/1`, `selected_as/1`
 
   Note the functions in this module exist for documentation
   purposes and one should never need to invoke them directly.

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -685,7 +685,7 @@ defmodule Ecto.Query.API do
   @doc """
   Refer to an alias of a selected value.
 
-  This is available only inside `group_by` and `order_by`.
+  This is available only inside `Ecto.Query.group_by/3` and `Ecto.Query.order_by/3`.
 
   See `alias/2` for more information.
   """

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -685,11 +685,15 @@ defmodule Ecto.Query.API do
   @doc """
   Refer to an alias of a selected value.
 
-  This is available only inside `Ecto.Query.group_by/3` and `Ecto.Query.order_by/3`.
+  This is available only inside `Ecto.Query.group_by/3` and `Ecto.Query.order_by/3`. If the alias
+  was not previously defined using `selected_as/2`, an error will be raised.
 
-  See `alias/2` for more information.
+  Please note every database has its own rules for referencing these alias. For instance,
+  SQL Server does not allow them inside `GROUP BY` statements while PostgreSQL and MySQL do.
+
+  See `selected_as/2` for more information.
   """
-  def alias(name), do: doc! [name]
+  def selected_as(name), do: doc! [name]
 
   @doc """
   Creates an alias for the given selected value.
@@ -703,19 +707,20 @@ defmodule Ecto.Query.API do
 
       from p in Post,
         select: %{
-          posted: alias(p.posted, :date),
-          sum_visits: p.visits |> coalesce(0) |> sum() |> alias(:sum_visits)
+          posted: selected_as(p.posted, :date),
+          sum_visits: p.visits |> coalesce(0) |> sum() |> selected_as(:sum_visits)
         },
-        group_by: alias(:date),
-        order_by: alias(:sum_visits)
+        group_by: selected_as(:date),
+        order_by: selected_as(:sum_visits)
 
   The name of the alias must be an atom and it can only be used in the outer most
-  select expression, otherwise an error is raised.
+  select expression, otherwise an error is raised. Please note that the alias name
+  does not have to match the key when `select` returns a map, struct or keyword list.
 
-  Using this in conjunction with `alias/1` is recommended to ensure only defined aliases
+  Using this in conjunction with `selected_as/1` is recommended to ensure only defined aliases
   are referenced.
   """
-  def alias(selected_value, name), do: doc! [selected_value, name]
+  def selected_as(selected_value, name), do: doc! [selected_value, name]
 
   defp doc!(_) do
     raise "the functions in Ecto.Query.API should not be invoked directly, " <>

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -11,7 +11,7 @@ defmodule Ecto.Query.API do
     * Null check functions: `is_nil/1`
     * Aggregates: `count/0`, `count/1`, `avg/1`, `sum/1`, `min/1`, `max/1`
     * Date/time intervals: `datetime_add/3`, `date_add/3`, `from_now/2`, `ago/2`
-    * Inside select: `struct/2`, `map/2`, `merge/2` and literals (map, tuples, lists, etc)
+    * Inside select: `struct/2`, `map/2`, `merge/2`, `alias/2` and literals (map, tuples, lists, etc)
     * General: `fragment/1`, `field/2`, `type/2`, `as/1`, `parent_as/1`
 
   Note the functions in this module exist for documentation
@@ -681,6 +681,30 @@ defmodule Ecto.Query.API do
   See the "Named binding" section in `Ecto.Query` for more information.
   """
   def parent_as(binding), do: doc! [binding]
+
+  @doc """
+  Creates an alias for the given selected value.
+
+  This is available only inside `Ecto.Query.select/3`.
+
+  When working with calculated values, an alias can be used to simplify
+  the query. Otherwise, the entire expression would need to be copied when
+  referencing it outside of select statements.
+
+  This comes in handy when, for instance, you would like to use the calculated
+  value in `Ecto.Query.group_by/3` or `Ecto.Query.order_by/3`:
+
+      from p in Post,
+        select: %{
+          posted: p.posted,
+          sum_visits: p.visits |> coalesce(0) |> sum() |> alias("sum_visits")
+        },
+        group_by: p.posted,
+        order_by: fragment("sum_visits")
+
+  The name of the alias must be a string, otherwise a compilation error is raised.
+  """
+  def alias(selected_value, name), do: doc! [selected_value, name]
 
   defp doc!(_) do
     raise "the functions in Ecto.Query.API should not be invoked directly, " <>

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -12,7 +12,7 @@ defmodule Ecto.Query.API do
     * Aggregates: `count/0`, `count/1`, `avg/1`, `sum/1`, `min/1`, `max/1`
     * Date/time intervals: `datetime_add/3`, `date_add/3`, `from_now/2`, `ago/2`
     * Inside select: `struct/2`, `map/2`, `merge/2`, `alias/2` and literals (map, tuples, lists, etc)
-    * General: `fragment/1`, `field/2`, `type/2`, `as/1`, `parent_as/1`
+    * General: `fragment/1`, `field/2`, `type/2`, `as/1`, `parent_as/1`, `alias/1`
 
   Note the functions in this module exist for documentation
   purposes and one should never need to invoke them directly.
@@ -683,9 +683,16 @@ defmodule Ecto.Query.API do
   def parent_as(binding), do: doc! [binding]
 
   @doc """
-  Creates an alias for the given selected value.
+  Refer to an alias of a selected value.
 
-  This is available only inside `Ecto.Query.select/3`.
+  This is available only inside `group_by` and `order_by`.
+
+  See `alias/2` for more information.
+  """
+  def alias(name), do: doc! [name]
+
+  @doc """
+  Creates an alias for the given selected value.
 
   When working with calculated values, an alias can be used to simplify
   the query. Otherwise, the entire expression would need to be copied when
@@ -696,13 +703,17 @@ defmodule Ecto.Query.API do
 
       from p in Post,
         select: %{
-          posted: p.posted,
-          sum_visits: p.visits |> coalesce(0) |> sum() |> alias("sum_visits")
+          posted: alias(p.posted, :date),
+          sum_visits: p.visits |> coalesce(0) |> sum() |> alias(:sum_visits)
         },
-        group_by: p.posted,
-        order_by: fragment("sum_visits")
+        group_by: alias(:date),
+        order_by: alias(:sum_visits)
 
-  The name of the alias must be a string, otherwise a compilation error is raised.
+  The name of the alias must be an atom and it can only be used in the outer most
+  select expression, otherwise an error is raised.
+
+  Using this in conjunction with `alias/1` is recommended to ensure only defined aliases
+  are referenced.
   """
   def alias(selected_value, name), do: doc! [selected_value, name]
 

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -31,6 +31,15 @@ defmodule Ecto.Query.Builder.GroupBy do
     {Macro.escape(to_field(field)), params_acc}
   end
 
+  defp do_escape({:alias, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:alias, [], [name]]}
+    {expr, params_acc}
+  end
+
+  defp do_escape({:alias, _, [name]}, _params_acc, _kind, _vars, _env) do
+    Builder.error! "alias/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  end
+
   defp do_escape(expr, params_acc, _kind, vars, env) do
     Builder.escape(expr, :any, params_acc, vars, env)
   end

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -31,13 +31,13 @@ defmodule Ecto.Query.Builder.GroupBy do
     {Macro.escape(to_field(field)), params_acc}
   end
 
-  defp do_escape({:alias, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
-    expr = {:{}, [], [:alias, [], [name]]}
+  defp do_escape({:selected_as, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:selected_as, [], [name]]}
     {expr, params_acc}
   end
 
-  defp do_escape({:alias, _, [name]}, _params_acc, _kind, _vars, _env) do
-    Builder.error! "alias/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  defp do_escape({:selected_as, _, [name]}, _params_acc, _kind, _vars, _env) do
+    Builder.error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
   end
 
   defp do_escape(expr, params_acc, _kind, vars, env) do

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -71,22 +71,22 @@ defmodule Ecto.Query.Builder.OrderBy do
     {{:asc, Macro.escape(to_field(field))}, params_acc}
   end
 
-  defp do_escape({dir, {:alias, _, [name]}}, params_acc, kind, _vars, _env) when is_atom(name) do
-    expr = {:{}, [], [:alias, [], [name]]}
+  defp do_escape({dir, {:selected_as, _, [name]}}, params_acc, kind, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:selected_as, [], [name]]}
     {{quoted_dir!(kind, dir), expr}, params_acc}
   end
 
-  defp do_escape({_dir, {:alias, _, [name]}}, _params_acc, _kind, _vars, _env) do
-    Builder.error! "alias/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  defp do_escape({_dir, {:selected_as, _, [name]}}, _params_acc, _kind, _vars, _env) do
+    Builder.error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
   end
 
-  defp do_escape({:alias, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
-    expr = {:{}, [], [:alias, [], [name]]}
+  defp do_escape({:selected_as, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:selected_as, [], [name]]}
     {{:asc, expr}, params_acc}
   end
 
-  defp do_escape({:alias, _, [name]}, _params_acc, _kind, _vars, _env) do
-    Builder.error! "alias/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  defp do_escape({:selected_as, _, [name]}, _params_acc, _kind, _vars, _env) do
+    Builder.error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
   end
 
   defp do_escape({dir, expr}, params_acc, kind, vars, env) do

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -71,6 +71,24 @@ defmodule Ecto.Query.Builder.OrderBy do
     {{:asc, Macro.escape(to_field(field))}, params_acc}
   end
 
+  defp do_escape({dir, {:alias, _, [name]}}, params_acc, kind, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:alias, [], [name]]}
+    {{quoted_dir!(kind, dir), expr}, params_acc}
+  end
+
+  defp do_escape({_dir, {:alias, _, [name]}}, _params_acc, _kind, _vars, _env) do
+    Builder.error! "alias/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  end
+
+  defp do_escape({:alias, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:alias, [], [name]]}
+    {{:asc, expr}, params_acc}
+  end
+
+  defp do_escape({:alias, _, [name]}, _params_acc, _kind, _vars, _env) do
+    Builder.error! "alias/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  end
+
   defp do_escape({dir, expr}, params_acc, kind, vars, env) do
     {ast, params_acc} = Builder.escape(expr, :any, params_acc, vars, env)
     {{quoted_dir!(kind, dir), ast}, params_acc}

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -111,6 +111,17 @@ defmodule Ecto.Query.Builder.Select do
     {expr, {params, acc}}
   end
 
+  # aliased values
+  defp escape({:alias, _, [expr, name]}, {params, acc}, vars, env) when is_binary(name) do
+    {escaped, {params, acc}} = Builder.escape(expr, :any, {params, acc}, vars, env)
+    expr = {:{}, [], [:alias, [], [escaped, name]]}
+    {expr, {params, acc}}
+  end
+
+  defp escape({:alias, _, [_expr, name]}, {_params, _acc}, _vars, _env) do
+    Builder.error! "alias/2 expects `name` to be a string, got `#{inspect(name)}`"
+  end
+
   defp escape(expr, params_acc, vars, env) do
     Builder.escape(expr, :any, params_acc, vars, {env, &escape_expansion/5})
   end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -5,6 +5,8 @@ defmodule Ecto.Query.Builder.Select do
 
   alias Ecto.Query.Builder
 
+  @dummy_value []
+
   @doc """
   Escapes a select.
 
@@ -14,13 +16,13 @@ defmodule Ecto.Query.Builder.Select do
   ## Examples
 
       iex> escape({1, 2}, [], __ENV__)
-      {{:{}, [], [:{}, [], [1, 2]]}, {[], %{take: %{}, subqueries: []}}}
+      {{:{}, [], [:{}, [], [1, 2]]}, {[], %{take: %{}, subqueries: [], aliases: %{}}}}
 
       iex> escape([1, 2], [], __ENV__)
-      {[1, 2], {[], %{take: %{}, subqueries: []}}}
+      {[1, 2], {[], %{take: %{}, subqueries: [], aliases: %{}}}}
 
       iex> escape(quote(do: x), [x: 0], __ENV__)
-      {{:{}, [], [:&, [], [0]]}, {[], %{take: %{}, subqueries: []}}}
+      {{:{}, [], [:&, [], [0]]}, {[], %{take: %{}, subqueries: [], aliases: %{}}}}
 
   """
   @spec escape(Macro.t, Keyword.t, Macro.Env.t) :: {Macro.t, {list, %{take: map, subqueries: list}}}
@@ -36,7 +38,7 @@ defmodule Ecto.Query.Builder.Select do
       take?(other) ->
         {
           {:{}, [], [:&, [], [0]]},
-          {[], %{take: %{0 => {:any, Macro.expand(other, env)}}, subqueries: []}}
+          {[], %{take: %{0 => {:any, Macro.expand(other, env)}}, subqueries: [], aliases: %{}}}
         }
 
       maybe_take?(other) ->
@@ -47,7 +49,7 @@ defmodule Ecto.Query.Builder.Select do
         """
 
       true ->
-        {expr, {params, acc}} = escape(other, {[], %{take: %{}, subqueries: []}}, vars, env)
+        {expr, {params, acc}} = escape(other, {[], %{take: %{}, subqueries: [], aliases: %{}}}, vars, env)
         acc = %{acc | subqueries: Enum.reverse(acc.subqueries)}
         {expr, {params, acc}}
     end
@@ -112,14 +114,15 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   # aliased values
-  defp escape({:alias, _, [expr, name]}, {params, acc}, vars, env) when is_binary(name) do
+  defp escape({:alias, _, [expr, name]}, {params, acc}, vars, env) when is_atom(name) do
     {escaped, {params, acc}} = Builder.escape(expr, :any, {params, acc}, vars, env)
     expr = {:{}, [], [:alias, [], [escaped, name]]}
+    acc = add_alias(acc, name)
     {expr, {params, acc}}
   end
 
   defp escape({:alias, _, [_expr, name]}, {_params, _acc}, _vars, _env) do
-    Builder.error! "alias/2 expects `name` to be a string, got `#{inspect(name)}`"
+    Builder.error! "alias/2 expects `name` to be an atom, got `#{inspect(name)}`"
   end
 
   defp escape(expr, params_acc, vars, env) do
@@ -294,6 +297,7 @@ defmodule Ecto.Query.Builder.Select do
     {expr, {params, acc}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
     take = {:%{}, [], Map.to_list(acc.take)}
+    aliases = {:%{}, [], Map.to_list(acc.aliases)}
 
     select = quote do: %Ecto.Query.SelectExpr{
                          expr: unquote(expr),
@@ -301,7 +305,8 @@ defmodule Ecto.Query.Builder.Select do
                          file: unquote(env.file),
                          line: unquote(env.line),
                          take: unquote(take),
-                         subqueries: unquote(acc.subqueries)}
+                         subqueries: unquote(acc.subqueries),
+                         aliases: unquote(aliases)}
 
     if kind == :select do
       Builder.apply_query(query, __MODULE__, [select], env)
@@ -454,6 +459,16 @@ defmodule Ecto.Query.Builder.Select do
   defp add_take(acc, key, value) do
     take = Map.update(acc.take, key, value, &merge_take_kind_and_fields(key, &1, value))
     %{acc | take: take}
+  end
+
+  defp add_alias(acc, name) do
+    case acc.aliases do
+      %{^name => _} ->
+        Builder.error! "the alias `#{inspect(name)}` has been specified more than once using `alias/2`"
+
+      aliases ->
+        %{acc | aliases: Map.put(aliases, name, @dummy_value)}
+    end
   end
 
   defp bump_subquery_params(new_params, old_subqueries) do

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -114,15 +114,15 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   # aliased values
-  defp escape({:alias, _, [expr, name]}, {params, acc}, vars, env) when is_atom(name) do
+  defp escape({:selected_as, _, [expr, name]}, {params, acc}, vars, env) when is_atom(name) do
     {escaped, {params, acc}} = Builder.escape(expr, :any, {params, acc}, vars, env)
-    expr = {:{}, [], [:alias, [], [escaped, name]]}
+    expr = {:{}, [], [:selected_as, [], [escaped, name]]}
     acc = add_alias(acc, name)
     {expr, {params, acc}}
   end
 
-  defp escape({:alias, _, [_expr, name]}, {_params, _acc}, _vars, _env) do
-    Builder.error! "alias/2 expects `name` to be an atom, got `#{inspect(name)}`"
+  defp escape({:selected_as, _, [_expr, name]}, {_params, _acc}, _vars, _env) do
+    Builder.error! "selected_as/2 expects `name` to be an atom, got `#{inspect(name)}`"
   end
 
   defp escape(expr, params_acc, vars, env) do
@@ -464,7 +464,7 @@ defmodule Ecto.Query.Builder.Select do
   defp add_alias(acc, name) do
     case acc.aliases do
       %{^name => _} ->
-        Builder.error! "the alias `#{inspect(name)}` has been specified more than once using `alias/2`"
+        Builder.error! "the alias `#{inspect(name)}` has been specified more than once using `selected_as/2`"
 
       aliases ->
         %{acc | aliases: Map.put(aliases, name, @dummy_value)}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1216,7 +1216,7 @@ defmodule Ecto.Query.Planner do
   end
 
   defp prewalk({:selected_as, [], [name]}, _kind, query, _expr, acc, _adapter) do
-    name = select_alias!(query.select.aliases, name)
+    name = selected_as!(query.select.aliases, name)
     {{:selected_as, [], [name]}, acc}
   end
 
@@ -1248,7 +1248,7 @@ defmodule Ecto.Query.Planner do
     {other, acc}
   end
 
-  defp select_alias!(select_aliases, name) do
+  defp selected_as!(select_aliases, name) do
     case select_aliases do
       %{^name => _} ->
         name

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1215,9 +1215,9 @@ defmodule Ecto.Query.Planner do
     {{:json_extract_path, meta, [json_field, path]}, acc}
   end
 
-  defp prewalk({:alias, [], [name]}, _kind, query, _expr, acc, _adapter) do
+  defp prewalk({:selected_as, [], [name]}, _kind, query, _expr, acc, _adapter) do
     name = select_alias!(query.select.aliases, name)
-    {{:alias, [], [name]}, acc}
+    {{:selected_as, [], [name]}, acc}
   end
 
   defp prewalk(%Ecto.Query.Tagged{value: v, type: type} = tagged, kind, query, expr, acc, adapter) do
@@ -1255,7 +1255,7 @@ defmodule Ecto.Query.Planner do
 
       _ ->
         raise ArgumentError,
-              "invalid alias: `#{inspect(name)}`. Use `alias/2` to define aliases in the outer most `select` expression."
+              "invalid alias: `#{inspect(name)}`. Use `selected_as/2` to define aliases in the outer most `select` expression."
     end
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1215,6 +1215,11 @@ defmodule Ecto.Query.Planner do
     {{:json_extract_path, meta, [json_field, path]}, acc}
   end
 
+  defp prewalk({:alias, [], [name]}, _kind, query, _expr, acc, _adapter) do
+    name = select_alias!(query.select.aliases, name)
+    {{:alias, [], [name]}, acc}
+  end
+
   defp prewalk(%Ecto.Query.Tagged{value: v, type: type} = tagged, kind, query, expr, acc, adapter) do
     if Ecto.Type.base?(type) do
       {tagged, acc}
@@ -1241,6 +1246,17 @@ defmodule Ecto.Query.Planner do
 
   defp prewalk(other, _kind, _query, _expr, acc, _adapter) do
     {other, acc}
+  end
+
+  defp select_alias!(select_aliases, name) do
+    case select_aliases do
+      %{^name => _} ->
+        name
+
+      _ ->
+        raise ArgumentError,
+              "invalid alias: `#{inspect(name)}`. Use `alias/2` to define aliases in the outer most `select` expression."
+    end
   end
 
   defp dump_param(kind, query, expr, v, type, adapter) do

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -26,16 +26,16 @@ defmodule Ecto.Query.Builder.GroupByTest do
       end
     end
 
-    test "can reference the alias of a selected value with alias/1" do
-      query = from p in "posts", select: alias(p.id, :ident), group_by: alias(:ident)
-      assert [{:alias, [], [:ident]}]  = hd(query.group_bys).expr
+    test "can reference the alias of a selected value with selected_as/1" do
+      query = from p in "posts", select: selected_as(p.id, :ident), group_by: selected_as(:ident)
+      assert [{:selected_as, [], [:ident]}]  = hd(query.group_bys).expr
     end
 
-    test "raises if name given to alias/1 is not an atom" do
-      message = "alias/1 expects `name` to be an atom, got `\"ident\"`"
+    test "raises if name given to selected_as/1 is not an atom" do
+      message = "selected_as/1 expects `name` to be an atom, got `\"ident\"`"
 
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:group_by, quote do alias("ident") end, {[], %{}}, [], __ENV__)
+        escape(:group_by, quote do selected_as("ident") end, {[], %{}}, [], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -25,6 +25,19 @@ defmodule Ecto.Query.Builder.GroupByTest do
         escape(:group_by, quote do x.y end, {[], %{}}, [], __ENV__)
       end
     end
+
+    test "can reference the alias of a selected value with alias/1" do
+      query = from p in "posts", select: alias(p.id, :ident), group_by: alias(:ident)
+      assert [{:alias, [], [:ident]}]  = hd(query.group_bys).expr
+    end
+
+    test "raises if name given to alias/1 is not an atom" do
+      message = "alias/1 expects `name` to be an atom, got `\"ident\"`"
+
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        escape(:group_by, quote do alias("ident") end, {[], %{}}, [], __ENV__)
+      end
+    end
   end
 
   describe "at runtime" do

--- a/test/ecto/query/builder/order_by_test.exs
+++ b/test/ecto/query/builder/order_by_test.exs
@@ -50,28 +50,28 @@ defmodule Ecto.Query.Builder.OrderByTest do
       end
     end
 
-    test "can reference the alias of a selected value with alias/1" do
+    test "can reference the alias of a selected value with selected_as/1" do
       # direction defaults to ascending
-      query = from p in "posts", select: alias(p.id, :ident), order_by: alias(:ident)
-      assert [asc: {:alias, [], [:ident]}]  = hd(query.order_bys).expr
+      query = from p in "posts", select: selected_as(p.id, :ident), order_by: selected_as(:ident)
+      assert [asc: {:selected_as, [], [:ident]}]  = hd(query.order_bys).expr
 
       # direction specified
-      query = from p in "posts", select: alias(p.id, :ident), order_by: [desc: alias(:ident)]
-      assert [desc: {:alias, [], [:ident]}]  = hd(query.order_bys).expr
+      query = from p in "posts", select: selected_as(p.id, :ident), order_by: [desc: selected_as(:ident)]
+      assert [desc: {:selected_as, [], [:ident]}]  = hd(query.order_bys).expr
 
-      query = from p in "posts", select: alias(p.id, :ident), order_by: [asc: alias(:ident)]
-      assert [asc: {:alias, [], [:ident]}]  = hd(query.order_bys).expr
+      query = from p in "posts", select: selected_as(p.id, :ident), order_by: [asc: selected_as(:ident)]
+      assert [asc: {:selected_as, [], [:ident]}]  = hd(query.order_bys).expr
     end
 
-    test "raises if name given to alias/1 is not an atom" do
-      message = "alias/1 expects `name` to be an atom, got `\"ident\"`"
+    test "raises if name given to selected_as/1 is not an atom" do
+      message = "selected_as/1 expects `name` to be an atom, got `\"ident\"`"
 
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:order_by, quote do alias("ident") end, {[], %{}}, [], __ENV__)
+        escape(:order_by, quote do selected_as("ident") end, {[], %{}}, [], __ENV__)
       end
 
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(:order_by, quote do [desc: alias("ident")] end, {[], %{}}, [], __ENV__)
+        escape(:order_by, quote do [desc: selected_as("ident")] end, {[], %{}}, [], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -88,43 +88,43 @@ defmodule Ecto.Query.Builder.SelectTest do
       end
     end
 
-    test "supports aliasing a selected value with alias/2" do
-      escaped_alias = {:alias, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident]}
+    test "supports aliasing a selected value with selected_as/2" do
+      escaped_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident]}
 
       # single field
-      query = from p in "posts", select: alias(p.id, :ident)
+      query = from p in "posts", select: selected_as(p.id, :ident)
       assert escaped_alias == query.select.expr
 
-      query = select("posts", [p], alias(p.id, :ident))
+      query = select("posts", [p], selected_as(p.id, :ident))
       assert escaped_alias == query.select.expr
 
       # maps
-      query = from p in "posts", select: %{id: alias(p.id, :ident)}
+      query = from p in "posts", select: %{id: selected_as(p.id, :ident)}
       assert {:%{}, [], [id: escaped_alias]} == query.select.expr
 
-      query = select("posts", [p], %{id: alias(p.id, :ident)})
+      query = select("posts", [p], %{id: selected_as(p.id, :ident)})
       assert {:%{}, [], [id: escaped_alias]} == query.select.expr
 
       # structs
-      query = from p in "posts", select: %{p | id: alias(p.id, :ident)}
+      query = from p in "posts", select: %{p | id: selected_as(p.id, :ident)}
       assert {:%{}, [], [{:|, [], [{:&, [], [0]}, [id: escaped_alias]]}]} == query.select.expr
 
-      query = select("posts", [p], %{p | id: alias(p.id, :ident)})
+      query = select("posts", [p], %{p | id: selected_as(p.id, :ident)})
       assert {:%{}, [], [{:|, [], [{:&, [], [0]}, [id: escaped_alias]]}]} == query.select.expr
 
       # keyword lists
-      query = from p in "posts", select: [id: alias(p.id, :ident)]
+      query = from p in "posts", select: [id: selected_as(p.id, :ident)]
       assert [{:{}, [], [:id, escaped_alias]}] == query.select.expr
 
-      query = select("posts", [p], [id: alias(p.id, :ident)])
+      query = select("posts", [p], [id: selected_as(p.id, :ident)])
       assert [{:{}, [], [:id, escaped_alias]}] == query.select.expr
     end
 
-    test "raises if name given to alias/2 is not an atom" do
-      message = "alias/2 expects `name` to be an atom, got `\"ident\"`"
+    test "raises if name given to selected_as/2 is not an atom" do
+      message = "selected_as/2 expects `name` to be an atom, got `\"ident\"`"
 
       assert_raise Ecto.Query.CompileError, message, fn ->
-        escape(quote do alias(p.id, "ident") end, [], __ENV__)
+        escape(quote do selected_as(p.id, "ident") end, [], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -127,6 +127,15 @@ defmodule Ecto.Query.Builder.SelectTest do
         escape(quote do selected_as(p.id, "ident") end, [], __ENV__)
       end
     end
+
+    test "raises if the name given to selected_as/2 already exists" do
+      message = "the alias `:ident` has been specified more than once using `selected_as/2`"
+
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        select_expr = quote do %{id: selected_as(^"id", :ident), id2: selected_as(^"id", :ident)} end
+        escape(select_expr, [], __ENV__)
+      end
+    end
   end
 
   describe "at runtime" do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -132,8 +132,8 @@ defmodule Ecto.Query.Builder.SelectTest do
       message = "the alias `:ident` has been specified more than once using `selected_as/2`"
 
       assert_raise Ecto.Query.CompileError, message, fn ->
-        select_expr = quote do %{id: selected_as(^"id", :ident), id2: selected_as(^"id", :ident)} end
-        escape(select_expr, [], __ENV__)
+        select_expr = quote do %{id: selected_as(p.id, :ident), id2: selected_as(p.id, :ident)} end
+        escape(select_expr, [p: 0], __ENV__)
       end
     end
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -86,6 +86,14 @@ defmodule Ecto.Query.Builder.SelectTest do
         escape(quote do [:foo, ^:bar] end, [], __ENV__)
       end
     end
+
+    test "supports column aliases" do
+      query_kw = from p in "posts", select: alias(p.id, "ident")
+      assert {:alias, _, [{{:., _, [{:&, [], [0]}, :id]}, [], []}, "ident"]} = query_kw.select.expr
+
+      query_expr = select("posts", [p], alias(p.id, "ident"))
+      assert {:alias, _, [{{:., _, [{:&, [], [0]}, :id]}, [], []}, "ident"]} = query_expr.select.expr
+    end
   end
 
   describe "at runtime" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1704,27 +1704,27 @@ defmodule Ecto.Query.PlannerTest do
   describe "selected aliases" do
     test "with group_by" do
       # defined alias
-      from(c in Comment, group_by: alias(:post), select: alias(c.post_id, :post)) |> normalize()
+      from(c in Comment, group_by: selected_as(:post), select: selected_as(c.post_id, :post)) |> normalize()
 
       # undefined alias
       message =
-        "invalid alias: `:post`. Use `alias/2` to define aliases in the outer most `select` expression."
+        "invalid alias: `:post`. Use `selected_as/2` to define aliases in the outer most `select` expression."
 
       assert_raise ArgumentError, message, fn ->
-        from(c in Comment, group_by: alias(:post)) |> normalize()
+        from(c in Comment, group_by: selected_as(:post)) |> normalize()
       end
     end
 
     test "with order_by" do
       # defined alias
-      from(c in Comment, order_by: alias(:post), select: alias(c.post_id, :post)) |> normalize()
+      from(c in Comment, order_by: selected_as(:post), select: selected_as(c.post_id, :post)) |> normalize()
 
       # undefined alias
       message =
-        "invalid alias: `:post`. Use `alias/2` to define aliases in the outer most `select` expression."
+        "invalid alias: `:post`. Use `selected_as/2` to define aliases in the outer most `select` expression."
 
       assert_raise ArgumentError, message, fn ->
-        from(c in Comment, order_by: alias(:post)) |> normalize()
+        from(c in Comment, order_by: selected_as(:post)) |> normalize()
       end
     end
   end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1700,4 +1700,32 @@ defmodule Ecto.Query.PlannerTest do
       |> normalize()
     end
   end
+
+  describe "selected aliases" do
+    test "with group_by" do
+      # defined alias
+      from(c in Comment, group_by: alias(:post), select: alias(c.post_id, :post)) |> normalize()
+
+      # undefined alias
+      message =
+        "invalid alias: `:post`. Use `alias/2` to define aliases in the outer most `select` expression."
+
+      assert_raise ArgumentError, message, fn ->
+        from(c in Comment, group_by: alias(:post)) |> normalize()
+      end
+    end
+
+    test "with order_by" do
+      # defined alias
+      from(c in Comment, order_by: alias(:post), select: alias(c.post_id, :post)) |> normalize()
+
+      # undefined alias
+      message =
+        "invalid alias: `:post`. Use `alias/2` to define aliases in the outer most `select` expression."
+
+      assert_raise ArgumentError, message, fn ->
+        from(c in Comment, order_by: alias(:post)) |> normalize()
+      end
+    end
+  end
 end


### PR DESCRIPTION
This can come in handy when there is a complicated select value that doesn't require `fragment` and is referenced in `order_by` and/or `group_by`.

Corresponding ecto_sql PR: https://github.com/elixir-ecto/ecto_sql/pull/432