### PR TITLE
Allow selected_as at the root of dynamic/2

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -557,6 +557,18 @@ defmodule Ecto.Query do
 
       from query, select: [:period, :metric], select_merge: ^%{metric: metric}
 
+  Aliasing fields with `selected_as/2` and referencing them with `selected_as/1`
+  is also allowed:
+
+      fields = %{
+        period: dynamic([p], selected_as(p.month, :month)),
+        metric: dynamic([p], p.distance)
+      }
+
+      order = dynamic(selected_as(:month))
+
+      from query, select: ^fields, order_by: ^order
+
   ## Updates
 
   A `dynamic` is also supported inside updates, for example:

--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -27,7 +27,7 @@ defmodule Ecto.Query.Builder.Dynamic do
     end
   end
 
-  defp escape({:selected_as, _, _} = expr, _type, _params_acc, vars, env) do
+  defp escape({:selected_as, _, [_, _]} = expr, _type, _params_acc, vars, env) do
     Select.escape(expr, vars, env)
   end
 

--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -4,6 +4,7 @@ defmodule Ecto.Query.Builder.Dynamic do
   @moduledoc false
 
   alias Ecto.Query.Builder
+  alias Ecto.Query.Builder.Select
 
   @doc """
   Builds a dynamic expression.
@@ -11,13 +12,14 @@ defmodule Ecto.Query.Builder.Dynamic do
   @spec build([Macro.t], Macro.t, Macro.Env.t) :: Macro.t
   def build(binding, expr, env) do
     {query, vars} = Builder.escape_binding(quote(do: query), binding, env)
-    {expr, {params, acc}} = Builder.escape(expr, :any, {[], %{subqueries: []}}, vars, env)
+    {expr, {params, acc}} = escape(expr, :any, {[], %{subqueries: [], aliases: %{}}}, vars, env)
+    aliases = Builder.escape_select_aliases(acc.aliases)
     params = Builder.escape_params(params)
 
     quote do
       %Ecto.Query.DynamicExpr{fun: fn query ->
                                 _ = unquote(query)
-                                {unquote(expr), unquote(params), unquote(Enum.reverse(acc.subqueries))}
+                                {unquote(expr), unquote(params), unquote(Enum.reverse(acc.subqueries)), unquote(aliases)}
                               end,
                               binding: unquote(Macro.escape(binding)),
                               file: unquote(env.file),
@@ -25,11 +27,19 @@ defmodule Ecto.Query.Builder.Dynamic do
     end
   end
 
+  defp escape({:selected_as, _, _} = expr, _type, _params_acc, vars, env) do
+    Select.escape(expr, vars, env)
+  end
+
+  defp escape(expr, type, params_acc, vars, env) do
+    Builder.escape(expr, type, params_acc, vars, env)
+  end
+
   @doc """
   Expands a dynamic expression for insertion into the given query.
   """
   def fully_expand(query, %{file: file, line: line, binding: binding} = dynamic) do
-    {expr, {binding, params, subqueries, _count}} = expand(query, dynamic, {binding, [], [], 0})
+    {expr, {binding, params, subqueries, _aliases, _count}} = expand(query, dynamic, {binding, [], [], %{}, 0})
     {expr, binding, Enum.reverse(params), Enum.reverse(subqueries), file, line}
   end
 
@@ -40,16 +50,16 @@ defmodule Ecto.Query.Builder.Dynamic do
   list is not reversed. This is useful when the dynamic expression
   is given in the middle of an expression.
   """
-  def partially_expand(query, %{binding: binding} = dynamic, params, subqueries, count) do
-    {expr, {_binding, params, subqueries, count}} =
-      expand(query, dynamic, {binding, params, subqueries, count})
+  def partially_expand(query, %{binding: binding} = dynamic, params, subqueries, aliases, count) do
+    {expr, {_binding, params, subqueries, aliases, count}} =
+      expand(query, dynamic, {binding, params, subqueries, aliases, count})
 
-    {expr, params, subqueries, count}
+    {expr, params, subqueries, aliases, count}
   end
 
   def partially_expand(kind, query, %{binding: binding} = dynamic, params, count) do
-    {expr, {_binding, params, subqueries, count}} =
-      expand(query, dynamic, {binding, params, [], count})
+    {expr, {_binding, params, subqueries, _aliases, count}} =
+      expand(query, dynamic, {binding, params, [], %{}, count})
 
     if subqueries != [] do
       raise ArgumentError, "subqueries are not allowed in `#{kind}` expressions"
@@ -58,27 +68,34 @@ defmodule Ecto.Query.Builder.Dynamic do
     {expr, params, count}
   end
 
-  defp expand(query, %{fun: fun}, {binding, params, subqueries, count}) do
-    {dynamic_expr, dynamic_params, dynamic_subqueries} = fun.(query)
+  defp expand(query, %{fun: fun}, {binding, params, subqueries, aliases, count}) do
+    {dynamic_expr, dynamic_params, dynamic_subqueries, dynamic_aliases} = fun.(query)
+    aliases = merge_aliases(aliases, dynamic_aliases)
 
-    Macro.postwalk(dynamic_expr, {binding, params, subqueries, count}, fn
-      {:^, meta, [ix]}, {binding, params, subqueries, count} ->
+    Macro.postwalk(dynamic_expr, {binding, params, subqueries, aliases, count}, fn
+      {:^, meta, [ix]}, {binding, params, subqueries, aliases, count} ->
         case Enum.fetch!(dynamic_params, ix) do
           {%Ecto.Query.DynamicExpr{binding: new_binding} = dynamic, _} ->
             binding = if length(new_binding) > length(binding), do: new_binding, else: binding
-            expand(query, dynamic, {binding, params, subqueries, count})
+            expand(query, dynamic, {binding, params, subqueries, aliases, count})
 
           param ->
-            {{:^, meta, [count]}, {binding, [param | params], subqueries, count + 1}}
+            {{:^, meta, [count]}, {binding, [param | params], subqueries, aliases, count + 1}}
         end
 
-      {:subquery, i}, {binding, params, subqueries, count} ->
+      {:subquery, i}, {binding, params, subqueries, aliases, count} ->
         subquery = Enum.fetch!(dynamic_subqueries, i)
         ix = length(subqueries)
-        {{:subquery, ix}, {binding, [{:subquery, ix} | params], [subquery | subqueries], count + 1}}
+        {{:subquery, ix}, {binding, [{:subquery, ix} | params], [subquery | subqueries], aliases, count + 1}}
 
       expr, acc ->
         {expr, acc}
+    end)
+  end
+
+  defp merge_aliases(old_aliases, new_aliases) do
+    Enum.reduce(new_aliases, old_aliases, fn {alias, _}, aliases ->
+      Builder.add_select_alias(aliases, alias)
     end)
   end
 end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -141,17 +141,17 @@ defmodule Ecto.Query.Builder.SelectTest do
     end
 
     test "supports dynamic selected values with selected_as/2" do
-      escaped_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :alias]}
-      escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :alias2]}
+      escaped_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :alias]}
+      escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :alias2]}
 
       # map
       fields = %{
-        id: dynamic([p], selected_as(p.id, :alias)),
-        id2: dynamic([p], selected_as(p.id, :alias2))
+        title: dynamic([p], selected_as(p.title, :alias)),
+        title2: dynamic([p], selected_as(p.title, :alias2))
       }
 
       query = from p in "posts", select: ^fields
-      assert {:%{}, [], [id: escaped_alias, id2: escaped_alias2]} == query.select.expr
+      assert {:%{}, [], [title: escaped_alias, title2: escaped_alias2]} == query.select.expr
       assert %{alias: _, alias2: _} = query.select.aliases
 
       # struct
@@ -160,11 +160,11 @@ defmodule Ecto.Query.Builder.SelectTest do
       }
 
       query = from p in "posts", select: ^fields
-      assert {:%{}, [], [{:|, [], [{:&, [], [0]}, [id: escaped_alias]]}]}
+      assert {:%, [], [_, {:%{}, [], [title: escaped_alias]}]} = query.select.expr
       assert %{alias: _} = query.select.aliases
 
       # single field
-      field = dynamic([p], selected_as(p.id, :alias))
+      field = dynamic([p], selected_as(p.title, :alias))
       query = from p in "posts", select: ^field
       assert escaped_alias == query.select.expr
       assert %{alias: _} = query.select.aliases

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -145,12 +145,10 @@ defmodule Ecto.Query.Builder.SelectTest do
       escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :alias2]}
 
       # map
-      fields = %{
-        title: dynamic([p], selected_as(p.title, :alias)),
-        title2: dynamic([p], selected_as(p.title, :alias2))
-      }
+      select_fields = %{title: dynamic([p], selected_as(p.title, :alias))}
+      merge_fields = %{title2: dynamic([p], selected_as(p.title, :alias2))}
 
-      query = from p in "posts", select: ^fields
+      query = from p in "posts", select: ^select_fields, select_merge: ^merge_fields
       assert {:%{}, [], [title: escaped_alias, title2: escaped_alias2]} == query.select.expr
       assert %{alias: _, alias2: _} = query.select.aliases
 

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -140,6 +140,36 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert %{select: _, merge: _} = query.select.aliases
     end
 
+    test "supports dynamic selected values with selected_as/2" do
+      escaped_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :alias]}
+      escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :alias2]}
+
+      # map
+      fields = %{
+        id: dynamic([p], selected_as(p.id, :alias)),
+        id2: dynamic([p], selected_as(p.id, :alias2))
+      }
+
+      query = from p in "posts", select: ^fields
+      assert {:%{}, [], [id: escaped_alias, id2: escaped_alias2]} == query.select.expr
+      assert %{alias: _, alias2: _} = query.select.aliases
+
+      # struct
+      fields = %Post{
+        title: dynamic([p], selected_as(p.title, :alias)),
+      }
+
+      query = from p in "posts", select: ^fields
+      assert {:%{}, [], [{:|, [], [{:&, [], [0]}, [id: escaped_alias]]}]}
+      assert %{alias: _} = query.select.aliases
+
+      # single field
+      field = dynamic([p], selected_as(p.id, :alias))
+      query = from p in "posts", select: ^field
+      assert escaped_alias == query.select.expr
+      assert %{alias: _} = query.select.aliases
+    end
+
     test "raises if name given to selected_as/2 is not an atom" do
       message = "selected_as/2 expects `name` to be an atom, got `\"ident\"`"
 

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1753,6 +1753,16 @@ defmodule Ecto.Query.PlannerTest do
       end
     end
 
+    test "with dynamic/2" do
+      fields = %{
+        id: dynamic([p], selected_as(p.id, :alias)),
+        id2: dynamic([p], selected_as(p.id, :alias2))
+      }
+
+      order = dynamic(selected_as(:alias))
+      from(p in "posts", select: ^fields, order_by: ^order) |> normalize()
+    end
+
     test "raises if selected_as/2 is used in a subquery" do
       message = ~r"`selected_as/2` can only be used in the outer most `select` expression."
 


### PR DESCRIPTION
This can probably be extended to subqueries as well but will look into that later.