### PR TITLE
Add `:autogenerate_fields` to the schema reflection API

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -429,6 +429,8 @@ defmodule Ecto.Schema do
     from the database after every write (insert or update);
 
   * `__schema__(:autogenerate_id)` - Primary key that is auto generated on insert;
+  * `__schema__(:autogenerate_fields)` - Returns a list of fields names that are auto
+    generated on insert, except for the primary key;
 
   * `__schema__(:redact_fields)` - Returns a list of redacted field names;
 
@@ -642,6 +644,7 @@ defmodule Ecto.Schema do
         def __schema__(:loaded), do: unquote(Macro.escape(loaded))
         def __schema__(:redact_fields), do: unquote(redacted_fields)
         def __schema__(:virtual_fields), do: unquote(Enum.map(virtual_fields, &elem(&1, 0)))
+        def __schema__(:autogenerate_fields), do: unquote(Enum.flat_map(autogenerate, &elem(&1, 0)))
 
         def __schema__(:query) do
           %Ecto.Query{

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -21,14 +21,14 @@ defmodule Ecto.SchemaTest do
   end
 
   test "schema metadata" do
-    assert Schema.__schema__(:source)              == "my schema"
-    assert Schema.__schema__(:prefix)              == nil
-    assert Schema.__schema__(:fields)              == [:id, :name, :email, :password, :count, :array, :uuid, :query_excluded_field, :comment_id]
-    assert Schema.__schema__(:virtual_fields)      == [:temp]
-    assert Schema.__schema__(:query_fields)        == [:id, :name, :email, :password, :count, :array, :uuid, :comment_id]
-    assert Schema.__schema__(:read_after_writes)   == [:email, :count]
-    assert Schema.__schema__(:primary_key)         == [:id]
-    assert Schema.__schema__(:autogenerate_id)     == {:id, :id, :id}
+    assert Schema.__schema__(:source) == "my schema"
+    assert Schema.__schema__(:prefix) == nil
+    assert Schema.__schema__(:fields) == [:id, :name, :email, :password, :count, :array, :uuid, :query_excluded_field, :comment_id]
+    assert Schema.__schema__(:virtual_fields) == [:temp]
+    assert Schema.__schema__(:query_fields) == [:id, :name, :email, :password, :count, :array, :uuid, :comment_id]
+    assert Schema.__schema__(:read_after_writes) == [:email, :count]
+    assert Schema.__schema__(:primary_key) == [:id]
+    assert Schema.__schema__(:autogenerate_id) == {:id, :id, :id}
     assert Schema.__schema__(:autogenerate_fields) == [:name, :uuid]
   end
 

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -21,13 +21,15 @@ defmodule Ecto.SchemaTest do
   end
 
   test "schema metadata" do
-    assert Schema.__schema__(:source)             == "my schema"
-    assert Schema.__schema__(:prefix)             == nil
-    assert Schema.__schema__(:fields)             == [:id, :name, :email, :password, :count, :array, :uuid, :query_excluded_field, :comment_id]
-    assert Schema.__schema__(:query_fields)       == [:id, :name, :email, :password, :count, :array, :uuid, :comment_id]
-    assert Schema.__schema__(:read_after_writes)  == [:email, :count]
-    assert Schema.__schema__(:primary_key)        == [:id]
-    assert Schema.__schema__(:autogenerate_id)    == {:id, :id, :id}
+    assert Schema.__schema__(:source)              == "my schema"
+    assert Schema.__schema__(:prefix)              == nil
+    assert Schema.__schema__(:fields)              == [:id, :name, :email, :password, :count, :array, :uuid, :query_excluded_field, :comment_id]
+    assert Schema.__schema__(:virtual_fields)      == [:temp]
+    assert Schema.__schema__(:query_fields)        == [:id, :name, :email, :password, :count, :array, :uuid, :comment_id]
+    assert Schema.__schema__(:read_after_writes)   == [:email, :count]
+    assert Schema.__schema__(:primary_key)         == [:id]
+    assert Schema.__schema__(:autogenerate_id)     == {:id, :id, :id}
+    assert Schema.__schema__(:autogenerate_fields) == [:name, :uuid]
   end
 
   test "types metadata" do
@@ -160,6 +162,7 @@ defmodule Ecto.SchemaTest do
   test "custom schema attributes" do
     assert %CustomSchema{perm: "abc"}.perm == "abc"
     assert CustomSchema.__schema__(:autogenerate_id) == {:perm, :PERM, CustomPermalink}
+    assert CustomSchema.__schema__(:autogenerate_fields) == [:inserted_at, :updated_at]
     assert CustomSchema.__schema__(:type, :comment_id) == :string
   end
 
@@ -293,6 +296,7 @@ defmodule Ecto.SchemaTest do
     assert TimestampsFalse.__schema__(:fields) == [:id]
     assert TimestampsFalse.__schema__(:autogenerate) == []
     assert TimestampsFalse.__schema__(:autoupdate) == []
+    assert TimestampsFalse.__schema__(:autogenerate_fields) == []
   end
 
   ## Schema prefix


### PR DESCRIPTION
Prior discussion: #3736

This PR adds `:autogenerate_fields` to the `__schema__` reflection API, which returns the field names of those fields that are auto generated on insert, _except for the primary key_, which is accessible through the existing `__schema__(:autogenerate_id)`.

There is currently no (public) API for accessing the fields that will be auto generated on insert. While this information is accessible through the private/undocumented `__schema__(:autogenerate)`, that would tie Ecto to the current storage of auto generated fields, as @josevalim mentioned in #3736. I've chosen instead to return a flat list of auto generated field names.

### Use-case

My specific use-case for this is to use it to skip auto generated fields in a library that constructs match ASTs from runtime values that can then be matched on later. To give a concrete example, the test:

```elixir
test "create_user/1 creates a user with valid attrs" do
  auto_assert Accounts.create_user(%{email: "valid@example.org"})
end
```

would be automatically updated the first time it is run to:

```elixir
test "create_user/1 creates a user with valid attrs" do
  auto_assert {:ok, %User{email: "valid@example.org"}} <- Accounts.create_user(%{email: "valid@example.org"})
end
```

The generated match pattern is minimized by comparing runtime field values to the default values returned by `User.__struct__()`, but without knowing which fields will be auto generated, it would _actually_ be written as:

```elixir
test "create_user/1 creates a user with valid attrs" do
  auto_assert {:ok,
               %User{
                 email: "valid@example.org",
                 inserted_at: ~N[2023-02-07 ...],
                 updated_at: ~N[2023-02-07 ...]
               }} <- Accounts.create_user(%{email: "valid@example.org"})
end
```

The next time this test is run, it would fail. `__schema__(:autogenerate_fields)` would be used to exclude by default fields that are auto generated if an Ecto schema is detected.