### PR TITLE
Remove double repetition of word in docs of Ecto.Repo

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1883,7 +1883,7 @@ defmodule Ecto.Repo do
   transaction won't be part of the same transaction and will use a separate
   connection altogether.
 
-  When using the the `Ecto.Adapters.SQL.Sandbox` in tests, while it may be
+  When using the `Ecto.Adapters.SQL.Sandbox` in tests, while it may be
   possible to share the connection between processes, the parent process
   will typically hold the connection until the transaction completes. This
   may lead to a deadlock if the child process attempts to use the same connection.


### PR DESCRIPTION
I was reading through the docs of Ecto.Repo.transaction/2 and saw that a `the` article was duplicated. I just removed it