### PR TITLE
Don't raise if query variables are used in limit/offset

### DIFF
--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -34,7 +34,7 @@ defmodule Ecto.Query.Builder.LimitOffset do
   defp contains_variable?(ast) do
     ast
     |> Macro.prewalk(false, fn
-         {:&, _, [_]} = expr, _ -> {expr, true}
+         {:{}, _, [:&, _, [_]]} = expr, _ -> {expr, true}
          expr, acc -> {expr, acc}
        end)
     |> elem(1)

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -18,10 +18,6 @@ defmodule Ecto.Query.Builder.LimitOffset do
     {expr, {params, _acc}} = Builder.escape(expr, :integer, {[], %{}}, binding, env)
     params = Builder.escape_params(params)
 
-    if contains_variable?(expr) do
-      Builder.error! "query variables are not allowed in #{type} expression"
-    end
-
     limoff = quote do: %Ecto.Query.QueryExpr{
                         expr: unquote(expr),
                         params: unquote(params),
@@ -29,15 +25,6 @@ defmodule Ecto.Query.Builder.LimitOffset do
                         line: unquote(env.line)}
 
     Builder.apply_query(query, __MODULE__, [type, limoff], env)
-  end
-
-  defp contains_variable?(ast) do
-    ast
-    |> Macro.prewalk(false, fn
-         {:{}, _, [:&, _, [_]]} = expr, _ -> {expr, true}
-         expr, acc -> {expr, acc}
-       end)
-    |> elem(1)
   end
 
   @doc """

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -1,7 +1,10 @@
+Code.require_file "../../../support/eval_helpers.exs", __DIR__
+
 defmodule Ecto.Query.Builder.LimitOffsetTest do
   use ExUnit.Case, async: true
 
   import Ecto.Query
+  import Support.EvalHelpers
 
   test "overrides on duplicated limit and offset" do
     query = "posts" |> limit([], 1) |> limit([], 2)
@@ -13,13 +16,11 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
 
   test "does not allow query variables in limit and offset" do
     assert_raise Ecto.Query.CompileError, "query variables are not allowed in limit expression", fn ->
-      quoted = quote do: from p in "posts", limit: p.x + 1
-      Code.eval_quoted(quoted, [], __ENV__)
+      quote_and_eval from p in "posts", limit: p.x + 1
     end
 
     assert_raise Ecto.Query.CompileError, "query variables are not allowed in offset expression", fn ->
-      quoted = quote do: from p in "posts", offset: p.x + 2
-      Code.eval_quoted(quoted, [], __ENV__)
+      quote_and_eval from p in "posts", offset: p.x + 2
     end
   end
 end

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -11,7 +11,7 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
     assert query.offset.expr == 2
   end
 
-  test "does not allow column names in limit and offset" do
+  test "does not allow query variables in limit and offset" do
     assert_raise Ecto.Query.CompileError, "query variables are not allowed in limit expression", fn ->
       quoted = quote do: from p in "posts", limit: p.x + 1
       Code.eval_quoted(quoted, [], __ENV__)

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -1,10 +1,7 @@
-Code.require_file "../../../support/eval_helpers.exs", __DIR__
-
 defmodule Ecto.Query.Builder.LimitOffsetTest do
   use ExUnit.Case, async: true
 
   import Ecto.Query
-  import Support.EvalHelpers
 
   test "overrides on duplicated limit and offset" do
     query = "posts" |> limit([], 1) |> limit([], 2)
@@ -12,15 +9,5 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
 
     query = "posts" |> offset([], 1) |> offset([], 2) |> select([], 3)
     assert query.offset.expr == 2
-  end
-
-  test "does not allow query variables in limit and offset" do
-    assert_raise Ecto.Query.CompileError, "query variables are not allowed in limit expression", fn ->
-      quote_and_eval from p in "posts", limit: p.x + 1
-    end
-
-    assert_raise Ecto.Query.CompileError, "query variables are not allowed in offset expression", fn ->
-      quote_and_eval from p in "posts", offset: p.x + 2
-    end
   end
 end

--- a/test/ecto/query/builder/limit_offset_test.exs
+++ b/test/ecto/query/builder/limit_offset_test.exs
@@ -10,4 +10,16 @@ defmodule Ecto.Query.Builder.LimitOffsetTest do
     query = "posts" |> offset([], 1) |> offset([], 2) |> select([], 3)
     assert query.offset.expr == 2
   end
+
+  test "does not allow column names in limit and offset" do
+    assert_raise Ecto.Query.CompileError, "query variables are not allowed in limit expression", fn ->
+      quoted = quote do: from p in "posts", limit: p.x + 1
+      Code.eval_quoted(quoted, [], __ENV__)
+    end
+
+    assert_raise Ecto.Query.CompileError, "query variables are not allowed in offset expression", fn ->
+      quoted = quote do: from p in "posts", offset: p.x + 2
+      Code.eval_quoted(quoted, [], __ENV__)
+    end
+  end
 end


### PR DESCRIPTION
Please let me know if I'm off base. But I think the intention was to not allow stuff like this: 

`SELECT a, b FROM table LIMIT a + 1`. 

If this is correct then the old check won't work because the query variable was being escaped before it got there. 

i.e. it is `{:{}, outer_meta, [:&, inner_meta, [var_num]]}` instead of `{:&, inner_meta, [var_num]}`.

