### PR TITLE
docs(Ecto.Repo): Inform that measurements may, but don't have to, be present

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -142,7 +142,7 @@ defmodule Ecto.Repo do
   This event should be invoked on every query sent to the adapter, including
   queries that are related to the transaction management.
 
-  The `:measurements` map will include the following, all given in the
+  The `:measurements` map may include the following, all given in the
   `:native` time unit:
 
     * `:idle_time` - the time the connection spent waiting before being checked out for the query


### PR DESCRIPTION


As described in https://github.com/elixir-ecto/ecto/issues/3405 , measurements like `:idle_time` may be nil. Documentation currently doesn't mention it. It gives impression that it those measurements are always present (that they are never `nil`).