### PR TITLE
Properly order subqueries in dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * [Ecto.Query] Fix `select_merge` not tracking `load_in_query: false` field
   * [Ecto.Query] Fix field source when used in `json_extract_path`
   * [Ecto.Query] Properly build CTEs at compile time
+  * [Ecto.Query] Properly order subqueries in `dynamic`
   * [Ecto.Repo] Fix `insert_all` query parameter count when using value queries alongside `placeholder`
   * [Ecto.Repo] Raise if combination query is used in a `many` preload
   * [Ecto.Schema] Ignore associations that aren't loaded on insert

--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -17,7 +17,7 @@ defmodule Ecto.Query.Builder.Dynamic do
     quote do
       %Ecto.Query.DynamicExpr{fun: fn query ->
                                 _ = unquote(query)
-                                {unquote(expr), unquote(params), unquote(acc.subqueries)}
+                                {unquote(expr), unquote(params), unquote(Enum.reverse(acc.subqueries))}
                               end,
                               binding: unquote(Macro.escape(binding)),
                               file: unquote(env.file),


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4008.

The issue is that there are 2 ways for there to be multiple subqueries: 

1) more than one subquery inside of a single dynamic
2) more than one dynamic with subqueries

(1) doesn't need its subqueries reversed at the end of `fully_expand` but (2) does. It looks to me like the only way to fix this is to do the triple reverse for (1). 