### PR TITLE
Enhance behaviour of alternative (or) in select

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1417,6 +1417,16 @@ defmodule Ecto.Query.Planner do
     end
   end
 
+  defp collect_fields({:or, _, [left, right]}, fields, from, query, take, keep_literals?, _drop) do
+    {left, left_fields, left_from} =
+      collect_fields(left, fields, from, query, take, keep_literals?, %{})
+
+    {right, right_fields, right_from} =
+      collect_fields(right, left_fields, left_from, query, take, keep_literals?, %{})
+
+    {{:or, left, right}, right_fields, right_from}
+  end
+
   defp collect_fields({:&, _, [0]}, fields, :none, query, take, _keep_literals?, drop) do
     {expr, taken} = source_take!(:select, query, take, 0, 0, drop)
     {{:source, :from}, fields, {{:source, :from}, expr, taken}}

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -292,6 +292,12 @@ defmodule Ecto.Repo.Queryable do
     struct_load!(types, row, [], true, struct, adapter)
   end
 
+  defp process(row, {:or, left, right}, from, adapter) do
+    {left, row} = process(row, left, from, adapter)
+    {right, row} = process(row, right, from, adapter)
+    {left || right, row}
+  end
+
   defp process(row, {:merge, left, right}, from, adapter) do
     {left, row} = process(row, left, from, adapter)
     {right, row} = process(row, right, from, adapter)


### PR DESCRIPTION
Hello!

I have interesting (I hope) contribution to the select functionality in Ecto.
In my project I was trying to explore ways to solve single/class table inheritance. 
It was looking fine but was missing one thing: Ecto couldn't guess what type it would be since it expects type to be known upfront.

So this pseudocode would return always one type (Details):
```
module Animal: 
    schema "animal": 
        field: number_of_legs,
        has_one: species_details, Details

module Dog: 
    schema "animal": 
        field: number_of_legs,
        has_one: species_details, DogDetails

module Cat: 
    schema "animal": 
        field: number_of_legs,
        has_one: species_details, CatDetails

Animal |> preload(species_details) |> Repo.all()
```

What I wanted was to have concrete type for `species_detail`
After long thinking I decided to try simplest solution that doesn't break many concepts (I hope 😅).

So I made this possible:
```
module Animal: 
    schema "animal": 
        field: number_of_legs,
        virtual field: species_details
        has_one: dog_details, DogDetails
        has_one: cat_details, CatDetails

Animal 
|> join(assoc(dog_details))
|> join(assoc(cat_details))
|> select_merge(species_details: cat_details or dog_details)
|> Repo.all()
```
This will return list of animals with `species_details` filled with appropriate struct responsible for specific species.

You can find some "dummy" examples in tests.

I'm aware that this **changes** current functionality of `or` in the `select`. Until now this would be sent to the DB and was evaluated there, with this change it still works for things like `a.active or b.active` but will be evaluated in code.
There are two reasons I think it's fine to change this behaviour:
1. One can easily do `fragment("? or ?")` to make it work as previously
2. I think (but may be wrong) that it's not very common to use `fieldA or fieldB` in select clause to get some value. One would rather use `coalesce`

Let me know your thoughts! 😄 