### PR TITLE
Use correct fields when select merging into a source

### DIFF
--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -566,6 +566,12 @@ defmodule Ecto.Query.Builder.SelectTest do
       assert query.select.params == []
       assert query.select.take == %{0 => {:any, [:dislikes, :title, :likes]}}
 
+      query = from p in "posts", join: c in Comment, on: true, select: c, select_merge: map(c, [:dislikes])
+
+      assert Macro.to_string(query.select.expr) == "&1"
+      assert query.select.params == []
+      assert query.select.take == %{1 => {:map, [:dislikes, :title, :likes]}}
+
       # On take with schemaless source
       query = from c in "comments", select: [:title], select_merge: [:likes]
 


### PR DESCRIPTION
When select merging into a source there is a bit of a hiccup where you don't immediately know all of the source's fields. Last year there was a fix made for this: https://github.com/elixir-ecto/ecto/pull/3989.

The issue is that it always assumed the source you are merging into is the `from` source. I was playing around with this and saw there are situations where might have a `join` source (see the new test).