### PR TITLE
Improve documentation of `:required` option for `cast_embed` and `cast_assoc`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1066,7 +1066,7 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:required` - if the association is a required field. For associations with cardinality
+    * `:required` - if the association is a required field. For associations of cardinality
       one, a non-nil value satisfies this validation. For associations with many entries,
       a non-empty list is satisfactory.
 
@@ -1113,7 +1113,7 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:required` - if the embed is a required field. For embeds with cardinality
+    * `:required` - if the embed is a required field. For embeds of cardinality
       one, a non-nil value satisfies this validation. For embeds with many entries,
       a non-empty list is satisfactory.
 

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1066,7 +1066,9 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:required` - if the association is a required field
+    * `:required` - if the association is a required field. For associations with cardinality
+      one, a non-nil value satisfies this validation. For associations with many entries,
+      a non-empty list is satisfactory.
 
     * `:required_message` - the message on failure, defaults to "can't be blank"
 
@@ -1111,7 +1113,9 @@ defmodule Ecto.Changeset do
 
   ## Options
 
-    * `:required` - if the embed is a required field
+    * `:required` - if the embed is a required field. For embeds with cardinality
+      one, a non-nil value satisfies this validation. For embeds with many entries,
+      a non-empty list is satisfactory.
 
     * `:required_message` - the message on failure, defaults to "can't be blank"
 


### PR DESCRIPTION
Nuance what 'required' actually means for one-style and many-style embeds/assocs.

This came from the confusion that one could think that it's enough to have an empty array for has/embeds_many to satisfy the required validation. But when enabling this option it actually has to be an array with at least one element.