### PR TITLE
Allow interpolated `selected_as/2` names in `dynamic/2`

### DIFF
--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -13,7 +13,7 @@ defmodule Ecto.Query.Builder.Dynamic do
   def build(binding, expr, env) do
     {query, vars} = Builder.escape_binding(quote(do: query), binding, env)
     {expr, {params, acc}} = escape(expr, {[], %{subqueries: [], aliases: %{}}}, vars, env)
-    aliases = Builder.escape_select_aliases(acc.aliases)
+    aliases = escape_select_aliases(acc.aliases)
     params = Builder.escape_params(params)
 
     quote do
@@ -38,6 +38,9 @@ defmodule Ecto.Query.Builder.Dynamic do
   defp escape_expansion(expr, _type, params_acc, vars, env) do
     escape(expr, params_acc, vars, env)
   end
+
+  defp escape_select_aliases(%{} = aliases), do: Builder.escape_select_aliases(aliases)
+  defp escape_select_aliases(aliases), do: aliases
 
   @doc """
   Expands a dynamic expression for insertion into the given query.

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -439,6 +439,18 @@ defmodule Ecto.Query.Builder.SelectTest do
       end
     end
 
+    test "supports interpolated atom names in selected_as/2 with dynamic/2" do
+      escaped_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :alias]}
+      escaped_alias2 = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :alias2]}
+
+      select_fields = %{title: dynamic([p], selected_as(p.title, ^:alias))}
+      merge_fields = %{title2: dynamic([p], selected_as(p.title, ^:alias2))}
+
+      query = from p in "posts", select: ^select_fields, select_merge: ^merge_fields
+      assert {:%{}, [], [title: escaped_alias, title2: escaped_alias2]} == query.select.expr
+      assert %{alias: _, alias2: _} = query.select.aliases
+    end
+
     test "supports interpolated atom names in selected_as/2 with select_merge" do
       escaped_select_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :visits]}, [], []}, :select]}
       escaped_merge_alias = {:selected_as, [], [{{:., [], [{:&, [], [0]}, :title]}, [], []}, :merge]}


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4234