### PR TITLE
Add Repo.update_all/2 example for a dependent value

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1158,6 +1158,9 @@ defmodule Ecto.Repo do
       from(p in Post, where: p.id < 10, update: [set: [title: fragment("upper(?)", ^new_title)]])
       |> MyRepo.update_all([])
 
+      from(p in Post, where: p.id < 10, update: [set: [view_count: p.view_count * 1000]])
+      |> MyRepo.update_all([])
+
   """
   @doc group: "Query API"
   @callback update_all(

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1158,7 +1158,7 @@ defmodule Ecto.Repo do
       from(p in Post, where: p.id < 10, update: [set: [title: fragment("upper(?)", ^new_title)]])
       |> MyRepo.update_all([])
 
-      from(p in Post, where: p.id < 10, update: [set: [view_count: p.view_count * 1000]])
+      from(p in Post, where: p.id < 10, update: [set: [visits: p.visits * 1000]])
       |> MyRepo.update_all([])
 
   """


### PR DESCRIPTION
Adds an example for using a value from the row when updating it.

This was the best example I could think of, open to other suggestions.