### PR TITLE
Add small clarification to Ecto.Query docs

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -32,7 +32,8 @@ defmodule Ecto.Query do
       Repo.all(query)
 
   In the example above, we are directly querying the "users" table
-  from the database.
+  from the database. Queries do not reach out to the data store until
+  they are passed as arguments to a function from `Ecto.Repo`.
 
   ## Query expressions
 


### PR DESCRIPTION
This makes sense to me, not sure if this makes sense to other people. LMK if this makes sense.

## Motivation

I was trying to find out if Ecto.Query functions would query the DB. Some examples call `Repo` functions so they imply that `Repo` must be used but it isn't too explicit. For instance `Ecto.Query.preload/3` has this description:

> Preloads the associations into the result set.

which sounds a lot like `Ecto.Repo.preload/3`

> Preloads the associations into the result set.

`Ecto.Repo.preload/3` also includes this bit, which makes sense but not while doubting whether Query.preload will fetch or not.

> This is similar to [Ecto.Query.preload/3](https://hexdocs.pm/ecto/Ecto.Query.html#preload/3) except it allows you to preload structs after they have been fetched from the database.