### PR TITLE
Add Repo.update_all/1

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -406,7 +406,7 @@ defmodule Ecto.Repo do
 
       if Ecto.Adapter.Queryable in behaviours do
         if not @read_only do
-          def update_all(queryable, updates, opts \\ []) do
+          def update_all(queryable, updates \\ [], opts \\ []) do
             repo = get_dynamic_repo()
 
             Ecto.Repo.Queryable.update_all(
@@ -1349,13 +1349,13 @@ defmodule Ecto.Repo do
       |> MyRepo.update_all([])
 
       from(p in Post, where: p.id < 10, update: [set: [title: ^new_title]])
-      |> MyRepo.update_all([])
+      |> MyRepo.update_all()
 
       from(p in Post, where: p.id < 10, update: [set: [title: fragment("upper(?)", ^new_title)]])
-      |> MyRepo.update_all([])
+      |> MyRepo.update_all()
 
       from(p in Post, where: p.id < 10, update: [set: [visits: p.visits * 1000]])
-      |> MyRepo.update_all([])
+      |> MyRepo.update_all([], [timeout: 5_000])
 
   """
   @doc group: "Query API"

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -707,9 +707,16 @@ defmodule Ecto.RepoTest do
 
       query = from(e in MySchema, where: e.x == "123", update: [set: [x: "321"]])
       TestRepo.update_all(query, [])
+      TestRepo.update_all(query)
 
       assert_raise Ecto.QueryError, fn ->
-        TestRepo.update_all from(e in MySchema, order_by: e.x), set: [x: "321"]
+        from(e in MySchema, order_by: e.x)
+        |> TestRepo.update_all(set: [x: "321"])
+      end
+
+      assert_raise Ecto.QueryError, fn ->
+        from(e in MySchema)
+        |> TestRepo.update_all()
       end
     end
   end


### PR DESCRIPTION
Convenience function to be used when query already has updates.
