### PR TITLE
Don't raise on insert when association is not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * [Ecto.Query] Fix `select_merge` not tracking `load_in_query: false` field
   * [Ecto.Query] Fix field source when used in `json_extract_path`
   * [Ecto.Repo] Fix `insert_all` query parameter count when using value queries alongside `placeholder`
+  * [Ecto.Schema] Ignore associations that aren't loaded on insert
 
 ## v3.8.4 (2022-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * [Ecto.Query] Don't select struct fields overridden with `nil`
   * [Ecto.Query] Fix `select_merge` not tracking `load_in_query: false` field
   * [Ecto.Query] Fix field source when used in `json_extract_path`
+  * [Ecto.Query] Properly build CTEs at compile time
   * [Ecto.Repo] Fix `insert_all` query parameter count when using value queries alongside `placeholder`
   * [Ecto.Schema] Ignore associations that aren't loaded on insert
 

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -537,7 +537,7 @@ defmodule Ecto.Changeset.Relation do
             # This is partly reimplementing the logic behind put_relation
             # in Ecto.Changeset but we need to do it in a way where we have
             # control over the current value.
-            value = load!(struct, Map.get(struct, field))
+            value = not_loaded_to_empty(Map.get(struct, field))
             empty = empty(embed_or_assoc)
             case change(embed_or_assoc, value, empty) do
               {:ok, change, _} when change != empty ->
@@ -562,4 +562,9 @@ defmodule Ecto.Changeset.Relation do
       _  -> %{changeset | errors: errors ++ changeset.errors, valid?: false, changes: changes}
     end
   end
+
+  defp not_loaded_to_empty(%NotLoaded{__cardinality__: cardinality}),
+    do: cardinality_to_empty(cardinality)
+
+  defp not_loaded_to_empty(loaded), do: loaded
 end

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -1225,4 +1225,17 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{posts: [%{}]}, :posts)
     assert Changeset.traverse_validations(changeset, &(&1)) == %{posts: [%{title: [length: [min: 3]]}]}
   end
+
+  @tag :not_loaded
+  test "insert not loaded assocs" do
+    loaded = put_in %Author{id: 1}.__meta__.state, :loaded
+    TestRepo.insert!(loaded)
+  end
+
+  @tag :not_loaded
+  test "update not loaded assocs" do
+    loaded = put_in %Author{id: 1}.__meta__.state, :loaded
+    cs = Changeset.change(loaded, %{})
+    TestRepo.update!(cs)
+  end
 end

--- a/test/ecto/changeset/has_assoc_test.exs
+++ b/test/ecto/changeset/has_assoc_test.exs
@@ -1225,17 +1225,4 @@ defmodule Ecto.Changeset.HasAssocTest do
     changeset = cast(%Author{}, %{posts: [%{}]}, :posts)
     assert Changeset.traverse_validations(changeset, &(&1)) == %{posts: [%{title: [length: [min: 3]]}]}
   end
-
-  @tag :not_loaded
-  test "insert not loaded assocs" do
-    loaded = put_in %Author{id: 1}.__meta__.state, :loaded
-    TestRepo.insert!(loaded)
-  end
-
-  @tag :not_loaded
-  test "update not loaded assocs" do
-    loaded = put_in %Author{id: 1}.__meta__.state, :loaded
-    cs = Changeset.change(loaded, %{})
-    TestRepo.update!(cs)
-  end
 end

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -474,4 +474,11 @@ defmodule Ecto.Repo.BelongsToTest do
     refute_received {:transaction, _}
     refute_received {:rollback, _}
   end
+
+  test "ignore not loaded assoc on insert" do
+    schema = %MySchema{}
+    %{assoc: %Ecto.Association.NotLoaded{}} = schema
+    loaded = put_in schema.__meta__.state, :loaded
+    TestRepo.insert!(loaded)
+  end
 end

--- a/test/ecto/repo/has_assoc_test.exs
+++ b/test/ecto/repo/has_assoc_test.exs
@@ -563,4 +563,11 @@ defmodule Ecto.Repo.HasAssocTest do
     refute_received {:transaction, _}
     refute_received {:rollback, _}
   end
+
+  test "ignore not loaded assoc on insert" do
+    schema = %MySchema{}
+    %{assoc: %Ecto.Association.NotLoaded{}, assocs: %Ecto.Association.NotLoaded{}} = schema
+    loaded = put_in schema.__meta__.state, :loaded
+    TestRepo.insert!(loaded)
+  end
 end

--- a/test/ecto/repo/many_to_many_test.exs
+++ b/test/ecto/repo/many_to_many_test.exs
@@ -644,4 +644,11 @@ defmodule Ecto.Repo.ManyToManyTest do
     refute_received {:rollback, _}
     refute_received {:insert_all, _, _}
   end
+
+  test "ignore not loaded assoc on insert" do
+    schema = %MySchema{}
+    %{assocs: %Ecto.Association.NotLoaded{}} = schema
+    loaded = put_in schema.__meta__.state, :loaded
+    TestRepo.insert!(loaded)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4002

It looks like `load!` is not ignored on insert. Probably it wasn't noticed because the struct is usually `built` instead of `loaded`.