### PR TITLE
Add support for dynamics in query preloads

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -570,7 +570,7 @@ defmodule Ecto.Query do
 
       from query, select: ^fields, order_by: ^order
 
-  ## Updates
+  ## `update`
 
   A `dynamic` is also supported inside updates, for example:
 
@@ -579,6 +579,42 @@ defmodule Ecto.Query do
       ]
 
       from query, update: ^updates
+
+  ## `preload`
+
+  Dynamics can be used with `preload` in order to dynamically
+  specify the binding for a joined association. For example, you can
+  write:
+
+      preloads = [
+        :non_joined_assoc,
+        joined_assoc: dynamic([joined: j], j)
+      ]
+
+      from query, preload: ^preloads
+
+  As with `where` and friends, it is not possible to pass dynamics
+  outside of an interpolated root. For example, this won't work:
+
+      from query, preload: [comments: ^dynamic(...)]
+
+  But this will:
+
+      from query, preload: ^[comments: dynamic(...)]
+
+  Dynamic expressions used in `preload` must evaluate to a single
+  binding. For instance, this won't work:
+
+      preloads = dynamic([comments: c, likes: l], [comments: {c, likes: l}])
+
+  But this will:
+
+      dynamic_comments = dynamic([comments: c], c)
+      dynamic_likes = dynamic([likes: l], l)
+
+      preloads = [
+        comments: {dynamic_comments, likes: dynamic_likes}
+      ]
   """
   defmacro dynamic(binding \\ [], expr) do
     Builder.Dynamic.build(binding, expr, __CALLER__)
@@ -2114,6 +2150,19 @@ defmodule Ecto.Query do
                    select: [:id]
                  ), on: top_five.id == c.id,
                  preload: [comments: c]
+
+  Preloaded joins can also be specified dynamically using `dynamic`:
+
+      preloads = [comments: dynamic([comments: c], c)]
+
+      Repo.all from p in Post,
+                 join: c in assoc(p, :comments),
+                 as: :comments,
+                 where: c.published_at > p.updated_at,
+                 preload: ^preloads
+
+  See "`preload`" in the documentation for `dynamic/2` for more
+  details.
 
   ## Preload queries
 

--- a/lib/ecto/query/builder/preload.ex
+++ b/lib/ecto/query/builder/preload.ex
@@ -88,6 +88,7 @@ defmodule Ecto.Query.Builder.Preload do
     idx = Builder.find_var!(var, vars)
     {inner_preloads, inner_assocs} = escape(list, :assoc, [], [], vars)
     assocs = [{key, {idx, Enum.reverse(inner_assocs)}}|assocs]
+
     case inner_preloads do
       [] -> {preloads, assocs}
       _  -> {[{key, Enum.reverse(inner_preloads)}|preloads], assocs}
@@ -116,12 +117,6 @@ defmodule Ecto.Query.Builder.Preload do
     Builder.error! "malformed key in preload `#{Macro.to_string(other)}` in query expression"
   end
 
-  defp assert_assoc!(mode, _atom, _var) when mode in [:both, :assoc], do: :ok
-  defp assert_assoc!(_mode, atom, var) do
-    Builder.error! "cannot preload join association `#{Macro.to_string atom}` with binding `#{var}` " <>
-                   "because parent preload is not a join association"
-  end
-
   @doc """
   Called at runtime to check dynamic preload keys.
   """
@@ -140,6 +135,12 @@ defmodule Ecto.Query.Builder.Preload do
   runtime work.
   """
   @spec build(Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  def build(query, _binding, {:^, _, [expr]}, _env) do
+    quote do
+      Ecto.Query.Builder.Preload.preload!(unquote(query), unquote(expr))
+    end
+  end
+
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {preloads, assocs} = escape(expr, binding)
@@ -155,5 +156,127 @@ defmodule Ecto.Query.Builder.Preload do
   end
   def apply(query, preloads, assocs) do
     apply(Ecto.Queryable.to_query(query), preloads, assocs)
+  end
+
+  @doc """
+  Called at runtime to assemble preload.
+  """
+  def preload!(query, preload) do
+    {preloads, assocs} = expand(preload, query)
+    apply(query, Enum.reverse(preloads), Enum.reverse(assocs))
+  end
+
+  @doc """
+  Expands preloads at runtime.
+  """
+  def expand(preloads, query) do
+    expand(preloads, query, :both, [], [])
+  end
+
+  defp expand(atom, _query, _mode, preloads, assocs) when is_atom(atom) do
+    {[atom|preloads], assocs}
+  end
+
+  defp expand(list, query, mode, preloads, assocs) when is_list(list) do
+    Enum.reduce(list, {preloads, assocs}, fn item, acc ->
+      expand_each(item, query, mode, acc)
+    end)
+  end
+
+  defp expand(other, _query, _mode, _preloads, _assocs) do
+    raise ArgumentError, "#{inspect(other)} is not a valid preload expression."
+  end
+
+  defp expand_each(atom, _query, _mode, {preloads, assocs}) when is_atom(atom) do
+    {[atom|preloads], assocs}
+  end
+
+  defp expand_each({key, atom}, _query, _mode, {preloads, assocs}) when is_atom(atom) do
+    assert_key!(key)
+
+    {[{key, atom}|preloads], assocs}
+  end
+
+  defp expand_each({key, %Ecto.Query.DynamicExpr{} = dynamic}, query, mode, {preloads, assocs}) do
+    assert_key!(key)
+    assert_assoc!(mode, key)
+
+    idx = expand_dynamic(dynamic, query)
+    {preloads, [{key!(key), {idx, []}}|assocs]}
+  end
+
+  defp expand_each({key, {%Ecto.Query.DynamicExpr{} = dynamic, inner}}, query, mode, {preloads, assocs}) do
+    assert_key!(key)
+    assert_assoc!(mode, key)
+
+    idx = expand_dynamic(dynamic, query)
+    {inner_preloads, inner_assocs} = expand(inner, query, :assoc, [], [])
+    assocs = [{key!(key), {idx, Enum.reverse(inner_assocs)}}|assocs]
+
+    case inner_preloads do
+      [] -> {preloads, assocs}
+      _ -> {[{key!(key), Enum.reverse(inner_preloads)}|preloads], assocs}
+    end
+  end
+
+  defp expand_each({key, {query_or_fun, inner}}, query, _mode, {preloads, assocs}) do
+    assert_key!(key)
+    assert_query_or_fun!(query_or_fun, key)
+
+    {inner_preloads, []} = expand(inner, query, :preload, [], [])
+    {[{key, {query_or_fun, Enum.reverse(inner_preloads)}}|preloads], assocs}
+  end
+
+  defp expand_each({key, list}, query, _mode, {preloads, assocs}) when is_list(list) do
+    assert_key!(key)
+
+    {inner_preloads, []} = expand(list, query, :preload, preloads, assocs)
+    {[{key, Enum.reverse(inner_preloads)}|preloads], assocs}
+  end
+
+  defp expand_each({key, query_or_fun}, _query, _mode, {preloads, assocs}) do
+    assert_key!(key)
+    assert_query_or_fun!(query_or_fun, key)
+
+    {[{key, query_or_fun}|preloads], assocs}
+  end
+
+  defp expand_dynamic(%Ecto.Query.DynamicExpr{} = dynamic, query) do
+    case Builder.Dynamic.fully_expand(query, dynamic) do
+      {{:&, [], [idx]}, _, _, _, _, _} when is_integer(idx) ->
+        idx
+
+      _ ->
+        raise ArgumentError,
+          "invalid dynamic in preload: #{inspect(dynamic)}. " <>
+          "Dynamic expressions in preload must evaluate to a single binding, as in: " <>
+          "`dynamic([comments: c], c)`"
+    end
+  end
+
+  defp assert_key!(key), do: key!(key) && :ok
+
+  defp assert_query_or_fun!(%Ecto.Query{}, _key), do: :ok
+  defp assert_query_or_fun!(fun, _key) when is_function(fun, 1), do: :ok
+  defp assert_query_or_fun!(other, key) do
+    raise ArgumentError,
+      "invalid preload for key `#{inspect(key)}`: #{inspect(other)}. " <>
+      "Preloads can be a query, a function (arity 1), or a dynamic that " <>
+      "evalutes to a single binding."
+  end
+
+  defp assert_assoc!(mode, _atom) when mode in [:both, :assoc], do: :ok
+  defp assert_assoc!(_mode, atom) do
+    raise ArgumentError,
+      "cannot preload join association `#{inspect(atom)}` " <>
+      "because parent preload is not a join association"
+  end
+
+  defp assert_assoc!(mode, _atom, _var) when mode in [:both, :assoc], do: :ok
+  defp assert_assoc!(_mode, atom, var) do
+    Builder.error!(
+      "cannot preload join association `#{Macro.to_string atom}` with binding `#{var}` " <>
+      "because parent preload is not a join association"
+    )
   end
 end

--- a/lib/ecto/query/builder/preload.ex
+++ b/lib/ecto/query/builder/preload.ex
@@ -184,7 +184,7 @@ defmodule Ecto.Query.Builder.Preload do
   end
 
   defp expand(other, _query, _mode, _preloads, _assocs) do
-    raise ArgumentError, "#{inspect(other)} is not a valid preload expression."
+    raise ArgumentError, "`#{inspect(other)}` is not a valid preload expression."
   end
 
   defp expand_each(atom, _query, _mode, {preloads, assocs}) when is_atom(atom) do
@@ -248,7 +248,7 @@ defmodule Ecto.Query.Builder.Preload do
 
       _ ->
         raise ArgumentError,
-          "invalid dynamic in preload: #{inspect(dynamic)}. " <>
+          "invalid dynamic in preload: `#{inspect(dynamic)}`. " <>
           "Dynamic expressions in preload must evaluate to a single binding, as in: " <>
           "`dynamic([comments: c], c)`"
     end

--- a/test/ecto/query/builder/preload_test.exs
+++ b/test/ecto/query/builder/preload_test.exs
@@ -83,6 +83,15 @@ defmodule Ecto.Query.Builder.PreloadTest do
       assert %{preloads: [], assocs: [comments: {1, [likes: {2, []}]}]} =
                preload(query, ^preloads)
     end
+
+    test "supports nested dynamics for join association bindings" do
+      query = from p in "posts", join: c in assoc(p, :comments), as: :comments
+
+      inner_dynamic = dynamic([comments: c], c)
+      outer_dynamic = dynamic(^inner_dynamic)
+      preloads = [comments: outer_dynamic]
+      assert %{preloads: [], assocs: [comments: {1, []}]} = preload(query, ^preloads)
+    end
   end
 
   describe "invalid preload" do

--- a/test/ecto/query/builder/preload_test.exs
+++ b/test/ecto/query/builder/preload_test.exs
@@ -26,22 +26,74 @@ defmodule Ecto.Query.Builder.PreloadTest do
     assert query.preloads == [:foo, :bar]
   end
 
-  test "supports interpolation" do
-    comments = :comments
-    assert preload("posts", ^comments).preloads == [:comments]
-    assert preload("posts", ^[comments]).preloads == [[:comments]]
-    assert preload("posts", [users: ^comments]).preloads == [users: :comments]
-    assert preload("posts", [users: ^[comments]]).preloads == [users: [:comments]]
-    assert preload("posts", [{^:users, ^comments}]).preloads == [users: :comments]
+  describe "at runtime" do
+    test "supports interpolation" do
+      comments = :comments
+      assert preload("posts", ^comments).preloads == [:comments]
+      assert preload("posts", ^[comments]).preloads == [:comments]
+      assert preload("posts", [users: ^comments]).preloads == [users: :comments]
+      assert preload("posts", ^[users: comments]).preloads == [users: :comments]
+      assert preload("posts", [users: ^[comments]]).preloads == [users: [:comments]]
+      assert preload("posts", ^[users: [comments]]).preloads == [users: [:comments]]
+      assert preload("posts", [{^:users, ^comments}]).preloads == [users: :comments]
 
-    query = from u in "users", limit: 10
-    assert preload("posts", [users: ^query]).preloads == [users: query]
-    assert preload("posts", [{^:users, ^query}]).preloads == [users: query]
-    assert preload("posts", [users: ^{query, :comments}]).preloads == [users: {query, :comments}]
+      query = from u in "users", limit: 10
+      assert preload("posts", [users: ^query]).preloads == [users: query]
+      assert preload("posts", [{^:users, ^query}]).preloads == [users: query]
+      assert preload("posts", ^[users: query]).preloads == [users: query]
+      assert preload("posts", [users: ^{query, :comments}]).preloads == [users: {query, :comments}]
+      assert preload("posts", ^[users: {query, :comments}]).preloads == [users: {query, [:comments]}]
 
-    fun = fn _ -> [] end
-    assert preload("posts", [users: ^fun]).preloads == [users: fun]
-    assert preload("posts", [{^:users, ^fun}]).preloads == [users: fun]
-    assert preload("posts", [users: ^{fun, :comments}]).preloads == [users: {fun, :comments}]
+      fun = fn _ -> [] end
+      assert preload("posts", [users: ^fun]).preloads == [users: fun]
+      assert preload("posts", [{^:users, ^fun}]).preloads == [users: fun]
+      assert preload("posts", ^[users: fun]).preloads == [users: fun]
+      assert preload("posts", [users: ^{fun, :comments}]).preloads == [users: {fun, :comments}]
+      assert preload("posts", ^[users: {fun, :comments}]).preloads == [users: {fun, [:comments]}]
+    end
+
+    test "supports interpolation with associations" do
+      comments = :comments
+
+      query = from p in "posts", join: c in assoc(p, :comments), as: ^comments
+      assert %{preloads: [], assocs: [{:comments, {1, []}}]} =
+               preload(query, [{^comments, c}], [{^comments, c}])
+      assert %{preloads: [:foo], assocs: [{:comments, {1, []}}]} =
+               preload(query, [{^comments, c}], [:foo, {^comments, c}])
+
+      query =
+        from p in "posts",
+          join: f in assoc(p, :foo), as: :foo,
+          join: c in assoc(f, :comments), as: ^comments
+      assert %{preloads: [], assocs: [{:foo, {1, [{:comments, {2, []}}]}}]} =
+               preload(query, [{:foo, f}, {^comments, c}], [foo: {f, [{^comments, c}]}])
+    end
+
+    test "supports dynamics with associations" do
+      comments = :comments
+
+      query = from p in "posts", join: c in assoc(p, :comments), as: ^comments
+      preloads = [comments: dynamic([{^comments, c}], c)]
+      assert %{preloads: [], assocs: [comments: {1, []}]} = preload(query, ^preloads)
+
+      query =
+        from p in "posts",
+        join: c in assoc(p, :comments), as: ^comments,
+        join: l in assoc(p, :likes), as: :likes
+      preloads = [
+        likes: dynamic([likes: l], l),
+        comments: dynamic([{^comments, c}], c)
+      ]
+      assert %{preloads: [], assocs: [likes: {2, []}, comments: {1, []}]} =
+               preload(query, ^preloads)
+
+      query =
+        from p in "posts",
+        join: c in assoc(p, :comments),
+        join: l in assoc(c, :likes)
+      preloads = [comments: {dynamic([_, c], c), likes: dynamic([_, _, l], l)}]
+      assert %{preloads: [], assocs: [comments: {1, [likes: {2, []}]}]} =
+               preload(query, ^preloads)
+    end
   end
 end


### PR DESCRIPTION
First-pass implementation of this proposal from the mailing list: [Support runtime dynamic preload bindings in Ecto.Query](https://groups.google.com/g/elixir-ecto/c/Z_tFUi6ONWU/m/e-YPRjIzCgAJ).

In the proposal, I pointed to `Ecto.Query.Builder.Update` as a potential "template", but ended up using the strategy used by the `OrderBy`, `GroupBy`, `Filter`, etc. modules instead. This strategy uses a separate `build/4` function clause that delegates to `Ecto.Query.Builder.Preload.preload!/2` at runtime if the outer-most expression is interpolated.

This means that any existing code that interpolates preloads at the root, regardless of whether they use dynamics, will go down this new code-path. Previously, anything that was interpolated at the root was just added to `query.preloads` via this clause:

```elixir
defp escape({:^, _, [inner]}, _mode, preloads, assocs, _vars) do
  {[inner|preloads], assocs}
end
```

Now, the preload structure will be walked at runtime and converted to a `{preloads, assocs}` tuple by `Ecto.Query.Builder.Preload.expand/2`. I've added additional tests to try and account for this, but more may be warranted.

Would love to get feedback at this point!