### PR TITLE
Add example to Changeset.validate_change/3

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2244,6 +2244,17 @@ defmodule Ecto.Changeset do
       iex> changeset.errors
       [title: {"cannot be foo", []}]
 
+      iex> changeset = change(%Post{}, %{title: "foo"})
+      iex> changeset = validate_change changeset, :title, fn :title, title  ->
+      ...>   if title == "foo" do
+      ...>     [title: {"cannot be foo", additional: "info"}]
+      ...>   else
+      ...>     []
+      ...>   end
+      ...> end
+      iex> changeset.errors
+      [title: {"cannot be foo", [additional: "info"]}]
+
   """
   @spec validate_change(t, atom, (atom, term -> [{atom, String.t} | {atom, {String.t, Keyword.t}}])) :: t
   def validate_change(%Changeset{} = changeset, field, validator) when is_atom(field) do


### PR DESCRIPTION
Hello! There's an almost-undocumented other type of return value in this function's typespec - `[{atom, {String.t, Keyword.t}}]` that I nearly made use of. I think it would be nice to add an example? I'm not so sure about the function documentation itself.

It's similar to how `add_error/4` can accept additional keywords to add contextual information. https://github.com/elixir-ecto/ecto/blob/23edc706c49dbfa95ca02eb6f2a559f212d948c2/lib/ecto/changeset.ex#L2202-L2205