### PR TITLE
Constraint match regex

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -236,15 +236,15 @@ defmodule Ecto.Changeset do
         |> Ecto.Changeset.validate_required(...)
         |> Ecto.Changeset.validate_length(...)
 
-  Besides the basic types which are mentioned above, such as `:boolean` and `:string`,
+  Besides the basic types which are mentioned above, such as `:boolean` and `:string`, 
   parameterized types can also be used in schemaless changesets. They implement
-  the `Ecto.ParameterizedType` behaviour and we can create the necessary type info by
+  the `Ecto.ParameterizedType` behaviour and we can create the necessary type info by 
   calling the `init/2` function.
 
   For example, to use `Ecto.Enum` in a schemaless changeset:
 
       types = %{
-        name: :string,
+        name: :string, 
         role: Ecto.ParameterizedType.init(Ecto.Enum, values: [:reader, :editor, :admin])
       }
 
@@ -2069,7 +2069,7 @@ defmodule Ecto.Changeset do
   Determines whether a field is missing in a changeset.
 
   The field passed into this function will have its presence evaluated
-  according to the same rules as `validate_required/3`.
+  according to the same rules as `validate_required/3`. 
 
   This is useful when performing complex validations that are not possible with
   `validate_required/3`. For example, evaluating whether at least one field
@@ -2083,7 +2083,7 @@ defmodule Ecto.Changeset do
       iex> changeset =
       ...>   case missing_fields do
       ...>     [_, _] -> add_error(changeset, :title, "at least one of `:title` or `:body` must be present")
-      ...>     _ -> changeset
+      ...>     _ -> changeset    
       ...>   end
       ...> changeset.errors
       [title: {"at least one of `:title` or `:body` must be present", []}]
@@ -2890,7 +2890,7 @@ defmodule Ecto.Changeset do
     * `:constraint` - the database constraint name as a string or `Regex`. The constraint at
       the database level will be checked against this according to `:match` type
     * `:match` - the type of match Ecto will perform on a violated constraint
-      against the `:constraint` value. It is `:exact`, `:suffix` or  `:prefix`
+      against the `:constraint` value. It is `:exact`, `:suffix` or `:prefix`
     * `:field` - the field a violated constraint will apply the error to
     * `:error_message` - the error message in case of violated constraints
     * `:error_type` - the type of error that identifies the error message

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -286,7 +286,17 @@ defmodule Ecto.ConstraintError do
           "The changeset has not defined any constraint."
         constraints ->
           "The changeset defined the following constraints:\n\n" <>
-            Enum.map_join(constraints, "\n", &"    * #{&1.constraint} (#{&1.type}_constraint)")
+            Enum.map_join(constraints, "\n", fn c ->
+              name =
+                case c.constraint do
+                  name when is_binary(name) ->
+                    name
+
+                  %Regex{} = r ->
+                    inspect(r)
+                end
+              "    * #{name} (#{c.type}_constraint)"
+            end)
       end
 
     msg = """

--- a/lib/ecto/exceptions.ex
+++ b/lib/ecto/exceptions.ex
@@ -286,17 +286,7 @@ defmodule Ecto.ConstraintError do
           "The changeset has not defined any constraint."
         constraints ->
           "The changeset defined the following constraints:\n\n" <>
-            Enum.map_join(constraints, "\n", fn c ->
-              name =
-                case c.constraint do
-                  name when is_binary(name) ->
-                    name
-
-                  %Regex{} = r ->
-                    inspect(r)
-                end
-              "    * #{name} (#{c.type}_constraint)"
-            end)
+            Enum.map_join(constraints, "\n", &"    * #{inspect(&1.constraint)} (#{&1.type}_constraint)")
       end
 
     msg = """

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -784,14 +784,7 @@ defmodule Ecto.Repo.Schema do
               {^type, ^constraint, :exact} -> true
               {^type, cc, :suffix} -> String.ends_with?(constraint, cc)
               {^type, cc, :prefix} -> String.starts_with?(constraint, cc)
-              {^type, cc, :regex} ->
-                case Regex.compile(cc) do
-                  {:ok, r} ->
-                    Regex.match?(r, constraint)
-
-                    _otherwise ->
-                      false
-                end
+              {^type, %Regex{} = r, _match} -> Regex.match?(r, constraint)
               _ -> false
             end
           end)

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -784,6 +784,14 @@ defmodule Ecto.Repo.Schema do
               {^type, ^constraint, :exact} -> true
               {^type, cc, :suffix} -> String.ends_with?(constraint, cc)
               {^type, cc, :prefix} -> String.starts_with?(constraint, cc)
+              {^type, cc, :regex} ->
+                case Regex.compile(cc) do
+                  {:ok, r} ->
+                    Regex.match?(r, constraint)
+
+                    _otherwise ->
+                      false
+                end
               _ -> false
             end
           end)

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1903,9 +1903,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :check, field: :title, constraint: "title_must_be_short", match: :prefix, error_message: "cannot be more than 15 characters", error_type: :check}]
 
-    changeset = change(%Post{}) |> check_constraint(:title, name: "title_must_be_short\\d+", match: :regex, message: "cannot be more than 15 characters")
+    changeset = change(%Post{}) |> check_constraint(:title, name: ~r/title_must_be_short\d+/, message: "cannot be more than 15 characters")
     assert constraints(changeset) ==
-          [%{type: :check, field: :title, constraint: "title_must_be_short\\d+", match: :regex, error_message: "cannot be more than 15 characters", error_type: :check}]
+          [%{type: :check, field: :title, constraint: ~r/title_must_be_short\d+/, match: :exact, error_message: "cannot be more than 15 characters", error_type: :check}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> check_constraint(:title, name: :title_must_be_short, match: :invalid, message: "match is invalid")
@@ -1935,9 +1935,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
            [%{type: :unique, field: :title, constraint: "whatever", match: :prefix, error_message: "is taken", error_type: :unique}]
 
-    changeset = change(%Post{}) |> unique_constraint(:title, name: "whatever\\d+", match: :regex, message: "is taken")
+    changeset = change(%Post{}) |> unique_constraint(:title, name: ~r/whatever\d+/, message: "is taken")
     assert constraints(changeset) ==
-          [%{type: :unique, field: :title, constraint: "whatever\\d+", match: :regex, error_message: "is taken", error_type: :unique}]
+          [%{type: :unique, field: :title, constraint: ~r/whatever\d+/, match: :exact, error_message: "is taken", error_type: :unique}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
@@ -1959,9 +1959,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
            [%{type: :unique, field: :permalink, constraint: "whatever", match: :suffix, error_message: "is taken", error_type: :unique}]
 
-    changeset = change(%Post{}) |> unique_constraint(:permalink, name: "whatever\\d+", match: :regex, message: "is taken")
+    changeset = change(%Post{}) |> unique_constraint(:permalink, name: ~r/whatever\d+/, message: "is taken")
     assert constraints(changeset) ==
-          [%{type: :unique, field: :permalink, constraint: "whatever\\d+", match: :regex, error_message: "is taken", error_type: :unique}]
+          [%{type: :unique, field: :permalink, constraint: ~r/whatever\d+/, match: :exact, error_message: "is taken", error_type: :unique}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :invalid, message: "is taken")
@@ -2004,9 +2004,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :prefix, error_message: "is not available", error_type: :foreign}]
 
-    changeset = change(%Comment{}) |> foreign_key_constraint(:post, name: "whatever\\d+", match: :regex, message: "is not available")
+    changeset = change(%Comment{}) |> foreign_key_constraint(:post, name: ~r/whatever\d+/, message: "is not available")
     assert constraints(changeset) ==
-          [%{type: :foreign_key, field: :post, constraint: "whatever\\d+", match: :regex, error_message: "is not available", error_type: :foreign}]
+          [%{type: :foreign_key, field: :post, constraint: ~r/whatever\d+/, match: :exact, error_message: "is not available", error_type: :foreign}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Comment{}) |> foreign_key_constraint(:post, name: :whatever, match: :invalid, message: "match is invalid")
@@ -2042,9 +2042,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :prefix, error_message: "is not available", error_type: :assoc}]
 
-    changeset = change(%Comment{}) |> assoc_constraint(:post, name: "whatever\\d+", match: :regex, message: "is not available")
+    changeset = change(%Comment{}) |> assoc_constraint(:post, name: ~r/whatever\d+/, message: "is not available")
     assert constraints(changeset) ==
-          [%{type: :foreign_key, field: :post, constraint: "whatever\\d+", match: :regex, error_message: "is not available", error_type: :assoc}]
+          [%{type: :foreign_key, field: :post, constraint: ~r/whatever\d+/, match: :exact, error_message: "is not available", error_type: :assoc}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Comment{}) |> assoc_constraint(:post, name: :whatever, match: :invalid, message: "match is invalid")
@@ -2087,9 +2087,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey", match: :prefix, error_message: "exists", error_type: :no_assoc}]
 
-    changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: "comments_post_id_fkey\\d+", match: :regex, message: "exists")
+    changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: ~r/comments_post_id_fkey\d+/, message: "exists")
     assert constraints(changeset) ==
-          [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey\\d+", match: :regex, error_message: "exists", error_type: :no_assoc}]
+          [%{type: :foreign_key, field: :comments, constraint: ~r/comments_post_id_fkey\d+/, match: :exact, error_message: "exists", error_type: :no_assoc}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> no_assoc_constraint(:comments, name: :comments_post_id_fkey, match: :invalid, message: "is taken")
@@ -2155,9 +2155,9 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :exclusion, field: :title, constraint: "whatever", match: :prefix, error_message: "is invalid", error_type: :exclusion}]
 
-    changeset = change(%Post{}) |> exclusion_constraint(:title, name: "whatever\\d+", match: :regex, message: "is invalid")
+    changeset = change(%Post{}) |> exclusion_constraint(:title, name: ~r/whatever\d+/, message: "is invalid")
     assert constraints(changeset) ==
-          [%{type: :exclusion, field: :title, constraint: "whatever\\d+", match: :regex, error_message: "is invalid", error_type: :exclusion}]
+          [%{type: :exclusion, field: :title, constraint: ~r/whatever\d+/, match: :exact, error_message: "is invalid", error_type: :exclusion}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1903,6 +1903,10 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :check, field: :title, constraint: "title_must_be_short", match: :prefix, error_message: "cannot be more than 15 characters", error_type: :check}]
 
+    changeset = change(%Post{}) |> check_constraint(:title, name: "title_must_be_short\\d+", match: :regex, message: "cannot be more than 15 characters")
+    assert constraints(changeset) ==
+          [%{type: :check, field: :title, constraint: "title_must_be_short\\d+", match: :regex, error_message: "cannot be more than 15 characters", error_type: :check}]
+
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> check_constraint(:title, name: :title_must_be_short, match: :invalid, message: "match is invalid")
     end
@@ -1931,6 +1935,10 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
            [%{type: :unique, field: :title, constraint: "whatever", match: :prefix, error_message: "is taken", error_type: :unique}]
 
+    changeset = change(%Post{}) |> unique_constraint(:title, name: "whatever\\d+", match: :regex, message: "is taken")
+    assert constraints(changeset) ==
+          [%{type: :unique, field: :title, constraint: "whatever\\d+", match: :regex, error_message: "is taken", error_type: :unique}]
+
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")
     end
@@ -1950,6 +1958,10 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :suffix, message: "is taken")
     assert constraints(changeset) ==
            [%{type: :unique, field: :permalink, constraint: "whatever", match: :suffix, error_message: "is taken", error_type: :unique}]
+
+    changeset = change(%Post{}) |> unique_constraint(:permalink, name: "whatever\\d+", match: :regex, message: "is taken")
+    assert constraints(changeset) ==
+          [%{type: :unique, field: :permalink, constraint: "whatever\\d+", match: :regex, error_message: "is taken", error_type: :unique}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> unique_constraint(:permalink, name: :whatever, match: :invalid, message: "is taken")
@@ -1992,6 +2004,10 @@ defmodule Ecto.ChangesetTest do
     assert constraints(changeset) ==
           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :prefix, error_message: "is not available", error_type: :foreign}]
 
+    changeset = change(%Comment{}) |> foreign_key_constraint(:post, name: "whatever\\d+", match: :regex, message: "is not available")
+    assert constraints(changeset) ==
+          [%{type: :foreign_key, field: :post, constraint: "whatever\\d+", match: :regex, error_message: "is not available", error_type: :foreign}]
+
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Comment{}) |> foreign_key_constraint(:post, name: :whatever, match: :invalid, message: "match is invalid")
     end
@@ -2025,6 +2041,10 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Comment{}) |> assoc_constraint(:post, name: :whatever, match: :prefix, message: "is not available")
     assert constraints(changeset) ==
           [%{type: :foreign_key, field: :post, constraint: "whatever", match: :prefix, error_message: "is not available", error_type: :assoc}]
+
+    changeset = change(%Comment{}) |> assoc_constraint(:post, name: "whatever\\d+", match: :regex, message: "is not available")
+    assert constraints(changeset) ==
+          [%{type: :foreign_key, field: :post, constraint: "whatever\\d+", match: :regex, error_message: "is not available", error_type: :assoc}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Comment{}) |> assoc_constraint(:post, name: :whatever, match: :invalid, message: "match is invalid")
@@ -2066,6 +2086,10 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: :comments_post_id_fkey, match: :prefix, message: "exists")
     assert constraints(changeset) ==
           [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey", match: :prefix, error_message: "exists", error_type: :no_assoc}]
+
+    changeset = change(%Post{}) |> no_assoc_constraint(:comments, name: "comments_post_id_fkey\\d+", match: :regex, message: "exists")
+    assert constraints(changeset) ==
+          [%{type: :foreign_key, field: :comments, constraint: "comments_post_id_fkey\\d+", match: :regex, error_message: "exists", error_type: :no_assoc}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> no_assoc_constraint(:comments, name: :comments_post_id_fkey, match: :invalid, message: "is taken")
@@ -2130,6 +2154,10 @@ defmodule Ecto.ChangesetTest do
     changeset = change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :prefix, message: "is invalid")
     assert constraints(changeset) ==
           [%{type: :exclusion, field: :title, constraint: "whatever", match: :prefix, error_message: "is invalid", error_type: :exclusion}]
+
+    changeset = change(%Post{}) |> exclusion_constraint(:title, name: "whatever\\d+", match: :regex, message: "is invalid")
+    assert constraints(changeset) ==
+          [%{type: :exclusion, field: :title, constraint: "whatever\\d+", match: :regex, error_message: "is invalid", error_type: :exclusion}]
 
     assert_raise ArgumentError, ~r/invalid match type: :invalid/, fn ->
       change(%Post{}) |> exclusion_constraint(:title, name: :whatever, match: :invalid, message: "match is invalid")

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1379,7 +1379,7 @@ defmodule Ecto.RepoTest do
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_part_90_custom_foo_index1234"]})
         |> Ecto.Changeset.change(x: "foo")
-        |> Ecto.Changeset.unique_constraint(:foo, name: "foo_table_part_.+_custom_foo_index\\d+", match: :regex)
+        |> Ecto.Changeset.unique_constraint(:foo, name: ~r/foo_table_part_.+_custom_foo_index\d+/)
       assert {:error, changeset} = TestRepo.insert(changeset)
       refute changeset.valid?
     end
@@ -1410,6 +1410,18 @@ defmodule Ecto.RepoTest do
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index")
+      assert_raise Ecto.ConstraintError, fn ->
+        TestRepo.insert(changeset)
+      end
+    end
+
+    test "may fail to map to repo constraint violation on name regex" do
+      my_schema = %MySchema{id: 1}
+      changeset =
+        put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
+        |> Ecto.Changeset.change(x: "foo")
+        |> Ecto.Changeset.unique_constraint(:foo, name: ~r/will_not_match/)
+
       assert_raise Ecto.ConstraintError, fn ->
         TestRepo.insert(changeset)
       end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1374,7 +1374,7 @@ defmodule Ecto.RepoTest do
       refute changeset.valid?
     end
 
-    test "are mapped to repo constraint violation using suffix match" do
+    test "are mapped to repo constraint violation using regex match" do
       my_schema = %MySchema{id: 1}
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_part_90_custom_foo_index1234"]})
@@ -1384,7 +1384,7 @@ defmodule Ecto.RepoTest do
       refute changeset.valid?
     end
 
-    test "are mapped to repo constraint violation using regex match" do
+    test "are mapped to repo constraint violation using suffix match" do
       my_schema = %MySchema{id: 1}
       changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1377,6 +1377,16 @@ defmodule Ecto.RepoTest do
     test "are mapped to repo constraint violation using suffix match" do
       my_schema = %MySchema{id: 1}
       changeset =
+        put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_part_90_custom_foo_index1234"]})
+        |> Ecto.Changeset.change(x: "foo")
+        |> Ecto.Changeset.unique_constraint(:foo, name: "foo_table_part_.+_custom_foo_index\\d+", match: :regex)
+      assert {:error, changeset} = TestRepo.insert(changeset)
+      refute changeset.valid?
+    end
+
+    test "are mapped to repo constraint violation using regex match" do
+      my_schema = %MySchema{id: 1}
+      changeset =
         put_in(my_schema.__meta__.context, {:invalid, [unique: "foo_table_custom_foo_index"]})
         |> Ecto.Changeset.change(x: "foo")
         |> Ecto.Changeset.unique_constraint(:foo, name: "custom_foo_index", match: :suffix)


### PR DESCRIPTION
## Why

I'm currently faced with a situation where we have a partitioned table in postgres where indexes are being generated with increased numbers in the middle and at the end, making both prefix and suffix match insufficient. We cannot change how this is defined at DB level.

Eg: `partition_table_XXX_index_name_idx_YY`

## How

This PR adds a `:regex` matcher for constraints, when doing so the constraint `name` is used to compile a regex and then check if the raised constraint matches it


Let me know if this is an acceptable solution.