### PR TITLE
Conditionally use Logger.warning/1

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -3151,7 +3151,7 @@ defmodule Ecto.Changeset do
     end)
 
     if is_nil(current) do
-      Logger.warn """
+      log_warn """
       the current value of `#{field}` is `nil` and will not be used as a filter for optimistic locking. \
       To ensure `#{field}` is never `nil`, consider setting a default value.
       """
@@ -3824,6 +3824,13 @@ defmodule Ecto.Changeset do
     |> Enum.reverse()
     |> merge_keyword_keys(msg_func, changeset)
     |> merge_related_keys(changes, types, msg_func, &traverse_validations/2)
+  end
+
+  # TODO: remove once we depend on Elixir 1.11+, which introduces Logger.warning/1.
+  if macro_exported?(Logger, :warning, 1) do
+    defp log_warn(message), do: Logger.warning(message)
+  else
+    defp log_warn(message), do: Logger.warn(message)
   end
 end
 

--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -471,7 +471,7 @@ defmodule Ecto.Changeset.Relation do
       end)
 
     if map_size(map) != counter do
-      Logger.warn """
+      log_warn """
       found duplicate primary keys for association/embed `#{inspect(relation.field)}` \
       in `#{inspect(relation.owner)}`. In case of duplicate IDs, only the last entry \
       with the same ID will be kept. Make sure that all entries in `#{inspect(relation.field)}` \
@@ -568,4 +568,11 @@ defmodule Ecto.Changeset.Relation do
     do: cardinality_to_empty(cardinality)
 
   defp not_loaded_to_empty(loaded), do: loaded
+  
+  # TODO: remove once we depend on Elixir 1.11+, which introduces Logger.warning/1.
+  if macro_exported?(Logger, :warning, 1) do
+    defp log_warn(message), do: Logger.warning(message)
+  else
+    defp log_warn(message), do: Logger.warn(message)
+  end
 end

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -205,7 +205,7 @@ defmodule Ecto.Repo.Preloader do
         loaded? = Ecto.assoc_loaded?(value) and not force?
 
         if loaded? and is_nil(id) and not Ecto.Changeset.Relation.empty?(assoc, value) do
-          Logger.warn """
+          log_warn """
           association `#{field}` for `#{inspect(module)}` has a loaded value but \
           its association key `#{owner_key}` is nil. This usually means one of:
 
@@ -601,5 +601,12 @@ defmodule Ecto.Repo.Preloader do
 
   defp filter_and_reraise(exception, stacktrace) do
     reraise exception, Enum.reject(stacktrace, &match?({__MODULE__, _, _, _}, &1))
+  end
+  
+  # TODO: remove once we depend on Elixir 1.11+, which introduces Logger.warning/1.
+  if macro_exported?(Logger, :warning, 1) do
+    defp log_warn(message), do: Logger.warning(message)
+  else
+    defp log_warn(message), do: Logger.warn(message)
   end
 end


### PR DESCRIPTION
Fixes the `Logger.warn/1` hard deprecation in Elixir 1.15.