### PR TITLE
Ensure that join_where conditions preload correctly

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1272,7 +1272,7 @@ defmodule Ecto.Association.ManyToMany do
       where: field(j, ^join_owner_key) in type(^values, {:in, ^owner_key_type})
     )
     |> Ecto.Association.combine_assoc_query(assoc.where)
-    |> Ecto.Association.combine_joins_query(assoc.join_where, 1)
+    |> then(&Ecto.Association.combine_joins_query(&1, assoc.join_where, length(&1.joins)))
   end
 
   @impl true

--- a/test/ecto/repo/many_to_many_test.exs
+++ b/test/ecto/repo/many_to_many_test.exs
@@ -65,6 +65,20 @@ defmodule Ecto.Repo.ManyToManyTest do
     end
   end
 
+  test "handles join_where when preloading with joins" do
+    import Ecto.Query
+
+    schema = %MySchema{id: 1}
+
+    bad_assocs_query = from(a in MyAssoc, join: sa in assoc(a, :sub_assoc), on: sa.y == ^"foo")
+
+    TestRepo.preload(schema, where_assocs: {bad_assocs_query, [:sub_assoc]})
+
+    assert_received {:all, %Ecto.Query{joins: [_, %{on: %{expr: expr}}]}}
+
+    assert "&0.id() == &2.my_assoc_id() and &2.public() == ^1" == Macro.to_string(expr)
+  end
+
   test "handles assocs on insert" do
     sample = %MyAssoc{x: "xyz"}
 


### PR DESCRIPTION
Every other place that `Ecto.Association.combine_joins_query` is called, the `Ecto.Query` it is called with contains `joins` against a fixed "base" queryable (usually `owner`). In those cases, a fixed value of `binding` is correct.

However, in the specific case of:
* a many-to-many with a `join_where` clause
* being preloaded with a query that contains one or many `joins`

the actual `binding` value desired is "the last one added" in `assoc_query`, so that the `join_where` query correctly references the join table.

Without this change, the `TestRepo.preload` call in the new test fails with the message:

```
** (Ecto.QueryError) lib/ecto/association.ex:1270: field `public` in `join` does not exist in schema Ecto.Repo.ManyToManyTest.SubAssoc in query:

from m0 in Ecto.Repo.ManyToManyTest.MyAssoc,
  join: s1 in Ecto.Repo.ManyToManyTest.SubAssoc,
  on: s1.my_assoc_id == m0.id and s1.y == ^"foo",
  join: s2 in "schemas_assocs",
  on: m0.id == s2.my_assoc_id and s1.public == ^true,
  where: s2.my_schema_id in ^[1],
  order_by: [asc: type(s2.my_schema_id, :id)],
  select: {type(s2.my_schema_id, :id), m0}
```