### PR TITLE
Ecto.Query Inspect: use correct lateral join keywords

### DIFF
--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -347,13 +347,13 @@ defimpl Inspect, for: Ecto.Query do
   end
 
   defp join_qual(:inner), do: :join
-  defp join_qual(:inner_lateral), do: :join_lateral
+  defp join_qual(:inner_lateral), do: :inner_lateral_join
   defp join_qual(:left), do: :left_join
-  defp join_qual(:left_lateral), do: :left_join_lateral
+  defp join_qual(:left_lateral), do: :left_lateral_join
   defp join_qual(:right), do: :right_join
   defp join_qual(:full), do: :full_join
   defp join_qual(:cross), do: :cross_join
-  defp join_qual(:cross_lateral), do: :cross_join_lateral
+  defp join_qual(:cross_lateral), do: :cross_lateral_join
 
   defp collect_sources(%{from: nil, joins: joins}) do
     ["query" | join_sources(joins)]

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -129,6 +129,15 @@ defmodule Ecto.Query.InspectTest do
     assert i(from(x in Post, full_join: y in {"user_comments", Comment}, on: x.id == y.id)) ==
            ~s[from p0 in Inspect.Post, full_join: c1 in {"user_comments", Inspect.Comment}, on: p0.id == c1.id]
 
+    assert i(from(x in Post, left_lateral_join: y in Comment, on: x.id == y.id)) ==
+           ~s{from p0 in Inspect.Post, left_lateral_join: c1 in Inspect.Comment, on: p0.id == c1.id}
+
+    assert i(from(x in Post, inner_lateral_join: y in Comment, on: x.id == y.id)) ==
+           ~s{from p0 in Inspect.Post, inner_lateral_join: c1 in Inspect.Comment, on: p0.id == c1.id}
+
+    assert i(from(x in Post, cross_lateral_join: y in Comment, on: x.id == y.id)) ==
+           ~s{from p0 in Inspect.Post, cross_lateral_join: c1 in Inspect.Comment, on: p0.id == c1.id}
+
     binding = :comments
     assert i(from(x in Post, left_join: y in assoc(x, ^binding), as: ^binding)) ==
            ~s{from p0 in Inspect.Post, left_join: c1 in assoc(p0, :comments), as: :comments}


### PR DESCRIPTION
While debugging some lateral joins, I was trying to copy/paste some inspected queries and noticed that the inspect protocol was using incorrect keywords for those queries.