### PR TITLE
Add abstract schema

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -13,6 +13,7 @@ defmodule Ecto.Integration.RepoTest do
   alias Ecto.Integration.Barebone
   alias Ecto.Integration.CompositePk
   alias Ecto.Integration.PostUserCompositePk
+  alias Ecto.Integration.Abstract
 
   test "returns already started for started repos" do
     assert {:error, {:already_started, _}} = TestRepo.start_link()
@@ -2162,5 +2163,17 @@ defmodule Ecto.Integration.RepoTest do
       assert updated_second.visits == 21
       assert updated_second.public == false
     end
+  end
+
+  test "xd" do
+    message = "Ecto.Integration.Abstract needs to be a schema with source"
+    assert_raise ArgumentError, message, fn ->
+      TestRepo.insert(%Abstract{})
+    end
+
+   {:ok, %Abstract{}} =
+     %Abstract{}
+     |> Ecto.put_meta([source: "concrete_table_for_abstract"])
+     |> TestRepo.insert()
   end
 end

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -2165,9 +2165,8 @@ defmodule Ecto.Integration.RepoTest do
     end
   end
 
-  test "xd" do
-    message = "Ecto.Integration.Abstract needs to be a schema with source"
-    assert_raise ArgumentError, message, fn ->
+  test "abstract schema usage" do
+    assert_raise ArgumentError, ~r/needs to be a schema with source/, fn ->
       TestRepo.insert(%Abstract{})
     end
 
@@ -2175,5 +2174,11 @@ defmodule Ecto.Integration.RepoTest do
      %Abstract{}
      |> Ecto.put_meta([source: "concrete_table_for_abstract"])
      |> TestRepo.insert()
+
+    assert [_] = TestRepo.all({"concrete_table_for_abstract", Abstract})
+
+    assert_raise Ecto.QueryError, ~r/can't use a schema without a source/, fn ->
+      TestRepo.all(Abstract)
+    end
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -378,3 +378,16 @@ defmodule Ecto.Integration.ArrayLogging do
     timestamps()
   end
 end
+
+defmodule Ecto.Integration.Abstract do
+  @moduledoc """
+  This module is used to test:
+
+  * Repo callbacks for schemas without a source defined
+  """
+  use Ecto.Integration.Schema
+
+  abstract_schema do
+    field :name, :string
+  end
+end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -239,6 +239,10 @@ defmodule Ecto.Query.Planner do
     error!(query, "cannot preload associations with a fragment source")
   end
 
+  defp plan_from(%{from: %{source: {nil, _}}} = query, _adapter) do
+    error!(query, "can't use a schema without a source")
+  end
+
   defp plan_from(%{from: from} = query, adapter) do
     plan_source(query, from, adapter)
   end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -663,9 +663,10 @@ defmodule Ecto.Repo.Schema do
     }
   end
   defp metadata(%{__struct__: schema, __meta__: %{context: context, source: source, prefix: prefix}},
-                autogen_id, opts) do
+                autogen_id, opts) when not is_nil(source) do
     metadata(schema, prefix, source, autogen_id, context, opts)
   end
+
   defp metadata(%{__struct__: schema}, _, _) do
     raise ArgumentError, "#{inspect(schema)} needs to be a schema with source"
   end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -247,6 +247,23 @@ defmodule Ecto.SchemaTest do
     assert InlineEmbeddedSchema.Many.__schema__(:fields) == [:id, :y]
   end
 
+  defmodule AbstractSchema do
+    use Ecto.Schema
+
+    abstract_schema do
+      field :name, :string, default: "renan"
+      field :age, :integer
+    end
+  end
+
+  test "abstract schema" do
+    assert AbstractSchema.__schema__(:source)          == nil
+    assert AbstractSchema.__schema__(:prefix)          == nil
+    assert AbstractSchema.__schema__(:fields)          == [:id, :name, :age]
+    assert AbstractSchema.__schema__(:primary_key)     == [:id]
+    assert AbstractSchema.__schema__(:autogenerate_id) == {:id, :id, :id}
+  end
+
   defmodule TimestampsAutoGen do
     use Ecto.Schema
 
@@ -422,7 +439,7 @@ defmodule Ecto.SchemaTest do
     end
   end
 
-  test "skipping validations on invalid types" do 
+  test "skipping validations on invalid types" do
     defmodule SchemaSkipValidationsDefault do
       use Ecto.Schema
 


### PR DESCRIPTION
This PR attempts to improve the API for schemas without source (because they want a dynamic source). 

Before, you had to use a regular schema with a fake source and override it (described in the documentation, I changed it, check the diff).

Would need more tests, and I'm willing to put the work if you think the idea is decent. The only issue I see with this is that the `Ecto.Meta.source()` can now be `nil`, which means that code relying on it being `String.t()` can break.