### PR TITLE
keep url scheme

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -100,6 +100,7 @@ defmodule Ecto.Repo.Supervisor do
     "/" <> database = info.path
 
     url_opts = [
+      scheme: info.scheme,
       username: username,
       password: password,
       database: database,

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -19,7 +19,7 @@ defmodule Ecto.Repo.SupervisorTest do
   test "invokes the init/2 callback on config" do
     assert Ecto.TestRepo.config() |> normalize() ==
            [database: "hello", hostname: "local", otp_app: :ecto, password: "pass",
-            user: "invalid", username: "user"]
+            scheme: "ecto", user: "invalid", username: "user"]
   end
 
   def handle_event(event, measurements, metadata, %{pid: pid}) do
@@ -55,13 +55,13 @@ defmodule Ecto.Repo.SupervisorTest do
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, [extra: "extra"])
     assert normalize(config) ==
            [database: "mydb", extra: "extra", hostname: "host",
-            otp_app: :ecto, password: "hunter2", port: 12345, username: "eric"]
+            otp_app: :ecto, password: "hunter2", port: 12345, scheme: "ecto", username: "eric"]
   end
 
   test "ignores empty hostname" do
     put_env(database: "hello", url: "ecto:///mydb")
     {:ok, config} = runtime_config(:runtime, __MODULE__, :ecto, extra: "extra")
-    assert normalize(config) == [database: "mydb", extra: "extra", otp_app: :ecto]
+    assert normalize(config) == [database: "mydb", extra: "extra", otp_app: :ecto, scheme: "ecto"]
   end
 
   test "is no-op for nil or empty URL" do


### PR DESCRIPTION
Clickhouse Ecto adapter uses HTTP to connect to the database where the scheme (http or https) is important to know. Right now [small hacks](https://github.com/plausible/analytics/pull/2427) are required to work around the missing scheme information when configuring the adapter with `:url`.