### PR TITLE
Add :force_changes option to cast/4

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -451,8 +451,7 @@ defmodule Ecto.Changeset do
       Empty values are always replaced by the default value of the respective field.
       If the field is an array type, any empty value inside of the array will be removed.
       Defaults to `[""]`
-    * `:force_changes` - a boolean indicating whether to include default values
-      in `:changes`. Defaults to `false`
+    * `:force_changes` - a boolean indicating whether to include values that don't alter the current data in `:changes`. Defaults to `false`
 
   ## Examples
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -362,6 +362,12 @@ defmodule Ecto.Changeset do
 
   See `cast/4` if you'd prefer to cast and validate external parameters.
 
+  ## Options
+
+    * `:force_changes` - a boolean indicating whether to include values
+      in `:changes` even if they match the current value or the field's default
+      value. Defaults to `false`
+
   ## Examples
 
       iex> changeset = change(%Post{})
@@ -378,6 +384,10 @@ defmodule Ecto.Changeset do
       iex> changeset = change(%Post{title: "title"}, title: "title")
       iex> changeset.changes
       %{}
+
+      iex> changeset = change(%Post{title: "title"}, %{title: "title"}, force_changes: true)
+      iex> changeset.changes
+      %{title: "title"}
 
       iex> changeset = change(changeset, %{title: "new title", body: "body"})
       iex> changeset.changes.title

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -436,7 +436,9 @@ defmodule Ecto.Changeset do
   During casting, all `permitted` parameters whose values match the specified
   type information will have their key name converted to an atom and stored
   together with the value as a change in the `:changes` field of the changeset.
-  All parameters that are not explicitly permitted are ignored.
+  If the cast value matches the default value for the schema, it will not be
+  included in the `:changes` unless the `:force_changes: true` option is
+  provided. All parameters that are not explicitly permitted are ignored.
 
   If casting of all fields is successful, the changeset is returned as valid.
 
@@ -449,6 +451,8 @@ defmodule Ecto.Changeset do
       Empty values are always replaced by the default value of the respective field.
       If the field is an array type, any empty value inside of the array will be removed.
       Defaults to `[""]`
+    * `:force_changes` - a boolean indicating whether to include default values
+      in `:changes`. Defaults to `false`
 
   ## Examples
 
@@ -523,6 +527,7 @@ defmodule Ecto.Changeset do
 
   defp cast(%{} = data, %{} = types, %{} = changes, %{} = params, permitted, opts) when is_list(permitted) do
     empty_values = Keyword.get(opts, :empty_values, @empty_values)
+    force? = Keyword.get(opts, :force_changes, false)
     params = convert_params(params)
 
     defaults = case data do
@@ -532,7 +537,7 @@ defmodule Ecto.Changeset do
 
     {changes, errors, valid?} =
       Enum.reduce(permitted, {changes, [], true},
-                  &process_param(&1, params, types, data, empty_values, defaults, &2))
+                  &process_param(&1, params, types, data, empty_values, defaults, force?, &2))
 
     %Changeset{params: params, data: data, valid?: valid?,
                errors: Enum.reverse(errors), changes: changes, types: types}
@@ -543,7 +548,7 @@ defmodule Ecto.Changeset do
                           message: "expected params to be a :map, got: `#{inspect params}`"
   end
 
-  defp process_param(key, params, types, data, empty_values, defaults, {changes, errors, valid?}) do
+  defp process_param(key, params, types, data, empty_values, defaults, force?, {changes, errors, valid?}) do
     {key, param_key} = cast_key(key)
     type = cast_type!(types, key)
 
@@ -553,7 +558,7 @@ defmodule Ecto.Changeset do
         _ -> Map.get(data, key)
       end
 
-    case cast_field(key, param_key, type, params, current, empty_values, defaults, valid?) do
+    case cast_field(key, param_key, type, params, current, empty_values, defaults, force?, valid?) do
       {:ok, value, valid?} ->
         {Map.put(changes, key, value), errors, valid?}
       :missing ->
@@ -588,13 +593,13 @@ defmodule Ecto.Changeset do
   defp cast_key(key),
     do: raise ArgumentError, "cast/3 expects a list of atom keys, got key: `#{inspect key}`"
 
-  defp cast_field(key, param_key, type, params, current, empty_values, defaults, valid?) do
+  defp cast_field(key, param_key, type, params, current, empty_values, defaults, force?, valid?) do
     case params do
       %{^param_key => value} ->
         value = filter_empty_values(type, value, empty_values, defaults, key)
         case Ecto.Type.cast(type, value) do
           {:ok, value} ->
-            if Ecto.Type.equal?(type, current, value) do
+            if !force? && Ecto.Type.equal?(type, current, value) do
               :missing
             else
               {:ok, value, valid?}

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -436,8 +436,8 @@ defmodule Ecto.Changeset do
   During casting, all `permitted` parameters whose values match the specified
   type information will have their key name converted to an atom and stored
   together with the value as a change in the `:changes` field of the changeset.
-  If the cast value matches the default value for the schema, it will not be
-  included in the `:changes` unless the `:force_changes: true` option is
+  If the cast value matches the current value for the field, it will not be
+  included in `:changes` unless the `:force_changes: true` option is
   provided. All parameters that are not explicitly permitted are ignored.
 
   If casting of all fields is successful, the changeset is returned as valid.

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -389,6 +389,10 @@ defmodule Ecto.Changeset do
       iex> changeset.changes
       %{title: "title"}
 
+      iex> changeset = change(%Post{}, %{title: nil}, force_changes: true)
+      iex> changeset.changes
+      %{title: nil}
+
       iex> changeset = change(changeset, %{title: "new title", body: "body"})
       iex> changeset.changes.title
       "new title"

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -399,7 +399,7 @@ defmodule Ecto.Changeset do
 
   def change(%Changeset{changes: changes, types: types} = changeset, new_changes, opts)
       when is_map(new_changes) or is_list(new_changes) do
-    {changes, errors, valid?, _force?} =
+    {changes, errors, valid?} =
       get_changed(changeset.data, types, changes, new_changes,
                   changeset.errors, changeset.valid?, Keyword.get(opts, :force_changes, false))
     %{changeset | changes: changes, errors: errors, valid?: valid?}
@@ -407,18 +407,19 @@ defmodule Ecto.Changeset do
 
   def change(%{__struct__: struct} = data, changes, opts) when is_map(changes) or is_list(changes) do
     types = struct.__changeset__()
-    {changes, errors, valid?, _force?} = get_changed(data, types, %{}, changes, [], true, Keyword.get(opts, :force_changes, false))
+    {changes, errors, valid?} = get_changed(data, types, %{}, changes, [], true, Keyword.get(opts, :force_changes, false))
     %Changeset{valid?: valid?, data: data, changes: changes,
                errors: errors, types: types}
   end
 
   defp get_changed(data, types, old_changes, new_changes, errors, valid?, force?) do
-    Enum.reduce(new_changes, {old_changes, errors, valid?, force?}, fn
-      {key, value}, {changes, errors, valid?, false = _force?} ->
-        {changes, errors, valid?} = put_change(data, changes, errors, valid?, key, value, Map.get(types, key))
-        {changes, errors, valid?, force?}
-      {key, value}, {changes, errors, valid?, true = _force?} ->
-        {Map.put(changes, key, value), errors, valid?, force?}
+    Enum.reduce(new_changes, {old_changes, errors, valid?}, fn
+      {key, value}, {changes, errors, valid?} ->
+        if force? do
+          {Map.put(changes, key, value), errors, valid?}
+        else
+          put_change(data, changes, errors, valid?, key, value, Map.get(types, key))
+        end
       _, _ ->
         raise ArgumentError,
               "invalid changes being applied to changeset. " <>
@@ -602,7 +603,7 @@ defmodule Ecto.Changeset do
         value = filter_empty_values(type, value, empty_values, defaults, key)
         case Ecto.Type.cast(type, value) do
           {:ok, value} ->
-            if !force? && Ecto.Type.equal?(type, current, value) do
+            if not force? and Ecto.Type.equal?(type, current, value) do
               :missing
             else
               {:ok, value, valid?}

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -591,11 +591,6 @@ defmodule Ecto.ChangesetTest do
     assert changeset.data == %Post{body: "bar"}
     assert changeset.changes == %{}
 
-    changeset = change(%Post{body: "bar"}, [body: "bar"], force_changes: true)
-    assert changeset.valid?
-    assert changeset.data == %Post{body: "bar"}
-    assert changeset.changes == %{body: "bar"}
-
     changeset = change(%Post{body: "bar"}, %{body: "bar", title: "foo"})
     assert changeset.valid?
     assert changeset.data == %Post{body: "bar"}
@@ -630,12 +625,6 @@ defmodule Ecto.ChangesetTest do
     assert changeset.data == %{title: "hello"}
     assert changeset.changes == %{}
     assert apply_changes(changeset) == %{title: "hello"}
-
-    changeset = change(datatypes, [title: "hello"], force_changes: true)
-    assert changeset.valid?
-    assert changeset.data == %{title: "hello"}
-    assert changeset.changes == %{title: "hello"}
-    assert apply_changes(changeset) == %{title: "hello"}
   end
 
   test "change/2 with a changeset" do
@@ -655,9 +644,6 @@ defmodule Ecto.ChangesetTest do
     changeset = change(base_changeset, body: nil)
     assert changeset.changes == %{title: "title"}
 
-    changeset = change(base_changeset, [body: nil], force_changes: true)
-    assert changeset.changes == %{title: "title", body: nil}
-
     changeset = change(base_changeset, %{upvotes: nil})
     assert changeset.changes == %{title: "title", upvotes: nil}
 
@@ -675,9 +661,6 @@ defmodule Ecto.ChangesetTest do
     post = %Post{decimal: Decimal.new("1.0")}
     changeset = change(post, decimal: Decimal.new(1))
     assert changeset.changes == %{}
-
-    changeset = change(post, [decimal: Decimal.new(1)], force_changes: true)
-    assert changeset.changes == %{decimal: Decimal.new(1)}
   end
 
   test "change/2 with unknown field" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -207,6 +207,14 @@ defmodule Ecto.ChangesetTest do
     assert changeset.changes == %{}
   end
 
+  test "cast/4: with force_changes" do
+    params = %{"title" => "", "body" => nil}
+    struct = %Post{title: "", body: nil}
+
+    changeset = cast(struct, params, ~w(title body)a, force_changes: true)
+    assert changeset.changes == %{title: "", body: nil}
+  end
+
   test "cast/4: with data and types" do
     data   = {%{title: "hello"}, %{title: :string, upvotes: :integer}}
     params = %{"title" => "world", "upvotes" => "0"}

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -591,6 +591,11 @@ defmodule Ecto.ChangesetTest do
     assert changeset.data == %Post{body: "bar"}
     assert changeset.changes == %{}
 
+    changeset = change(%Post{body: "bar"}, [body: "bar"], force_changes: true)
+    assert changeset.valid?
+    assert changeset.data == %Post{body: "bar"}
+    assert changeset.changes == %{body: "bar"}
+
     changeset = change(%Post{body: "bar"}, %{body: "bar", title: "foo"})
     assert changeset.valid?
     assert changeset.data == %Post{body: "bar"}
@@ -625,6 +630,12 @@ defmodule Ecto.ChangesetTest do
     assert changeset.data == %{title: "hello"}
     assert changeset.changes == %{}
     assert apply_changes(changeset) == %{title: "hello"}
+
+    changeset = change(datatypes, [title: "hello"], force_changes: true)
+    assert changeset.valid?
+    assert changeset.data == %{title: "hello"}
+    assert changeset.changes == %{title: "hello"}
+    assert apply_changes(changeset) == %{title: "hello"}
   end
 
   test "change/2 with a changeset" do
@@ -644,6 +655,9 @@ defmodule Ecto.ChangesetTest do
     changeset = change(base_changeset, body: nil)
     assert changeset.changes == %{title: "title"}
 
+    changeset = change(base_changeset, [body: nil], force_changes: true)
+    assert changeset.changes == %{title: "title", body: nil}
+
     changeset = change(base_changeset, %{upvotes: nil})
     assert changeset.changes == %{title: "title", upvotes: nil}
 
@@ -661,6 +675,9 @@ defmodule Ecto.ChangesetTest do
     post = %Post{decimal: Decimal.new("1.0")}
     changeset = change(post, decimal: Decimal.new(1))
     assert changeset.changes == %{}
+
+    changeset = change(post, [decimal: Decimal.new(1)], force_changes: true)
+    assert changeset.changes == %{decimal: Decimal.new(1)}
   end
 
   test "change/2 with unknown field" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -213,6 +213,9 @@ defmodule Ecto.ChangesetTest do
 
     changeset = cast(struct, params, ~w(title body)a, force_changes: true)
     assert changeset.changes == %{title: "", body: nil}
+
+    changeset = cast(struct, %{"title" => "not empty", "body" => "empty"}, ~w(title body)a, force_changes: true, empty_values: ["empty"])
+    assert changeset.changes == %{title: "not empty", body: nil}
   end
 
   test "cast/4: with data and types" do


### PR DESCRIPTION
Add a `:force_changes` option to `Ecto.Changeset.cast/4`.
When set to true all changes given will be put in the changeset's `:changes` event if they
match the current value or default value.

This is useful for doing an upsert without having to do a read first. Currently to "clear" a value,
which is often the default value for a field, you either need to read the original row first or call `Ecto.Changeset.force_change/3` for each relevant field.