### PR TITLE
Refactor selected_as planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
   * [Ecto.Query] Support `^%{field: dynamic(...)}` in `select` and `select_merge`
   * [Ecto.Query] Support `%{field: subquery(...)}` in `select` and `select_merge`
+  * [Ecto.Query] Support select aliases through `selected_as/1` and `selected_as/2`
+  * [Ecto.Query] Allow `parent_as/1` in `type/2`
   * [Ecto.Repo] Support `idle_interval` query parameter in connection URL
   * [Ecto.Repo] Log human-readable UUIDs by using pre-dumped query parameters
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -404,7 +404,7 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:over, [], [aggregate, window]]}, params_acc}
   end
 
-  def escape({:selected_as, _, [_expr, name]}, _type, _params_acc, _vars, _env) do
+  def escape({:selected_as, _, [_expr, _name]}, _type, _params_acc, _vars, _env) do
     error! """
     selected_as/2 cannot be used unless it is at the root of a select statement. \
     If you are trying to use it inside of an expression, consider putting the \

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -406,7 +406,7 @@ defmodule Ecto.Query.Builder do
 
   def escape({:selected_as, _, [_expr, _name]}, _type, _params_acc, _vars, _env) do
     error! """
-    selected_as/2 cannot be used unless it is at the root of a select statement. \
+    selected_as/2 can only be used at the root of a select statement. \
     If you are trying to use it inside of an expression, consider putting the \
     expression inside of `selected_as/2` instead. For instance, instead of:
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -404,6 +404,20 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [:over, [], [aggregate, window]]}, params_acc}
   end
 
+  def escape({:selected_as, _, [_expr, name]}, _type, _params_acc, _vars, _env) do
+    error! """
+    selected_as/2 cannot be used unless it is at the root of a select statement. \
+    If you are trying to use it inside of an expression, consider putting the \
+    expression inside of `selected_as/2` instead. For instance, instead of:
+
+        from p in Post, select: coalesce(selected_as(p.visits, :v), 0)
+
+    use:
+
+        from p in Post, select: selected_as(coalesce(p.visits, 0), :v)
+    """
+  end
+
   def escape({:selected_as, _, [name]}, _type, params_acc, _vars, _env) when is_atom(name) do
     expr = {:{}, [], [:selected_as, [], [name]]}
     {expr, params_acc}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1344,7 +1344,18 @@ defmodule Ecto.Query.Planner do
     {put_in(query.select.fields, fields), select}
   end
 
-  defp normalize_selected_as(fields, false), do: fields
+  defp normalize_selected_as(fields, false) do
+    Enum.map(fields, fn
+      {:selected_as, _, [_select_expr, _name]} ->
+        raise ArgumentError,
+              "`selected_as/2` can only be used in the outer most `select` expression. " <>
+                "If you are attempting to alias a field from a subquery, it is not allowed " <>
+                "because subquery fields are automatically aliased by the corresponding map/struct key."
+
+      field ->
+        field
+    end)
+  end
 
   defp normalize_selected_as(fields, true) do
     Enum.map(fields, fn

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1524,6 +1524,10 @@ defmodule Ecto.Query.Planner do
     {{:value, :boolean}, [expr | fields], from}
   end
 
+  defp collect_fields({:selected_as, _, [select_expr, as]}, fields, from, _query, _take, _keep_literals?, _drop) do
+    {{:value, :any}, [{as, select_expr} | fields], from}
+  end
+
   defp collect_fields(expr, fields, from, _query, _take, _keep_literals?, _drop) do
     {{:value, :any}, [expr | fields], from}
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -120,6 +120,13 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert [{:{}, [], [:id, escaped_alias]}] == query.select.expr
     end
 
+    test "supports aliasing a selected value in select_merge with selected_as/2" do
+      escaped_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident]}
+
+      query = from p in "posts", select: p.visits, select_merge: %{id: selected_as(p.id, :ident)}
+      assert {:merge, [], [{{:., [], [{:&, [], [0]}, :visits]}, [], []}, {:%{}, [], [id: escaped_alias]}]} == query.select.expr
+    end
+
     test "raises if name given to selected_as/2 is not an atom" do
       message = "selected_as/2 expects `name` to be an atom, got `\"ident\"`"
 
@@ -133,6 +140,15 @@ defmodule Ecto.Query.Builder.SelectTest do
 
       assert_raise Ecto.Query.CompileError, message, fn ->
         select_expr = quote do %{id: selected_as(p.id, :ident), id2: selected_as(p.id, :ident)} end
+        escape(select_expr, [p: 0], __ENV__)
+      end
+    end
+
+    test "raises if selected_as/2 is not at the root of the select statement" do
+      message = ~r/selected_as\/2 cannot be used unless it is at the root of a select statement/
+
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        select_expr = quote do coalesce(selected_as(p.visits, :v), 0) end
         escape(select_expr, [p: 0], __ENV__)
       end
     end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -145,7 +145,7 @@ defmodule Ecto.Query.Builder.SelectTest do
     end
 
     test "raises if selected_as/2 is not at the root of the select statement" do
-      message = ~r/selected_as\/2 cannot be used unless it is at the root of a select statement/
+      message = ~r/selected_as\/2 can only be used at the root of a select statement/
 
       assert_raise Ecto.Query.CompileError, message, fn ->
         select_expr = quote do coalesce(selected_as(p.visits, :v), 0) end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1742,5 +1742,14 @@ defmodule Ecto.Query.PlannerTest do
         from(q in subquery(query)) |> normalize()
       end
     end
+
+    test "raises if selected_as/2 is used in a cte" do
+      message = ~r"`selected_as/2` can only be used in the outer most `select` expression."
+
+      assert_raise ArgumentError, message, fn ->
+        query = "schema" |> select([s], %{x: selected_as(s.x, :integer)})
+        Post |> with_cte("cte", as: ^query) |> normalize()
+      end
+    end
   end
 end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1733,5 +1733,14 @@ defmodule Ecto.Query.PlannerTest do
         from(c in Comment, order_by: selected_as(:post)) |> normalize()
       end
     end
+
+    test "raises if selected_as/2 is used in a subquery" do
+      message = ~r"`selected_as/2` can only be used in the outer most `select` expression."
+
+      assert_raise Ecto.SubQueryError, message, fn ->
+        query = "schema" |> select([s], %{x: selected_as(s.x, :integer)})
+        from(q in subquery(query)) |> normalize()
+      end
+    end
   end
 end


### PR DESCRIPTION
This will turn the `selected_as` field into a 2-tuple so that it can be aliased the same way subquery fields are aliased. Subquery reference: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query/planner.ex#L1007

Will update this with the corresponding ecto_sql PR

ecto_sql PR: https://github.com/elixir-ecto/ecto_sql/pull/434