### PR TITLE
Move selected_as/1 to generic builder

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1583,6 +1583,48 @@ defmodule Ecto.Integration.RepoTest do
       assert [%{posted: ~D[2020-12-21], min_visits: 2}, %{posted: ~D[2020-12-20], min_visits: 0}] =
                results
     end
+
+    @tag :selected_as_with_order_by_expression
+    test "selected_as/2 with order_by expression" do
+      TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 3, intensity: 2.0})
+      TestRepo.insert!(%Post{posted: ~D[2020-12-20], visits: nil, intensity: 10.0})
+
+      results =
+        from(p in Post,
+          select: %{
+            posted: p.posted,
+            visits: p.visits |> coalesce(0) |> selected_as(:num_visits),
+            intensity: selected_as(p.intensity, :strength)
+          },
+          order_by: [desc: (selected_as(:num_visits) + selected_as(:strength))]
+        )
+        |> TestRepo.all()
+
+      assert [%{posted: ~D[2020-12-20], visits: 0}, %{posted: ~D[2020-12-21], visits: 3}] =
+               results
+    end
+
+    @tag :selected_as_with_having
+    test "selected_as/2 with having" do
+      TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 3})
+      TestRepo.insert!(%Post{posted: ~D[2020-12-21], visits: 2})
+      TestRepo.insert!(%Post{posted: ~D[2020-12-20], visits: nil})
+
+      results =
+        from(p in Post,
+          select: %{
+            posted: p.posted,
+            min_visits: p.visits |> coalesce(0) |> min() |> selected_as(:min_visits)
+          },
+          group_by: p.posted,
+          having: selected_as(:min_visits) > 0,
+          or_having: not(selected_as(:min_visits) > 0),
+          order_by: p.posted
+        )
+        |> TestRepo.all()
+
+      assert [%{posted: ~D[2020-12-20], min_visits: 0}, %{posted: ~D[2020-12-21], min_visits: 2}] = results
+    end
   end
 
   test "query count distinct" do

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -685,13 +685,13 @@ defmodule Ecto.Query.API do
   @doc """
   Refer to an alias of a selected value.
 
-  This is available only inside `Ecto.Query.group_by/3` and `Ecto.Query.order_by/3`. If the alias
-  was not previously defined using `selected_as/2`, an error will be raised.
+  This can be used to refer to aliases created using `selected_as/2`. If
+  the alias hasn't been created using `selected_as/2`, an error will be raised.
 
-  Please note every database has its own rules for referencing these alias. For instance,
-  SQL Server does not allow them inside `GROUP BY` statements while PostgreSQL and MySQL do.
-
-  See `selected_as/2` for more information.
+  Each database has its own rules governing which clauses can reference these aliases.
+  If an error is raised mentioning an unknown column, most likely the alias is being
+  referenced somewhere that is not allowed. Consult the documentation for the database
+  to ensure the alias is being referenced correctly.
   """
   def selected_as(name), do: doc! [name]
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -399,6 +399,15 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:over, [], [aggregate, window]]}, params_acc}
   end
 
+  def escape({:selected_as, _, [name]}, _type, params_acc, _vars, _env) when is_atom(name) do
+    expr = {:{}, [], [:selected_as, [], [name]]}
+    {expr, params_acc}
+  end
+
+  def escape({:selected_as, _, [name]}, _type, _params_acc, _vars, _env) do
+    error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
+  end
+
   def escape({quantifier, meta, [subquery]}, type, params_acc, vars, env) when quantifier in [:all, :any, :exists] do
     {subquery, params_acc} = escape({:subquery, meta, [subquery]}, type, params_acc, vars, env)
     {{:{}, [], [quantifier, [], [subquery]]}, params_acc}

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -31,15 +31,6 @@ defmodule Ecto.Query.Builder.GroupBy do
     {Macro.escape(to_field(field)), params_acc}
   end
 
-  defp do_escape({:selected_as, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
-    expr = {:{}, [], [:selected_as, [], [name]]}
-    {expr, params_acc}
-  end
-
-  defp do_escape({:selected_as, _, [name]}, _params_acc, _kind, _vars, _env) do
-    Builder.error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
-  end
-
   defp do_escape(expr, params_acc, _kind, vars, env) do
     Builder.escape(expr, :any, params_acc, vars, env)
   end

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -71,24 +71,6 @@ defmodule Ecto.Query.Builder.OrderBy do
     {{:asc, Macro.escape(to_field(field))}, params_acc}
   end
 
-  defp do_escape({dir, {:selected_as, _, [name]}}, params_acc, kind, _vars, _env) when is_atom(name) do
-    expr = {:{}, [], [:selected_as, [], [name]]}
-    {{quoted_dir!(kind, dir), expr}, params_acc}
-  end
-
-  defp do_escape({_dir, {:selected_as, _, [name]}}, _params_acc, _kind, _vars, _env) do
-    Builder.error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
-  end
-
-  defp do_escape({:selected_as, _, [name]}, params_acc, _kind, _vars, _env) when is_atom(name) do
-    expr = {:{}, [], [:selected_as, [], [name]]}
-    {{:asc, expr}, params_acc}
-  end
-
-  defp do_escape({:selected_as, _, [name]}, _params_acc, _kind, _vars, _env) do
-    Builder.error! "selected_as/1 expects `name` to be an atom, got `#{inspect(name)}`"
-  end
-
   defp do_escape({dir, expr}, params_acc, kind, vars, env) do
     {ast, params_acc} = Builder.escape(expr, :any, params_acc, vars, env)
     {{quoted_dir!(kind, dir), ast}, params_acc}

--- a/test/ecto/query/builder/order_by_test.exs
+++ b/test/ecto/query/builder/order_by_test.exs
@@ -53,14 +53,28 @@ defmodule Ecto.Query.Builder.OrderByTest do
     test "can reference the alias of a selected value with selected_as/1" do
       # direction defaults to ascending
       query = from p in "posts", select: selected_as(p.id, :ident), order_by: selected_as(:ident)
-      assert [asc: {:selected_as, [], [:ident]}]  = hd(query.order_bys).expr
+      assert [asc: {:selected_as, [], [:ident]}] = hd(query.order_bys).expr
 
       # direction specified
-      query = from p in "posts", select: selected_as(p.id, :ident), order_by: [desc: selected_as(:ident)]
-      assert [desc: {:selected_as, [], [:ident]}]  = hd(query.order_bys).expr
+      query =
+        from p in "posts",
+          select: selected_as(p.id, :ident),
+          order_by: [desc: selected_as(:ident)]
 
-      query = from p in "posts", select: selected_as(p.id, :ident), order_by: [asc: selected_as(:ident)]
-      assert [asc: {:selected_as, [], [:ident]}]  = hd(query.order_bys).expr
+      assert [desc: {:selected_as, [], [:ident]}] = hd(query.order_bys).expr
+
+      query =
+        from p in "posts", select: selected_as(p.id, :ident), order_by: [asc: selected_as(:ident)]
+
+      assert [asc: {:selected_as, [], [:ident]}] = hd(query.order_bys).expr
+
+      # expression containing selected_as/1
+      query =
+        from p in "posts",
+          select: %{id: selected_as(p.id, :ident), id2: selected_as(p.id, :ident2)},
+          order_by: selected_as(:ident) + selected_as(:ident2)
+
+      assert [asc: {:+, [], [{:selected_as, [], [:ident]}, {:selected_as, [], [:ident2]}]}] = hd(query.order_bys).expr
     end
 
     test "raises if name given to selected_as/1 is not an atom" do


### PR DESCRIPTION
I would like to suggest moving the escaping of `selected_as/1` to the generic builder for a couple of reasons:

1. Some databases (i.e. MySQL) let you build expressions using column aliases so having it at the root level of the order by/group by builders won't always work.
2. Probably shouldn't limit the places `selected_as/1` can be used based on the built-in adapters only. 

I added some new integration tests that require some exclusions in ecto_sql. The corresponding ecto_sql PR is here: https://github.com/elixir-ecto/ecto_sql/pull/433