### PR TITLE
Pass `nil` through adapter dumpers and loaders

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -890,9 +890,6 @@ defmodule Ecto.Type do
   def adapter_load(adapter, {:parameterized, module, params} = type, value) do
     process_loaders(adapter.loaders(module.type(params), type), {:ok, value}, adapter)
   end
-  def adapter_load(_adapter, _type, nil) do
-    {:ok, nil}
-  end
   def adapter_load(adapter, type, value) do
     if of_base_type?(type, value) do
       {:ok, value}
@@ -913,9 +910,6 @@ defmodule Ecto.Type do
   @doc false
   def adapter_dump(adapter, {:parameterized, module, params} = type, value) do
     process_dumpers(adapter.dumpers(module.type(params), type), {:ok, value}, adapter)
-  end
-  def adapter_dump(_adapter, type, nil) do
-    dump(type, nil)
   end
   def adapter_dump(adapter, type, value) do
     process_dumpers(adapter.dumpers(type(type), type), {:ok, value}, adapter)


### PR DESCRIPTION
This is necessary for our work in [Exandra](https://github.com/vinniefranco/exandra), a Cassandra/Scylla Ecto adapter. Xandra (the underlying driver we use) needs to pass query params to Cassandra as `{type, value}`, so we need every single term to go through our adapter's dumpers and loaders.

This change causes some issues with the MSSQL adapter, but I think they can be fixed, and I'll be working on that next.

cc @josevalim 