### PR TITLE
Compile time CTE fix.

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1292,7 +1292,15 @@ defmodule Ecto.Query.Builder do
 
   # Escapes an `Ecto.Query` and associated structs.
   @spec escape_query(Query.t) :: Macro.t
-  defp escape_query(%Query{} = query), do: {:%{}, [], Map.to_list(query)}
+  defp escape_query(%Query{} = query) do
+    escaped_entries =
+      query |> Map.to_list() |> Enum.map(fn {k, v} -> {k, escape_struct(v)} end)
+
+    {:%{}, [], escaped_entries}
+  end
+
+  defp escape_struct(%_{} = struct), do: {:%{}, [], Map.to_list(struct)}
+  defp escape_struct(other), do: other
 
   defp parse_access_get({{:., _, [Access, :get]}, _, [left, right]}, acc) do
     parse_access_get(left, [right | acc])

--- a/test/ecto/query/builder/cte_test.exs
+++ b/test/ecto/query/builder/cte_test.exs
@@ -17,6 +17,14 @@ defmodule Ecto.Query.Builder.CTETest do
     refute query.with_ctes.recursive
   end
 
+  test "compile time CTE" do
+    cte = from c in "categories", where: not is_nil(c.parent_id)
+    query = from(p in "products") |> with_cte("categories", as: ^cte)
+
+    assert [{"categories", %Ecto.Query{from: from}}] = query.with_ctes.queries
+    assert %Ecto.Query.FromExpr{source: {"categories", nil}} = from
+  end
+
   test "recursive CTE" do
     initial = "categories" |> where([c], is_nil(c.parent_id))
     recursion = "categories" |> join(:inner, [c], ct in "tree", on: c.parent_id == ct.id)


### PR DESCRIPTION
When building a CTE  the `apply` function adds at a `%Ecto.Query.WithExpr{}` struct for the first CTE. This causes an issue for compile time queries because that struct is not escaped afterwards.

Since `apply` doesn't know whether it's called at runtime or compile time I think the right way to fix this is to escape any added structs when re-escaping the compile time query. But please let me know if I'm missing a better way to do it.