### PR TITLE
Use unsafe_fragment for dynamic hints.

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -975,7 +975,7 @@ defmodule Ecto.Query do
   >
   > The output of `unsafe_fragment/1` will be injected directly into the
   > SQL statement without being escaped. For this reason, user input should
-  > **never** be used.
+  > **never** be used because it can lead to SQL injections.
 
   ## Keywords examples
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -974,8 +974,9 @@ defmodule Ecto.Query do
   > ### Unsafe Fragments {: .warning}
   >
   > The output of `unsafe_fragment/1` will be injected directly into the
-  > SQL statement without being escaped. For this reason, user input should
-  > **never** be used because it can lead to SQL injections.
+  > resulting SQL statement without being escaped. For this reason, input
+  > from uncontrolled sources, such as user input, should **never** be used.
+  > Otherwise, it could lead to harmful SQL injection attacks.
 
   ## Keywords examples
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1311,7 +1311,7 @@ defmodule Ecto.Query do
 
   ## Hints
 
-  `join` also supports index hints, as found in databases such as
+  `join` also supports table hints, as found in databases such as
   [MySQL](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html),
   [MSSQL](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-2017) and
   [Clickhouse](https://clickhouse.tech/docs/en/sql-reference/statements/select/sample/).

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -948,6 +948,35 @@ defmodule Ecto.Query do
   a value that implements the `Ecto.Queryable` protocol
   and the second argument the expression.
 
+  ## Hints
+
+  The `hints` keyword can be used to specify query hints:
+
+      from p in Post,
+        hints: ["USE INDEX FOO"],
+        where: p.title == "title"
+
+  They can also be used as general mechanism for adding statements that
+  come after the `from` clause. For example, they can be used to enabled
+  table sampling:
+
+      from p in Post,
+        hints: "TABLESAMPLE SYSTEM(1)"
+
+  `from` hints must be a (list of) compile-time strings or unsafe fragments. An unsafe
+  fragment can be used to specify dynamic hints:
+
+      sample_method = "SYSTEM_ROWS"
+
+      from p in Post,
+        hints: ["TABLESAMPLE ", unsafe_fragment(^sample_method), "(1)"]
+
+  > ### Unsafe Fragments {: .warning}
+  >
+  > The output of `unsafe_fragment/1` will be injected directly into the
+  > SQL statement without being escaped. For this reason, user input should
+  > **never** be used.
+
   ## Keywords examples
 
       # `in` expression
@@ -957,7 +986,7 @@ defmodule Ecto.Query do
       from(City, limit: 1)
 
       # Fragment with user-defined function and predefined columns
-      from(f in fragment("my_table_valued_function(arg)"), select: f.x))
+      from(f in fragment("my_table_valued_function(arg)"), select: f.x)
 
       # Fragment with built-in function and undefined columns
       from(f in fragment("select generate_series(?::integer, ?::integer) as x", ^0, ^10), select: f.x)
@@ -1281,7 +1310,7 @@ defmodule Ecto.Query do
 
   ## Hints
 
-  `from` and `join` also support index hints, as found in databases such as
+  `join` also supports index hints, as found in databases such as
   [MySQL](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html),
   [MSSQL](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-2017) and
   [Clickhouse](https://clickhouse.tech/docs/en/sql-reference/statements/select/sample/).
@@ -1297,12 +1326,7 @@ defmodule Ecto.Query do
   Keep in mind you want to use hints rarely, so don't forget to read the database
   disclaimers about such functionality.
 
-  Hints must be static compile-time strings when they are specified as (list of) strings.
-  Certain Ecto adapters may also accept dynamic hints using the tuple form:
-
-      from e in Event,
-        hints: [sample: sample_threshold()],
-        select: e
+  Join hints must be static compile-time strings when they are specified as (list of) strings.
 
   ## Array joins
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -956,8 +956,8 @@ defmodule Ecto.Query do
         hints: ["USE INDEX FOO"],
         where: p.title == "title"
 
-  They can also be used as general mechanism for adding statements that
-  come after the `from` clause. For example, they can be used to enable
+  It can also be used as a general mechanism for adding statements that
+  come after the `from` clause. For example, it can be used to enable
   table sampling:
 
       from p in Post,

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -957,7 +957,7 @@ defmodule Ecto.Query do
         where: p.title == "title"
 
   They can also be used as general mechanism for adding statements that
-  come after the `from` clause. For example, they can be used to enabled
+  come after the `from` clause. For example, they can be used to enable
   table sampling:
 
       from p in Post,

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -966,10 +966,10 @@ defmodule Ecto.Query do
   `from` hints must be a (list of) compile-time strings or unsafe fragments. An unsafe
   fragment can be used to specify dynamic hints:
 
-      sample_method = "SYSTEM_ROWS"
+      sample = "SYSTEM_ROWS(1)"
 
       from p in Post,
-        hints: ["TABLESAMPLE ", unsafe_fragment(^sample_method), "(1)"]
+        hints: ["TABLESAMPLE", unsafe_fragment(^sample)]
 
   > ### Unsafe Fragments {: .warning}
   >

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -148,10 +148,7 @@ defmodule Ecto.Query.Builder.From do
   def hint!({:unsafe_fragment, _, [fragment]}) do
     case fragment do
       {:^, _, [value]} ->
-        quote do
-          checked = Ecto.Query.Builder.From.hint!(unquote(value))
-          {:unsafe_fragment, checked}
-        end
+        quote do: Ecto.Query.Builder.From.hint!(unquote(value))
 
       hint when is_binary(hint) ->
         hint

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -60,8 +60,8 @@ defmodule Ecto.Query.Builder.From do
         escape_source(other, env)
     end
   end
-  
-  @typep hints :: [String.t() | {atom, term}]
+
+  @typep hints :: [String.t() | Macro.t()]
 
   @doc """
   Builds a quoted expression.
@@ -73,12 +73,7 @@ defmodule Ecto.Query.Builder.From do
   @spec build(Macro.t(), Macro.Env.t(), atom, {:ok, String.t | nil} | nil, hints) ::
           {Macro.t(), Keyword.t(), non_neg_integer | nil}
   def build(query, env, as, prefix, hints) do
-    unless Enum.all?(hints, &is_valid_hint/1) do
-      Builder.error!(
-        "`hints` must be a compile time string, list of strings, a tuple, or a list of tuples " <>
-          "got: `#{Macro.to_string(hints)}`"
-      )
-    end
+    hints = Enum.map(hints, &hint!(&1))
 
     prefix = case prefix do
       nil -> nil
@@ -146,6 +141,37 @@ defmodule Ecto.Query.Builder.From do
   def prefix!(prefix), do: raise("`prefix` must be a string, got: #{inspect(prefix)}")
 
   @doc """
+  Validates hints at compile time and runtime
+  """
+  def hint!(hint) when is_binary(hint), do: hint
+
+  def hint!({:unsafe_fragment, _, [fragment]}) do
+    case fragment do
+      {:^, _, [value]} ->
+        quote do
+          checked = Ecto.Query.Builder.From.hint!(unquote(value))
+          {:unsafe_fragment, checked}
+        end
+
+      hint when is_binary(hint) ->
+        hint
+
+      other ->
+        Builder.error!(
+          "`hints` must be a compile time string, an unsafe fragment of the form `unsafe_fragment(^...)`, " <>
+            "or a list containing either, got: `#{Macro.to_string(other)}`"
+        )
+    end
+  end
+
+  def hint!(other) do
+    Builder.error!(
+      "`hints` must be a compile time string, an unsafe fragment of the form `unsafe_fragment(^...)`, " <>
+        "or a list containing either, got: `#{Macro.to_string(other)}`"
+    )
+  end
+
+  @doc """
   The callback applied by `build/2` to build the query.
   """
   @spec apply(Ecto.Queryable.t(), non_neg_integer, Macro.t(), {:ok, String.t} | nil, hints) :: Ecto.Query.t()
@@ -193,10 +219,6 @@ defmodule Ecto.Query.Builder.From do
 
   defp maybe_apply_hints(query, []), do: query
   defp maybe_apply_hints(query, hints), do: update_in(query.from.hints, &(&1 ++ hints))
-
-  defp is_valid_hint(hint) when is_binary(hint), do: true
-  defp is_valid_hint({_key, _val}), do: true
-  defp is_valid_hint(_), do: false
 
   defp check_binds(query, count) do
     if count > 1 and count > Builder.count_binds(query) do

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -155,16 +155,16 @@ defmodule Ecto.Query.Builder.From do
 
       other ->
         Builder.error!(
-          "`hints` must be a compile time string, an unsafe fragment of the form `unsafe_fragment(^...)`, " <>
-            "or a list containing either, got: `#{Macro.to_string(other)}`"
+          "`hints` must be a compile time string, unsafe fragment of the form `unsafe_fragment(^...)`, " <>
+            "or list containing either, got: `#{Macro.to_string(other)}`"
         )
     end
   end
 
   def hint!(other) do
     Builder.error!(
-      "`hints` must be a compile time string, an unsafe fragment of the form `unsafe_fragment(^...)`, " <>
-        "or a list containing either, got: `#{Macro.to_string(other)}`"
+      "`hints` must be a compile time string, unsafe fragment of the form `unsafe_fragment(^...)`, " <>
+        "or list containing either, got: `#{Macro.to_string(other)}`"
     )
   end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -554,20 +554,32 @@ defmodule Ecto.QueryTest do
       assert query.from.hints == ["hello", "world"]
     end
 
-    test "binary values are expected to be compile-time strings or list of strings" do
+    test "supports interpolation through unsafe_fragment" do
+      hint = "fragment"
+      query = from "posts", hints: unsafe_fragment(^hint)
+      assert query.from.hints == [{:unsafe_fragment, "fragment"}]
+
+      hint = "hint"
+      query = from "posts", hints: ["string", unsafe_fragment(^hint)]
+      assert query.from.hints == ["string", {:unsafe_fragment, "hint"}]
+    end
+
+    test "are expected to be strings or unsafe fragments that evaluate to strings" do
       assert_raise Ecto.Query.CompileError, ~r"`hints` must be a compile time string", fn ->
         quote_and_eval(from "posts", hints: 123)
       end
 
       assert_raise Ecto.Query.CompileError, ~r"`hints` must be a compile time string", fn ->
-        quote_and_eval(from "posts", join: "comments", on: true, hints: 123)
+        quote_and_eval(from "posts", hints: ["string", :atom])
       end
-    end
 
-    test "tuple values are not checked for contents" do
-      hint = "hint_from_config"
-      query = from "posts", hints: [dynamic: hint, number: 123]
-      assert query.from.hints == [dynamic: hint, number: 123]
+      assert_raise Ecto.Query.CompileError, ~r"`hints` must be a compile time string", fn ->
+        quote_and_eval(from "posts", hints: unsafe_fragment(^123))
+      end
+
+      assert_raise Ecto.Query.CompileError, ~r"`hints` must be a compile time string", fn ->
+        quote_and_eval(from "posts", hints: ["string", unsafe_fragment(123)])
+      end
     end
   end
 

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -557,11 +557,11 @@ defmodule Ecto.QueryTest do
     test "supports interpolation through unsafe_fragment" do
       hint = "fragment"
       query = from "posts", hints: unsafe_fragment(^hint)
-      assert query.from.hints == [{:unsafe_fragment, "fragment"}]
+      assert query.from.hints == ["fragment"]
 
       hint = "hint"
       query = from "posts", hints: ["string", unsafe_fragment(^hint)]
-      assert query.from.hints == ["string", {:unsafe_fragment, "hint"}]
+      assert query.from.hints == ["string", "hint"]
     end
 
     test "are expected to be strings or unsafe fragments that evaluate to strings" do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4253

I wavered on the `:sample` idea. We would have to duplicate what we are doing here because sampling needs `unsafe_fragment` (the sample method is part of the sql and it can be anything, people can make extensions). Plus there are other things that can come after `from`. So I just tried to improve the docs to make it clear `hints` is the mechanism for anything coming after `from`.

I will update this with the ecto_sql PR

edit: compainion ecto_sql PR https://github.com/elixir-ecto/ecto_sql/pull/546