### PR TITLE
add dependency docs for telemetry

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -47,7 +47,7 @@ defmodule Ecto.Repo do
       Defaults to `10`
 
     * `:telemetry_prefix` - we recommend adapters to publish events
-      using the `Telemetry` library. By default, the telemetry prefix
+      using the [`:telemetry`](`:telemetry`) library. By default, the telemetry prefix
       is based on the module name, so if your module is called
       `MyApp.Repo`, the prefix will be `[:my_app, :repo]`. See the
       "Telemetry Events" section to see which events we recommend

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -47,7 +47,7 @@ defmodule Ecto.Repo do
       Defaults to `10`
 
     * `:telemetry_prefix` - we recommend adapters to publish events
-      using the [`:telemetry`](`:telemetry`) library. By default, the telemetry prefix
+      using the [Telemetry](`:telemetry`) library. By default, the telemetry prefix
       is based on the module name, so if your module is called
       `MyApp.Repo`, the prefix will be `[:my_app, :repo]`. See the
       "Telemetry Events" section to see which events we recommend

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,6 @@ defmodule Ecto.MixProject do
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: extras(),
       groups_for_extras: groups_for_extras(),
-      deps: deps_for_docs(),
       groups_for_functions: [
         group_for_function("Query API"),
         group_for_function("Schema API"),
@@ -139,12 +138,6 @@ defmodule Ecto.MixProject do
       Introduction: ~r/guides\/introduction\/.?/,
       Cheatsheets: ~r/cheatsheets\/.?/,
       "How-To's": ~r/guides\/howtos\/.?/
-    ]
-  end
-
-  defp deps_for_docs do
-    [
-      telemetry: "https://hexdocs.pm/telemetry"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Ecto.MixProject do
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: extras(),
       groups_for_extras: groups_for_extras(),
+      deps: deps_for_docs(),
       groups_for_functions: [
         group_for_function("Query API"),
         group_for_function("Schema API"),
@@ -138,6 +139,12 @@ defmodule Ecto.MixProject do
       Introduction: ~r/guides\/introduction\/.?/,
       Cheatsheets: ~r/cheatsheets\/.?/,
       "How-To's": ~r/guides\/howtos\/.?/
+    ]
+  end
+
+  defp deps_for_docs do
+    [
+      telemetry: "https://hexdocs.pm/telemetry"
     ]
   end
 


### PR DESCRIPTION
Not sure if this is right. But reading the Repo section about telemetry. The `telemetry` library is not linked accordingly.