### PR TITLE
Add explicit Ecto.Multi.failure() type

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -148,6 +148,14 @@ defmodule Ecto.Multi do
   5}`.
   """
   @type name :: any
+
+  @typedoc """
+  Result of a failed transaction using a Multi.
+  """
+  @type failure ::
+          {:error, failed_operation :: Ecto.Multi.name(), failed_value :: any(),
+           changes_so_far :: %{Ecto.Multi.name() => any}}
+
   @type t :: %__MODULE__{operations: operations, names: names}
 
   @doc """

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -2100,7 +2100,7 @@ defmodule Ecto.Repo do
   @callback transaction(fun_or_multi :: fun | Ecto.Multi.t(), opts :: Keyword.t()) ::
               {:ok, any}
               | {:error, any}
-              | {:error, Ecto.Multi.name(), any, %{Ecto.Multi.name() => any}}
+              | Ecto.Multi.failure()
 
   @doc """
   Returns true if the current process is inside a transaction.


### PR DESCRIPTION
This can be useful for typespecs in codebases that use Ecto.