### PR TITLE
Expand Multi transaction error message

### DIFF
--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -16,9 +16,19 @@ defmodule Ecto.Repo.Transaction do
     return = &adapter.rollback(adapter_meta, &1)
 
     case Ecto.Multi.__apply__(multi, repo, wrap, return) do
-      {:ok, values} -> {:ok, values}
-      {:error, {key, error_value, values}} -> {:error, key, error_value, values}
-      {:error, operation} -> raise "operation #{inspect operation} is manually rolling back, which is not supported by Ecto.Multi"
+      {:ok, values} -> 
+        {:ok, values}
+
+      {:error, {key, error_value, values}} -> 
+        {:error, key, error_value, values}
+
+      {:error, operation} -> 
+        raise """
+          Operation #{inspect operation} is manually rolling back, which is not supported by Ecto.Multi.
+
+          This can occur if you try to commit an outer transaction when the inner transaction has failed 
+          (and rolled back). Instead, allow the outer transaction to fail as well and handle the error case.
+        """
     end
   end
 

--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -24,10 +24,10 @@ defmodule Ecto.Repo.Transaction do
 
       {:error, operation} -> 
         raise """
-          Operation #{inspect operation} is manually rolling back, which is not supported by Ecto.Multi.
+        operation #{inspect operation} is manually rolling back, which is not supported by Ecto.Multi.
 
-          This can occur if you try to commit an outer transaction when the inner transaction has failed 
-          (and rolled back). Instead, allow the outer transaction to fail as well and handle the error case.
+        This can occur if you try to commit an outer transaction when the inner transaction has failed 
+        (and rolled back). Instead, allow the outer transaction to fail as well and handle the error case.
         """
     end
   end

--- a/lib/ecto/repo/transaction.ex
+++ b/lib/ecto/repo/transaction.ex
@@ -24,10 +24,13 @@ defmodule Ecto.Repo.Transaction do
 
       {:error, operation} -> 
         raise """
-        operation #{inspect operation} is manually rolling back, which is not supported by Ecto.Multi.
+        operation #{inspect operation} is rolling back unexpectedly.
 
-        This can occur if you try to commit an outer transaction when the inner transaction has failed 
-        (and rolled back). Instead, allow the outer transaction to fail as well and handle the error case.
+        This can happen if `repo.rollback/1` is manually called, which is not \
+        supported by `Ecto.Multi`. It can also occur if a nested transaction \
+        has rolled back and its error is not bubbled up to the outer multi. \
+        Nested transactions are discouraged when using `Ecto.Multi`. Consider \
+        flattening out the transaction instead.
         """
     end
   end

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -489,7 +489,7 @@ defmodule Ecto.MultiTest do
           repo.rollback(:bar)
         end)
 
-      assert_raise RuntimeError, ~r"operation :bar is manually rolling back, which is not supported by Ecto.Multi", fn ->
+      assert_raise RuntimeError, ~r"operation :bar is rolling back unexpectedly", fn ->
         TestRepo.transaction(multi)
       end
     end


### PR DESCRIPTION
Opening a draft to serve as a starting point for discussion. I have run into this error a few times and I've never been able to decipher exactly what it means. It usually appears to result from invalid error handling inside a Multi. Usually that has been unintentional but in a recent case I ran into when handling a nested multi transaction that failed as a success in the parent multi. I've added that case as an example in the docs to point future wayward souls in the right direction. Please advise on accuracy and clarity, although I do think clearly _something_ should be added to this error because it doesn't seem very helpful/instructive currently.