### PR TITLE
Add `with_ties/3` to `Ecto.Query`

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -951,7 +951,7 @@ defmodule Ecto.Query do
   @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge, :with_ctes]
 
-  defp from([{type, expr}|_t] = kw, env, count_bind, quoted, binds) when type in @binds do
+  defp from([{type, expr}|_] = kw, env, count_bind, quoted, binds) when type in @binds do
     # If all bindings are integer indexes keep AST Macro expandable to %Query{},
     # otherwise ensure that quoted code is evaluated before macro call
     quoted =

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2000,7 +2000,7 @@ defmodule Ecto.Query do
     Builder.LimitOffset.build(:limit, query, binding, expr, __CALLER__)
   end
 
-   @doc """
+  @doc """
   Enables or disables ties for limit expressions.
 
   If there are multiple records tied for the last position in an ordered

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -951,7 +951,7 @@ defmodule Ecto.Query do
   @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge, :with_ctes]
 
-  defp from([{type, expr}|_] = kw, env, count_bind, quoted, binds) when type in @binds do
+  defp from([{type, expr}|t], env, count_bind, quoted, binds) when type in @binds do
     # If all bindings are integer indexes keep AST Macro expandable to %Query{},
     # otherwise ensure that quoted code is evaluated before macro call
     quoted =
@@ -966,7 +966,7 @@ defmodule Ecto.Query do
         end
       end
 
-    {t, quoted} = maybe_with_ties(kw, quoted, binds)
+    {t, quoted} = maybe_with_ties(type, t, quoted, binds)
 
     from(t, env, count_bind, quoted, binds)
   end
@@ -1010,7 +1010,7 @@ defmodule Ecto.Query do
     quoted
   end
 
-  defp maybe_with_ties([{:limit, _expr} | t], quoted, binds) do
+  defp maybe_with_ties(:limit, t, quoted, binds) do
     {t, with_ties} = collect_with_ties(t, nil)
 
     quoted =
@@ -1025,7 +1025,7 @@ defmodule Ecto.Query do
     {t, quoted}
   end
 
-  defp maybe_with_ties([_ | t], quoted, _binds), do: {t, quoted}
+  defp maybe_with_ties(_type, t, quoted, _binds), do: {t, quoted}
 
   defp to_query_binds(binds) do
     for {k, v} <- binds, do: {{k, [], nil}, v}

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1994,8 +1994,8 @@ defmodule Ecto.Query do
   Enables or disables ties for limit expressions.
 
   If there are multiple records tied for the last position in an ordered
-  limit expression, setting this value to `true` will return all of the
-  tied records, even if the final result exceeds the specified limit.
+  limit result, setting this value to `true` will return all of the tied
+  records, even if the final result exceeds the specified limit.
 
   Must be a boolean or evaluate to a boolean at runtime. Can only be applied
   to queries with a `limit` expression or an error is raised. If `limit`

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -971,8 +971,7 @@ defmodule Ecto.Query do
     quoted =
       if with_ties != nil do
         quote do
-          query = unquote(quoted)
-          Ecto.Query.with_ties(query, unquote(binds), unquote(with_ties))
+          Ecto.Query.with_ties(unquote(quoted), unquote(binds), unquote(with_ties))
         end
       else
         quoted

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -951,7 +951,7 @@ defmodule Ecto.Query do
   @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge, :with_ctes]
 
-  defp from([{type, expr}|t] = kw, env, count_bind, quoted, binds) when type in @binds do
+  defp from([{type, expr}|_t] = kw, env, count_bind, quoted, binds) when type in @binds do
     # If all bindings are integer indexes keep AST Macro expandable to %Query{},
     # otherwise ensure that quoted code is evaluated before macro call
     quoted =

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2001,20 +2001,27 @@ defmodule Ecto.Query do
   end
 
    @doc """
-  A limit query expression.
+  Enables or disables ties for limit expressions.
 
-  Limits the number of rows returned from the result. Can be any expression but
-  has to evaluate to an integer value and it can't include any field.
+  If there are multiple records tied for the last position in an ordered
+  limit expression, setting this value to `true` will return all of the
+  tied records, even if the final result exceeds the specified limit.
 
-  If `limit` is given twice, it overrides the previous value.
+  Must be a boolean or evaluate to a boolean at runtime. Can only be applied
+  to queries containing a limit or an error is raised. If `limit` is redefined
+  then `with_ties` must be reapplied.
+
+  Not all databases support this option and the ones that do might list it
+  under the `FETCH` command. Databases may require a corresponding `order_by`
+  statement to evaluate ties.
 
   ## Keywords example
 
-      from(u in User, where: u.id == ^current_user, limit: 1)
+      from(p in Post, where: p.author_id == ^current_user, order_by: [desc: p.visits], limit: 10, with_ties: true)
 
   ## Expressions example
 
-      User |> where([u], u.id == ^current_user) |> limit(1)
+      Post |> where([p], p.author_id == ^current_user) |> order_by([p], desc: p.visits) |> limit(10) |> with_ties(true)
 
   """
   defmacro with_ties(query, binding \\ [], expr) do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2008,8 +2008,8 @@ defmodule Ecto.Query do
   tied records, even if the final result exceeds the specified limit.
 
   Must be a boolean or evaluate to a boolean at runtime. Can only be applied
-  to queries containing a limit or an error is raised. If `limit` is redefined
-  then `with_ties` must be reapplied.
+  to queries with a `limit` expression or an error is raised. If `limit`
+  is redefined then `with_ties` must be reapplied.
 
   Not all databases support this option and the ones that do might list it
   under the `FETCH` command. Databases may require a corresponding `order_by`

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -6,38 +6,90 @@ defmodule Ecto.Query.Builder.LimitOffset do
   alias Ecto.Query.Builder
 
   @doc """
+  Validates `with_ties` at runtime.
+  """
+  @spec with_ties!(any) :: boolean
+  def with_ties!(with_ties) when is_boolean(with_ties), do: with_ties
+
+  def with_ties!(with_ties),
+    do: Builder.error! "`with_ties` must be a boolean, got: #{inspect(with_ties)}"
+
+  @doc """
   Builds a quoted expression.
 
   The quoted expression should evaluate to a query at runtime.
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(:limit | :offset, Macro.t, [Macro.t], Macro.t, Macro.Env.t) :: Macro.t
+  @spec build(:limit | :with_ties | :offset, Macro.t(), [Macro.t()], Macro.t(), Macro.Env.t()) ::
+          Macro.t()
   def build(type, query, binding, expr, env) do
-    {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _acc}} = Builder.escape(expr, :integer, {[], %{}}, binding, env)
+    {query, vars} = Builder.escape_binding(query, binding, env)
+    {expr, {params, _acc}} = escape(type, expr, {[], %{}}, vars, env)
     params = Builder.escape_params(params)
+    quoted = build_quoted(type, expr, params, env)
 
-    limoff = quote do: %Ecto.Query.QueryExpr{
-                        expr: unquote(expr),
-                        params: unquote(params),
-                        file: unquote(env.file),
-                        line: unquote(env.line)}
-
-    Builder.apply_query(query, __MODULE__, [type, limoff], env)
+    Builder.apply_query(query, __MODULE__, [type, quoted], env)
   end
+
+  defp escape(type, expr, params_acc, vars, env) when type in [:limit, :offset] do
+    Builder.escape(expr, :integer, params_acc, vars, env)
+  end
+
+  defp escape(:with_ties, expr, params_acc, _vars, _env) when is_boolean(expr) do
+    {expr, params_acc}
+  end
+
+  defp escape(:with_ties, {:^, _, [expr]}, params_acc, _vars, _env) do
+    {quote(do: Ecto.Query.Builder.LimitOffset.with_ties!(unquote(expr))), params_acc}
+  end
+
+  defp build_quoted(:limit, expr, params, env) do
+    quote do: %Ecto.Query.LimitExpr{
+            expr: unquote(expr),
+            params: unquote(params),
+            with_ties: false,
+            file: unquote(env.file),
+            line: unquote(env.line)
+          }
+  end
+
+  defp build_quoted(:offset, expr, params, env) do
+    quote do: %Ecto.Query.QueryExpr{
+            expr: unquote(expr),
+            params: unquote(params),
+            file: unquote(env.file),
+            line: unquote(env.line)
+          }
+  end
+
+  defp build_quoted(:with_ties, expr, _params, _env), do: expr
 
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t, :limit | :offset, term) :: Ecto.Query.t
+  @spec apply(Ecto.Queryable.t(), :limit | :offset, term) :: Ecto.Query.t()
   def apply(%Ecto.Query{} = query, :limit, expr) do
     %{query | limit: expr}
   end
+
+  def apply(%Ecto.Query{limit: limit} = query, :with_ties, expr) do
+    %{query | limit: apply_limit(limit, expr)}
+  end
+
   def apply(%Ecto.Query{} = query, :offset, expr) do
     %{query | offset: expr}
   end
+
   def apply(query, kind, expr) do
     apply(Ecto.Queryable.to_query(query), kind, expr)
+  end
+
+  defp apply_limit(nil, _with_ties) do
+    Builder.error! "`with_ties` can only be applied to queries containing a `limit`"
+  end
+
+  defp apply_limit(limit, with_ties) do
+    %{limit | with_ties: with_ties}
   end
 end

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -91,6 +91,7 @@ defmodule Ecto.Query.Builder.LimitOffset do
     apply(Ecto.Queryable.to_query(query), kind, expr)
   end
 
+  @doc false
   def apply_limit(nil, _with_ties) do
     Builder.error!("`with_ties` can only be applied to queries containing a `limit`")
   end

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -12,7 +12,7 @@ defmodule Ecto.Query.Builder.LimitOffset do
   def with_ties!(with_ties) when is_boolean(with_ties), do: with_ties
 
   def with_ties!(with_ties),
-    do: raise("`with_ties` expression must be a boolean, got: `#{inspect(with_ties)}`")
+    do: raise("`with_ties` expression must evaluate to a boolean at runtime, got: `#{inspect(with_ties)}`")
 
   @doc """
   Builds a quoted expression.
@@ -44,7 +44,7 @@ defmodule Ecto.Query.Builder.LimitOffset do
     {quote(do: Ecto.Query.Builder.LimitOffset.with_ties!(unquote(expr))), params_acc}
   end
 
-  defp escape(:with_ties, expr, params_acc, vars, env) do
+  defp escape(:with_ties, expr, _params_acc, _vars, _env) do
     Builder.error!(
       "`with_ties` expression must be a compile time boolean or an interpolated value using ^, got: `#{Macro.to_string(expr)}`"
     )

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -91,7 +91,9 @@ defmodule Ecto.Query.Builder.LimitOffset do
     apply(Ecto.Queryable.to_query(query), kind, expr)
   end
 
-  @doc false
+  @doc """
+  Applies the `with_ties` value to the `limit` struct.
+  """
   def apply_limit(nil, _with_ties) do
     Builder.error!("`with_ties` can only be applied to queries containing a `limit`")
   end

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -74,7 +74,7 @@ defmodule Ecto.Query.Builder.LimitOffset do
   @doc """
   The callback applied by `build/4` to build the query.
   """
-  @spec apply(Ecto.Queryable.t(), :limit | :offset, term) :: Ecto.Query.t()
+  @spec apply(Ecto.Queryable.t(), :limit | :with_ties | :offset, term) :: Ecto.Query.t()
   def apply(%Ecto.Query{} = query, :limit, expr) do
     %{query | limit: expr}
   end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2,7 +2,7 @@ defmodule Ecto.Query.Planner do
   # Normalizes a query and its parameters.
   @moduledoc false
 
-  alias Ecto.Query.{BooleanExpr, DynamicExpr, FromExpr, JoinExpr, QueryExpr, SelectExpr}
+  alias Ecto.Query.{BooleanExpr, DynamicExpr, FromExpr, JoinExpr, QueryExpr, SelectExpr, LimitExpr}
 
   if map_size(%Ecto.Query{}) != 21 do
     raise "Ecto.Query match out of date in builder"
@@ -773,6 +773,7 @@ defmodule Ecto.Query.Planner do
     # Current strategy appends [{:subquery, i, cache}], where cache is the cache key for this subquery.
     {op, expr, Enum.map(subqueries, fn %{cache: cache} -> {:subquery, cache} end)}
   end
+  defp expr_to_cache(%LimitExpr{expr: expr, with_ties: with_ties}), do: {with_ties, expr}
 
   @spec cast_and_merge_params(atom, Ecto.Query.t, any, list, module) :: {params :: list, cacheable? :: boolean}
   defp cast_and_merge_params(kind, query, expr, params, adapter) do

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -47,7 +47,7 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
   end
 
   test "with_ties must be a runtime or compile time boolean" do
-    msg = "`with_ties` expression must be a boolean, got: `1`"
+    msg = "`with_ties` expression must evaluate to a boolean at runtime, got: `1`"
     assert_raise RuntimeError, msg, fn ->
       with_ties("posts", ^1)
     end

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -10,4 +10,35 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
     query = "posts" |> offset([], 1) |> offset([], 2) |> select([], 3)
     assert query.offset.expr == 2
   end
+
+  test "with_ties" do
+    # compile time 
+    query = from(p in Post) |> limit([], 1) |> with_ties(true)
+    assert query.limit.expr == 1
+    assert query.limit.with_ties == true
+
+    # run time
+    query = from(p in Post) |> limit([], 2) |> with_ties(^true)
+    assert query.limit.expr == 2
+    assert query.limit.with_ties == true
+  end
+
+  test "with_ties is removed when a new limit is set" do
+    # compile time 
+    query = from(p in Post) |> limit([], 1) |> with_ties(true) |> limit([], 2)
+    assert query.limit.expr == 2
+    assert query.limit.with_ties == false
+
+    # run time
+    query = from(p in Post) |> limit([], 3) |> with_ties(^true) |> limit([], 4)
+    assert query.limit.expr == 4
+    assert query.limit.with_ties == false
+  end
+
+  test "with_ties requires a limit" do
+    msg = "`with_ties` can only be applied to queries containing a `limit`"
+    assert_raise Ecto.Query.CompileError, msg, fn ->
+      with_ties("posts", true)
+    end
+  end
 end

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -1,7 +1,18 @@
+Code.require_file "../../../support/eval_helpers.exs", __DIR__
+
 defmodule Ecto.Query.Builder.LimitOffsetTest do
   use ExUnit.Case, async: true
 
   import Ecto.Query
+  import Support.EvalHelpers
+
+  defmodule Post do
+    use Ecto.Schema
+
+    schema "posts" do
+      field :title
+    end
+  end
 
   test "overrides on duplicated limit and offset" do
     query = "posts" |> limit([], 1) |> limit([], 2)
@@ -12,27 +23,39 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
   end
 
   test "with_ties" do
-    # compile time 
+    # compile time query
     query = from(p in Post) |> limit([], 1) |> with_ties(true)
     assert query.limit.expr == 1
     assert query.limit.with_ties == true
 
-    # run time
-    query = from(p in Post) |> limit([], 2) |> with_ties(^true)
+    # runtime query
+    query = "posts" |> limit([], 2) |> with_ties(^true)
     assert query.limit.expr == 2
     assert query.limit.with_ties == true
   end
 
   test "with_ties is removed when a new limit is set" do
-    # compile time 
+    # compile time query
     query = from(p in Post) |> limit([], 1) |> with_ties(true) |> limit([], 2)
     assert query.limit.expr == 2
     assert query.limit.with_ties == false
 
-    # run time
-    query = from(p in Post) |> limit([], 3) |> with_ties(^true) |> limit([], 4)
+    # runtime query
+    query = "posts" |> limit([], 3) |> with_ties(true) |> limit([], 4)
     assert query.limit.expr == 4
     assert query.limit.with_ties == false
+  end
+
+  test "with_ties must be a runtime or compile time boolean" do
+    msg = "`with_ties` expression must be a boolean, got: `1`"
+    assert_raise RuntimeError, msg, fn ->
+      with_ties("posts", ^1)
+    end
+
+    msg = "`with_ties` expression must be a compile time boolean or an interpolated value using ^, got: `1`"
+    assert_raise Ecto.Query.CompileError, msg, fn ->
+      quote_and_eval with_ties("posts", 1)
+    end
   end
 
   test "with_ties requires a limit" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -476,6 +476,7 @@ defmodule Ecto.Query.PlannerTest do
         on: true,
         hints: ["join hint"],
         prefix: "world",
+        limit: 1, with_ties: true,
         preload: :comments
       )
 
@@ -483,6 +484,7 @@ defmodule Ecto.Query.PlannerTest do
     assert key == [:all,
                    {:lock, "foo"},
                    {:prefix, "foo"},
+                   {:limit, {true, 1}},
                    {:where, [{:and, {:is_nil, [], [nil]}}, {:or, {:is_nil, [], [nil]}}]},
                    {:join, [{:inner, {"comments", Comment, 38292156, "world"}, true, ["join hint"]}]},
                    {:from, {"posts", Post, 32915161, "hello"}, ["hint"]},
@@ -749,7 +751,7 @@ defmodule Ecto.Query.PlannerTest do
                :all,
                {:prefix, "another"},
                {:take, %{0 => {:any, [:id]}}},
-               {:limit, {:^, [], [0]}},
+               {:limit, {false, {:^, [], [0]}}},
                {:order_by, [[desc: _]]},
                {:from, {"comments", Comment, _, nil}, []},
                {:select, {:&, [], [0]}}
@@ -781,7 +783,7 @@ defmodule Ecto.Query.PlannerTest do
                :all,
                {:prefix, "another"},
                {:take, %{0 => {:any, [:id]}}},
-               {:limit, {:^, [], [0]}},
+               {:limit, {false, {:^, [], [0]}}},
                {:order_by, [[desc: _]]},
                {:from, {"comments", Comment, _, nil}, []},
                {:select, {:&, [], [0]}}


### PR DESCRIPTION
Companion ecto_sql PR: https://github.com/elixir-ecto/ecto_sql/pull/471. The integration tests fail here but pass there because I was hesitant to update the earthfile.

**Background**

The SQL standard version of the `LIMIT` command is `FETCH`. The commands are almost identical except `FETCH` comes with an option `WITH TIES` which says that the result should include any records that are tied with the last record. For example `LIMIT 3` might return `1, 2, 3` while `FETCH 3 WITH TIES` would return `1, 2, 3, 3` because 2 records have the number 3.

**Proposal**

Add a `:with_ties` option to the current `limit` macro. There are a few reasons I'm proposing reusing the existing macro instead of creating a new `fetch` macro:

1. There is already [normalization happening in the SQL Server adapter](https://github.com/elixir-ecto/ecto_sql/blob/master/lib/ecto/adapters/tds/connection.ex#L592), which has `FETCH` and `TOP` but not `LIMIT`.
2. If there are 2 macros then we need to decide whether to normalize both to each other in situations where they are the same and an adapter supports one but not the other. Normalizing both ways increases the code complexity and number of decisions we have to make. And if we decide not to normalize then we need to justify why we're already doing it for SQL Server.

This proposal has a couple difficulties:

1. `limit` was using the generic `%QueryExpr{}` struct so doesn't have a place to store this new option. If we create a new struct for limits then any adapter pattern matching on `%QueryExpr{}` instead of `%{}` will have to be updated. All the built-in adapters had to be updated and I noticed SQLite will have to be as well.
2. Because the signature will be `limit(query, bindings \\ [], expr, opts \\ [])` it's a little awkward specifying the option outside of keyword queries if you don't care about bindings. But this would be the case for a new macro as well.

**Reference**

The postgres docs talk about it here: https://www.postgresql.org/docs/current/sql-select.html. It's the only built-in adapter that supports `FETCH WITH TIES`. SQL Server supports `FETCH` but not `WITH TIES` option. And MySQL supports neither.