### PR TITLE
Fix a typo that can lead to confusion

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -113,7 +113,7 @@ defmodule Ecto.Schema do
   >
   > - import `Ecto.Schema` macros `schema/2` and `embedded_schema/1`
   > - register default values for module attributes that can be overridden, such as
-  > `@primary_key` and `@timestamp_opts`
+  > `@primary_key` and `@timestamps_opts`
   > - define reflection functions such as `__schema__/1` and `__changeset__/1`
   >
   > We detail those throughout the module documentation.


### PR DESCRIPTION
There's a little typo in the docs that can lead to confusion: At one place it refers to `@timestamp_opts` instead of `@timestamps_opts`.