### PR TITLE
Fix runtime nested preload expansion (fixes #4069)

### DIFF
--- a/test/ecto/query/builder/preload_test.exs
+++ b/test/ecto/query/builder/preload_test.exs
@@ -28,6 +28,8 @@ defmodule Ecto.Query.Builder.PreloadTest do
       assert preload("posts", ^[[[users: comments]]]).preloads == [users: :comments]
       assert preload("posts", [[users: [[^comments]]]]).preloads == [users: [:comments]]
       assert preload("posts", ^[[users: [[comments]]]]).preloads == [users: [:comments]]
+      assert preload("posts", [[:likes, users: [[^comments]]]]).preloads == [{:users, [:comments]}, :likes]
+      assert preload("posts", ^[[:likes, users: [[comments]]]]).preloads == [{:users, [:comments]}, :likes]
 
       query = from u in "users", limit: 10
       assert preload("posts", [users: ^query]).preloads == [users: query]


### PR DESCRIPTION
The call to `expand/5` on line 269 incorrectly passed the currently accumulated preloads and associations instead of resetting the accumulators, causing already accumulated values to be applied to inner preloads.

* Fix bug reported in #4069 
* Add doctests for `expand/2`, similar to those present for `escape/2`
* Reverse accumulated lists in `expand/5` instead of `preload!/2`; this simplifies some code elsewhere and is more consistent with `escape`