### PR TITLE
Discriminated Union Type Embeds - Proof of Concept

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1254,6 +1254,21 @@ defmodule Ecto.Changeset do
 
   defp key_as_int(key_val), do: key_val
 
+  defp on_cast_default(_relation_type, {:one_of, variants}) do
+    fn struct, params ->
+      with {_, type} <- Enum.find(params, &to_string(elem(&1, 0)) == "type"),
+           {_, data} <- Enum.find(params, &to_string(elem(&1, 0)) == "data"),
+           {_type, mod} <- Enum.find(variants, fn {key, _val} -> to_string(key) == to_string(type) end) do
+        mod.changeset(struct, data)
+      else
+        _ ->
+          raise ArgumentError, """
+            Expected a type and a data field
+          """
+      end
+    end
+  end
+
   defp on_cast_default(type, module) do
     fn struct, params ->
       try do

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -103,6 +103,15 @@ defmodule Ecto.Changeset.Relation do
     end
   end
 
+  def cast(%{related: {:one_of, variants}} = relation, owner, params, current, on_cast) do
+    with {_key, type} <- Enum.find(params, fn {key, _val} -> to_string(key) == "type" end),
+         {_type, mod} <- Enum.find(variants, fn {key, _val} -> to_string(key) == to_string(type) end) do
+      cast(%{relation | related: mod}, owner, params, current, on_cast)
+    else
+      _ -> {:error, {"is invalid", [type: expected_type(relation)]}}
+    end
+  end
+
   def cast(%{related: mod} = relation, owner, params, current, on_cast) do
     pks = mod.__schema__(:primary_key)
     fun = &do_cast(relation, owner, &1, &2, &3, on_cast)

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1656,7 +1656,7 @@ defmodule Ecto.Schema do
   that, when using embedded schemas with databases like PG or MySQL,
   make sure all of your types can be JSON encoded/decoded correctly.
   Ecto provides this guarantee for all built-in types.
-  
+
   When decoding, if a key exists in the database not defined in the
   schema, it'll be ignored. If a field exists in the schema thats not
   in the database, it's value will be `nil`.
@@ -2078,6 +2078,11 @@ defmodule Ecto.Schema do
   @valid_embeds_one_options [:on_replace, :source]
 
   @doc false
+  def __embeds_one__(mod, name, {:one_of, variants}, opts) when is_list(variants) do
+    check_options!(opts, @valid_embeds_one_options, "embeds_one/3")
+    embed(mod, :one, name, {:one_of, variants}, opts)
+  end
+
   def __embeds_one__(mod, name, schema, opts) when is_atom(schema) do
     check_options!(opts, @valid_embeds_one_options, "embeds_one/3")
     embed(mod, :one, name, schema, opts)
@@ -2091,6 +2096,12 @@ defmodule Ecto.Schema do
   @valid_embeds_many_options [:on_replace, :source]
 
   @doc false
+  def __embeds_many__(mod, name, {:one_of, variants}, opts) when is_list(variants) do
+    check_options!(opts, @valid_embeds_many_options, "embeds_many/3")
+    opts = Keyword.put(opts, :default, [])
+    embed(mod, :many, name, {:one_of, variants}, opts)
+  end
+
   def __embeds_many__(mod, name, schema, opts) when is_atom(schema) do
     check_options!(opts, @valid_embeds_many_options, "embeds_many/3")
     opts = Keyword.put(opts, :default, [])

--- a/lib/ecto/schema/loader.ex
+++ b/lib/ecto/schema/loader.ex
@@ -27,6 +27,18 @@ defmodule Ecto.Schema.Loader do
   Assumes data does not all belongs to schema/struct
   and that it may also require source-based renaming.
   """
+  def unsafe_load({:one_of, variants}, data, loader) do
+    variants = Map.new(variants, fn {key, value} -> {to_string(key), value} end)
+
+    with {:ok, type} <- fetch_string_or_atom_field(data, :type),
+         {:ok, data} <- fetch_string_or_atom_field(data, :data),
+         {:ok, schema} <- Map.fetch(variants, to_string(type)) do
+      unsafe_load(schema, data, loader)
+    else
+      _ -> :error
+    end
+  end
+
   def unsafe_load(schema, data, loader) do
     types = schema.__schema__(:load)
     struct = schema.__schema__(:loaded)

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -34,6 +34,66 @@ defmodule Ecto.EmbeddedTest do
     end
   end
 
+  defmodule OneOfSchema do
+    use Ecto.Schema
+
+    embedded_schema do
+      embeds_one :thing, {:one_of, author: Author, post: Post}
+      embeds_many :things, {:one_of, author: Author, post: Post}
+    end
+  end
+
+  describe "one of embeds" do
+    test "__schema__" do
+      assert OneOfSchema.__schema__(:embeds) == [:thing, :things]
+
+      assert OneOfSchema.__schema__(:embed, :thing) ==
+        %Embedded{field: :thing, cardinality: :one, owner: OneOfSchema, related: {:one_of, author: Author, post: Post}}
+
+      assert OneOfSchema.__schema__(:embed, :things) ==
+        %Embedded{field: :things, cardinality: :many, owner: OneOfSchema, related: {:one_of, author: Author, post: Post}}
+    end
+
+    test "embedded_load/3" do
+      assert %OneOfSchema{thing: %Post{title: "Title"}} =
+              Ecto.embedded_load(OneOfSchema, %{"thing" => %{"type" => "post", "data" => %{"title" => "Title"}}}, :json)
+
+      assert %OneOfSchema{thing: %Post{title: "Title"}} =
+              Ecto.embedded_load(OneOfSchema, %{thing: %{type: "post", data: %{title: "Title"}}}, :json)
+
+      assert %OneOfSchema{thing: %Post{title: "Title"}} =
+              Ecto.embedded_load(OneOfSchema, %{thing: %{type: :post, data: %{title: "Title"}}}, :json)
+
+      assert %OneOfSchema{things: [%Post{title: "Title"}, %Author{name: "Name"}]} =
+              Ecto.embedded_load(OneOfSchema, %{"things" => [
+                %{"type" => "post", "data" => %{"title" => "Title"}},
+                %{"type" => "author", "data" => %{"name" => "Name"}}
+              ]}, :json)
+
+      assert %OneOfSchema{things: [%Post{title: "Title"}, %Author{name: "Name"}]} =
+              Ecto.embedded_load(OneOfSchema, %{things: [
+                %{type: "post", data: %{title: "Title"}},
+                %{type: "author", data: %{name: "Name"}}
+              ]}, :json)
+    end
+
+    test "embedded_dump/2" do
+      struct = %OneOfSchema{things: [%Post{title: "Title"}, %Author{name: "Name"}]}
+
+      dumped = Ecto.embedded_dump(struct, :json)
+      assert not Map.has_key?(dumped, :__struct__)
+      assert [%{type: :post, data: %{title: "Title"}} = post | _] = dumped.things
+      assert not Map.has_key?(post, :__struct__)
+      assert not Map.has_key?(post, :__meta__)
+
+      assert_raise ArgumentError,
+        ~s[cannot dump embed `things`, expected a list of Ecto.EmbeddedTest.Author or Ecto.EmbeddedTest.Post struct values but got: :something],
+        fn ->
+          Ecto.embedded_dump(%OneOfSchema{things: [:something]}, :json)
+        end
+    end
+  end
+
   test "__schema__" do
     assert Author.__schema__(:embeds) ==
       [:profile, :post, :posts]


### PR DESCRIPTION
For a long time I've been re-implementing some sort of this idea in multiple different ways, although most of the time I'd implement as an Ecto.Type that serializes, but I've been thinking that maybe this could be part of Ecto's embeds. Let me elaborate.

The idea is to allow embeds_one and embeds_many to contain different embedded schemas based on a discriminator (a "tag").

This is useful to allow people to model their domain (I like it because it makes invalid states harder and because it allows a more flexible schema). One of the use cases I've used a lot in the past was having a `EventLog` schema that would embed the event, which could be one of multiple different embedded schemas representing the event (like `UserSignedUp`, `OrderPlaced`, etc).

This is just a proof of concept to start sketching out the idea. My approach is to make the Embed relationship `:related` field also accept a `{:one_of, variants}`. Although maybe we could represent with another struct and some helper functions, like `Ecto.Embedded.OneOf`, but for now I just wanted to implement the basic of the idea since some of the Ecto internals are still pretty new to me.

The current solution also expects the dumped format and the "to-be-casted" format to have a type and data values, but maybe we should allow this to be customized (I just wanted to avoid that complexity for now).

I'm opening this PR to start a discussion around:
- Do we think this idea has value?
- If yes, how can I improve and change it to the point it is good enough?