### PR TITLE
Optionally update_change only on valid changesets

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -775,7 +775,7 @@ defmodule Ecto.ChangesetTest do
     assert get_change(changeset, :upvotes, "other") == nil
   end
 
-  test "update_change/3" do
+  test "update_change/4" do
     changeset =
       changeset(%{"title" => "foo"})
       |> update_change(:title, & &1 <> "bar")

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -786,6 +786,11 @@ defmodule Ecto.ChangesetTest do
       |> update_change(:upvotes, & &1 || 10)
     assert changeset.changes.upvotes == 10
 
+    changeset = changeset(%{"title" => "foo"})
+    invalid_changeset = %{changeset | valid?: false}
+    update_change(invalid_changeset, :title, & &1 <> "bar", only_valid: true)
+    assert changeset.changes.title == "foo"
+
     changeset =
       changeset(%{})
       |> update_change(:title, & &1 || "bar")


### PR DESCRIPTION
This PR introduces an opt to `Changeset.update_change/4` that allows us to only invoke the update fn if the changeset is valid.

This can be useful in cases of dangerous or expensive updates. Examples:

```elixir
changeset
|> validate_inclusion(:reason, ["account_ownership_changed"])
|> update_change(:reason, &String.to_existing_atom/1, only_valid: true)
```

```elixir
changeset
|> update_change(:value, &call_slow_external_service_to_update_value/1, only_valid: true)
```

It keeps the default behavior of always invoking the updating fn.