### PR TITLE
Add `:nulls_distinct` option to `unsafe_validate_unique`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2405,11 +2405,11 @@ defmodule Ecto.Changeset do
       in Postgres or the database in MySQL). See `Ecto.Repo` documentation
       for more information.
 
-    * `:nulls_distinct` - a boolean controlling whether all null values are considered
-      equal. If `false`, `nil` values will have their uniqueness checked. Otherwise, the
-      check will not be performed. This is only meaningful when paired with a unique index
-      that treats nulls as equal, such as Postgres 15's `NULLS NOT DISTINCT` option.
-      Defaults to `true`
+    * `:nulls_distinct` - a boolean controlling whether different null values
+      are considered distinct (not equal). If `false`, `nil` values will have
+      their uniqueness checked. Otherwise, the check will not be performed. This
+      is only meaningful when paired with a unique index that treats nulls as equal,
+      such as Postgres 15's `NULLS NOT DISTINCT` option. Defaults to `true`
 
     * `:repo_opts` - the options to pass to the `Ecto.Repo` call.
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2369,8 +2369,6 @@ defmodule Ecto.Changeset do
       ensure_field_exists!(changeset, changeset.types, field)
   end
 
-  import Ecto.Query, only: [dynamic: 1, dynamic: 2]
-
   @doc """
   Validates that no existing record with a different primary key
   has the same values for these fields.
@@ -2500,10 +2498,10 @@ defmodule Ecto.Changeset do
   end
 
   defp unsafe_unique_filter(fields, changeset, false) do
-    Enum.reduce(fields, dynamic(true), fn field, dynamic ->
+    Enum.reduce(fields, Ecto.Query.dynamic(true), fn field, dynamic ->
       case get_field(changeset, field) do
-        nil -> dynamic([q], ^dynamic and is_nil(field(q, ^field)))
-        value -> dynamic([q], ^dynamic and field(q, ^field) == ^value)
+        nil -> Ecto.Query.dynamic([q], ^dynamic and is_nil(field(q, ^field)))
+        value -> Ecto.Query.dynamic([q], ^dynamic and field(q, ^field) == ^value)
       end
     end)
   end

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2369,6 +2369,8 @@ defmodule Ecto.Changeset do
       ensure_field_exists!(changeset, changeset.types, field)
   end
 
+  import Ecto.Query, only: [dynamic: 1, dynamic: 2]
+
   @doc """
   Validates that no existing record with a different primary key
   has the same values for these fields.
@@ -2402,6 +2404,12 @@ defmodule Ecto.Changeset do
     * `:prefix` - the prefix to run the query on (such as the schema path
       in Postgres or the database in MySQL). See `Ecto.Repo` documentation
       for more information.
+
+    * `:nulls_distinct` - a boolean controlling whether all null values are considered
+      equal. If `false`, `nil` values will have their uniqueness checked. Otherwise, the
+      check will not be performed. This is only meaningful when paired with a unique index
+      that treats nulls as equal, such as Postgres 15's `NULLS NOT DISTINCT` option.
+      Defaults to `true`
 
     * `:repo_opts` - the options to pass to the `Ecto.Repo` call.
 
@@ -2448,9 +2456,8 @@ defmodule Ecto.Changeset do
     fields = List.wrap(fields)
     changeset = %{changeset | validations: [{hd(fields), {:unsafe_unique, fields: fields}} | validations]}
 
-    where_clause = for field <- fields do
-      {field, get_field(changeset, field)}
-    end
+    nulls_distinct = Keyword.get(opts, :nulls_distinct, true)
+    where_clause = unsafe_unique_filter(fields, changeset, nulls_distinct)
 
     # No need to query if there is a prior error for the fields
     any_prior_errors_for_fields? = Enum.any?(changeset.errors, &(elem(&1, 0) in fields))
@@ -2458,10 +2465,15 @@ defmodule Ecto.Changeset do
     # No need to query if we haven't changed any of the fields in question
     unrelated_changes? = Enum.all?(fields, &not Map.has_key?(changeset.changes, &1))
 
-    # If we don't have values for all fields, we can't query for uniqueness
-    any_nil_values_for_fields? = Enum.any?(where_clause, &(&1 |> elem(1) |> is_nil()))
+    # If one or more fields are `nil` and `nulls_distinct` is not false, we can't query for uniqueness
+    distinct_nils? =
+      if nulls_distinct == false do
+        false
+      else
+        Enum.any?(where_clause, &(&1 |> elem(1) |> is_nil()))
+      end
 
-    if unrelated_changes? or any_nil_values_for_fields? or any_prior_errors_for_fields? do
+    if unrelated_changes? or distinct_nils? or any_prior_errors_for_fields? do
       changeset
     else
       query =
@@ -2484,6 +2496,21 @@ defmodule Ecto.Changeset do
       else
         changeset
       end
+    end
+  end
+
+  defp unsafe_unique_filter(fields, changeset, false) do
+    Enum.reduce(fields, dynamic(true), fn field, dynamic ->
+      case get_field(changeset, field) do
+        nil -> dynamic([q], ^dynamic and is_nil(field(q, ^field)))
+        value -> dynamic([q], ^dynamic and field(q, ^field) == ^value)
+      end
+    end)
+  end
+
+  defp unsafe_unique_filter(fields, changeset, _nulls_distinct) do
+    for field <- fields do
+      {field, get_field(changeset, field)}
     end
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1774,8 +1774,8 @@ defmodule Ecto.ChangesetTest do
     end
 
     test "accepts nulls_distinct option" do
-      body_change = changeset(%Post{title: nil, body: "hi", color: "red"}, %{body: nil})
-      unsafe_validate_unique(body_change, [:body, :title, :color], MockRepo, nulls_distinct: false)
+      cs = changeset(%Post{title: nil, body: "hi", color: "red"}, %{body: nil})
+      unsafe_validate_unique(cs, [:body, :title, :color], MockRepo, nulls_distinct: false)
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: check_expr}] = wheres
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -1773,6 +1773,15 @@ defmodule Ecto.ChangesetTest do
       assert Macro.to_string(check_expr) == "&0.body() == ^0"
     end
 
+    test "accepts nulls_distinct option" do
+      body_change = changeset(%Post{title: nil, body: "hi", color: "red"}, %{body: nil})
+      unsafe_validate_unique(body_change, [:body, :title, :color], MockRepo, nulls_distinct: false)
+      assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
+      assert [%{expr: check_expr}] = wheres
+
+      assert Macro.to_string(check_expr) == "true and is_nil(&0.body()) and is_nil(&0.title()) and &0.color() == ^0"
+    end
+
     test "generates correct where clause for single primary key without query option for loaded schema" do
       body_change =
         %SinglePkSchema{id: 0, body: "hi"}


### PR DESCRIPTION
This option allows the user to check uniqueness for `nil` values. It is useful when paired with Postgres 15's `NULLS NOT DISTINCT` option that was added here: https://github.com/elixir-ecto/ecto_sql/pull/439.

I saw someone ask for this feature on Elixir Forum and thought it was a good idea.