### PR TITLE
Add `map/1` to `Ecto.Query.API`

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -514,6 +514,24 @@ defmodule Ecto.Query.API do
   def struct(source, fields), do: doc! [source, fields]
 
   @doc """
+  Used in `select` to return the source as a map instead of a struct.
+
+  For example:
+
+      # from source
+      from p in Post, select: map(p)
+
+      # join source
+      from(p in Post, join: c in Comment, on: true,
+           select: {p, map(c)})
+
+  It can also be used with `select_merge`:
+
+      from p in Post, select: map(p), select_merge: [:payload]
+  """
+  def map(source), do: doc! [source]
+
+  @doc """
   Used in `select` to specify which fields should be returned as a map.
 
   For example, if you don't need all fields to be returned or

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -362,8 +362,8 @@ defmodule Ecto.Query.Builder.Select do
   defp merge(query, select, old_expr, old_params, old_subqueries, old_take, old_aliases, new_select) do
     %{expr: new_expr, params: new_params, subqueries: new_subqueries, take: new_take, aliases: new_aliases} = new_select
 
-    {old_expr, old_take} = expand_map(query, old_expr, old_take)
-    {new_expr, new_take} = expand_map(query, new_expr, new_take)
+    {old_expr, old_take} = expand_map!(query, old_expr, old_take)
+    {new_expr, new_take} = expand_map!(query, new_expr, new_take)
 
     new_expr =
       new_expr
@@ -436,7 +436,7 @@ defmodule Ecto.Query.Builder.Select do
     %{query | select: select}
   end
 
-  defp expand_map(query, {:map, _, [{:&, _, [ix]} = amp]}, take) do
+  defp expand_map!(query, {:map, _, [{:&, _, [ix]} = amp]}, take) do
     take =
       case get_source(query, ix) do
         {_, schema} when schema != nil ->
@@ -450,7 +450,7 @@ defmodule Ecto.Query.Builder.Select do
     {amp, take}
   end
 
-  defp expand_map(_, expr, take), do: {expr, take}
+  defp expand_map!(_, expr, take), do: {expr, take}
 
   defp get_source(query, ix) do
     Enum.at([query.from | query.joins], ix).source

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -444,7 +444,7 @@ defmodule Ecto.Query.Builder.Select do
           add_take(take, ix, {:map, fields})
 
         _ ->
-          take
+          raise "map/1 requires a source with a schema"
       end
 
     {amp, take}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1434,7 +1434,6 @@ defmodule Ecto.Query.Planner do
     {put_in(query.select.fields, fields), select}
   end
 
-
   defp normalize_selected_as(fields, aliases) when aliases == %{}, do: fields
 
   defp normalize_selected_as(fields, _aliases) do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -664,5 +664,15 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert Macro.to_string(query.select.expr) == "&0"
       assert query.select.take == %{0 => {:map, [:dislikes] ++ comment_fields}}
     end
+
+    test "map/1 requires a source with a schema" do
+      assert_raise RuntimeError, "map/1 requires a source with a schema", fn ->
+        from c in "comments", select: c, select_merge: map(c)
+      end
+
+      assert_raise RuntimeError, "map/1 requires a source with a schema", fn ->
+        from c in "comments", select: map(c), select_merge: [:dislikes]
+      end
+    end
   end
 end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -490,6 +490,11 @@ defmodule Ecto.Query.InspectTest do
     assert i(query) == ~s<from p0 in Inspect.Post, select: type(^..., {:parameterized, Ecto.Query.InspectTest.MyParameterizedType, :foo})>
   end
 
+  test "map/1" do
+    query = from p in Post, select: map(p)
+    assert i(query) == ~s<from p0 in Inspect.Post, select: map(p0)>
+  end
+
   def plan(query) do
     {query, _, _} = Ecto.Adapter.Queryable.plan_query(:all, Ecto.TestAdapter, query)
     query

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -441,6 +441,13 @@ defmodule Ecto.Query.SubqueryTest do
       end
     end
 
+    test "with map/1" do
+      post_fields = Post.__schema__(:query_fields)
+      subquery = from p in Post, select: map(p)
+      query = normalize(from(p in subquery(subquery)))
+      assert query.select.fields == select_fields(post_fields, 0)
+    end
+
     test "invalid usage" do
       assert_raise Ecto.SubQueryError, ~r/does not allow `update` expressions in query/, fn ->
         query = from p in Post, update: [set: [title: nil]]


### PR DESCRIPTION
**Motivation** 

It seems it helps with LiveBook: https://groups.google.com/g/elixir-ecto/c/8E8MGOma-XM. 

**Implementation**

There were 2 options I thought were possible:

1. Change the select `expr` to signify it is a map.
2. Change the `take` value to signify we want all the fields

This PR was done with option 2. I thought the blast radius would be a lot larger for option 1.

Basically I am setting take to be `nil` if `map/1` is used. I believe this is safe because otherwise it's guaranteed to be a list. Also `nil` is safer over other atoms because sometimes `Access.fetch` is called on `take` to find association fields.