### PR TITLE
Embedded schemas overwrite conflicting aliases

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2387,7 +2387,7 @@ defmodule Ecto.Schema do
     end
   end
 
-  defp expand_nested_module_alias({:__aliases__, _, [h | t]} = m, env) when is_atom(h) do
+  defp expand_nested_module_alias({:__aliases__, _, [h | t]}, env) when is_atom(h) do
     module = Module.concat([env.module, h])
 
     case t do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2387,11 +2387,11 @@ defmodule Ecto.Schema do
     end
   end
 
-  defp expand_nested_module_alias(expanded, _env) when is_atom(expanded), do: expanded
-
   defp expand_nested_module_alias({:__aliases__, _, [Elixir, _ | _] = alias}, _env),
     do: Module.concat(alias)
 
   defp expand_nested_module_alias({:__aliases__, _, [h | t]}, env) when is_atom(h),
     do: Module.concat([env.module, h | t])
+
+  defp expand_nested_module_alias(other, _env), do: other
 end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2387,12 +2387,11 @@ defmodule Ecto.Schema do
     end
   end
 
-  defp expand_nested_module_alias({:__aliases__, _, [h | t]}, env) when is_atom(h) do
-    module = Module.concat([env.module, h])
+  defp expand_nested_module_alias(expanded, _env) when is_atom(expanded), do: expanded
 
-    case t do
-      [] -> module
-      _ -> String.to_atom(Enum.join([module | t], "."))
-    end
-  end
+  defp expand_nested_module_alias({:__aliases__, _, [Elixir, _ | _] = alias}, _env),
+    do: Module.concat(alias)
+
+  defp expand_nested_module_alias({:__aliases__, _, [h | t]}, env) when is_atom(h),
+    do: Module.concat([env.module, h | t])
 end

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -99,8 +99,8 @@ defmodule Ecto.Changeset.EmbeddedTest do
     use Ecto.Schema
     alias Alias.One, warn: false
     alias Alias.Many, warn: false
-    alias Alias.OneNoPk, warn: false
-    alias Alias.ManyNoPk, warn: false
+    alias Alias.OneNoPK, warn: false
+    alias Alias.ManyNoPK, warn: false
 
 
     schema "aliases" do
@@ -119,7 +119,11 @@ defmodule Ecto.Changeset.EmbeddedTest do
     end
   end
 
-  test "nested embed alias conflict" do
+  test "nested embed overwrites conflicting alias" do
+    assert Alias.One.__schema__(:fields) == [:id, :name]
+    assert Alias.OneNoPK.__schema__(:fields) == [:name]
+    assert Alias.Many.__schema__(:fields) == [:id, :title]
+    assert Alias.ManyNoPK.__schema__(:fields) == [:title]
     assert %Ecto.Embedded{related: Alias.One} =
       Alias.__schema__(:embed, :one)
     assert %Ecto.Embedded{related: Alias.OneNoPK} =
@@ -128,10 +132,6 @@ defmodule Ecto.Changeset.EmbeddedTest do
       Alias.__schema__(:embed, :many)
     assert %Ecto.Embedded{related: Alias.ManyNoPK} =
       Alias.__schema__(:embed, :many_no_pk)
-    assert Alias.One.__schema__(:fields) == [:id, :name]
-    assert Alias.OneNoPK.__schema__(:fields) == [:name]
-    assert Alias.Many.__schema__(:fields) == [:id, :title]
-    assert Alias.ManyNoPK.__schema__(:fields) == [:title]
   end
 
   defp cast(schema, params, embed, opts \\ []) do

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -102,7 +102,6 @@ defmodule Ecto.Changeset.EmbeddedTest do
     alias Alias.OneNoPK, warn: false
     alias Alias.ManyNoPK, warn: false
 
-
     schema "aliases" do
       embeds_one :one, One do
         field :name, :string

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -95,6 +95,45 @@ defmodule Ecto.Changeset.EmbeddedTest do
     end
   end
 
+  defmodule Alias do
+    use Ecto.Schema
+    alias Alias.One, warn: false
+    alias Alias.Many, warn: false
+    alias Alias.OneNoPk, warn: false
+    alias Alias.ManyNoPk, warn: false
+
+
+    schema "aliases" do
+      embeds_one :one, One do
+        field :name, :string
+      end
+      embeds_one :one_no_pk, OneNoPK, primary_key: false do
+        field :name, :string
+      end
+      embeds_many :many, Many do
+        field :title, :string
+      end
+      embeds_many :many_no_pk, ManyNoPK, primary_key: false do
+        field :title, :string
+      end
+    end
+  end
+
+  test "nested embed alias conflict" do
+    assert %Ecto.Embedded{related: Alias.One} =
+      Alias.__schema__(:embed, :one)
+    assert %Ecto.Embedded{related: Alias.OneNoPK} =
+      Alias.__schema__(:embed, :one_no_pk)
+    assert %Ecto.Embedded{related: Alias.Many} =
+      Alias.__schema__(:embed, :many)
+    assert %Ecto.Embedded{related: Alias.ManyNoPK} =
+      Alias.__schema__(:embed, :many_no_pk)
+    assert Alias.One.__schema__(:fields) == [:id, :name]
+    assert Alias.OneNoPK.__schema__(:fields) == [:name]
+    assert Alias.Many.__schema__(:fields) == [:id, :title]
+    assert Alias.ManyNoPK.__schema__(:fields) == [:title]
+  end
+
   defp cast(schema, params, embed, opts \\ []) do
     schema
     |> Changeset.cast(params, ~w())

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -95,14 +95,14 @@ defmodule Ecto.Changeset.EmbeddedTest do
     end
   end
 
-  defmodule Alias do
+  defmodule NestedInline do
     use Ecto.Schema
     alias Alias.One, warn: false
     alias Alias.Many, warn: false
     alias Alias.OneNoPK, warn: false
     alias Alias.ManyNoPK, warn: false
 
-    schema "aliases" do
+    schema "nested_inline" do
       embeds_one :root, Elixir.Root do
         field :name, :string
       end
@@ -129,20 +129,26 @@ defmodule Ecto.Changeset.EmbeddedTest do
     end
   end
 
-  test "nested embed overwrites conflicting alias" do
+  test "nested inline embed can be a root module" do
     assert Root.__schema__(:fields) == [:id, :name]
-    assert Expanded.__schema__(:fields) == [:id, :name]
-    assert Alias.One.__schema__(:fields) == [:id, :name]
-    assert Alias.OneNoPK.__schema__(:fields) == [:name]
-    assert Alias.Many.__schema__(:fields) == [:id, :title]
-    assert Alias.ManyNoPK.__schema__(:fields) == [:title]
+    assert %Ecto.Embedded{related: Root} = NestedInline.__schema__(:embed, :root)
+  end
 
-    assert %Ecto.Embedded{related: Root} = Alias.__schema__(:embed, :root)
-    assert %Ecto.Embedded{related: Expanded} = Alias.__schema__(:embed, :expanded)
-    assert %Ecto.Embedded{related: Alias.One} = Alias.__schema__(:embed, :one)
-    assert %Ecto.Embedded{related: Alias.OneNoPK} = Alias.__schema__(:embed, :one_no_pk)
-    assert %Ecto.Embedded{related: Alias.Many} = Alias.__schema__(:embed, :many)
-    assert %Ecto.Embedded{related: Alias.ManyNoPK} = Alias.__schema__(:embed, :many_no_pk)
+  test "nested inline embed alias can already be expanded" do
+    assert Expanded.__schema__(:fields) == [:id, :name]
+    assert %Ecto.Embedded{related: Expanded} = NestedInline.__schema__(:embed, :expanded)
+  end
+
+  test "nested inilne embed overwrites conflicting alias" do
+    assert NestedInline.One.__schema__(:fields) == [:id, :name]
+    assert NestedInline.OneNoPK.__schema__(:fields) == [:name]
+    assert NestedInline.Many.__schema__(:fields) == [:id, :title]
+    assert NestedInline.ManyNoPK.__schema__(:fields) == [:title]
+
+    assert %Ecto.Embedded{related: NestedInline.One} = NestedInline.__schema__(:embed, :one)
+    assert %Ecto.Embedded{related: NestedInline.OneNoPK} = NestedInline.__schema__(:embed, :one_no_pk)
+    assert %Ecto.Embedded{related: NestedInline.Many} = NestedInline.__schema__(:embed, :many)
+    assert %Ecto.Embedded{related: NestedInline.ManyNoPK} = NestedInline.__schema__(:embed, :many_no_pk)
   end
 
   defp cast(schema, params, embed, opts \\ []) do

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -103,15 +103,26 @@ defmodule Ecto.Changeset.EmbeddedTest do
     alias Alias.ManyNoPK, warn: false
 
     schema "aliases" do
+      embeds_one :root, Elixir.Root do
+        field :name, :string
+      end
+
+      embeds_one :expanded, :"Elixir.Expanded" do
+        field :name, :string
+      end
+
       embeds_one :one, One do
         field :name, :string
       end
+
       embeds_one :one_no_pk, OneNoPK, primary_key: false do
         field :name, :string
       end
+
       embeds_many :many, Many do
         field :title, :string
       end
+
       embeds_many :many_no_pk, ManyNoPK, primary_key: false do
         field :title, :string
       end
@@ -119,18 +130,19 @@ defmodule Ecto.Changeset.EmbeddedTest do
   end
 
   test "nested embed overwrites conflicting alias" do
+    assert Root.__schema__(:fields) == [:id, :name]
+    assert Expanded.__schema__(:fields) == [:id, :name]
     assert Alias.One.__schema__(:fields) == [:id, :name]
     assert Alias.OneNoPK.__schema__(:fields) == [:name]
     assert Alias.Many.__schema__(:fields) == [:id, :title]
     assert Alias.ManyNoPK.__schema__(:fields) == [:title]
-    assert %Ecto.Embedded{related: Alias.One} =
-      Alias.__schema__(:embed, :one)
-    assert %Ecto.Embedded{related: Alias.OneNoPK} =
-      Alias.__schema__(:embed, :one_no_pk)
-    assert %Ecto.Embedded{related: Alias.Many} =
-      Alias.__schema__(:embed, :many)
-    assert %Ecto.Embedded{related: Alias.ManyNoPK} =
-      Alias.__schema__(:embed, :many_no_pk)
+
+    assert %Ecto.Embedded{related: Root} = Alias.__schema__(:embed, :root)
+    assert %Ecto.Embedded{related: Expanded} = Alias.__schema__(:embed, :expanded)
+    assert %Ecto.Embedded{related: Alias.One} = Alias.__schema__(:embed, :one)
+    assert %Ecto.Embedded{related: Alias.OneNoPK} = Alias.__schema__(:embed, :one_no_pk)
+    assert %Ecto.Embedded{related: Alias.Many} = Alias.__schema__(:embed, :many)
+    assert %Ecto.Embedded{related: Alias.ManyNoPK} = Alias.__schema__(:embed, :many_no_pk)
   end
 
   defp cast(schema, params, embed, opts \\ []) do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4124

Properly expands the nested embed module name so that it won't be overwritten by conflicting aliases.

I think we only need to care about expanding nested module aliases so I didn't consider the other cases from: https://github.com/elixir-lang/elixir/blob/50741091baa10170805730ed91943c481b7ab270/lib/elixir/lib/kernel.ex#L4971-L4993.

But this is not my strong suit so please correct me if I'm mistaken.
