### PR TITLE
Allow safe interpolation on Fragment query strings

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2694,49 +2694,4 @@ defmodule Ecto.Query do
           end)
     }
   end
-
-  @doc """
-  Syntax sugar for writing fragments with interpolations.
-
-      dynamic([user: user], ~f\"""
-        CASE
-          WHEN \#{user.role == :admin} THEN 3
-          WHEN \#{user.role == :manager} THEN 2
-          ELSE 1
-        END
-      \""")
-
-  Is equivalent to
-
-      dynamic([user: user], fragment(
-        \"""
-          CASE
-            WHEN ? THEN 3
-            WHEN ? THEN 2
-            ELSE 1
-          END
-        \""",
-        user.role == :admin,
-        user.role == :manager
-      ))
-
-  But with the benefit of interpolated values being in the right place.
-  """
-  defmacro sigil_f({:<<>>, meta, pieces}, _) do
-    query =
-      pieces
-      |> Enum.map(fn
-        "" <> binary -> binary
-        _ -> "?"
-      end)
-      |> Enum.join()
-
-    args =
-      Enum.flat_map(pieces, fn
-        {:"::", _, [{_, _, [val]} | _]} -> [val]
-        _ -> []
-      end)
-
-    {:fragment, meta, [query | args]}
-  end
 end

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -2722,7 +2722,7 @@ defmodule Ecto.Query do
 
   But with the benefit of interpolated values being in the right place.
   """
-  defmacro sigil_f({:<<>>, _meta, pieces}, _) do
+  defmacro sigil_f({:<<>>, meta, pieces}, _) do
     query =
       pieces
       |> Enum.map(fn
@@ -2737,8 +2737,6 @@ defmodule Ecto.Query do
         _ -> []
       end)
 
-    quote do
-      fragment(unquote_splicing([query | args]))
-    end
+    {:fragment, meta, [query | args]}
   end
 end

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -478,33 +478,33 @@ defmodule Ecto.Query.API do
   """
   def fragment(fragments), do: doc! [fragments]
 
-  @doc """
+  @doc ~S'''
   Syntax sugar for writing fragments with interpolations.
 
-      dynamic([user: user], ~f\"""
+      dynamic([user: user], ~f"""
         CASE
-          WHEN \#{user.role == :admin} THEN 3
-          WHEN \#{user.role == :manager} THEN 2
+          WHEN #{user.role == :admin} THEN 3
+          WHEN #{user.role == :manager} THEN 2
           ELSE 1
         END
-      \""")
+      """)
 
   Is equivalent to
 
       dynamic([user: user], fragment(
-        \"""
+        """
           CASE
             WHEN ? THEN 3
             WHEN ? THEN 2
             ELSE 1
           END
-        \""",
+        """,
         user.role == :admin,
         user.role == :manager
       ))
 
   But with the benefit of interpolated values being in the right place.
-  """
+  '''
   def sigil_f(ast, modifiers), do: doc! [ast, modifiers]
 
   @doc """

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -446,6 +446,16 @@ defmodule Ecto.Query.API do
 
       from p in Post, where: fragment("? in (?,?,?)", p.id, ^1, ^2, ^3)
 
+  ## Interpolation
+
+  As an alternative splicing, fragments also support safe interpolations
+  as a syntax sugar for splicing, so the query above could be rewriten as
+
+      from p in Post, where: fragment("#{p.id} in (#{^1},#{^2},#{^3})")
+
+  Which has the benefit of more easily understanding where each expression
+  is used.
+
   ## Defining custom functions using macros and fragment
 
   You can add a custom Ecto query function using macros.  For example
@@ -477,35 +487,6 @@ defmodule Ecto.Query.API do
 
   """
   def fragment(fragments), do: doc! [fragments]
-
-  @doc ~S'''
-  Syntax sugar for writing fragments with interpolations.
-
-      dynamic([user: user], ~f"""
-        CASE
-          WHEN #{user.role == :admin} THEN 3
-          WHEN #{user.role == :manager} THEN 2
-          ELSE 1
-        END
-      """)
-
-  Is equivalent to
-
-      dynamic([user: user], fragment(
-        """
-          CASE
-            WHEN ? THEN 3
-            WHEN ? THEN 2
-            ELSE 1
-          END
-        """,
-        user.role == :admin,
-        user.role == :manager
-      ))
-
-  But with the benefit of interpolated values being in the right place.
-  '''
-  def sigil_f(ast, modifiers), do: doc! [ast, modifiers]
 
   @doc """
   Allows a literal identifier to be injected into a fragment:

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -479,6 +479,35 @@ defmodule Ecto.Query.API do
   def fragment(fragments), do: doc! [fragments]
 
   @doc """
+  Syntax sugar for writing fragments with interpolations.
+
+      dynamic([user: user], ~f\"""
+        CASE
+          WHEN \#{user.role == :admin} THEN 3
+          WHEN \#{user.role == :manager} THEN 2
+          ELSE 1
+        END
+      \""")
+
+  Is equivalent to
+
+      dynamic([user: user], fragment(
+        \"""
+          CASE
+            WHEN ? THEN 3
+            WHEN ? THEN 2
+            ELSE 1
+          END
+        \""",
+        user.role == :admin,
+        user.role == :manager
+      ))
+
+  But with the benefit of interpolated values being in the right place.
+  """
+  def sigil_f(ast, modifiers), do: doc! [ast, modifiers]
+
+  @doc """
   Allows a literal identifier to be injected into a fragment:
 
       collation = "es_ES"

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -162,7 +162,7 @@ defmodule Ecto.Query.Builder do
   end
 
   # fragments
-  def escape({:sigil_f, _sigil_meta, [{:<<>>, _meta, pieces}, _modifiers]}, given_type, params_acc, vars, env) do
+  def escape({:fragment, _sigil_meta, [{:<<>>, _meta, pieces} | rest]}, given_type, params_acc, vars, env) do
     query =
       pieces
       |> Enum.map(fn
@@ -176,6 +176,10 @@ defmodule Ecto.Query.Builder do
         {:"::", _, [{_, _, [val]} | _]} -> [val]
         _ -> []
       end)
+
+    if not Enum.empty?(frags) and not Enum.empty?(rest) do
+      error! "fragment\(...\) does not allow mixing interpolation and positional arguments"
+    end
 
     escape({:fragment, [], [query | frags]}, given_type, params_acc, vars, env)
   end

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -162,6 +162,24 @@ defmodule Ecto.Query.Builder do
   end
 
   # fragments
+  def escape({:sigil_f, _sigil_meta, [{:<<>>, _meta, pieces}, _modifiers]}, given_type, params_acc, vars, env) do
+    query =
+      pieces
+      |> Enum.map(fn
+        "" <> binary -> binary
+        _ -> "?"
+      end)
+      |> Enum.join()
+
+    frags =
+      Enum.flat_map(pieces, fn
+        {:"::", _, [{_, _, [val]} | _]} -> [val]
+        _ -> []
+      end)
+
+    escape({:fragment, [], [query | frags]}, given_type, params_acc, vars, env)
+  end
+
   def escape({:fragment, _, [query]}, _type, params_acc, vars, env) when is_list(query) do
     {escaped, params_acc} =
       Enum.map_reduce(query, params_acc, &escape_kw_fragment(&1, &2, vars, env))

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1133,4 +1133,22 @@ defmodule Ecto.QueryTest do
       assert inspect(reverse_order(q)) == inspect(order_by(q, desc: :id))
     end
   end
+
+  describe "sigil_f/1" do
+    test "builds a fragment without interpolation" do
+      assert inspect(select("t", ~f"NOW()")) == inspect(select("t", fragment("NOW()")))
+    end
+
+    test "builds a fragment with one interpolation" do
+      assert inspect(select("t", [t], ~f"LOWER(#{t.email})")) ==
+               inspect(select("t", [t], fragment("LOWER(?)", t.email)))
+    end
+
+    test "builds a fragment with multiple interpolation" do
+      date = ~D[2020-01-01]
+
+      assert inspect(select("t", [t], ~f"GREATEST(#{t.date}, #{^date})")) ==
+               inspect(select("t", [t], fragment("GREATEST(?, ?)", t.date, ^date)))
+    end
+  end
 end


### PR DESCRIPTION
I was playing around with the idea yesterday and I saw there was already a discussion regarding that in the mailing list, so I'm creating this PR.

## Problem

When writing complex fragments with a lot of arguments, it can become easily a mess due to positional arguments. To know where something would go in the query, you have to count the `?` and then count the `,` (or lines if you have in multiple lines) to be able to know where everything goes.

## Solution

The idea is to allow interpolation using a sigil that just compiles to the same `fragment` call underneath.

One thing to note that I'd like input on:

When I checked the mailing list, I saw @josevalim suggested `~FRAGMENT`, but because it is an uppercase sigil, it does not automatically interpolate the contents (which also means editor support don't treat `#{}` as interpolations and you get worse autocomplete).

We could probably just get the string, parse it and then it would work the same, but we would still have worse support for tooling.

Because of that, I went with `~f` instead, but of course this is something we might want to discuss.