### PR TITLE
Clarify how the equal?/2 callback is used

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -248,6 +248,9 @@ defmodule Ecto.Type do
 
   @doc """
   Checks if two terms are semantically equal.
+
+  This callback is used for determining equality of types in
+  `Ecto.Changeset`.
   """
   @callback equal?(term, term) :: boolean
 


### PR DESCRIPTION
I'm working on a custom ecto type for postgres `range` types, and I wanted to better understand how `equal?/2` would be used. Knowing this sent me down the right path :) 

It was also helpful to read https://github.com/elixir-ecto/ecto/pull/2651/files