### PR TITLE
unsafe_validate_unique: raise when embed is used without base query

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -616,7 +616,7 @@ defmodule Ecto.Integration.RepoTest do
     |> Ecto.Changeset.assoc_constraint(:post)
   end
 
-  test "unsafe_validate_unique/3" do
+  test "unsafe_validate_unique/4" do
     {:ok, inserted_post} = TestRepo.insert(%Post{title: "Greetings", visits: 13})
     new_post_changeset = Post.changeset(%Post{}, %{title: "Greetings", visits: 17})
 
@@ -632,7 +632,7 @@ defmodule Ecto.Integration.RepoTest do
     assert changeset.errors[:title] == nil # cannot conflict with itself
   end
 
-  test "unsafe_validate_unique/3 with composite keys" do
+  test "unsafe_validate_unique/4 with composite keys" do
     {:ok, inserted_post} = TestRepo.insert(%CompositePk{a: 123, b: 456, name: "UniqueName"})
 
     different_pk = CompositePk.changeset(%CompositePk{}, %{name: "UniqueName", a: 789, b: 321})

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1900,15 +1900,15 @@ defmodule Ecto.Changeset do
             "unsafe_validate_unique/4 does not work with schemaless changesets, got #{inspect(data)}"
     end
 
-    {validations, schema} =
+    schema =
       case {changeset.data, opts[:query]} do
-        # schema
+        # regular schema
         {%schema{__meta__: %Metadata{}}, _} ->
-          {validations, schema}
+          schema
 
         # embedded schema with base query
         {%schema{}, base_query} when base_query != nil ->
-          {validations, schema}
+          schema
 
         # embedded schema without base query
         {data, _} ->

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1914,7 +1914,7 @@ defmodule Ecto.Changeset do
         {data, _} ->
           raise ArgumentError,
                 "unsafe_validate_unique/4 does not work with embedded schemas unless " <>
-                  "the `:query` option is specified, data received: #{inspect(data)}"
+                  "the `:query` option is specified, got: #{inspect(data)}"
       end
 
     fields = List.wrap(fields)


### PR DESCRIPTION
Related to the reversion of this commit: https://github.com/elixir-ecto/ecto/commit/7b4f016cc2e7a16796a81ac525324bc407ee3324.

My old commit didn't allow embedded schemas when a base query was specified which caused the reported issue. 

It was reported as not working with "schemaless" but that has to be mixed up with embeds because schemaless never worked: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/changeset.ex#L1946