### PR TITLE
Allow interpolated names in selected_as/1 and selected_as/2

### DIFF
--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -112,15 +112,12 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   # aliased values
-  defp escape({:selected_as, _, [expr, name]}, {params, acc}, vars, env) when is_atom(name) do
+  defp escape({:selected_as, _, [expr, name]}, {params, acc}, vars, env) do
+    name = Builder.quoted_atom!(name, "selected_as/2")
     {escaped, {params, acc}} = Builder.escape(expr, :any, {params, acc}, vars, env)
     expr = {:{}, [], [:selected_as, [], [escaped, name]]}
     aliases = Builder.add_select_alias(acc.aliases, name)
     {expr, {params, %{acc | aliases: aliases}}}
-  end
-
-  defp escape({:selected_as, _, [_expr, name]}, {_params, _acc}, _vars, _env) do
-    Builder.error! "selected_as/2 expects `name` to be an atom, got `#{inspect(name)}`"
   end
 
   defp escape(expr, params_acc, vars, env) do
@@ -296,7 +293,7 @@ defmodule Ecto.Query.Builder.Select do
     {expr, {params, acc}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
     take = {:%{}, [], Map.to_list(acc.take)}
-    aliases = {:%{}, [], Map.to_list(acc.aliases)}
+    aliases = escape_aliases(acc.aliases)
 
     select = quote do: %Ecto.Query.SelectExpr{
                          expr: unquote(expr),
@@ -316,6 +313,9 @@ defmodule Ecto.Query.Builder.Select do
       end
     end
   end
+
+  def escape_aliases(%{} = aliases), do: {:%{}, [], Map.to_list(aliases)}
+  def escape_aliases(aliases), do: aliases
 
   @doc """
   The callback applied by `build/5` to build the query.

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -314,8 +314,8 @@ defmodule Ecto.Query.Builder.Select do
     end
   end
 
-  def escape_aliases(%{} = aliases), do: {:%{}, [], Map.to_list(aliases)}
-  def escape_aliases(aliases), do: aliases
+  defp escape_aliases(%{} = aliases), do: {:%{}, [], Map.to_list(aliases)}
+  defp escape_aliases(aliases), do: aliases
 
   @doc """
   The callback applied by `build/5` to build the query.

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -32,7 +32,7 @@ defmodule Ecto.Query.Builder.GroupByTest do
     end
 
     test "raises if name given to selected_as/1 is not an atom" do
-      message = "selected_as/1 expects `name` to be an atom, got `\"ident\"`"
+      message = "expected literal atom or interpolated value in selected_as/1, got: `\"ident\"`"
 
       assert_raise Ecto.Query.CompileError, message, fn ->
         escape(:group_by, quote do selected_as("ident") end, {[], %{}}, [], __ENV__)
@@ -64,6 +64,17 @@ defmodule Ecto.Query.Builder.GroupByTest do
       assert_raise ArgumentError, message, fn ->
         temp = "temp"
         group_by("posts", [p], ^temp)
+      end
+    end
+
+    test "supports dynamic names in selected_as/1" do
+      query = from p in "posts", select: selected_as(p.id, :ident), group_by: selected_as(^:ident)
+      assert [{:selected_as, [], [:ident]}]  = hd(query.group_bys).expr
+
+      message = "expected atom in selected_as/1, got: `\"ident\"`"
+
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        from p in "posts", select: selected_as(p.id, :ident), group_by: selected_as(^"ident")
       end
     end
   end

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -69,7 +69,7 @@ defmodule Ecto.Query.Builder.GroupByTest do
 
     test "supports interpolated atom names in selected_as/1" do
       query = from p in "posts", select: selected_as(p.id, :ident), group_by: selected_as(^:ident)
-      assert [{:selected_as, [], [:ident]}]  = hd(query.group_bys).expr
+      assert [{:selected_as, [], [:ident]}] = hd(query.group_bys).expr
 
       message = "expected atom in selected_as/1, got: `\"ident\"`"
 

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -67,7 +67,7 @@ defmodule Ecto.Query.Builder.GroupByTest do
       end
     end
 
-    test "supports dynamic names in selected_as/1" do
+    test "supports interpolated atom names in selected_as/1" do
       query = from p in "posts", select: selected_as(p.id, :ident), group_by: selected_as(^:ident)
       assert [{:selected_as, [], [:ident]}]  = hd(query.group_bys).expr
 

--- a/test/ecto/query/builder/order_by_test.exs
+++ b/test/ecto/query/builder/order_by_test.exs
@@ -174,7 +174,7 @@ defmodule Ecto.Query.Builder.OrderByTest do
              [{1, {0, :foo}}, {"bar", {0, :bar}}, {2, {0, :baz}}, {"bat", {0, :bat}}]
     end
 
-    test "supports dynamic names in selected_as/1" do
+    test "supports interpolated atomnames in selected_as/1" do
       query = from p in "posts", select: selected_as(p.id, :ident), order_by: selected_as(^:ident)
       assert [asc: {:selected_as, [], [:ident]}] = hd(query.order_bys).expr
 

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -175,7 +175,7 @@ defmodule Ecto.Query.Builder.SelectTest do
     end
 
     test "raises if name given to selected_as/2 is not an atom" do
-      message = "selected_as/2 expects `name` to be an atom, got `\"ident\"`"
+      message = "expected literal atom or interpolated value in selected_as/2, got: `\"ident\"`"
 
       assert_raise Ecto.Query.CompileError, message, fn ->
         escape(quote do selected_as(p.id, "ident") end, [], __ENV__)
@@ -415,6 +415,37 @@ defmodule Ecto.Query.Builder.SelectTest do
         assert length(query.select.subqueries) == 3
         assert query.select.params == [{:subquery, 0}, {:subquery, 1}, {ignore_template_id, {0, :from_template_id}}, {:subquery, 2}]
       end
+    end
+
+    test "supports dynamic names in selected_as/2" do
+      escaped_alias1 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident]}
+      escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident2]}
+
+      query = from p in "posts", select: {selected_as(p.id, ^:ident), selected_as(p.id, :ident2)}
+      assert {:{}, [], [escaped_alias1, escaped_alias2]} == query.select.expr
+
+      message = "expected atom in selected_as/2, got: `\"ident\"`"
+
+      assert_raise Ecto.Query.CompileError, message, fn ->
+        from p in "posts", select: selected_as(p.id, ^"ident")
+      end
+    end
+
+    test "supports dynamic names in selected_as/2 with select_merge" do
+      escaped_select_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :visits]}, [], []}, :select]}
+      escaped_merge_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :merge]}
+
+      # merging into a map
+      select = :select
+      merge = :merge
+      query = from p in "posts", select: %{v: selected_as(p.visits, ^select)}, select_merge: %{title: selected_as(p.title, ^merge)}
+      assert {:%{}, [], [v: escaped_select_alias, title: escaped_merge_alias]} == query.select.expr
+      assert %{select: _, merge: _} = query.select.aliases
+
+      # merging into a source
+      query = from c in Comment, select_merge: %{title: selected_as(c.title, ^:merge)}
+      assert {:merge, [], [{:&, [], [0]}, {:%{}, [], [title: escaped_merge_alias]}]} == query.select.expr
+      assert %{merge: _} = query.select.aliases
     end
 
     test "raises on list or tuple values in interpolated map" do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -421,9 +421,16 @@ defmodule Ecto.Query.Builder.SelectTest do
       escaped_alias1 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident]}
       escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident2]}
 
-      query = from p in "posts", select: {selected_as(p.id, ^:ident), selected_as(p.id, :ident2)}
-      assert %{ident: _, ident2: _} = query.select.aliases
-      assert {:{}, [], [escaped_alias1, escaped_alias2]} == query.select.expr
+      query1 = from p in "posts", select: {selected_as(p.id, ^:ident), selected_as(p.id, :ident2)}
+      query2 = from p in "posts", select: {selected_as(p.id, :ident), selected_as(p.id, ^:ident2)}
+      query3 = from p in "posts", select: {selected_as(p.id, ^:ident), selected_as(p.id, ^:ident2)}
+
+      assert query1.select.expr == query2.select.expr
+      assert query2.select.expr == query3.select.expr
+      assert query1.select.aliases == query2.select.aliases
+      assert query2.select.aliases == query3.select.aliases
+      assert %{ident: _, ident2: _} = query1.select.aliases
+      assert {:{}, [], [escaped_alias1, escaped_alias2]} == query1.select.expr
 
       message = "expected atom in selected_as/2, got: `\"ident\"`"
 

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -417,7 +417,7 @@ defmodule Ecto.Query.Builder.SelectTest do
       end
     end
 
-    test "supports dynamic names in selected_as/2" do
+    test "supports interpolated atom names in selected_as/2" do
       escaped_alias1 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident]}
       escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident2]}
 
@@ -431,7 +431,7 @@ defmodule Ecto.Query.Builder.SelectTest do
       end
     end
 
-    test "supports dynamic names in selected_as/2 with select_merge" do
+    test "supports interpolated atom names in selected_as/2 with select_merge" do
       escaped_select_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :visits]}, [], []}, :select]}
       escaped_merge_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :merge]}
 

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -422,6 +422,7 @@ defmodule Ecto.Query.Builder.SelectTest do
       escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :id]}, [], []}, :ident2]}
 
       query = from p in "posts", select: {selected_as(p.id, ^:ident), selected_as(p.id, :ident2)}
+      assert %{ident: _, ident2: _} = query.select.aliases
       assert {:{}, [], [escaped_alias1, escaped_alias2]} == query.select.expr
 
       message = "expected atom in selected_as/2, got: `\"ident\"`"
@@ -439,12 +440,12 @@ defmodule Ecto.Query.Builder.SelectTest do
       select = :select
       merge = :merge
       query = from p in "posts", select: %{v: selected_as(p.visits, ^select)}, select_merge: %{title: selected_as(p.title, ^merge)}
-      assert {:%{}, [], [v: escaped_select_alias, title: escaped_merge_alias]} == query.select.expr
+      assert query.select.expr == {:%{}, [], [v: escaped_select_alias, title: escaped_merge_alias]}
       assert %{select: _, merge: _} = query.select.aliases
 
       # merging into a source
       query = from c in Comment, select_merge: %{title: selected_as(c.title, ^:merge)}
-      assert {:merge, [], [{:&, [], [0]}, {:%{}, [], [title: escaped_merge_alias]}]} == query.select.expr
+      assert query.select.expr == {:merge, [], [{:&, [], [0]}, {:%{}, [], [title: escaped_merge_alias]}]}
       assert %{merge: _} = query.select.aliases
     end
 


### PR DESCRIPTION
I saw [this post on Elixir forum](https://elixirforum.com/t/ecto-query-api-selected-as-1-with-a-variable/57092) and thought I would see how bad the change is. I think it's not too big so probably we can support this?