### PR TITLE
Add optional format/1 callback to ParameterizedType

### DIFF
--- a/lib/ecto/association.ex
+++ b/lib/ecto/association.ex
@@ -1409,7 +1409,7 @@ defmodule Ecto.Association.ManyToMany do
       :error ->
         raise Ecto.ChangeError,
           "value `#{inspect value}` for `#{inspect struct.__struct__}.#{field}` " <>
-            "in `#{action}` does not match type #{inspect type}"
+            "in `#{action}` does not match type #{Ecto.Type.format(type)}"
     end
   end
 

--- a/lib/ecto/enum.ex
+++ b/lib/ecto/enum.ex
@@ -208,6 +208,11 @@ defmodule Ecto.Enum do
   @impl true
   def embed_as(_, %{embed_as: embed_as}), do: embed_as
 
+  @impl true
+  def format(%{mappings: mappings}) do
+    "#Ecto.Enum<values: #{inspect Keyword.keys(mappings)}>"
+  end
+
   @doc "Returns the possible values for a given schema and field"
   @spec values(module, atom) :: [atom()]
   def values(schema, field) do

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -145,7 +145,7 @@ defmodule Ecto.CastError do
   def exception(opts) do
     type  = Keyword.fetch!(opts, :type)
     value = Keyword.fetch!(opts, :value)
-    msg   = opts[:message] || "cannot cast #{inspect value} to #{inspect type}"
+    msg   = opts[:message] || "cannot cast #{inspect value} to #{Ecto.Type.format(type)}"
     %__MODULE__{message: msg, type: type, value: value}
   end
 end

--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -169,7 +169,17 @@ defmodule Ecto.ParameterizedType do
   """
   @callback autogenerate(params()) :: term()
 
-  @optional_callbacks autogenerate: 1
+  @doc """
+  Formats output when a ParameterizedType is printed in exceptions and
+  other logs.
+
+  Note this callback is not used when constructing `Ecto.Changeset` validation
+  errors. See the `:message` option of most `Ecto.Changeset` validation
+  functions for how to customize error messaging on a per `Ecto.Changeset` basis.
+  """
+  @callback format(params()) :: String.t()
+
+  @optional_callbacks autogenerate: 1, format: 1
 
   @doc """
   Inits a parameterized type given by `type` with `opts`.

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1913,7 +1913,7 @@ defmodule Ecto.Query.Planner do
       {:ok, v} ->
         {:ok, v}
       _ ->
-        {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{inspect type}"}
+        {:error, "value `#{inspect v}` in `#{kind}` cannot be cast to type #{Ecto.Type.format(type)}"}
     end
   end
 
@@ -1922,7 +1922,7 @@ defmodule Ecto.Query.Planner do
       {:ok, v} ->
         {:ok, v}
       :error ->
-        {:error, "value `#{inspect v}` cannot be dumped to type #{inspect type}"}
+        {:error, "value `#{inspect v}` cannot be dumped to type #{Ecto.Type.format(type)}"}
     end
   end
 

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -417,7 +417,7 @@ defmodule Ecto.Repo.Queryable do
         struct = struct && " in #{inspect(struct)}"
 
         raise ArgumentError,
-              "cannot load `#{inspect(value)}` as type #{inspect(type)}#{field}#{struct}"
+              "cannot load `#{inspect(value)}` as type #{Ecto.Type.format(type)}#{field}#{struct}"
     end
   end
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -836,7 +836,7 @@ defmodule Ecto.Repo.Schema do
       {:ok, value} ->
         load_each(%{struct | key => value}, kv, types, adapter)
       :error ->
-        raise ArgumentError, "cannot load `#{inspect value}` as type #{inspect type} " <>
+        raise ArgumentError, "cannot load `#{inspect value}` as type #{Ecto.Type.format(type)} " <>
                              "for field `#{key}` in schema #{inspect struct.__struct__}"
     end
   end
@@ -1009,7 +1009,7 @@ defmodule Ecto.Repo.Schema do
       :error ->
         raise Ecto.ChangeError,
               "value `#{inspect(value)}` for `#{inspect(schema)}.#{field}` " <>
-              "in `#{action}` does not match type #{inspect type}"
+              "in `#{action}` does not match type #{Ecto.Type.format(type)}"
     end
   end
 

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2223,7 +2223,7 @@ defmodule Ecto.Schema do
       {:ok, _} ->
         :ok
       _ ->
-        raise ArgumentError, "value #{inspect(value)} is invalid for type #{inspect(type)}, can't set default"
+        raise ArgumentError, "value #{inspect(value)} is invalid for type #{Ecto.Type.format(type)}, can't set default"
     end
   end
 
@@ -2259,7 +2259,7 @@ defmodule Ecto.Schema do
         {outer_type, check_field_type!(mod, name, inner_type, opts)}
 
       not is_atom(type) ->
-        raise ArgumentError, "invalid type #{inspect type} for field #{inspect name}"
+        raise ArgumentError, "invalid type #{Ecto.Type.format(type)} for field #{inspect name}"
 
       Ecto.Type.base?(type) ->
         type
@@ -2314,7 +2314,7 @@ defmodule Ecto.Schema do
 
       not function_exported?(typemod, :autogenerate, 1) ->
         raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "parameterized type #{inspect type} that does not define autogenerate/1"
+                             "parameterized type #{Ecto.Type.format(type)} that does not define autogenerate/1"
 
       true ->
         Module.put_attribute(mod, :ecto_autogenerate, {[name], {typemod, :autogenerate, [params]}})
@@ -2328,12 +2328,12 @@ defmodule Ecto.Schema do
 
       Ecto.Type.primitive?(type) ->
         raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "primitive type #{inspect type}"
+                             "primitive type #{Ecto.Type.format(type)}"
 
       # Note the custom type has already been loaded in check_type!/3
       not function_exported?(type, :autogenerate, 0) ->
         raise ArgumentError, "field #{inspect name} does not support :autogenerate because it uses a " <>
-                             "custom type #{inspect type} that does not define autogenerate/0"
+                             "custom type #{Ecto.Type.format(type)} that does not define autogenerate/0"
 
       true ->
         Module.put_attribute(mod, :ecto_autogenerate, {[name], {type, :autogenerate, []}})
@@ -2346,7 +2346,7 @@ defmodule Ecto.Schema do
         false
 
       not pk? ->
-        raise ArgumentError, "only primary keys allow :autogenerate for type #{inspect type}, " <>
+        raise ArgumentError, "only primary keys allow :autogenerate for type #{Ecto.Type.format(type)}, " <>
                              "field #{inspect name} is not a primary key"
 
       Module.get_attribute(mod, :ecto_autogenerate_id) ->

--- a/lib/ecto/schema/loader.ex
+++ b/lib/ecto/schema/loader.ex
@@ -74,7 +74,7 @@ defmodule Ecto.Schema.Loader do
 
       :error ->
         raise ArgumentError,
-              "cannot load `#{inspect(value)}` as type #{inspect(type)} " <>
+              "cannot load `#{inspect(value)}` as type #{Ecto.Type.format(type)} " <>
                 "for field `#{field}`#{error_data(struct)}"
     end
   end
@@ -98,7 +98,7 @@ defmodule Ecto.Schema.Loader do
         {:ok, value} ->
           Map.put(acc, source, value)
         :error ->
-          raise ArgumentError, "cannot dump `#{inspect value}` as type #{inspect type} " <>
+          raise ArgumentError, "cannot dump `#{inspect value}` as type #{Ecto.Type.format(type)} " <>
                                "for field `#{field}` in schema #{inspect struct.__struct__}"
       end
     end)

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1209,6 +1209,23 @@ defmodule Ecto.Type do
     false
   end
 
+  @doc """
+  Format type for error messaging and logs.
+  """
+  def format({:array, type}) do
+    "{:array, #{format(type)}}"
+  end
+
+  def format({:parameterized, type, params}) do
+    if function_exported?(type, :format, 1) do
+      apply(type, :format, [params])
+    else
+      "##{inspect(type)}<#{inspect(params)}>"
+    end
+  end
+
+  def format(type), do: inspect(type)
+
   ## Helpers
 
   # Checks if a value is of the given primitive type.

--- a/test/ecto/enum_test.exs
+++ b/test/ecto/enum_test.exs
@@ -380,7 +380,7 @@ defmodule Ecto.EnumTest do
 
     test "rejects invalid atom" do
       msg =
-        ~r"value `:foo2` for `Ecto.EnumTest.EnumSchema.my_enum` in `insert` does not match type"
+        ~r"value `:foo2` for `Ecto.EnumTest.EnumSchema.my_enum` in `insert` does not match type #Ecto\.Enum<values: \[:foo, :bar, :baz\]>"
 
       assert_raise Ecto.ChangeError, msg, fn ->
         TestRepo.insert!(%EnumSchema{my_enum: :foo2})
@@ -391,7 +391,7 @@ defmodule Ecto.EnumTest do
 
     test "rejects invalid value" do
       msg =
-        ~r"value `\[:a, :b, :c\]` for `Ecto.EnumTest.EnumSchema.my_enum` in `insert` does not match type"
+        ~r"value `\[:a, :b, :c\]` for `Ecto.EnumTest.EnumSchema.my_enum` in `insert` does not match type #Ecto\.Enum<values: \[:foo, :bar, :baz\]>"
 
       assert_raise Ecto.ChangeError, msg, fn ->
         TestRepo.insert!(%EnumSchema{my_enum: [:a, :b, :c]})
@@ -402,7 +402,7 @@ defmodule Ecto.EnumTest do
 
     test "rejects invalid mapped string value" do
       msg =
-        ~r"value `\[:a, :b, :c\]` for `Ecto.EnumTest.EnumSchema.my_string_enum` in `insert` does not match type"
+        ~r"value `\[:a, :b, :c\]` for `Ecto.EnumTest.EnumSchema.my_string_enum` in `insert` does not match type #Ecto\.Enum<values: \[:foo, :bar, :baz\]>"
 
       assert_raise Ecto.ChangeError, msg, fn ->
         TestRepo.insert!(%EnumSchema{my_string_enum: [:a, :b, :c]})
@@ -413,7 +413,7 @@ defmodule Ecto.EnumTest do
 
     test "rejects invalid integer value" do
       msg =
-        ~r"value `\[1, 2, 3\]` for `Ecto.EnumTest.EnumSchema.my_integer_enum` in `insert` does not match type"
+        ~r"value `\[1, 2, 3\]` for `Ecto.EnumTest.EnumSchema.my_integer_enum` in `insert` does not match type #Ecto\.Enum<values: \[:foo, :bar, :baz\]>"
 
       assert_raise Ecto.ChangeError, msg, fn ->
         TestRepo.insert!(%EnumSchema{my_integer_enum: [1, 2, 3]})
@@ -453,7 +453,7 @@ defmodule Ecto.EnumTest do
     test "reject invalid values" do
       Process.put(:test_repo_all_results, {1, [[1, "foo2", nil]]})
 
-      assert_raise ArgumentError, ~r/cannot load `\"foo2\"` as type/, fn ->
+      assert_raise ArgumentError, ~r/cannot load `\"foo2\"` as type #Ecto\.Enum<values: \[:foo, :bar, :baz\]>/, fn ->
         TestRepo.all(EnumSchema)
       end
     end

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -13,6 +13,7 @@ defmodule Ecto.ParameterizedTypeTest do
     def equal?(true, _, _), do: true
     def equal?(_, _, _), do: false
     def embed_as(_, %{embed: embed}), do: embed
+    def format(:format), do: "#MyParameterizedType<:format>"
   end
 
   defmodule Schema do
@@ -71,6 +72,8 @@ defmodule Ecto.ParameterizedTypeTest do
 
     assert Ecto.Type.cast(@p_self_type, :foo) == {:ok, :cast}
     assert Ecto.Type.cast(@p_self_type, nil) == {:ok, :cast}
+
+    assert Ecto.Type.format({:parameterized, MyParameterizedType, :format}) == "#MyParameterizedType<:format>"
   end
 
   test "on error" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -829,11 +829,11 @@ defmodule Ecto.Query.PlannerTest do
       normalize(Post |> where([p], p.title == :atoms_are_not_strings))
     end
 
-    assert_raise Ecto.QueryError, ~r/value `:unknown_status` cannot be dumped to type \{:parameterized, Ecto.Enum/, fn ->
+    assert_raise Ecto.QueryError, ~r/value `:unknown_status` cannot be dumped to type #Ecto.Enum<values: \[:draft, :published, :deleted\]>/, fn ->
       normalize(Post |> where([p], p.status == :unknown_status))
     end
 
-    assert_raise Ecto.Query.CastError, ~r/value `:pinned` in `where` cannot be cast to type {:parameterized, Ecto.Enum/, fn ->
+    assert_raise Ecto.Query.CastError, ~r/value `:pinned` in `where` cannot be cast to type #Ecto.Enum<values: \[:draft, :published, :deleted\]>/, fn ->
       normalize(Post |> where([p], p.status == ^:pinned))
     end
   end


### PR DESCRIPTION
The purpose of this callback is to format the output of a type when it
needs to be injected into errors and other logs. Previously, types were
injected into messaging by using `inspect(type)`. For ParameterizedTypes
this resulted in very noisy output. An example of this was `Ecto.Enum`.
Given this schema:

```elixir
defmodule User do
  use Ecto.Schema

  schema "users" do
    field :email, :string
    field :role, Ecto.Enum, values: [:admin, :editor], default: :editor

    timestamps()
  end
end
```

Doing the following action:

```elixir
Repo.insert!(%User{email: "alice@example.com", role: "admin"})
```

Would give you an error message similar to this

```
** (Ecto.ChangeError) value `"admin"` for `User.role` in `insert` does not match type
{:parameterized, Ecto.Enum, %{embed_as: :self, mappings: [admin: "admin", editor: "editor"],
on_cast: %{"admin" => :admin, "editor" => :editor}, on_dump: %{admin: "admin", editor:
"editor"}, on_load: %{"admin" => :admin, "editor" => :editor}, type: :string}}
```

The first implementer of this callback is `Ecto.Enum`. Given the
previous schema and incorrect type usage will result in the new error:

```
** (Ecto.ChangeError) value `"admin"` for `User.role` in `insert` does
not match type #Ecto.Enum<values: [:admin, :editor]>
```

This also includes parameterized types used in composite types. Given a
schema of:

```elixir
defmodule UserPermissions do
  use Ecto.Schema

  schema "user_permissions" do
    field :actions, {:array, Ecto.Enum}, values: [:read, :create, :update]

    timestamps()
  end
end
```

The following error could be produced:

```
** (Ecto.ChangeError) value `["write"]` for `UserPermissions.action` in `insert` does
not match type {:array, #Ecto.Enum<values: [:read, :create, :update]>}
```

For types that do not implement `format/1` the old behaviour of
`inspect(type)` will be the fallback.

RESOLVES: elixir-ecto#4093