### PR TITLE
Require interpolation for dynamic hints

### DIFF
--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -150,9 +150,6 @@ defmodule Ecto.Query.Builder.From do
       {:^, _, [value]} ->
         quote do: Ecto.Query.Builder.From.hint!(unquote(value))
 
-      hint when is_binary(hint) ->
-        hint
-
       other ->
         Builder.error!(
           "`hints` must be a compile time string, unsafe fragment of the form `unsafe_fragment(^...)`, " <>

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -152,8 +152,8 @@ defmodule Ecto.Query.Builder.From do
 
       other ->
         Builder.error!(
-          "`hints` must be a compile time string, unsafe fragment of the form `unsafe_fragment(^...)`, " <>
-            "or list containing either, got: `#{Macro.to_string(other)}`"
+          "`unsafe_fragment/1` in `hints` expects an interpolated value, such as " <>
+            "unsafe_fragment(^value), got: `#{Macro.to_string(fragment)}`"
         )
     end
   end

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -150,7 +150,7 @@ defmodule Ecto.Query.Builder.From do
       {:^, _, [value]} ->
         quote do: Ecto.Query.Builder.From.hint!(unquote(value))
 
-      other ->
+      _ ->
         Builder.error!(
           "`unsafe_fragment/1` in `hints` expects an interpolated value, such as " <>
             "unsafe_fragment(^value), got: `#{Macro.to_string(fragment)}`"

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -577,8 +577,10 @@ defmodule Ecto.QueryTest do
         quote_and_eval(from "posts", hints: unsafe_fragment(^123))
       end
 
-      assert_raise Ecto.Query.CompileError, ~r"`hints` must be a compile time string", fn ->
-        quote_and_eval(from "posts", hints: ["string", unsafe_fragment(123)])
+      msg = ~r"`unsafe_fragment/1` in `hints` expects an interpolated value"
+
+      assert_raise Ecto.Query.CompileError, msg, fn ->
+        quote_and_eval(from "posts", hints: ["string", unsafe_fragment("123")])
       end
     end
   end


### PR DESCRIPTION
I realized a bit late I wanted to do this. Since they should always be dynamic I think it should be interpolated.