### PR TITLE
Fix select merging a selected_as field into a source

### DIFF
--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -133,11 +133,17 @@ defmodule Ecto.Query.Builder.SelectTest do
 
     test "supports aliasing a selected value in select_merge with selected_as/2" do
       escaped_select_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :visits]}, [], []}, :select]}
-      escaped_merge_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :merge]}
+      escaped_merge_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :merge]}
 
-      query = from p in "posts", select: selected_as(p.visits, :select), select_merge: %{id: selected_as(p.id, :merge)}
-      assert {:merge, [], [escaped_select_alias, {:%{}, [], [id: escaped_merge_alias]}]} == query.select.expr
+      # merging into a map
+      query = from p in "posts", select: %{v: selected_as(p.visits, :select)}, select_merge: %{title: selected_as(p.title, :merge)}
+      assert {:%{}, [], [v: escaped_select_alias, title: escaped_merge_alias]} == query.select.expr
       assert %{select: _, merge: _} = query.select.aliases
+
+      # merging into a source
+      query = from c in Comment, select_merge: %{title: selected_as(c.title, :merge)}
+      assert {:merge, [], [{:&, [], [0]}, {:%{}, [], [title: escaped_merge_alias]}]} == query.select.expr
+      assert %{merge: _} = query.select.aliases
     end
 
     test "supports dynamic selected values with selected_as/2" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1782,6 +1782,23 @@ defmodule Ecto.Query.PlannerTest do
       assert [^field1, ^field2] = select.fields
     end
 
+    test "with select_merge" do
+      # merging into a map
+      query =
+        from(p in Post,
+          select: %{id: p.id},
+          select_merge: %{title: selected_as(p.title, :alias)}
+        )
+        |> normalize()
+
+      assert [{:alias, _} | _] = Enum.reverse(query.select.fields)
+
+      # merging into a source
+      query = from(p in Post, select_merge: %{title: selected_as(p.title, :alias)}) |> normalize()
+      assert [{:alias, _} | _] = Enum.reverse(query.select.fields)
+    end
+
+
     test "raises when subquery key conflicts with selected_as/2 alias" do
       message = ~r"the alias, :integer, provided to `selected_as/2` conflicts"
 


### PR DESCRIPTION
Fixes the issue reported in this comment: https://github.com/elixir-ecto/ecto/issues/4011#issuecomment-1300389141.

The problem was with using select_merge into a source. I wasn't normalizing the `take` values from the source but they can contain selected_as if merged into.