### PR TITLE
Cheatsheet update docs.

### DIFF
--- a/cheatsheets/associations.cheatmd
+++ b/cheatsheets/associations.cheatmd
@@ -200,7 +200,7 @@ Repo.get_by!(Movie, title: "The Shawshank Redemption")
 params = %{"name" => "Red", "age" => 60}
 
 Repo.get_by!(Movie, title: "The Shawshank Redemption")
-|> Ecto.build_assoc(movie, :characters)
+|> Ecto.build_assoc(:characters)
 |> cast(params, [:name, :age])
 |> Repo.insert()
 ```


### PR DESCRIPTION
`Ecto.build_assoc(movie, :characters)` tooke the `movie` from previous pipe operator. So, `build_assoc/2` is now correct.