### PR TITLE
Update `Ecto.Query.exclude/2` to be able to exclude `:update`

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -798,6 +798,7 @@ defmodule Ecto.Query do
       Ecto.Query.exclude(query, :offset)
       Ecto.Query.exclude(query, :lock)
       Ecto.Query.exclude(query, :preload)
+      Ecto.Query.exclude(query, :update)
 
   You can also remove specific joins as well such as `left_join` and
   `inner_join`:
@@ -839,6 +840,7 @@ defmodule Ecto.Query do
   defp do_exclude(%Ecto.Query{} = query, :offset), do: %{query | offset: nil}
   defp do_exclude(%Ecto.Query{} = query, :lock), do: %{query | lock: nil}
   defp do_exclude(%Ecto.Query{} = query, :preload), do: %{query | preloads: [], assocs: []}
+  defp do_exclude(%Ecto.Query{} = query, :update), do: %{query | updates: []}
 
   @doc """
   Creates a query.

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -825,7 +825,7 @@ defmodule Ecto.Query do
   defp do_exclude(%Ecto.Query{} = query, join_keyword) when join_keyword in @joins do
     qual = join_qual(join_keyword)
     {excluded, remaining} = Enum.split_with(query.joins, &(&1.qual == qual))
-    aliases =  Map.drop(query.aliases, Enum.map(excluded, & &1.as))
+    aliases = Map.drop(query.aliases, Enum.map(excluded, & &1.as))
     %{query | joins: remaining, aliases: aliases}
   end
   defp do_exclude(%Ecto.Query{} = query, :where), do: %{query | wheres: []}

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -621,6 +621,7 @@ defmodule Ecto.QueryTest do
           having: p.comments > 10,
           distinct: p.category,
           lock: "FOO",
+          update: [set: [title: "foo"]],
           select: p
         )
 
@@ -639,6 +640,7 @@ defmodule Ecto.QueryTest do
       refute query.limit == base.limit
       refute query.offset == base.offset
       refute query.lock == base.lock
+      refute query.updates == base.updates
 
       excluded_query =
         query
@@ -654,6 +656,7 @@ defmodule Ecto.QueryTest do
         |> exclude(:limit)
         |> exclude(:offset)
         |> exclude(:lock)
+        |> exclude(:update)
 
       # Post-exclusion assertions
       assert excluded_query.with_ctes == base.with_ctes
@@ -668,6 +671,7 @@ defmodule Ecto.QueryTest do
       assert excluded_query.limit == base.limit
       assert excluded_query.offset == base.offset
       assert excluded_query.lock == base.lock
+      assert excluded_query.updates == base.updates
     end
 
     test "works on any queryable" do


### PR DESCRIPTION
Per [my proposal](https://groups.google.com/g/elixir-ecto/c/z59zF3I_r68/m/oWguRKoAAgAJ), I extended the ability of `Ecto.Query.exclude/2` to be able to exclude the `select` keyword in the form:

```elixir
query = from x in MySchema, update: [set: [name: "test"]]
Ecto.Query.exclude(query, :update)
```