### PR TITLE
Preload with union query

### DIFF
--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -778,7 +778,7 @@ defmodule Ecto.Integration.PreloadTest do
       q2 = from c in Comment, select: map(c, ^fields), where: c.text == "b"
       query = union(q1, ^q2)
 
-      p1 = TestRepo.preload([p1], [{:comments, query}], [])
+      [p1] = TestRepo.preload([p1], [{:comments, query}], [])
 
       assert [] == p1.comments
     end

--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -768,6 +768,32 @@ defmodule Ecto.Integration.PreloadTest do
     end
   end
 
+  describe "union queries" do
+    test "should preload comments into posts" do
+      p1 = TestRepo.insert!(%Post{title: "p1"})
+      TestRepo.insert!(%Comment{text: "c1", post: p1})
+
+      q1 = from c in Comment, where: c.text == "a"
+      q2 = from c in Comment, where: c.text == "b"
+      query = union(q1, ^q2)
+
+      p1 = TestRepo.preload([p1], [{:comments, query}], [])
+
+      assert [] == p1.comments
+    end
+
+    test "should also fetch comments" do
+      p1 = TestRepo.insert!(%Post{title: "p1"})
+      TestRepo.insert!(%Comment{text: "c1", post: p1})
+
+      q1 = from c in Comment, where: c.text == "a"
+      q2 = from c in Comment, where: c.text == "b"
+
+      query = union(q1, ^q2)
+      assert [] = TestRepo.all(query)
+    end
+  end
+
   defp sort_by_id(values) do
     Enum.sort_by(values, &(&1.id))
   end

--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -774,7 +774,8 @@ defmodule Ecto.Integration.PreloadTest do
       TestRepo.insert!(%Comment{text: "c1", post: p1})
 
       q1 = from c in Comment, where: c.text == "a"
-      q2 = from c in Comment, where: c.text == "b"
+      fields = Comment.__schema__(:fields) ++ [:post_id]
+      q2 = from c in Comment, select: map(c, ^fields), where: c.text == "b"
       query = union(q1, ^q2)
 
       p1 = TestRepo.preload([p1], [{:comments, query}], [])


### PR DESCRIPTION
I am raising this PR to illustrate a scenario that involves preloading and union or intersect queries that I can't quite figure out. 

The CI will fail with the error below.
 
In this PR, I've got two integration tests.  Each test builds the same query on `comments` which is the union of two other queries:

```elixir
q1 = from c in Comment, where: c.text == "a"
q2 = from c in Comment, where: c.text == "b"
query = union(q1, ^q2)
```

When I use this query to fetch all comments that match, using `Repo.all(query)`, I get an empty list, as expected. This means the query was properly accepted by the database and did execute successfully. 

However, if I use the same query to preload a specific post with some comments, using `Repo.preload([p1], [{:comments, query}], [])`, then I get the error:

```
** (Postgrex.Error) ERROR 42601 (syntax_error) each UNION query must have the same number of columns
``` 

and if I take a look at the generated sql: 

```
query: SELECT c0."id", c0."text", c0."lock_version", c0."post_id", c0."author_id", c0."post_id" FROM "comments" AS c0 WHERE (c0."text" = 'a') AND (c0."post_id" = $1) UNION (SELECT c0."id", c0."text", c0."lock_version", c0."post_id", c0."author_id" FROM "comments" AS c0 WHERE (c0."text" = 'b')) ORDER BY c0."post_id"
```

I can see indeed there is a difference in the number of columns selected by the two queries. The first query is selecting `c0.post_id` twice (not expected?), while the second is selecting it just once (expected).

The same happens with intersect queries. It is highly possible that I am abusing the preloader, or maybe this is expected, but I was curious to know why this behaviour?  

And most importantly, is there a way I could workaround it ? :)

Thanks in advance!

 
