### PR TITLE
Fix validate_json_path for nested map inside embed

### DIFF
--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -63,6 +63,7 @@ defmodule Ecto.Query.PlannerTest do
 
     embedded_schema do
       field :slug, :string
+      field :map_inside_embed, :map
       embeds_one :author, Author
     end
   end
@@ -1151,6 +1152,12 @@ defmodule Ecto.Query.PlannerTest do
     normalize(query)
 
     query = from(Post, []) |> select([p], p.prefs["unknown_field"])
+    normalize(query)
+
+    query = from(Post, []) |> select([p], p.meta["map_inside_embed"]["unknown_field"])
+    normalize(query)
+
+    query = from(Post, []) |> select([p], json_extract_path(field(p, :meta), ^["map_inside_embed", "unknown_field"]))
     normalize(query)
 
     query = from(p in "posts") |> select([p], p.meta["slug"])


### PR DESCRIPTION
Currently `validate_json_path!` assumes that once it finds one embedded, everything down the path will also be embeds, which breaks when we have for example a `:map` inside an embedded schema.