### PR TITLE
Update `Code.can_await_module_compilation?/0` todo

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2101,7 +2101,7 @@ defmodule Ecto.Schema do
     # If we are compiling code, we can validate associations now,
     # as the Elixir compiler will solve dependencies.
     #
-    # TODO: Use Code.can_await_module_compilation?/0 from Elixir v1.10+.
+    # TODO: Use Code.can_await_module_compilation?/0 from Elixir v1.11+.
     if Process.info(self(), :error_handler) == {:error_handler, Kernel.ErrorHandler} do
       for name <- module.__schema__(:associations) do
         assoc = module.__schema__(:association, name)


### PR DESCRIPTION
I was about to switch this out until I noticed this function was introduced in Elixir 1.11.