### PR TITLE
Allow selected_as to be used in subquery

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -727,17 +727,18 @@ defmodule Ecto.Query.API do
 
   ## Subqueries
 
-  When used inside of a subquery, the alias given to `selected_as/2` must be referenced
-  by the outer query. For example, the outer query below selects `s.num_visits` instead of
-  `s.visits`:
+  Subqueries automatically alias the selected fields, for example, one can write:
 
-      s = from p in Post, select: %{visits: p.visits |> coalesce(0) |> selected_as(:num_visits)}
+      s = from p in Post, select: %{visits: coalesce(p.visits, 0)}
+      from(s in subquery(s), select: s.visits)
+
+  However, one can also use `selected_as` to override the default naming:
+
+      s = from p in Post, select: %{visits: coalesce(p.visits, 0) |> selected_as(:num_visits)}
       from(s in subquery(s), select: s.num_visits)
 
-  This is because queries must reference the fields of the query source and not the
-  Elixir data structure. In some circumstances, such as a subquery without `selected_as/2`,
-  these two are the same. This does not hold true when the user modifies the names of the fields
-  using `selected_as/2`.
+  The name given to `selected_as/2` can also be referenced in `selected_as/1`,
+  as in regular queries.
   """
   def selected_as(selected_value, name), do: doc! [selected_value, name]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -697,8 +697,6 @@ defmodule Ecto.Query.API do
   If an error is raised mentioning an unknown column, most likely the alias is being
   referenced somewhere that is not allowed. Consult the documentation for the database
   to ensure the alias is being referenced correctly.
-
-
   """
   def selected_as(name), do: doc! [name]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -697,6 +697,8 @@ defmodule Ecto.Query.API do
   If an error is raised mentioning an unknown column, most likely the alias is being
   referenced somewhere that is not allowed. Consult the documentation for the database
   to ensure the alias is being referenced correctly.
+
+
   """
   def selected_as(name), do: doc! [name]
 
@@ -724,6 +726,20 @@ defmodule Ecto.Query.API do
 
   Using this in conjunction with `selected_as/1` is recommended to ensure only defined aliases
   are referenced.
+
+  ## Subqueries
+
+  When used inside of a subquery, the alias given to `selected_as/2` must be referenced
+  by the outer query. For example, the outer query below selects `s.num_visits` instead of
+  `s.visits`:
+
+      s = from p in Post, select: %{visits: p.visits |> coalesce(0) |> selected_as(:num_visits)}
+      from(s in subquery(s), select: s.num_visits)
+
+  This is because queries must reference the fields of the query source and not the
+  Elixir data structure. In some circumstances, such as a subquery without `selected_as/2`,
+  these two are the same. This does not hold true when the user modifies the names of the fields
+  using `selected_as/2`.
   """
   def selected_as(selected_value, name), do: doc! [selected_value, name]
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -329,8 +329,8 @@ defmodule Ecto.Query.Planner do
   defp normalize_subquery_types([{source_alias, type_value} | types], [field | fields], select_aliases, acc) do
     if Map.has_key?(select_aliases, source_alias) do
       raise ArgumentError, """
-      the alias, #{inspect(source_alias)}, provided to `selected_as/2`
-      conflicts with the subquery's automatically aliasing.
+      the alias, #{inspect(source_alias)}, provided to `selected_as/2` conflicts 
+      with the subquery's automatically aliasing.
 
       For example, the following query is not allowed because the alias `:y`
       given to `selected_as/2` is also used by the subquery to automatically

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1376,8 +1376,6 @@ defmodule Ecto.Query.Planner do
       collect_fields(expr, [], :none, query, take, keep_literals?, %{})
 
     # Convert selected_as/2 to a tuple so it can be aliased by the adapters.
-    # Don't convert if the select expression belongs to a CTE or subquery
-    # because those fields are already automatically aliased.
     fields = normalize_selected_as(fields, select.aliases)
 
     {fields, preprocess, from} =

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -330,12 +330,11 @@ defmodule Ecto.Query.Planner do
     if Map.has_key?(select_aliases, source_alias) do
       raise ArgumentError, """
       the alias, #{inspect(source_alias)}, provided to `selected_as/2`
-      conflicts with the subquery's automatically aliasing. Please ensure
-      the aliases provided to `selected_as/2` do not overlap with the identifiers
-      of different fields.
+      conflicts with the subquery's automatically aliasing.
 
-      For instance, the following query is not allowed because the alias `:y`
-      used in `selected_as/2` is the same as another field's key:
+      For example, the following query is not allowed because the alias `:y`
+      given to `selected_as/2` is also used by the subquery to automatically
+      alias `s.y`:
 
         s = from(s in Schema, select: %{x: selected_as(s.x, :y), y: s.y})
         from s in subquery(s)

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -307,8 +307,50 @@ defmodule Ecto.Query.Planner do
   defp normalize_subquery_select(query, adapter, source?) do
     {schema_or_source, expr, %{select: select} = query} = rewrite_subquery_select_expr(query, source?)
     {expr, _} = prewalk(expr, :select, query, select, 0, adapter)
-    {{:map, types}, _fields, _from} = collect_fields(expr, [], :never, query, select.take, true, %{})
+    {{:map, types}, fields, _from} = collect_fields(expr, [], :never, query, select.take, true, %{})
+    # types must take into account selected_as/2 aliases so that the correct fields are
+    # referenced when the outer query selects the entire subquery
+    types = normalize_subquery_types(types, Enum.reverse(fields), query.select.aliases, [])
     {query, subquery_source(schema_or_source, types)}
+  end
+
+  defp normalize_subquery_types(types, _fields, select_aliases, _acc) when select_aliases == %{} do
+    types
+  end
+
+  defp normalize_subquery_types([], [], _aliases, acc) do
+    Enum.reverse(acc)
+  end
+
+  defp normalize_subquery_types([{alias, _} = type | types], [{:selected_as, _, [_, alias]} | fields], select_aliases, acc) do
+    normalize_subquery_types(types, fields, select_aliases, [type | acc])
+  end
+
+  defp normalize_subquery_types([{source_alias, type_value} | types], [field | fields], select_aliases, acc) do
+    if Map.has_key?(select_aliases, source_alias) do
+      raise ArgumentError, """
+      the alias, #{inspect(source_alias)}, provided to `selected_as/2` conflicts with the subquery's
+      `select` statement. Please ensure there is no overlap between the aliases provided to
+      `selected_as/2` and the identifiers used in the `select` statement.
+
+      For instance, the following query is not allowed because the alias `:x2` used in `selected_as/2`
+      is the same as another key in the map being selected:
+
+        s = from(s in Schema, select: %{x: selected_as(s.x, :x2), x2: s.x})
+        from s in subquery(s)
+
+      If the alias provided to `selected_as/2` is changed to any atom other than `:x2`, the above query will work.
+      The alias `:x` would also be allowed because it is the key corresponding to the `selected_as/2` value.
+      """
+    end
+
+    type =
+      case field do
+        {:selected_as, _, [_, select_alias]} -> {select_alias, type_value}
+        _ -> {source_alias, type_value}
+      end
+
+    normalize_subquery_types(types, fields, select_aliases, [type | acc])
   end
 
   defp subquery_source(nil, types), do: {:map, types}
@@ -937,7 +979,7 @@ defmodule Ecto.Query.Planner do
     query
     |> normalize_query(operation, adapter, counter)
     |> elem(0)
-    |> normalize_select(keep_literals?(operation, query), true)
+    |> normalize_select(keep_literals?(operation, query))
   rescue
     e ->
       # Reraise errors so we ignore the planner inner stacktrace
@@ -1055,7 +1097,7 @@ defmodule Ecto.Query.Planner do
     {combinations, counter} =
       Enum.reduce combinations, {[], counter}, fn {type, combination_query}, {combinations, counter} ->
         {combination_query, counter} = traverse_exprs(combination_query, operation, counter, fun)
-        {combination_query, _} = combination_query |> normalize_select(true, true)
+        {combination_query, _} = combination_query |> normalize_select(true)
         {[{type, combination_query} | combinations], counter}
       end
 
@@ -1096,7 +1138,7 @@ defmodule Ecto.Query.Planner do
     try do
       inner_query = put_in inner_query.aliases[@parent_as], query
       {inner_query, counter} = normalize_query(inner_query, :all, adapter, counter)
-      {inner_query, _} = normalize_select(inner_query, true, false)
+      {inner_query, _} = normalize_select(inner_query, true)
       {_, inner_query} = pop_in(inner_query.aliases[@parent_as])
 
       inner_query =
@@ -1105,7 +1147,15 @@ defmodule Ecto.Query.Planner do
           inner_query
         else
           update_in(inner_query.select.fields, fn fields ->
-            subquery.select |> subquery_source_fields() |> Enum.zip(fields)
+            # fields are aliased by the subquery source, unless
+            # already aliased by selected_as/2
+            subquery.select
+            |> subquery_source_fields()
+            |> Enum.zip(fields)
+            |> Enum.map(fn
+              {_source_alias, {select_alias, field}} -> {select_alias, field}
+              {source_alias, field} -> {source_alias, field}
+            end)
           end)
         end
 
@@ -1299,11 +1349,11 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp normalize_select(%{select: nil} = query, _keep_literals?, _allow_alias?) do
+  defp normalize_select(%{select: nil} = query, _keep_literals?) do
     {query, nil}
   end
 
-  defp normalize_select(query, keep_literals?, allow_alias?) do
+  defp normalize_select(query, keep_literals?) do
     %{assocs: assocs, preloads: preloads, select: select} = query
     %{take: take, expr: expr} = select
     {tag, from_take} = Map.get(take, 0, {:any, []})
@@ -1328,7 +1378,7 @@ defmodule Ecto.Query.Planner do
     # Convert selected_as/2 to a tuple so it can be aliased by the adapters.
     # Don't convert if the select expression belongs to a CTE or subquery
     # because those fields are already automatically aliased.
-    fields = normalize_selected_as(fields, allow_alias?, select.aliases)
+    fields = normalize_selected_as(fields, select.aliases)
 
     {fields, preprocess, from} =
       case from do
@@ -1356,17 +1406,9 @@ defmodule Ecto.Query.Planner do
     {put_in(query.select.fields, fields), select}
   end
 
-  defp normalize_selected_as(fields, _allow_alias?, aliases) when aliases == %{}, do: fields
+  defp normalize_selected_as(fields, aliases) when aliases == %{}, do: fields
 
-  defp normalize_selected_as(_fields, false, aliases) do
-    raise ArgumentError,
-          "`selected_as/2` can only be used in the outer most `select` expression. " <>
-            "If you are attempting to alias a field from a subquery or cte, it is not allowed " <>
-            "because the fields are automatically aliased by the corresponding map/struct key. " <>
-            "The following field aliases were specified: #{inspect(Map.keys(aliases))}."
-  end
-
-  defp normalize_selected_as(fields, true, _aliases) do
+  defp normalize_selected_as(fields, _aliases) do
     Enum.map(fields, fn
       {:selected_as, _, [select_expr, name]} -> {name, select_expr}
       field -> field

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -329,18 +329,16 @@ defmodule Ecto.Query.Planner do
   defp normalize_subquery_types([{source_alias, type_value} | types], [field | fields], select_aliases, acc) do
     if Map.has_key?(select_aliases, source_alias) do
       raise ArgumentError, """
-      the alias, #{inspect(source_alias)}, provided to `selected_as/2` conflicts with the subquery's
-      `select` statement. Please ensure there is no overlap between the aliases provided to
-      `selected_as/2` and the identifiers used in the `select` statement.
+      the alias, #{inspect(source_alias)}, provided to `selected_as/2`
+      conflicts with the subquery's automatically aliasing. Please ensure
+      the aliases provided to `selected_as/2` do not overlap with the identifiers
+      of different fields.
 
-      For instance, the following query is not allowed because the alias `:x2` used in `selected_as/2`
-      is the same as another key in the map being selected:
+      For instance, the following query is not allowed because the alias `:y`
+      used in `selected_as/2` is the same as another field's key:
 
-        s = from(s in Schema, select: %{x: selected_as(s.x, :x2), x2: s.x})
+        s = from(s in Schema, select: %{x: selected_as(s.x, :y), y: s.y})
         from s in subquery(s)
-
-      If the alias provided to `selected_as/2` is changed to any atom other than `:x2`, the above query will work.
-      The alias `:x` would also be allowed because it is the key corresponding to the `selected_as/2` value.
       """
     end
 

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -449,6 +449,16 @@ defmodule Ecto.Query.InspectTest do
     assert i(query) == ~s{from p0 in Inspect.Post, select: type(^..., :integer)}
   end
 
+  test "subquery with selected_as/2 after planner" do
+    query =
+      from(x in Post, select: %{visits: selected_as(x.visits, :visits2)})
+      |> subquery()
+      |> plan
+
+
+    assert i(query) =~ ~s"select: %{visits: selected_as(p0.visits, :visits2)})"
+  end
+
   defmodule MyParameterizedType do
     use Ecto.ParameterizedType
 

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -455,7 +455,6 @@ defmodule Ecto.Query.InspectTest do
       |> subquery()
       |> plan
 
-
     assert i(query) =~ ~s"select: %{visits: selected_as(p0.visits, :visits2)})"
   end
 


### PR DESCRIPTION
This addresses the concern raised in https://github.com/elixir-ecto/ecto/issues/4033. 

I'm not sure how desirable this change is, but wanted to put it out there for feedback. I think the issue reporter has a valid point about re-using the same query inside and outside of a subquery. But it's not the cleanest change to make it work.

The idea is that the subquery tracks which of its fields are aliased and then `collect_fields` and `source_take!` will swap them. This is for better UX so that the user can always use the map/keyword list key to reference the subquery fields from the outer query.

Since the change is kind of dirty I won't fuss if it's rejected :).