### PR TITLE
Fix `select_merge` not tracking `load_in_query: false` fields

### DIFF
--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -491,11 +491,11 @@ defmodule Ecto.Query.Builder.Select do
           # is merging fields with load_in_query = false.
           # If merging with a schemaless source, do nothing so the planner can take all the fields.
           case {old_expr, source} do
-            {{:&, _, [^binding]}, {_source, nil}} ->
-              acc
-
-            {{:&, _, [^binding]}, {_source, schema}} ->
+            {{:&, _, [^binding]}, {_source, schema}} when not is_nil(schema) ->
               Map.put(acc, binding, {new_kind, Enum.uniq(new_fields ++ schema.__schema__(:query_fields))})
+
+            {{:&, _, [^binding]}, _} ->
+                acc
 
             _ ->
               Map.put(acc, binding, new_value)

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -413,7 +413,7 @@ defmodule Ecto.Query.Builder.Select do
       select | expr: expr,
                params: old_params ++ bump_subquery_params(new_params, old_subqueries),
                subqueries: old_subqueries ++ new_subqueries,
-               take: merge_take(old_expr, old_take, new_take)
+               take: merge_take(query.from.source, old_expr, old_take, new_take)
     }
 
     %{query | select: select}
@@ -480,17 +480,25 @@ defmodule Ecto.Query.Builder.Select do
     end)
   end
 
-  defp merge_take(old_expr, %{} = old_take, %{} = new_take) do
-    Enum.reduce(new_take, old_take, fn {binding, new_value}, acc ->
+  defp merge_take(source, old_expr, %{} = old_take, %{} = new_take) do
+    Enum.reduce(new_take, old_take, fn {binding, {new_kind, new_fields} = new_value}, acc ->
       case acc do
         %{^binding => old_value} ->
           Map.put(acc, binding, merge_take_kind_and_fields(binding, old_value, new_value))
 
         %{} ->
-          # If the binding is a not filtered source, merge shouldn't restrict it
-          case old_expr do
-            {:&, _, [^binding]} -> acc
-            _ -> Map.put(acc, binding, new_value)
+          # If merging with a schema, add the schema's query fields. This comes in handy if the user
+          # is merging fields with load_in_query = false.
+          # If merging with a schemaless source, do nothing so the planner can take all the fields.
+          case {old_expr, source} do
+            {{:&, _, [^binding]}, {_source, nil}} ->
+              acc
+
+            {{:&, _, [^binding]}, {_source, schema}} ->
+              Map.put(acc, binding, {new_kind, Enum.uniq(new_fields ++ schema.__schema__(:query_fields))})
+
+            _ ->
+              Map.put(acc, binding, new_value)
           end
       end
     end)

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -526,12 +526,19 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert query.select.params == []
       assert query.select.take == %{0 => {:any, [:dislikes, :title, :likes]}}
 
-      # On take
+      # On take with schemaless source
       query = from c in "comments", select: [:title], select_merge: [:likes]
 
       assert Macro.to_string(query.select.expr) == "&0"
       assert query.select.params == []
       assert query.select.take == %{0 => {:any, [:title, :likes]}}
+
+      # On take with schema
+      query = from c in Comment, select: [:title, :likes], select_merge: [:dislikes]
+
+      assert Macro.to_string(query.select.expr) == "&0"
+      assert query.select.params == []
+      assert query.select.take == %{0 => {:any, [:title, :likes, :dislikes]}}
     end
 
     test "on conflicting take" do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -9,6 +9,17 @@ defmodule Ecto.Query.Builder.SelectTest do
     defstruct [:title]
   end
 
+  defmodule Comment do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "comments" do
+      field :title, :string
+      field :likes, :integer
+      field :dislikes, :integer, load_in_query: false
+    end
+  end
+
   defp params_acc(opts \\ []) do
     params = opts[:params] || []
     take = opts[:take] || %{}
@@ -501,19 +512,26 @@ defmodule Ecto.Query.Builder.SelectTest do
     end
 
     test "with take" do
-      # On select
-      query = from p in "posts", select: p, select_merge: [:title]
+      # On select with schemaless source
+      query = from c in "comments", select: c, select_merge: [:title]
 
       assert Macro.to_string(query.select.expr) == "&0"
       assert query.select.params == []
       assert query.select.take == %{}
 
-      # On take
-      query = from p in "posts", select: [:body], select_merge: [:title]
+      # On select with schema
+      query = from c in Comment, select: c, select_merge: [:dislikes]
 
       assert Macro.to_string(query.select.expr) == "&0"
       assert query.select.params == []
-      assert query.select.take == %{0 => {:any, [:body, :title]}}
+      assert query.select.take == %{0 => {:any, [:dislikes, :title, :likes]}}
+
+      # On take
+      query = from c in "comments", select: [:title], select_merge: [:likes]
+
+      assert Macro.to_string(query.select.expr) == "&0"
+      assert query.select.params == []
+      assert query.select.take == %{0 => {:any, [:title, :likes]}}
     end
 
     test "on conflicting take" do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -534,11 +534,11 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert query.select.take == %{0 => {:any, [:title, :likes]}}
 
       # On take with schema
-      query = from c in Comment, select: [:title, :likes], select_merge: [:dislikes]
+      query = from c in Comment, select: [:title], select_merge: [:dislikes]
 
       assert Macro.to_string(query.select.expr) == "&0"
       assert query.select.params == []
-      assert query.select.take == %{0 => {:any, [:title, :likes, :dislikes]}}
+      assert query.select.take == %{0 => {:any, [:title, :dislikes]}}
     end
 
     test "on conflicting take" do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/3987.

I think this is the simplest way to fix it. If the `select_merge` is on top of a source that has a schema, add schema's query fields to the `take` map instead of ignoring the `take` map.