### PR TITLE
Don't wrap changes to embeds in a transaction

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -980,10 +980,10 @@ defmodule Ecto.Repo.Schema do
     end
   end
 
-  defp wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fun) do
+  defp wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, _embeds, prepare, fun) do
     %{changes: changes} = changeset
     changed = &Map.has_key?(changes, &1)
-    relations_changed? = Enum.any?(assocs, changed) or Enum.any?(embeds, changed)
+    relations_changed? = Enum.any?(assocs, changed)
     wrap_in_transaction(adapter, adapter_meta, opts, relations_changed?, prepare, fun)
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1357,7 +1357,7 @@ defmodule Ecto.RepoTest do
 
       %MySchemaEmbedsMany{embeds: [embed]} = TestRepo.insert!(changeset)
       assert embed.x == "ONE"
-      assert_received {:transaction, _}
+      assert_received {:insert, _}
       assert Process.get(:ecto_repo) == TestRepo
       assert Process.get(:ecto_counter) == 2
     end


### PR DESCRIPTION
Hi all,

I came across this line while attempting to discover why Ecto is wrapping some inserts in a transaction.

As far as I can tell, inserting or updating an embed should always be a single row insert / update, and therefore does not require a transaction.

Or am I missing something?