### PR TITLE
Support dynamic field inside json_extract_path

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -580,6 +580,11 @@ defmodule Ecto.Query.API do
       path = ["author", "name"]
       from(post in Post, select: json_extract_path(post.meta, ^path))
 
+  And the field can also be dynamic in combination with it:
+
+      path = ["author", "name"]
+      from(post in Post, select: json_extract_path(field(post, :meta), ^path))
+
   The query can be also rewritten as:
 
       from(post in Post, select: post.meta["author"]["name"])

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -237,6 +237,11 @@ defmodule Ecto.Query.Builder do
         {field, params_acc} = escape(field, type, params_acc, vars, env)
         {{:{}, [], [:json_extract_path, [], [field, path]]}, params_acc}
 
+      {:field, _, _} ->
+        path = escape_json_path(path)
+        {field, params_acc} = escape(field, type, params_acc, vars, env)
+        {{:{}, [], [:json_extract_path, [], [field, path]]}, params_acc}
+
       _ ->
         error!("`#{Macro.to_string(expr)}` is not a valid query expression")
     end

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -230,21 +230,12 @@ defmodule Ecto.Query.Builder do
   end
 
   # json
-  def escape({:json_extract_path, _, [field, path]} = expr, type, params_acc, vars, env) do
-    case field do
-      {{:., _, _}, _, _} ->
-        path = escape_json_path(path)
-        {field, params_acc} = escape(field, type, params_acc, vars, env)
-        {{:{}, [], [:json_extract_path, [], [field, path]]}, params_acc}
+  def escape({:json_extract_path, _, [field, path]}, type, params_acc, vars, env) do
+    validate_json_field!(field)
 
-      {:field, _, _} ->
-        path = escape_json_path(path)
-        {field, params_acc} = escape(field, type, params_acc, vars, env)
-        {{:{}, [], [:json_extract_path, [], [field, path]]}, params_acc}
-
-      _ ->
-        error!("`#{Macro.to_string(expr)}` is not a valid query expression")
-    end
+    path = escape_json_path(path)
+    {field, params_acc} = escape(field, type, params_acc, vars, env)
+    {{:{}, [], [:json_extract_path, [], [field, path]]}, params_acc}
   end
 
   def escape({{:., meta, [Access, :get]}, _, [left, _]} = expr, type, params_acc, vars, env) do
@@ -536,6 +527,10 @@ defmodule Ecto.Query.Builder do
 
   defp escape_type({:parameterized, _, _} = param), do: Macro.escape(param)
   defp escape_type(type), do: type
+
+  defp validate_json_field!({{:., _, _}, _, _}), do: :ok
+  defp validate_json_field!({:field, _, _}), do: :ok
+  defp validate_json_field!(unsupported_field), do: error!("`#{Macro.to_string(unsupported_field)}` is not a valid json field")
 
   defp wrap_nil(params, {:{}, _, [:^, _, [ix]]}), do: wrap_nil(params, length(params) - ix - 1, [])
   defp wrap_nil(params, _other), do: params

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -53,6 +53,10 @@ defmodule Ecto.Query.BuilderTest do
     actual = escape(quote do json_extract_path(x.y, ["a", "b"]) end, [x: 0], __ENV__)
     assert actual == expected
 
+    expected = {Macro.escape(quote do: json_extract_path(&0.y(), ["a", "b"])), []}
+    actual = escape(quote do json_extract_path(field(x, :y), ["a", "b"]) end, [x: 0], __ENV__)
+    assert actual == expected
+
     actual = escape(quote do x.y["a"]["b"] end, [x: 0], __ENV__)
     assert actual == expected
 

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -68,7 +68,7 @@ defmodule Ecto.Query.BuilderTest do
     actual = escape(quote do x.y[0]["a"] end, [x: 0], __ENV__)
     assert actual == expected
 
-    assert_raise Ecto.Query.CompileError, "`json_extract_path(x, [\"a\"])` is not a valid query expression", fn ->
+    assert_raise Ecto.Query.CompileError, "`x` is not a valid json field", fn ->
       escape(quote do json_extract_path(x, ["a"]) end, [x: 0], __ENV__)
     end
 


### PR DESCRIPTION
This PR adds support for dynamic fields inside `json_extract_path`, useful when not only the JSON path is dynamic, but also which JSON field we want to access. 