### PR TITLE
Allow updates in CTE

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1473,10 +1473,6 @@ defmodule Ecto.Query do
     if !with_query do
       Builder.error!("`as` option must be specified")
     end
-    
-    unless operation in [nil, :all, :update_all, :delete_all, :insert_all] do
-      Builder.error!("`operation` option must be one of :all, :update_all, :delete_all, :insert_all")
-    end
 
     Builder.CTE.build(query, name, with_query, opts[:materialized], operation, __CALLER__)
   end

--- a/lib/ecto/query/builder/cte.ex
+++ b/lib/ecto/query/builder/cte.ex
@@ -75,6 +75,15 @@ defmodule Ecto.Query.Builder.CTE do
   """
   @spec apply(Ecto.Queryable.t, bitstring, Ecto.Queryable.t, nil | boolean(), nil | :all | :update_all | :delete_all | :insert_all) :: Ecto.Query.t
   # Runtime
+  def apply(query, name, with_query, materialized, nil) do
+    apply(query, name, with_query, materialized, :all)
+  end
+  
+  def apply(_query, _name, _with_query, _materialized, operation) 
+    when operation not in [:all, :update_all, :delete_all, :insert_all] do
+    Builder.error!("`operation` option must be one of :all, :update_all, :delete_all, :insert_all")
+  end
+  
   def apply(%Ecto.Query{with_ctes: with_expr} = query, name, %_{} = with_query, materialized, operation) do
     %{query | with_ctes: apply_cte(with_expr, name, with_query, materialized, operation)}
   end

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1051,7 +1051,7 @@ defmodule Ecto.Query.Planner do
           # We don't want to use normalize_subquery_select because we are
           # going to prepare the whole query ourselves next.
           {_, _, inner_query} = rewrite_subquery_select_expr(inner_query, true)
-          {inner_query, counter} = traverse_exprs(inner_query, :all, counter, fun)
+          {inner_query, counter} = traverse_exprs(inner_query, :all_cte, counter, fun)
 
           # Now compute the fields as keyword lists so we emit AS in Ecto query.
           %{select: %{expr: expr, take: take, aliases: aliases}} = inner_query
@@ -1783,8 +1783,9 @@ defmodule Ecto.Query.Planner do
 
   @all_exprs [with_cte: :with_ctes, distinct: :distinct, select: :select, from: :from, join: :joins,
               where: :wheres, group_by: :group_bys, having: :havings, windows: :windows,
-              combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset, update: :updates]
-
+              combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset]
+  @all_cte_exprs @all_exprs ++ [update: :updates]
+  
   # Although joins come before updates in the actual query,
   # the on fields are moved to where, so they effectively
   # need to come later for MySQL. This means subqueries
@@ -1803,6 +1804,7 @@ defmodule Ecto.Query.Planner do
     exprs =
       case operation do
         :all -> @all_exprs
+        :all_cte -> @all_cte_exprs
         :insert_all -> @all_exprs
         :update_all -> @update_all_exprs
         :delete_all -> @delete_all_exprs

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1783,7 +1783,7 @@ defmodule Ecto.Query.Planner do
 
   @all_exprs [with_cte: :with_ctes, distinct: :distinct, select: :select, from: :from, join: :joins,
               where: :wheres, group_by: :group_bys, having: :havings, windows: :windows,
-              combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset]
+              combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset, update: :updates]
 
   # Although joins come before updates in the actual query,
   # the on fields are moved to where, so they effectively

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1042,6 +1042,7 @@ defmodule Ecto.Query.Planner do
 
   defp validate_and_increment(:with_cte, query, with_expr, counter, _operation, adapter) do
     fun = &validate_and_increment(&1, &2, &3, &4, :all, adapter)
+
     {queries, counter} =
       Enum.reduce with_expr.queries, {[], counter}, fn
         {name, opts, %Ecto.Query{} = inner_query}, {queries, counter} ->

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1042,7 +1042,6 @@ defmodule Ecto.Query.Planner do
 
   defp validate_and_increment(:with_cte, query, with_expr, counter, _operation, adapter) do
     fun = &validate_and_increment(&1, &2, &3, &4, :all, adapter)
-    
     {queries, counter} =
       Enum.reduce with_expr.queries, {[], counter}, fn
         {name, opts, %Ecto.Query{} = inner_query}, {queries, counter} ->

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1051,7 +1051,7 @@ defmodule Ecto.Query.Planner do
           # We don't want to use normalize_subquery_select because we are
           # going to prepare the whole query ourselves next.
           {_, _, inner_query} = rewrite_subquery_select_expr(inner_query, true)
-          {inner_query, counter} = traverse_exprs(inner_query, opts[:operation], counter, fun)
+          {inner_query, counter} = traverse_exprs(inner_query, opts.operation, counter, fun)
 
           # Now compute the fields as keyword lists so we emit AS in Ecto query.
           %{select: %{expr: expr, take: take, aliases: aliases}} = inner_query
@@ -1799,10 +1799,6 @@ defmodule Ecto.Query.Planner do
 
   # Traverse all query components with expressions.
   # Therefore from, preload, assocs and lock are not traversed.
-  defp traverse_exprs(query, nil, acc, fun) do
-    traverse_exprs(query, :all, acc, fun)
-  end
-
   defp traverse_exprs(query, operation, acc, fun) do
     exprs =
       case operation do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1051,7 +1051,7 @@ defmodule Ecto.Query.Planner do
           # We don't want to use normalize_subquery_select because we are
           # going to prepare the whole query ourselves next.
           {_, _, inner_query} = rewrite_subquery_select_expr(inner_query, true)
-          {inner_query, counter} = traverse_exprs(inner_query, :all_cte, counter, fun)
+          {inner_query, counter} = traverse_exprs(inner_query, :cte, counter, fun)
 
           # Now compute the fields as keyword lists so we emit AS in Ecto query.
           %{select: %{expr: expr, take: take, aliases: aliases}} = inner_query
@@ -1784,7 +1784,9 @@ defmodule Ecto.Query.Planner do
   @all_exprs [with_cte: :with_ctes, distinct: :distinct, select: :select, from: :from, join: :joins,
               where: :wheres, group_by: :group_bys, having: :havings, windows: :windows,
               combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset]
-  @all_cte_exprs @all_exprs ++ [update: :updates]
+  @cte_exprs [with_cte: :with_ctes, distinct: :distinct, select: :select, from: :from, update: :updates, 
+              join: :joins, where: :wheres, group_by: :group_bys, having: :havings, windows: :windows, 
+              combination: :combinations, order_by: :order_bys, limit: :limit, offset: :offset]
   
   # Although joins come before updates in the actual query,
   # the on fields are moved to where, so they effectively
@@ -1804,7 +1806,7 @@ defmodule Ecto.Query.Planner do
     exprs =
       case operation do
         :all -> @all_exprs
-        :all_cte -> @all_cte_exprs
+        :cte -> @cte_exprs
         :insert_all -> @all_exprs
         :update_all -> @update_all_exprs
         :delete_all -> @delete_all_exprs


### PR DESCRIPTION
As suggested by https://github.com/elixir-ecto/ecto_sql/pull/532#issuecomment-1611644324 the planner does not allow updates in CTEs, which fail the test [for the PR that introduces](https://github.com/elixir-ecto/ecto_sql/pull/532) data-modifying CTEs for PostgreSQL.

This PR adds `update` to the allowed list for `:all` planner, to enable it in CTEs.