### PR TITLE
Support interpolated values for from/join prefixes

### DIFF
--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -134,8 +134,11 @@ defmodule Ecto.Query.Builder.Join do
       )
     end
 
-    unless is_binary(prefix) or is_nil(prefix) do
-      Builder.error! "`prefix` must be a compile time string, got: `#{Macro.to_string(prefix)}`"
+    prefix = case prefix do
+      nil -> nil
+      prefix when is_binary(prefix) -> prefix
+      {:^, _, [prefix]} -> quote(do: Ecto.Query.Builder.From.prefix!(unquote(prefix)))
+      prefix -> Builder.error!("`prefix` must be a compile time string or an interpolated value using ^, got: #{Macro.to_string(prefix)}")
     end
 
     as = case as do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -480,6 +480,26 @@ defmodule Ecto.QueryTest do
       assert hd(query.joins).prefix == "world"
     end
 
+    test "are assigned from a variable" do
+      from_prefix = "hello"
+      join_prefix = "world"
+      query = from p in "posts", prefix: ^from_prefix, join: "comments", on: true, prefix: ^join_prefix
+      assert query.from.prefix == from_prefix
+      assert hd(query.joins).prefix == join_prefix
+    end
+
+    test "variables are validated at runtime" do
+      prefix = 123
+
+      assert_raise RuntimeError, ~r/`prefix` must be a string/, fn ->
+        from p in "posts", prefix: ^prefix
+      end
+
+      assert_raise RuntimeError, ~r/`prefix` must be a string/, fn ->
+        from p in "posts", join: "comments", on: true, prefix: ^prefix
+      end
+    end
+
     test "are supported and overridden from schemas" do
       query = from(Post)
       assert query.from.prefix == "another"


### PR DESCRIPTION
Hi :wave: 

This patch adds support for interpolated prefix options on the from/join keywords of `Ecto.Query.from/2`.

## Problem

We have a little library called [Carbonite](https://github.com/bitcrowd/carbonite) which maintains a bunch of tables in a Postgres schema, defaulting to `carbonite_default`. We want to support "normal" Ecto usage of the corresponding schema modules, e.g. to allow the user to write `Repo.all(Carbonite.Change)`. Hence we have set the `@schema_prefix` option on our schemas. 

However, at the same time we need to support other (dynamic) schema prefixes and thus need to be able to override the `@schema_prefix` in various functions. Some of these functions are part of `Ecto.Repo`'s "Query API", so we figured ideally we'd like to be able to pass a variable to the `:prefix` option of `Ecto.Query.from/2`.

## Example

    prefix = "hello"
    from(c in "comments", prefix: ^prefix)

Hope this is a welcome addition. If there's good reason not to support this which we didn't see, sorry for the noise.

cheers,
malte