### PR TITLE
Clarify :returning option for inserts

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1524,7 +1524,9 @@ defmodule Ecto.Repo do
 
     * Specify `read_after_writes: true` in your schema for choosing
       fields that are read from the database after every operation.
-      Or pass `returning: true` to `insert` to read all fields back:
+      Or pass `returning: true` to `insert` to read all fields back.
+      (Note that it will only read from the database if at least one
+      field is updated).
 
           MyRepo.insert(%Post{title: "this is unique"}, returning: true,
                         on_conflict: on_conflict, conflict_target: :title)


### PR DESCRIPTION
I was confused when I had `on_conflict: :nothing` and I got back a struct with `id: nil`.

If that behavior is PostgreSQL-specific, is there some other way we can alert people to this?