### PR TITLE
support map(q, [:list, :of, :fields]) in source query of insert_all 

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -114,6 +114,11 @@ defmodule Ecto.Repo.Schema do
       %Ecto.Query.SelectExpr{expr: {:%{}, _ctx, args}} ->
         Enum.map(args, &elem(&1, 0))
 
+      %Ecto.Query.SelectExpr{take: take} when is_map(take) ->
+        # we want to support any table index, so we just get the first entry
+        {:map, fields} = take |> Enum.at(0) |> elem(1)
+        fields
+
       _ ->
         raise ArgumentError, """
         cannot generate a fields list for insert_all from the given source query
@@ -130,7 +135,7 @@ defmodule Ecto.Repo.Schema do
               field_b: x.foo
             }
 
-        The keys must exist in the schema that is being inserted into
+        All keys must exist in the schema that is being inserted into
         """
     end
 


### PR DESCRIPTION
It allows insert_all source queries to be written like this:

```elixir
fields = [:a, :foo, :baz]
query = from d in Data, select: map(d, ^fields)
Repo.insert_all(Stuff, query)
```