### PR TITLE
Fix docs on :prefix option for Repo Queryable callbacks

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -380,9 +380,10 @@ defmodule Ecto.Query do
     1. The `:prefix` option given to `from`/`join` has the highest precedence
     2. Then it falls back to the `@schema_prefix` attribute declared in the schema
       given to `from`/`join`
-    3. Then it falls back to the query prefix as applied with `put_query_prefix/2`
-    4. Last it falls back to the prefix option given to the respective
-       function on the `Repo` module
+    3. Then it falls back to the query prefix. The query prefix may be
+       set either on the query with `put_query_prefix/2` or by passing
+       the `:prefix` option when calling the `Repo` module (where the
+       former wins if both methods are used)
 
   The prefixes set in the query will be preserved when loading data.
   """

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -380,7 +380,9 @@ defmodule Ecto.Query do
     1. The `:prefix` option given to `from`/`join` has the highest precedence
     2. Then it falls back to the `@schema_prefix` attribute declared in the schema
       given to `from`/`join`
-    3. Then it falls back to the query prefix
+    3. Then it falls back to the query prefix as applied with `put_query_prefix/2`
+    4. Last it falls back to the prefix option given to the respective
+       function on the `Repo` module
 
   The prefixes set in the query will be preserved when loading data.
   """

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1138,8 +1138,11 @@ defmodule Ecto.Repo do
   ## Options
 
     * `:prefix` - The prefix to run the query on (such as the schema path
-      in Postgres or the database in MySQL). This overrides the prefix set
-      in the query and any `@schema_prefix` set in the schema.
+      in Postgres or the database in MySQL). This will be applied to all `from`
+      and `join`s in the query that did not have a prefix previously given
+      either via the `:prefix` option on `join`/`from` or via `@schema_prefix`
+      in the schema. For more information see the "Query Prefix" section of the
+      `Ecto.Query` documentation.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for remaining options.
@@ -1184,8 +1187,11 @@ defmodule Ecto.Repo do
   ## Options
 
     * `:prefix` - The prefix to run the query on (such as the schema path
-      in Postgres or the database in MySQL). This overrides the prefix set
-      in the query and any `@schema_prefix` set in the schema.
+      in Postgres or the database in MySQL). This will be applied to all `from`
+      and `join`s in the query that did not have a prefix previously given
+      either via the `:prefix` option on `join`/`from` or via `@schema_prefix`
+      in the schema. For more information see the "Query Prefix" section of the
+      `Ecto.Query` documentation.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for remaining options.
@@ -1405,7 +1411,7 @@ defmodule Ecto.Repo do
 
     * `:prefix` - The prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). This overrides the prefix set
-      in the query and any `@schema_prefix` set any schemas. Also, the
+      in the query and any `@schema_prefix` set on any schemas. Also, the
       `@schema_prefix` for the parent record will override all default
       `@schema_prefix`s set in any child schemas for associations.
 
@@ -1586,7 +1592,7 @@ defmodule Ecto.Repo do
 
     * `:prefix` - The prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). This overrides the prefix set
-      in the query and any `@schema_prefix` set any schemas. Also, the
+      in the query and any `@schema_prefix` set on any schemas. Also, the
       `@schema_prefix` for the parent record will override all default
       `@schema_prefix`s set in any child schemas for associations.
 


### PR DESCRIPTION
Hi :wave: 

We noticed that the docs for `c:Ecto.Repo.update_all/3` and `c:Ecto.Repo.delete_all/2` read

> This overrides the prefix set in the query and any
> `@schema_prefix` set in the schema.

This is not true, `update_all` and `delete_all` follow the query prefix precendence as the other functions in `Queryable`.

We also added a fourth precendence rule to point out that an already set query prefix (e.g. applied with `put_query_prefix/2`) takes precendence over the `:prefix` option of the `Repo` function.