### PR TITLE
Add warning for selecting literal atoms from combinations

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1845,7 +1845,10 @@ defmodule Ecto.Query do
   A union query expression.
 
   Combines result sets of multiple queries. The `select` of each query
-  must be exactly the same, with the same types in the same order.
+  must be exactly the same, with the same types in the same order. When
+  selecting a literal atom, its value must be the same all queries.
+  Otherwise, the value from the parent query wille be applied to all
+  other queries.
 
   Union expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -1891,7 +1894,10 @@ defmodule Ecto.Query do
   A union all query expression.
 
   Combines result sets of multiple queries. The `select` of each query
-  must be exactly the same, with the same types in the same order.
+  must be exactly the same, with the same types in the same order. When
+  selecting a literal atom, its value must be the same all queries.
+  Otherwise, the value from the parent query wille be applied to all
+  other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the union. `order_by` must
@@ -1932,7 +1938,9 @@ defmodule Ecto.Query do
 
   Takes the difference of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order.
+  types in the same order. When selecting a literal atom, its value
+  must be the same all queries. Otherwise, the value from the parent
+  query wille be applied to all other queries.
 
   Except expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -1978,7 +1986,9 @@ defmodule Ecto.Query do
 
   Takes the difference of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order.
+  types in the same order.  When selecting a literal atom, its value
+  must be the same all queries. Otherwise, the value from the parent
+  query wille be applied to all other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`
@@ -2019,7 +2029,9 @@ defmodule Ecto.Query do
 
   Takes the overlap of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order.
+  types in the same order. When selecting a literal atom, its value
+  must be the same all queries. Otherwise, the value from the parent
+  query wille be applied to all other queries.
 
   Intersect expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2065,7 +2077,9 @@ defmodule Ecto.Query do
 
   Takes the overlap of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order.
+  types in the same order. When selecting a literal atom, its value
+  must be the same all queries. Otherwise, the value from the parent
+  query wille be applied to all other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1849,9 +1849,9 @@ defmodule Ecto.Query do
 
   > ### Selecting literal atoms {: .warning}
   >
-  > When selecting a literal atom, its value must be the same all queries.
-  > Otherwise, the value from the parent query will be applied to all
-  > other queries.
+  > When selecting a literal atom, its value must be the same across
+  > all queries. Otherwise, the value from the parent query will be
+  > applied to all other queries.
 
   Union expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -1901,9 +1901,9 @@ defmodule Ecto.Query do
 
   > ### Selecting literal atoms {: .warning}
   >
-  > When selecting a literal atom, its value must be the same all queries.
-  > Otherwise, the value from the parent query will be applied to all
-  > other queries.
+  > When selecting a literal atom, its value must be the same across
+  > all queries. Otherwise, the value from the parent query will be
+  > applied to all other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the union. `order_by` must
@@ -1948,9 +1948,9 @@ defmodule Ecto.Query do
 
   > ### Selecting literal atoms {: .warning}
   >
-  > When selecting a literal atom, its value must be the same all queries.
-  > Otherwise, the value from the parent query will be applied to all
-  > other queries.
+  > When selecting a literal atom, its value must be the same across
+  > all queries. Otherwise, the value from the parent query will be
+  > applied to all other queries.
 
   Except expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2000,9 +2000,9 @@ defmodule Ecto.Query do
 
   > ### Selecting literal atoms {: .warning}
   >
-  > When selecting a literal atom, its value must be the same all queries.
-  > Otherwise, the value from the parent query will be applied to all
-  > other queries.
+  > When selecting a literal atom, its value must be the same across
+  > all queries. Otherwise, the value from the parent query will be
+  > applied to all other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`
@@ -2047,9 +2047,9 @@ defmodule Ecto.Query do
 
   > ### Selecting literal atoms {: .warning}
   >
-  > When selecting a literal atom, its value must be the same all queries.
-  > Otherwise, the value from the parent query will be applied to all
-  > other queries.
+  > When selecting a literal atom, its value must be the same across
+  > all queries. Otherwise, the value from the parent query will be
+  > applied to all other queries.
 
   Intersect expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2099,9 +2099,9 @@ defmodule Ecto.Query do
 
   > ### Selecting literal atoms {: .warning}
   >
-  > When selecting a literal atom, its value must be the same all queries.
-  > Otherwise, the value from the parent query will be applied to all
-  > other queries.
+  > When selecting a literal atom, its value must be the same across
+  > all queries. Otherwise, the value from the parent query will be
+  > applied to all other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1845,10 +1845,13 @@ defmodule Ecto.Query do
   A union query expression.
 
   Combines result sets of multiple queries. The `select` of each query
-  must be exactly the same, with the same types in the same order. When
-  selecting a literal atom, its value must be the same all queries.
-  Otherwise, the value from the parent query wille be applied to all
-  other queries.
+  must be exactly the same, with the same types in the same order.
+
+  > ### Selecting literal atoms {: .warning}
+  >
+  > When selecting a literal atom, its value must be the same all queries.
+  > Otherwise, the value from the parent query will be applied to all
+  > other queries.
 
   Union expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -1894,10 +1897,13 @@ defmodule Ecto.Query do
   A union all query expression.
 
   Combines result sets of multiple queries. The `select` of each query
-  must be exactly the same, with the same types in the same order. When
-  selecting a literal atom, its value must be the same all queries.
-  Otherwise, the value from the parent query wille be applied to all
-  other queries.
+  must be exactly the same, with the same types in the same order.
+
+  > ### Selecting literal atoms {: .warning}
+  >
+  > When selecting a literal atom, its value must be the same all queries.
+  > Otherwise, the value from the parent query will be applied to all
+  > other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the union. `order_by` must
@@ -1938,9 +1944,13 @@ defmodule Ecto.Query do
 
   Takes the difference of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order. When selecting a literal atom, its value
-  must be the same all queries. Otherwise, the value from the parent
-  query wille be applied to all other queries.
+  types in the same order.
+
+  > ### Selecting literal atoms {: .warning}
+  >
+  > When selecting a literal atom, its value must be the same all queries.
+  > Otherwise, the value from the parent query will be applied to all
+  > other queries.
 
   Except expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -1986,9 +1996,13 @@ defmodule Ecto.Query do
 
   Takes the difference of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order.  When selecting a literal atom, its value
-  must be the same all queries. Otherwise, the value from the parent
-  query wille be applied to all other queries.
+  types in the same order.
+
+  > ### Selecting literal atoms {: .warning}
+  >
+  > When selecting a literal atom, its value must be the same all queries.
+  > Otherwise, the value from the parent query will be applied to all
+  > other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`
@@ -2029,9 +2043,13 @@ defmodule Ecto.Query do
 
   Takes the overlap of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order. When selecting a literal atom, its value
-  must be the same all queries. Otherwise, the value from the parent
-  query wille be applied to all other queries.
+  types in the same order.
+
+  > ### Selecting literal atoms {: .warning}
+  >
+  > When selecting a literal atom, its value must be the same all queries.
+  > Otherwise, the value from the parent query will be applied to all
+  > other queries.
 
   Intersect expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2077,9 +2095,13 @@ defmodule Ecto.Query do
 
   Takes the overlap of the result sets of multiple queries. The
   `select` of each query must be exactly the same, with the same
-  types in the same order. When selecting a literal atom, its value
-  must be the same all queries. Otherwise, the value from the parent
-  query wille be applied to all other queries.
+  types in the same order.
+
+  > ### Selecting literal atoms {: .warning}
+  >
+  > When selecting a literal atom, its value must be the same all queries.
+  > Otherwise, the value from the parent query will be applied to all
+  > other queries.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4247

I went the documentation route because:

1. I don't believe there is any way to make it work. The literal atoms are part of the post processor and we have no idea how many rows will be returned from each query in the combination.
2. It will be pretty complicated to detect literal atoms in select expressions in combinations and raise if they are different. I think this is an uncommon enough case that it's not worth the extra complexity.

Technically only rows from the parent query are returned from except(_all) and intersect(_all) but I thought I'd add the warning to them just in case people expect the results to honour the literal atoms.