### PR TITLE
Reset fields in a struct

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -571,6 +571,27 @@ defmodule Ecto do
   def assoc_loaded?(nil), do: true
 
   @doc """
+  Resets fields in a struct to their default values.
+
+  ## Examples
+
+      iex> post = post |> Repo.preload(:author)
+      %Post{title: "hello world", author: %Author{}}
+      iex> Ecto.reset_fields(post, [:title, :author])
+      %Post{
+        title: "default title",
+        author: #Ecto.Association.NotLoaded<association :author is not loaded>
+      }
+
+  """
+  @spec reset_fields(Ecto.Schema.t(), list()) :: Ecto.Schema.t()
+  def reset_fields(%{__struct__: schema} = struct, fields) do
+    default_struct = schema.__struct__()
+    default_fields = Map.take(default_struct, fields)
+    Map.merge(struct, default_fields)
+  end
+
+  @doc """
   Gets the metadata from the given struct.
   """
   def get_meta(struct, :context),

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2191,6 +2191,8 @@ defmodule Ecto.Query do
       function, the function will receive a list of "post_ids" as the argument
       and it must return a tuple in the format of `{post_id, tag}`
 
+  If you want to reset the loaded fields, see `Ecto.reset_fields/2`.
+
   ## Keywords example
 
       # Returns all posts, their associated comments, and the associated

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -952,6 +952,8 @@ defmodule Ecto.Repo do
   In case the association was already loaded, preload won't attempt
   to reload it.
 
+  If you want to reset the loaded fields, see `Ecto.reset_fields/2`.
+
   ## Options
 
     * `:force` - By default, Ecto won't preload associations that

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -109,4 +109,51 @@ defmodule EctoTest do
 
     query
   end
+
+  defmodule Post do
+    use Ecto.Schema
+
+    schema "posts" do
+      field :title, :string, default: "default title"
+      field :body, :string
+      belongs_to :author, Author
+    end
+  end
+
+  defmodule Author do
+    use Ecto.Schema
+
+    schema "authors" do
+      field :name, :string
+      has_many :posts, Post
+    end
+  end
+
+  test "Ecto.reset_fields/2 resets fields" do
+    post = %Post{
+      title: "hello world",
+      body: "This is a beautiful world.",
+      author: %Author{},
+    }
+
+    assert %Post{
+             title: "default title",
+             body: "This is a beautiful world.",
+             author: build_not_loaded(Post, :author),
+           } == Ecto.reset_fields(post, [:title, :author])
+  end
+
+  defp build_not_loaded(schema, association) do
+    %{
+      cardinality: cardinality,
+      field: field,
+      owner: owner
+    } = schema.__schema__(:association, association)
+
+    %Ecto.Association.NotLoaded{
+      __cardinality__: cardinality,
+      __field__: field,
+      __owner__: owner
+    }
+  end
 end


### PR DESCRIPTION
In case I go too far down the wrong path, I created a **a preview version** of [PROPOSAL - Reverse the preload operation](https://groups.google.com/g/elixir-ecto/c/ZiBUdqB9snQ) in this PR.

> When the implementation is solid, I will create more docs and tests.

---

I have several questions about this PR.

1. Is there a better way to get the default value of a field? [Current implementation](https://github.com/elixir-ecto/ecto/pull/4053/files#diff-e87892b8525e7873f0a7a7b05d8c63f759eca40941a8da7755b29c607849664dR610) works, but I don't think it is a good one.

2. `Ecto.Schema` is distinguishing **fields** from **associations**. For example, in the [Reflection section](https://hexdocs.pm/ecto/Ecto.Schema.html#module-reflection), `__schema__(:fields)` and `__schema__(:associations)` are different things. Although @josevalim  said `reset_fields` is more general name, I think it is blurring the boundary between **fields** and **associations**. I'm in a mess, help me, please.