### PR TITLE
docs: fix code block rendering

### DIFF
--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -76,8 +76,8 @@ defmodule Ecto.Enum do
         end
       end
 
-  The `:embed_as_values` field value will save `:foo | :bar`, while the
-  `:embed_as_dump` field value will save as `1 | 2`.
+  The `:embed_as_values` field value will save `:foo` or `:bar`, while the
+  `:embed_as_dump` field value will save `1` or `2`.
   """
 
   use Ecto.ParameterizedType


### PR DESCRIPTION
It doesn't seem to render properly using
```
`1 | 2`
```
![image](https://user-images.githubusercontent.com/22566656/208918569-005b1ac6-185a-4945-a36c-c5be7fdeb4d6.png)
