### PR TITLE
Respect nil struct in through preloads

### DIFF
--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -212,6 +212,11 @@ defmodule Ecto.Integration.PreloadTest do
     assert c.post_permalink == nil
   end
 
+  test "preload through with nil struct" do
+    %Comment{} = c = TestRepo.insert!(%Comment{})
+    [%Comment{}, nil] = TestRepo.preload([c, nil], [:post, :post_permalink])
+  end
+
   test "preload has_many through-through" do
     %Post{id: pid1} = TestRepo.insert!(%Post{})
     %Post{id: pid2} = TestRepo.insert!(%Post{})

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -402,6 +402,10 @@ defmodule Ecto.Repo.Preloader do
     Map.put(struct, field, loaded)
   end
 
+  defp load_through({:through, _assoc, _throughs}, nil) do
+    nil
+  end
+
   defp load_through({:through, assoc, throughs}, struct) do
     %{cardinality: cardinality, field: field, owner: owner} = assoc
     {loaded, _} = Enum.reduce(throughs, {[struct], owner}, &recur_through/2)


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4029.

The issue is that you might try to preload a through association on `nil` instead of a struct. There is a similar guard for regular assocs: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/preloader.ex#L387