### PR TITLE
Add `get_assoc`/`get_embed`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1161,9 +1161,10 @@ defmodule Ecto.Changeset do
   then falls back on the data, finally returning `default` if
   no value is available.
 
-  For relations consider using `get_assoc/3`/`get_embed/3`. This
-  function will return the changeset data with all changes applied,
-  which might not be what you're looking for.
+  For associations and embeds, this function returns the changeset
+  data with all changes applied. Use  `get_assoc/3`/`get_embed/3`
+  if you want to retrieve the relations as changesets or if you want
+  more fine-grained control.
 
       iex> post = %Post{title: "A title", body: "My body is a cage"}
       iex> changeset = change(post, %{title: "A new title"})

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1242,8 +1242,8 @@ defmodule Ecto.Changeset do
   @doc """
   Gets the embedded entry or entries from changes or from the data.
 
-  Returned data is either normalized to be changesets or structs with any changes
-  applied to them. The `:struct` option returns the same value as `get_field/2`.
+  Returned data is normalized to changesets by default. Pass the `:struct`
+  flag to retrieve the data as structs with changes applied, similar to `get_field/2`.
 
   ## Examples
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1281,9 +1281,14 @@ defmodule Ecto.Changeset do
     raise ArgumentError, "changeset does not have types information"
   end
 
-  defp get_relation(tag, %{types: types} = changeset, name) do
+  defp get_relation(tag, %{changes: changes, data: data, types: types}, name) do
     _ = relation!(:get, tag, name, Map.get(types, name))
-    existing = get_change(changeset, name) || get_field(changeset, name)
+
+    existing =
+      case Map.fetch(changes, name) do
+        {:ok, value} -> value
+        :error -> Relation.load!(data, Map.fetch!(data, name))
+      end
 
     case existing do
       nil -> nil

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1285,9 +1285,9 @@ defmodule Ecto.Changeset do
     _ = relation!(:get, tag, name, Map.get(types, name))
 
     existing =
-      case Map.fetch(changes, name) do
-        {:ok, value} -> value
-        :error -> Relation.load!(data, Map.fetch!(data, name))
+      case changes do
+        %{^name => value} -> value
+        %{} -> Relation.load!(data, Map.fetch!(data, name))
       end
 
     case existing do

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1208,8 +1208,8 @@ defmodule Ecto.Changeset do
   @doc """
   Gets the association entry or entries from changes or from the data.
 
-  Returned data is either normalized to be changesets or structs with any changes
-  applied to them. The `:struct` option returns the same value as `get_field/2`.
+  Returned data is normalized to changesets by default. Pass the `:struct`
+  flag to retrieve the data as structs with changes applied, similar to `get_field/2`.
 
   ## Examples
 

--- a/test/ecto/changeset/belongs_to_test.exs
+++ b/test/ecto/changeset/belongs_to_test.exs
@@ -532,7 +532,7 @@ defmodule Ecto.Changeset.BelongsToTest do
     refute Map.has_key?(changeset.changes, :profile)
   end
 
-  test "get_field/3, fetch_field/2 with assocs" do
+  test "get_field/3, fetch_field/2, get_assoc/3 with assocs" do
     profile_changeset = Changeset.change(%Profile{}, name: "michal")
     profile = Changeset.apply_changes(profile_changeset)
 
@@ -542,10 +542,14 @@ defmodule Ecto.Changeset.BelongsToTest do
       |> Changeset.put_assoc(:profile, profile_changeset)
     assert Changeset.get_field(changeset, :profile) == profile
     assert Changeset.fetch_field(changeset, :profile) == {:changes, profile}
+    assert Changeset.get_assoc(changeset, :profile, :changeset) == %{profile_changeset | action: :insert}
+    assert Changeset.get_assoc(changeset, :profile, :struct) == profile
 
     changeset = Changeset.change(%Author{profile: profile})
     assert Changeset.get_field(changeset, :profile) == profile
     assert Changeset.fetch_field(changeset, :profile) == {:data, profile}
+    assert Changeset.get_assoc(changeset, :profile, :changeset) == Changeset.change(profile)
+    assert Changeset.get_assoc(changeset, :profile, :struct) == profile
   end
 
   test "on_replace: :nilify" do

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -930,7 +930,7 @@ defmodule Ecto.Changeset.EmbeddedTest do
     refute Map.has_key?(changeset.changes, :posts)
   end
 
-  test "get_field/3, fetch_field/2 with embeds" do
+  test "get_field/3, fetch_field/2, get_embed/3 with embeds" do
     profile_changeset = Changeset.change(%Profile{}, name: "michal")
     profile = Changeset.apply_changes(profile_changeset)
 
@@ -940,10 +940,14 @@ defmodule Ecto.Changeset.EmbeddedTest do
       |> Changeset.put_embed(:profile, profile_changeset)
     assert Changeset.get_field(changeset, :profile) == profile
     assert Changeset.fetch_field(changeset, :profile) == {:changes, profile}
+    assert Changeset.get_embed(changeset, :profile, :changeset) == %{profile_changeset | action: :insert}
+    assert Changeset.get_embed(changeset, :profile, :struct) == profile
 
     changeset = Changeset.change(%Author{profile: profile})
     assert Changeset.get_field(changeset, :profile) == profile
     assert Changeset.fetch_field(changeset, :profile) == {:data, profile}
+    assert Changeset.get_embed(changeset, :profile, :changeset) == Changeset.change(profile)
+    assert Changeset.get_embed(changeset, :profile, :struct) == profile
 
     post = %Post{id: 1}
     post_changeset = %{Changeset.change(post) | action: :delete}
@@ -953,6 +957,14 @@ defmodule Ecto.Changeset.EmbeddedTest do
       |> Changeset.put_embed(:posts, [post_changeset])
     assert Changeset.get_field(changeset, :posts) == []
     assert Changeset.fetch_field(changeset, :posts) == {:changes, []}
+    assert Changeset.get_embed(changeset, :posts, :changeset) == [post_changeset]
+    assert Changeset.get_embed(changeset, :posts, :struct) == []
+
+    changeset = Changeset.change(%Author{})
+    assert Changeset.get_field(changeset, :posts) == []
+    assert Changeset.fetch_field(changeset, :posts) == {:data, []}
+    assert Changeset.get_embed(changeset, :posts, :changeset) == []
+    assert Changeset.get_embed(changeset, :posts, :struct) == []
   end
 
   test "empty" do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -731,6 +731,20 @@ defmodule Ecto.ChangesetTest do
     assert get_field(changeset, :comments) == []
   end
 
+  test "get_assoc/3" do
+    post = %Post{comments: [%Comment{}]}
+    base_changesset = change(post)
+
+    assert get_assoc(base_changesset, :comments, :changeset) == [change(%Comment{})]
+    assert get_assoc(base_changesset, :comments, :struct) == [%Comment{}]
+
+    comment_changeset = change(%Comment{}, %{id: 123})
+    base_changesset = change(post) |> put_assoc(:comments, [comment_changeset])
+
+    assert get_assoc(base_changesset, :comments, :changeset) == [%{comment_changeset | action: :update}]
+    assert get_assoc(base_changesset, :comments, :struct) == [%Comment{id: 123}]
+  end
+
   test "fetch_change/2" do
     changeset = changeset(%{"title" => "foo", "body" => nil, "upvotes" => nil})
 


### PR DESCRIPTION
I've recently written a [blog post](https://kobrakai.de/kolumne/one-to-many-liveview-form) about a common one-to-many form setup using LV. There's a lot of footguns to consider, but one common pain point mentioned, which I had also talked about with a few people on slack doing similar thing, is is modifying assocs/embeds (usually the *_many variant) on an existing changeset. This is possible with existing APIs (as seen in the blogpost), but it's more complex than it needs to be.

- There's no function, which returns a list of changesets of the relation and transparently falls back to the unchanged field data if there are no changes (yet)
- `get_field` returns a list of structs with changes applied, but using `put_assoc/embed` "forgets" those changes
- The same happens when editing the structs returned by `get_field` and putting them back using `put_assoc/embed`

The code in the PR is a proposal to add a `update_assoc/embed` API, which basically consolidates gathering the "current state of the relation" as changesets, passes it to a user prodived function to allow for updates, and then puts the result back into the changeset. Passing data normalized to changesets should make it clear that adding additional changes is supposed to happen via the `Ecto.Changeset` APIs and not by applying existing changes and editing the returned struct.

I'm aware that LV is meant to have its form integration updated, but this feels useful even beyond the immediate LV forms usecase.

Edit:
One such usecase could be "assign positional values" to order assocs by, when the input didn't include such and relied on the order of the list passed into the changeset.