### PR TITLE
Add minimal example for `Multi.one/2` and `Multi.all/2` using function

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -406,6 +406,9 @@ defmodule Ecto.Multi do
 
       Ecto.Multi.new()
       |> Ecto.Multi.one(:post, Post)
+      |> Ecto.Multi.one(:author, fn %{ post: post } -> 
+        from(a in Author, where: a.id == ^post.author_id)
+      end)
       |> MyApp.Repo.transaction()
   """
   @spec one(
@@ -433,6 +436,10 @@ defmodule Ecto.Multi do
 
       Ecto.Multi.new()
       |> Ecto.Multi.all(:all, Post)
+      |> MyApp.Repo.transaction()
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.all(:all, fn _changes -> Post end)
       |> MyApp.Repo.transaction()
   """
   @spec all(

--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -406,7 +406,7 @@ defmodule Ecto.Multi do
 
       Ecto.Multi.new()
       |> Ecto.Multi.one(:post, Post)
-      |> Ecto.Multi.one(:author, fn %{ post: post } -> 
+      |> Ecto.Multi.one(:author, fn %{post: post} -> 
         from(a in Author, where: a.id == ^post.author_id)
       end)
       |> MyApp.Repo.transaction()


### PR DESCRIPTION
I think this kind of example should help some people.

When using `one/2` and `all/2` I was wondering why this example was missing from the method documentation as it was supported.