### PR TITLE
Add splice to `fragment`

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -479,13 +479,13 @@ defmodule Ecto.Query.API do
   def fragment(fragments), do: doc! [fragments]
 
   @doc """
-    Allows a list argument to be spliced into a fragment.
+  Allows a list argument to be spliced into a fragment.
 
-        from p in Post, where: fragment("? in (?)", p.id, splice(^[1, 2, 3]))
+      from p in Post, where: fragment("? in (?)", p.id, splice(^[1, 2, 3]))
 
-    The example above will be transformed at runtime into the following:
+  The example above will be transformed at runtime into the following:
 
-        from p in Post, where: fragment("? in (?,?,?)", p.id, ^1, ^2, ^3)
+      from p in Post, where: fragment("? in (?,?,?)", p.id, ^1, ^2, ^3)
   """
   def splice(list), do: doc! [list]
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -416,7 +416,6 @@ defmodule Ecto.Query.API do
 
   Ecto will then escape it and make it part of the query.
 
-
   > #### Literals and query caching {: .warning}
   >
   > Because literals are made part of the query, each interpolated

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -697,11 +697,11 @@ defmodule Ecto.Query.Builder do
   defp escape_fragment({:splice, _meta, [splice]}, params_acc, vars, env) do
     case splice do
       {:^, _, [value]} = expr ->
-          checked = quote do: Ecto.Query.Builder.splice!(unquote(value))
-          length = quote do: length(unquote(checked))
-          {expr, params_acc} = escape(expr, {:splice, :any}, params_acc, vars, env)
-          escaped =  {:{}, [], [:splice, [], [expr, length]]}
-          {escaped, params_acc}
+        checked = quote do: Ecto.Query.Builder.splice!(unquote(value))
+        length = quote do: length(unquote(checked))
+        {expr, params_acc} = escape(expr, {:splice, :any}, params_acc, vars, env)
+        escaped =  {:{}, [], [:splice, [], [expr, length]]}
+        {escaped, params_acc}
 
       _ ->
         error! "splice/1 in fragment expects an interpolated list, such as splice(^[1, 2, 3]), got `#{Macro.to_string(splice)}`"

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -699,8 +699,8 @@ defmodule Ecto.Query.Builder do
     case spliced do
       {:^, _, [_]} = expr ->
           {expr, params_acc} = escape(expr, {:splice, :any}, params_acc, vars, env)
-          escaped_splice =  {:{}, [], [:splice, [], [expr]]}
-          {escaped_splice, params_acc}
+          escaped =  {:{}, [], [:splice, [], [expr]]}
+          {escaped, params_acc}
 
       _ ->
         error! "splice/1 in fragment expects an interpolated list, such as splice(^[1, 2, 3]), got `#{Macro.to_string(spliced)}`"

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -704,7 +704,7 @@ defmodule Ecto.Query.Builder do
         {escaped, params_acc}
 
       _ ->
-        error! "splice/1 in fragment expects an interpolated list, such as splice(^[1, 2, 3]), got `#{Macro.to_string(splice)}`"
+        error! "splice/1 in fragment expects an interpolated value, such as splice(^value), got `#{Macro.to_string(splice)}`"
     end
   end
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -90,9 +90,17 @@ defmodule Ecto.Query.Builder do
 
   # param interpolation
   def escape({:^, _, [arg]}, type, {params, acc}, _vars, _env) do
-    expr = {:{}, [], [:^, [], [length(params)]]}
-    params = [{arg, type} | params]
-    {expr, {params, acc}}
+      case params do
+        {:^, [], params} ->
+          expr = {:{}, [], [:^, [], [quote do: length(unquote(params))]]}
+          params = {:^, [], quote do: [{unquote(arg), unquote(type)} | unquote(params)]}
+          {expr, {params, acc}}
+
+        _ ->
+          expr = {:{}, [], [:^, [], [length(params)]]}
+          params = [{arg, type} | params]
+          {expr, {params, acc}}
+      end
   end
 
   # tagged types
@@ -695,12 +703,13 @@ defmodule Ecto.Query.Builder do
     end
   end
 
-  defp escape_fragment({:splice, _meta, [expr]}, params_acc, _vars, _env) do
+  defp escape_fragment({:splice, _meta, [expr]}, {params, acc}, _vars, _env) do
     case expr do
       {:^, _, [expr]} ->
           checked = quote do: Ecto.Query.Builder.splice!(unquote(expr))
-          escaped = {:{}, [], [:splice, [], [checked]]}
-          {escaped, params_acc}
+          escaped = {:{}, [], [:splice, [], [quote do: [length(unquote(params)), length(unquote(checked))]]]}
+          params = {:^, [], quote do: Enum.reduce(unquote(checked), unquote(params), &[{&1, :any} | &2])}
+          {escaped, {params, acc}}
 
       _ ->
         error! "splice/1 in fragment expects an interpolated list, such as splice(^[1, 2, 3]), got `#{Macro.to_string(expr)}`"
@@ -711,8 +720,8 @@ defmodule Ecto.Query.Builder do
     escape(expr, :any, params_acc, vars, env)
   end
 
-  defp merge_fragments([h1|t1], [{:{}, [], [:splice, [], [list]]}|t2]) do
-    quote do: [{:raw, unquote(h1)} | Ecto.Query.Builder.merge_splice(unquote(list), unquote(t1), unquote(t2))]
+  defp merge_fragments([h1|t1], [{:{}, [], [:splice, [], [[start_ix, len]]]}|t2]) do
+    quote do: [{:raw, unquote(h1)} | Ecto.Query.Builder.merge_splice(unquote(start_ix), unquote(len), unquote(t1), unquote(t2))]
   end
 
   defp merge_fragments([h1|t1], [h2|t2]),
@@ -721,12 +730,12 @@ defmodule Ecto.Query.Builder do
   defp merge_fragments([h1], []),
     do: [{:raw, h1}]
 
-  def merge_splice([h], pieces, frags) do
-    [{:expr, h} | merge_fragments(pieces, frags)]
+  def merge_splice(ix, 1, pieces, frags) do
+    [{:expr, {:^, [], [ix]}} | merge_fragments(pieces, frags)]
   end
 
-  def merge_splice([h|t], pieces, frags) do
-    [{:expr, h}, {:raw, ", ", } | merge_splice(t, pieces, frags)]
+  def merge_splice(ix, num_left, pieces, frags) do
+    [{:expr, {:^, [], [ix]}}, {:raw, ", ", } | merge_splice(ix + 1, num_left - 1, pieces, frags)]
   end
 
   for {agg, arity} <- @dynamic_aggregates do
@@ -809,6 +818,7 @@ defmodule Ecto.Query.Builder do
   Escape the params entries list.
   """
   @spec escape_params(list()) :: list()
+  def escape_params({:^, [], list}), do: quote do: Enum.reverse(unquote(list))
   def escape_params(list), do: Enum.reverse(list)
 
   @doc """

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -182,7 +182,6 @@ defmodule Ecto.Query.Builder do
     end
 
     {frags, params_acc} = Enum.map_reduce(frags, params_acc, &escape_fragment(&1, &2, vars, env))
-
     {{:{}, [], [:fragment, [], merge_fragments(pieces, frags)]}, params_acc}
   end
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -695,14 +695,12 @@ defmodule Ecto.Query.Builder do
     end
   end
 
-  defp escape_fragment({:splice, _meta, [expr]}, {params, acc}, _vars, _env) do
+  defp escape_fragment({:splice, _meta, [expr]}, params_acc, _vars, _env) do
     case expr do
       {:^, _, [expr]} ->
           checked = quote do: Ecto.Query.Builder.splice!(unquote(expr))
-          num_spliced = quote do: length(unquote(checked))
-          escaped = {:{}, [], [:splice, [], [length(params), num_spliced]]}
-          params = [{{:splice, checked}, :any} | params]
-          {escaped, {params, acc}}
+          escaped = {:{}, [], [:splice, [], [checked]]}
+          {escaped, params_acc}
 
       _ ->
         error! "splice/1 in fragment expects an interpolated list, such as splice(^[1, 2, 3]), got `#{Macro.to_string(expr)}`"
@@ -713,8 +711,8 @@ defmodule Ecto.Query.Builder do
     escape(expr, :any, params_acc, vars, env)
   end
 
-  defp merge_fragments([h1|t1], [{:{}, [], [:splice, [], [start_ix, num_spliced]]}|t2]) do
-    quote do: [{:raw, unquote(h1)} | Ecto.Query.Builder.merge_splice(unquote(start_ix), unquote(num_spliced), unquote(t1), unquote(t2))]
+  defp merge_fragments([h1|t1], [{:{}, [], [:splice, [], [list]]}|t2]) do
+    quote do: [{:raw, unquote(h1)} | Ecto.Query.Builder.merge_splice(unquote(list), unquote(t1), unquote(t2))]
   end
 
   defp merge_fragments([h1|t1], [h2|t2]),
@@ -723,12 +721,12 @@ defmodule Ecto.Query.Builder do
   defp merge_fragments([h1], []),
     do: [{:raw, h1}]
 
-  def merge_splice(ix, 1, pieces, frags) do
-    [{:expr, {:{}, [], [:^, [], [ix]]}} | merge_fragments(pieces, frags)]
+  def merge_splice([h], pieces, frags) do
+    [{:expr, h} | merge_fragments(pieces, frags)]
   end
 
-  def merge_splice(ix, num_left, pieces, frags) do
-    [{:expr, {:{}, [], [:^, [], [ix]]}}, {:raw, ", ", } | merge_splice(ix + 1, num_left - 1, pieces, frags)]
+  def merge_splice([h|t], pieces, frags) do
+    [{:expr, h}, {:raw, ", ", } | merge_splice(t, pieces, frags)]
   end
 
   for {agg, arity} <- @dynamic_aggregates do

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -182,6 +182,7 @@ defmodule Ecto.Query.Builder do
     end
 
     {frags, params_acc} = Enum.map_reduce(frags, params_acc, &escape_fragment(&1, &2, vars, env))
+
     {{:{}, [], [:fragment, [], merge_fragments(pieces, frags)]}, params_acc}
   end
 
@@ -694,8 +695,24 @@ defmodule Ecto.Query.Builder do
     end
   end
 
+  defp escape_fragment({:splice, _meta, [expr]}, params_acc, _vars, _env) do
+    case expr do
+      {:^, _, [expr]} ->
+          checked = quote do: Ecto.Query.Builder.splice!(unquote(expr))
+          escaped = {:{}, [], [:splice, [], [checked]]}
+          {escaped, params_acc}
+
+      _ ->
+        error! "splice/1 in fragment expects an interpolated list, such as splice(^[1, 2, 3]), got `#{Macro.to_string(expr)}`"
+    end
+  end
+
   defp escape_fragment(expr, params_acc, vars, env) do
     escape(expr, :any, params_acc, vars, env)
+  end
+
+  defp merge_fragments([h1|t1], [{:{}, [], [:splice, [], [list]]}|t2]) do
+    quote do: [{:raw, unquote(h1)} | Ecto.Query.Builder.merge_splice(unquote(list), unquote(t1), unquote(t2))]
   end
 
   defp merge_fragments([h1|t1], [h2|t2]),
@@ -703,6 +720,14 @@ defmodule Ecto.Query.Builder do
 
   defp merge_fragments([h1], []),
     do: [{:raw, h1}]
+
+  def merge_splice([h], pieces, frags) do
+    [{:expr, h} | merge_fragments(pieces, frags)]
+  end
+
+  def merge_splice([h|t], pieces, frags) do
+    [{:expr, h}, {:raw, ", ", } | merge_splice(t, pieces, frags)]
+  end
 
   for {agg, arity} <- @dynamic_aggregates do
     defp call_type(unquote(agg), unquote(arity)), do: {:any, :any}
@@ -1081,6 +1106,20 @@ defmodule Ecto.Query.Builder do
     else
       raise ArgumentError,
             "literal(^value) expects `value` to be a string, got `#{inspect(literal)}`"
+    end
+  end
+
+  @doc """
+  Called by escaper at runtime to verify splice in fragments.
+  """
+  def splice!(value) do
+    case value do
+      [_ | _] ->
+        value
+
+      _ ->
+        raise ArgumentError,
+              "splice(^value) expects `value` to be a non-empty list, got `#{inspect(value)}`"
     end
   end
 

--- a/lib/ecto/query/builder/filter.ex
+++ b/lib/ecto/query/builder/filter.ex
@@ -65,7 +65,6 @@ defmodule Ecto.Query.Builder.Filter do
   def build(kind, op, query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, acc}} = escape(kind, expr, 0, binding, env)
-
     params = Builder.escape_params(params)
     subqueries = Enum.reverse(acc.subqueries)
 

--- a/lib/ecto/query/builder/filter.ex
+++ b/lib/ecto/query/builder/filter.ex
@@ -65,6 +65,7 @@ defmodule Ecto.Query.Builder.Filter do
   def build(kind, op, query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, acc}} = escape(kind, expr, 0, binding, env)
+
     params = Builder.escape_params(params)
     subqueries = Enum.reverse(acc.subqueries)
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -783,14 +783,6 @@ defmodule Ecto.Query.Planner do
         %Ecto.SubQuery{params: subparams, cache: cache} = Enum.fetch!(expr.subqueries, i)
         {Enum.reverse(subparams, acc), cacheable? and cache != :nocache}
 
-      {{:splice, splice_params}, :any}, {acc, cacheable?} ->
-        Enum.reduce(splice_params, {acc, cacheable?}, fn v, {acc, cacheable?} ->
-          case cast_param(kind, query, expr, v, :any, adapter) do
-            {cast_v, {:in, dump_v}} -> {split_in_params(cast_v, dump_v, acc), false}
-            cast_v_and_dump_v -> {[cast_v_and_dump_v | acc], cacheable?}
-          end
-        end)
-
       {v, type}, {acc, cacheable?} ->
         case cast_param(kind, query, expr, v, type, adapter) do
           {cast_v, {:in, dump_v}} -> {split_in_params(cast_v, dump_v, acc), false}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -10,7 +10,6 @@ defmodule Ecto.Query.Planner do
 
   @parent_as __MODULE__
   @aggs ~w(count avg min max sum row_number rank dense_rank percent_rank cume_dist ntile lag lead first_value last_value nth_value)a
-  @variadic ~w(in splice)a
 
   @doc """
   Converts a query to a list of joins.
@@ -786,7 +785,8 @@ defmodule Ecto.Query.Planner do
 
       {v, type}, {acc, cacheable?} ->
         case cast_param(kind, query, expr, v, type, adapter) do
-          {cast_v, {qual, dump_v}} when qual in @variadic -> {split_variadic_params(cast_v, dump_v, acc), false}
+          {cast_v, {:in, dump_v}} -> {split_variadic_params(cast_v, dump_v, acc), false}
+          {cast_v, {:splice, dump_v}} -> {split_variadic_params(cast_v, dump_v, acc), cacheable?}
           cast_v_and_dump_v -> {[cast_v_and_dump_v | acc], cacheable?}
         end
     end
@@ -1249,10 +1249,9 @@ defmodule Ecto.Query.Planner do
     {{quantifier, meta, [subquery]}, acc}
   end
 
-  defp prewalk({:splice, in_meta, [{:^, meta, [param]}]}, _kind, _query, expr, acc, _adapter) do
-    {v, _t} = Enum.fetch!(expr.params, param)
-    length = length(v)
-    {{:splice, in_meta, [{:^, meta, [acc, length]}]}, acc + length}
+  defp prewalk({:splice, splice_meta, [{:^, meta, [_]}, length]}, _kind, _query, _expr, acc, _adapter) do
+    param = {:^, meta, [acc, length]}
+    {{:splice, splice_meta, [param]}, acc + length}
   end
 
   defp prewalk({{:., dot_meta, [left, field]}, meta, []},

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -783,6 +783,14 @@ defmodule Ecto.Query.Planner do
         %Ecto.SubQuery{params: subparams, cache: cache} = Enum.fetch!(expr.subqueries, i)
         {Enum.reverse(subparams, acc), cacheable? and cache != :nocache}
 
+      {{:splice, splice_params}, :any}, {acc, cacheable?} ->
+        Enum.reduce(splice_params, {acc, cacheable?}, fn v, {acc, cacheable?} ->
+          case cast_param(kind, query, expr, v, :any, adapter) do
+            {cast_v, {:in, dump_v}} -> {split_in_params(cast_v, dump_v, acc), false}
+            cast_v_and_dump_v -> {[cast_v_and_dump_v | acc], cacheable?}
+          end
+        end)
+
       {v, type}, {acc, cacheable?} ->
         case cast_param(kind, query, expr, v, type, adapter) do
           {cast_v, {:in, dump_v}} -> {split_in_params(cast_v, dump_v, acc), false}

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -211,6 +211,7 @@ defmodule Ecto.Type do
     utc_datetime_usec naive_datetime_usec time_usec
   )a
   @composite ~w(array map maybe in param)a
+  @variadic ~w(in splice)a
 
   @doc """
   Returns the underlying schema type for the custom type.
@@ -507,9 +508,9 @@ defmodule Ecto.Type do
     end
   end
 
-  def dump({:in, type}, value, dumper) do
+  def dump({qual, type}, value, dumper) when qual in @variadic do
     case dump({:array, type}, value, dumper) do
-      {:ok, value} -> {:ok, {:in, value}}
+      {:ok, value} -> {:ok, {qual, value}}
       :error -> :error
     end
   end
@@ -795,7 +796,7 @@ defmodule Ecto.Type do
   defp cast_fun(:utc_datetime_usec), do: &maybe_pad_usec(cast_utc_datetime(&1))
   defp cast_fun({:param, :any_datetime}), do: &cast_any_datetime(&1)
   defp cast_fun({:parameterized, mod, params}), do: &mod.cast(&1, params)
-  defp cast_fun({:in, type}), do: cast_fun({:array, type})
+  defp cast_fun({qual, type}) when qual in @variadic, do: cast_fun({:array, type})
 
   defp cast_fun({:array, {:parameterized, _, _} = type}) do
     fun = cast_fun(type)

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1539,16 +1539,6 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
-  @tag :splice
-  test "normalize: fragment splice" do
-    a = 2
-    b = 3
-    query = from(p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), 5), select: p.id) |> normalize()
-
-    IO.inspect query.wheres
-    IO.inspect query
-  end
-
   test "normalize: select with map/2" do
     query = Post |> select([p], map(p, [:id, :title])) |> normalize()
     assert query.select.expr == {:&, [], [0]}

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1538,15 +1538,6 @@ defmodule Ecto.Query.PlannerTest do
       |> normalize()
     end
   end
-  @tag :splice
-  test "normalize: fragment splice" do
-    a = 2
-    b = 3
-    query = from(p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), ^5), select: p.id) |> normalize()
-
-    IO.inspect query.wheres
-    IO.inspect query
-  end
 
   test "normalize: select with map/2" do
     query = Post |> select([p], map(p, [:id, :title])) |> normalize()

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1539,6 +1539,16 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
+  @tag :splice
+  test "normalize: fragment splice" do
+    a = 2
+    b = 3
+    query = from(p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), 5), select: p.id) |> normalize()
+
+    IO.inspect query.wheres
+    IO.inspect query
+  end
+
   test "normalize: select with map/2" do
     query = Post |> select([p], map(p, [:id, :title])) |> normalize()
     assert query.select.expr == {:&, [], [0]}

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1538,6 +1538,15 @@ defmodule Ecto.Query.PlannerTest do
       |> normalize()
     end
   end
+  @tag :splice
+  test "normalize: fragment splice" do
+    a = 2
+    b = 3
+    query = from(p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), ^5), select: p.id) |> normalize()
+
+    IO.inspect query.wheres
+    IO.inspect query
+  end
 
   test "normalize: select with map/2" do
     query = Post |> select([p], map(p, [:id, :title])) |> normalize()

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -995,7 +995,7 @@ defmodule Ecto.QueryTest do
     test "supports list splicing" do
       a = 2
       b = 3
-      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), ^5)
+      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)
 
       IO.inspect query.wheres
       IO.inspect query

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -995,7 +995,7 @@ defmodule Ecto.QueryTest do
     test "supports list splicing" do
       a = 2
       b = 3
-      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)
+      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), 5)
 
       IO.inspect query.wheres
       IO.inspect query

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -780,10 +780,10 @@ defmodule Ecto.QueryTest do
 
       excluded_left_lateral_query = exclude(left_lateral_query, :left_lateral_join)
       assert excluded_left_lateral_query.joins == base.joins
-      
+
       excluded_array_query = exclude(array_query, :array_join)
       assert excluded_array_query.joins == base.joins
-      
+
       excluded_left_array_query = exclude(left_array_query, :left_array_join)
       assert excluded_left_array_query.joins == base.joins
     end
@@ -868,13 +868,13 @@ defmodule Ecto.QueryTest do
       assert map_size(excluded_left_lateral_join_query.aliases) == original_aliases_number - 1
       refute Map.has_key?(excluded_left_lateral_join_query.aliases, :blogs_ll)
       assert Map.has_key?(excluded_left_lateral_join_query.aliases, :base)
-      
+
       excluded_array_join_query = exclude(query, :array_join)
       assert length(excluded_array_join_query.joins) == original_joins_number - 1
       assert map_size(excluded_array_join_query.aliases) == original_aliases_number - 1
       refute Map.has_key?(excluded_array_join_query.aliases, :blogs_a)
       assert Map.has_key?(excluded_array_join_query.aliases, :base)
-      
+
       excluded_left_array_join_query = exclude(query, :left_array_join)
       assert length(excluded_left_array_join_query.joins) == original_joins_number - 1
       assert map_size(excluded_left_array_join_query.aliases) == original_aliases_number - 1
@@ -989,6 +989,16 @@ defmodule Ecto.QueryTest do
       assert_raise ArgumentError, "literal(^value) expects `value` to be a string, got `123`", fn ->
         from p in "posts", select: fragment("? COLLATE ?", p.name, literal(^123))
       end
+    end
+
+    @tag :splice
+    test "supports list splicing" do
+      a = 2
+      b = 3
+      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)
+
+      IO.inspect query.wheres
+      IO.inspect query
     end
 
     test "keeps UTF-8 encoding" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -995,7 +995,7 @@ defmodule Ecto.QueryTest do
     test "supports list splicing" do
       a = 2
       b = 3
-      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), 5)
+      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)
 
       IO.inspect query.wheres
       IO.inspect query

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1004,7 +1004,7 @@ defmodule Ecto.QueryTest do
                raw: "(",
                expr: {:^, _, [0]},
                raw: ", ",
-               expr: {:splice, _, [{:^, _, [1]}]},
+               expr: {:splice, _, [{:^, _, [1]}, 3]},
                raw: ", ",
                expr: {:^, _, [2]},
                raw: ")"

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -995,7 +995,7 @@ defmodule Ecto.QueryTest do
     test "supports list splicing" do
       a = 2
       b = 3
-      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)
+      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[a, b, 4]), ^5)
 
       IO.inspect query.wheres
       IO.inspect query

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1009,6 +1009,10 @@ defmodule Ecto.QueryTest do
                expr: {:^, _, [2]},
                raw: ")"
              ] = parts
+
+      assert_raise ArgumentError, "splice(^value) expects `value` to be a list, got `234`", fn ->
+        from p in "posts", where: p.id in fragment("(?)", splice(^234))
+      end
     end
 
     test "keeps UTF-8 encoding" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -991,14 +991,24 @@ defmodule Ecto.QueryTest do
       end
     end
 
-    @tag :splice
     test "supports list splicing" do
-      a = 2
-      b = 3
-      query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)
+      two = 2
+      three = 3
 
-      IO.inspect query.wheres
-      IO.inspect query
+      query =
+        from p in "posts", where: p.id in fragment("(?, ?, ?)", ^1, splice(^[two, three, 4]), ^5)
+
+      assert {:in, _, [_, {:fragment, _, parts}]} = hd(query.wheres).expr
+
+      assert [
+               raw: "(",
+               expr: {:^, _, [0]},
+               raw: ", ",
+               expr: {:splice, _, [{:^, _, [1]}]},
+               raw: ", ",
+               expr: {:^, _, [2]},
+               raw: ")"
+             ] = parts
     end
 
     test "keeps UTF-8 encoding" do


### PR DESCRIPTION
This is a proposal to add a splice capability to `fragment`. It is taking inspiration from `literal/1` as well as `unquote_splicing`.  

The idea is that the user would supply a list argument to `fragment` and then this would be spliced into the query string. Something like this

```elixir
a = 2
b = 3
query = from p in "posts", where: p.id in fragment("(?, ?, ?)", 1, splice(^[a, b, 4]), 5)

IO.inspect query
#Ecto.Query<from p0 in "posts", where: p0.id in fragment("(?, ?, ?, ?, ?)", 1, 2, 3, 4, 5)>
```

There are several use cases where this could come in handy:

1. Wanting to change the default Ecto behaviour using `fragment` when you require a variable number of arguments. For example changing the `where` operator behaviour: https://github.com/elixir-ecto/ecto/issues/2570#issuecomment-1632895072
2. Wanting to use `VALUE` lists that might have different sizes.
3. Some databases allow variadic functions. This would allow users to supply a variable number of arguments using the same fragment. This is a good fit because fragments would need to be used to call these types of functions anyway.

If the proposal is accepted I could finish up the PR. Just didn't want to get ahead of myself before receiving feedback.