### PR TITLE
Add with_ties default to `LimitExpr`.

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -437,7 +437,7 @@ defmodule Ecto.Query do
 
   defmodule LimitExpr do
     @moduledoc false
-    defstruct [:expr, :file, :line, :with_ties, params: []]
+    defstruct [:expr, :file, :line, with_ties: false, params: []]
   end
 
   defmodule Tagged do
@@ -2416,7 +2416,7 @@ defmodule Ecto.Query do
   def last(queryable, key), do: last(order_by(queryable, ^key), nil)
 
   defp limit do
-    %LimitExpr{expr: 1, params: [], with_ties: false, file: __ENV__.file, line: __ENV__.line}
+    %LimitExpr{expr: 1, params: [], file: __ENV__.file, line: __ENV__.line}
   end
 
   defp field(ix, field) when is_integer(ix) and is_atom(field) do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2416,7 +2416,7 @@ defmodule Ecto.Query do
   def last(queryable, key), do: last(order_by(queryable, ^key), nil)
 
   defp limit do
-    %LimitExpr{expr: 1, params: [], file: __ENV__.file, line: __ENV__.line}
+    %LimitExpr{expr: 1, params: [], with_ties: false, file: __ENV__.file, line: __ENV__.line}
   end
 
   defp field(ix, field) when is_integer(ix) and is_atom(field) do

--- a/lib/ecto/query/builder/limit_offset.ex
+++ b/lib/ecto/query/builder/limit_offset.ex
@@ -54,7 +54,6 @@ defmodule Ecto.Query.Builder.LimitOffset do
     quote do: %Ecto.Query.LimitExpr{
             expr: unquote(expr),
             params: unquote(params),
-            with_ties: false,
             file: unquote(env.file),
             line: unquote(env.line)
           }


### PR DESCRIPTION
Maybe it's better to explicitly put `false` as the struct's default because `LimitExpr` is built in other places like here: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query.ex#L2418