### PR TITLE
Allow `nil` map updates in select

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1360,6 +1360,17 @@ defmodule Ecto.Integration.RepoTest do
       end
     end
 
+    test "map update on association" do
+      p = TestRepo.insert!(%Post{})
+      TestRepo.insert!(%Comment{post_id: p.id, text: "comment text"})
+      TestRepo.insert!(%Comment{})
+
+      query =
+        from(c in Comment, left_join: p in Post, on: c.post_id == p.id, select: %{p | temp: c.text})
+
+      assert [%Post{:temp => "comment text"}, nil] = TestRepo.all(query)
+    end
+
     test "take with structs" do
       %{id: pid1} = TestRepo.insert!(%Post{title: "1"})
       %{id: pid2} = TestRepo.insert!(%Post{title: "2"})

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -386,6 +386,11 @@ defmodule Ecto.Repo.Queryable do
     {value, row}
   end
 
+  defp process_update(nil, args, row, from, adapter) do
+    {_args, row} = process_kv(args, row, from, adapter)
+    {nil, row}
+  end
+
   defp process_update(data, args, row, from, adapter) do
     {args, row} = process_kv(args, row, from, adapter)
     data = Enum.reduce(args, data, fn {key, value}, acc -> %{acc | key => value} end)


### PR DESCRIPTION
**Reference** 

https://elixirforum.com/t/ecto-merge-select-or-select-merge-into-a-possibly-nil-value-left-join/57133

**Issue**

When performing a query like this, it will fail with `BadMapError` if one of the main rows doesn't have an associated row:

```elixir
from(c in Comment, left_join: p in Post, on: c.post_id == p.id, select: %{p | temp: c.text}
```

**Proposal**

I think we should allow this and simply return `nil`. It seems like the intuitive thing to expect and also there is some precedent. We will return `nil` in this situation

```elixir
from(c in Comment, left_join: p in Post, on: c.post_id == p.id, select: map(p, [:field1, :field2, ...])
```