### PR TITLE
docs: Provide CTE prefix replacement

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1359,6 +1359,16 @@ defmodule Ecto.Query do
       |> join(:left, [c], p in assoc(c, :products))
       |> group_by([c], c.id)
       |> select([c, p], %{c | products_count: count(p.id)})
+  
+  For the above example, because the `{"category_tree", Category}` tuple is a Queryable,
+  if your Ecto schema has a prefix set, selecting on the CTE table will default to
+  the CTE table prefixed with the Ecto schema defined prefix.
+  In order to avoid selecting from the CTE table using the Ecto schema prefix, 
+  you can pass a new From query and specify a prefix on it instead:
+  
+      from(cte in {"category_tree", Category}, prefix: nil)
+      |> recursive_ctes(true)
+      |> with_cte("category_tree", as: ^category_tree_query)
 
   Keyword syntax is not supported for this feature.
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1348,10 +1348,10 @@ defmodule Ecto.Query do
       |> with_cte("category_tree", as: fragment(@raw_sql_category_tree))
       |> join(:inner, [p], c in "category_tree", on: c.id == p.category_id)
 
-  If you don't have any Ecto schema pointing to the CTE table, you can pass a
+  You can also query over the CTE table itself. In such cases, you can pass
   tuple with the CTE table name as the first element and an Ecto schema as the second
   element. This will cast the result rows to Ecto structs as long as the Ecto
-  schema maps to the same fields in the CTE table:
+  schema maps over the same fields in the CTE table:
 
       {"category_tree", Category}
       |> recursive_ctes(true)
@@ -1359,13 +1359,11 @@ defmodule Ecto.Query do
       |> join(:left, [c], p in assoc(c, :products))
       |> group_by([c], c.id)
       |> select([c, p], %{c | products_count: count(p.id)})
-  
-  For the above example, because the `{"category_tree", Category}` tuple is a Queryable,
-  if your Ecto schema has a prefix set, selecting on the CTE table will default to
-  the CTE table prefixed with the Ecto schema defined prefix.
-  In order to avoid selecting from the CTE table using the Ecto schema prefix, 
-  you can pass a new From query and specify a prefix on it instead:
-  
+
+  Keep in mind that the query above will inherit all properties from the `Category` schema,
+  include a `@schema_prefix` if any is set. In such cases, you can disable those properties
+  by setting them as option:
+
       from(cte in {"category_tree", Category}, prefix: nil)
       |> recursive_ctes(true)
       |> with_cte("category_tree", as: ^category_tree_query)


### PR DESCRIPTION
When Ecto schemas have a prefix set, using CTEs references the Schema prefix which breaks the SQL query.
There already exists [an issue closed on this](https://github.com/elixir-ecto/ecto/issues/3406), but [the solution](https://github.com/elixir-ecto/ecto/issues/3406#issuecomment-690953646) doesn't appear to have been documented.

Personally, I'd prefer having a better option, such as maybe `put_query_prefix/2` to handle tuples and set the _From query prefix_ itself, instead of delegating to `Queryable.to_query/1` which sets the schema prefix in the From query and then `put_query_prefix/2` would be setting the prefix on the Query.

Because it took me a couple of hours to figure out the issue and find the solution, I propose that this gets at least mentioned in the documentation as well, to save others using prefixed Ecto schemas some time.