### PR TITLE
Fix raise when trying to autogenerate :id in embed

### DIFF
--- a/lib/ecto/embedded.ex
+++ b/lib/ecto/embedded.ex
@@ -259,7 +259,7 @@ defmodule Ecto.Embedded do
       {key, _source, :binary_id} ->
         Map.put_new_lazy(changes, key, fn -> adapter.autogenerate(:embed_id) end)
 
-      {_key, :id} ->
+      {_key, _source, :id} ->
         raise ArgumentError,
               "embedded schema `#{inspect(schema)}` cannot autogenerate `:id` primary keys, " <>
                 "those are typically used for auto-incrementing constraints. " <>

--- a/test/ecto/repo/embedded_test.exs
+++ b/test/ecto/repo/embedded_test.exs
@@ -163,6 +163,31 @@ defmodule Ecto.Repo.EmbeddedTest do
     assert errors == %{embeds: [%{}, %{id: ["has already been taken"]}]}
   end
 
+  test "raise when trying to autogenerate embed primary keys with type `:id`" do
+    defmodule EmbedWithPrimaryKeyTypeId do
+      use Ecto.Schema
+
+      @primary_key {:id, :id, autogenerate: true}
+      embedded_schema do
+      end
+    end
+
+    defmodule SchemaWithPrimaryKeyTypeIdEmbed do
+      use Ecto.Schema
+
+      schema "" do
+        embeds_one :embed, EmbedWithPrimaryKeyTypeId
+      end
+    end
+
+    embed = struct(EmbedWithPrimaryKeyTypeId)
+    schema = struct(SchemaWithPrimaryKeyTypeIdEmbed, embed: embed)
+
+    assert_raise ArgumentError, ~r/cannot autogenerate `:id` primary keys/, fn ->
+      TestRepo.insert!(schema)
+    end
+  end
+
   ## update
 
   test "skips embeds on update when not changing" do


### PR DESCRIPTION
Setting `{:id, :id, autogenerate: true}` as the primary key in an embed, for example:

```elixir
@primary_key {:id, :id, autogenerate: true}
embedded_schema do
# ...
end
```

```elixir
embeds_one :item, Item, primary_key: {:id, :id, autogenerate: true} do
# ...
end
```

```elixir
embeds_many :items, Item, primary_key: {:id, :id, autogenerate: true} do
# ...
end
```


results in this error:

```
** (CaseClauseError) no case clause matching: {:id, :id, :id}
stacktrace:
  (ecto 3.10.3) lib/ecto/embedded.ex:245: Ecto.Embedded.autogenerate_id/5
  (ecto 3.10.3) lib/ecto/embedded.ex:208: Ecto.Embedded.to_struct/4
  (ecto 3.10.3) lib/ecto/embedded.ex:175: anonymous fn/6 in Ecto.Embedded.prepare_each/5
  (elixir 1.15.2) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
  (ecto 3.10.3) lib/ecto/embedded.ex:172: Ecto.Embedded.prepare_each/5
  (ecto 3.10.3) lib/ecto/embedded.ex:157: anonymous fn/6 in Ecto.Embedded.prepare/5
```

Whereas it should raise with the  specified `ArgumentError`.

I did some digging and this was the original addition: 8460f42
and believe the fix was missed after this change: 543e97a

Happy to write some tests/update the docs with a note here:
https://github.com/elixir-ecto/ecto/blob/26308b2ac8a3905daa9752cac13c7844df1d8720/lib/ecto/schema.ex#L1568-L1571

and here:
https://github.com/elixir-ecto/ecto/blob/26308b2ac8a3905daa9752cac13c7844df1d8720/lib/ecto/schema.ex#L1836-L1840

if needed, lmk :)