### PR TITLE
Proposal: Derived fields

### DIFF
--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -46,7 +46,6 @@ defmodule Ecto.Integration.Post do
     field :links, {:map, :string}
     field :intensities, {:map, :float}
     field :posted, :date
-    field :derived, :decimal, derived_as: {__MODULE__, :derived, []}
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
     has_many :force_comments, Ecto.Integration.Comment, on_replace: :delete_if_exists
     has_many :ordered_comments, Ecto.Integration.Comment, preload_order: [:text]
@@ -69,10 +68,6 @@ defmodule Ecto.Integration.Post do
     has_many :comments_authors_permalinks, through: [:comments_authors, :permalink]
     has_one :post_user_composite_pk, Ecto.Integration.PostUserCompositePk
     timestamps()
-  end
-
-  def derived() do
-    dynamic([p], p.counter + p.visits)
   end
 
   def preload_order() do

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -46,6 +46,7 @@ defmodule Ecto.Integration.Post do
     field :links, {:map, :string}
     field :intensities, {:map, :float}
     field :posted, :date
+    field :derived, :decimal, derived_as: {__MODULE__, :derived, []}
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
     has_many :force_comments, Ecto.Integration.Comment, on_replace: :delete_if_exists
     has_many :ordered_comments, Ecto.Integration.Comment, preload_order: [:text]
@@ -68,6 +69,10 @@ defmodule Ecto.Integration.Post do
     has_many :comments_authors_permalinks, through: [:comments_authors, :permalink]
     has_one :post_user_composite_pk, Ecto.Integration.PostUserCompositePk
     timestamps()
+  end
+
+  def derived() do
+    dynamic([p], p.counter + p.visits)
   end
 
   def preload_order() do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1475,7 +1475,7 @@ defmodule Ecto.Query.Planner do
     case collect_fields(left, fields, from, query, take, keep_literals?, %{}) do
       {{:source, :from}, fields, left_from} ->
         {right, right_fields, _} =
-          collect_fields(right, [] , left_from, query, take, keep_literals?, %{})
+          collect_fields(right, [], left_from, query, take, keep_literals?, %{})
 
         {from_expr, from_source, from_fields} = left_from
         from = {{:merge, from_expr, right}, from_source, from_fields ++ Enum.reverse(right_fields)}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1447,22 +1447,6 @@ defmodule Ecto.Query.Planner do
     {put_in(query.select.fields, fields), select}
   end
 
-  defp expand_derived_fields(fields, query, select_expr, adapter) do
-    Enum.map(fields, fn
-      {{:., [], [{:&, [], [ix]}, field]}, [], []} = field_expr ->
-        source = get_source!(:select, query, ix)
-
-        if derived_mfa = derived_mfa(source, field) do
-          expand_derived_expr(derived_mfa, ix, query, select_expr, adapter)
-        else
-          field_expr
-        end
-
-      field_expr ->
-        field_expr
-    end)
-  end
-
   # Handling of source
 
   # The idea of collect_fields is to collect all fields used in select.
@@ -2004,6 +1988,22 @@ defmodule Ecto.Query.Planner do
   end
 
   defp derived_mfa(_, _), do: nil
+
+  defp expand_derived_fields(fields, query, select_expr, adapter) do
+    Enum.map(fields, fn
+      {{:., [], [{:&, [], [ix]}, field]}, [], []} = field_expr ->
+        source = get_source!(:select, query, ix)
+
+        if derived_mfa = derived_mfa(source, field) do
+          expand_derived_expr(derived_mfa, ix, query, select_expr, adapter)
+        else
+          field_expr
+        end
+
+      field_expr ->
+        field_expr
+    end)
+  end
 
   defp expand_derived_expr({m, f, a}, source_ix, query, expr, adapter) do
     %DynamicExpr{fun: fun} = apply(m, f, a)

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -40,6 +40,7 @@ defmodule Ecto.Query.PlannerTest do
       field :posted, :naive_datetime
       field :uuid, :binary_id
       field :crazy_comment, :string
+      field :json, :map
 
       belongs_to :post, Ecto.Query.PlannerTest.Post
 
@@ -121,6 +122,7 @@ defmodule Ecto.Query.PlannerTest do
       field :payload, :map, load_in_query: false
       field :status, Ecto.Enum, values: [:draft, :published, :deleted]
       field :parameterized_map, ParameterizedMap
+      field :derived, :string, derived_as: {__MODULE__, :derived, []}
 
       embeds_one :meta, PostMeta
       embeds_many :metas, PostMeta
@@ -131,6 +133,10 @@ defmodule Ecto.Query.PlannerTest do
       many_to_many :crazy_comments, Comment, join_through: CommentPost, where: [text: "crazycomment"]
       many_to_many :crazy_comments_with_list, Comment, join_through: CommentPost, where: [text: {:in, ["crazycomment1", "crazycomment2"]}], join_where: [deleted: true]
       many_to_many :crazy_comments_without_schema, Comment, join_through: "comment_posts", join_where: [deleted: true]
+    end
+
+    def derived() do
+      dynamic([p], p.visits)
     end
   end
 
@@ -159,6 +165,64 @@ defmodule Ecto.Query.PlannerTest do
     for field <- fields do
       {{:., [], [{:&, [], [ix]}, field]}, [], []}
     end
+  end
+
+  @tag :derived
+  test "derived" do
+    # all the queries below output some variant of the following
+
+    # %{
+    #   assocs: [],
+    #   from: :none,
+    #   postprocess: {:value, :string},
+    #   preprocess: [],
+    #   take: []
+    # }
+    # [{{:., [type: :integer], [{:&, [], [0]}, :visits]}, [], []}]
+
+    # 1. select the field by itself
+    q = from p in Post, select: p.derived
+    {q, _, _, select} = normalize_with_params(q)
+    IO.inspect select
+    IO.inspect q.select.fields
+
+    # 2. select the field inside of another data structure
+    q = from p in Post, select: %{derived: p.derived}
+    {q, _, _, select} = normalize_with_params(q)
+    IO.inspect select
+    IO.inspect q.select.fields
+
+    # 3. select entire struct
+    q = from p in Post, select: p
+    {q, _, _, select} = normalize_with_params(q)
+    IO.inspect select
+    IO.inspect q.select.fields
+
+    # 4. select from assoc struct
+    q = from p1 in Post, join: p2 in Post, select: p2
+    {q, _, _, select} = normalize_with_params(q)
+    IO.inspect select
+    IO.inspect q.select.fields
+
+    # 5. select from assoc field
+    q = from p1 in Post, join: p2 in Post, select: p2.derived
+    {q, _, _, select} = normalize_with_params(q)
+    IO.inspect select
+    IO.inspect q.select.fields
+
+    #6. select from subquery
+    q = from p1 in subquery(from p2 in Post, select: p2.derived), select: p1
+    {q, _, _, _} = normalize_with_params(q)
+    IO.inspect q.from.source.query.select.fields
+
+    #7. select from cte
+    q =
+      from(p in Post)
+      |> with_cte("cte", as: ^from(p2 in Post, select: p2))
+      |> join(:inner, [p], c in "cte", on: c.id == p.id)
+      |> select([p1, c], c)
+    {q, _, _, _} = normalize_with_params(q)
+    IO.inspect elem(hd(q.with_ctes.queries), 2).select.fields
   end
 
   test "plan: merges all parameters" do

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -1042,7 +1042,7 @@ defmodule Ecto.SchemaTest do
 
   describe "type :any" do
     test "raises on non-virtual" do
-      assert_raise ArgumentError, ~r"only virtual fields can have type :any", fn ->
+      assert_raise ArgumentError, ~r"only virtual and derived fields can have type :any", fn ->
         defmodule FieldAny do
           use Ecto.Schema
 


### PR DESCRIPTION
I was playing around with the idea of introducing derived fields into schemas. I understand this has been proposed before but I wasn't able to see it proposed in exactly this way.

**The Gist**

A derived field is composed of one or more fields in the same schema (or none at all!). They can be composed the same way a normal select expression is. This could be useful in several situations:

-  Wanting the same database column more than once in your schema. There was a recent issue about this.
-  The same as above but possibly wanting the same column with different types
-  Wanting to compose multiple columns into one field, e.g. first name + last name into full name
-  Wanting to transform an existing column, maybe using `coalesce` or something like that to remove nulls.

**The Proposal**

- allow an additional option onto `field/2` macro called `derived_as`. This takes an MFA that must return a dynamic expression with a single binding
- the planner will catch these derived fields and expand the dynamic fragment. there are two to catch it:
    - the prewalker (to catch stuff like `select: p.derived`)
    - collect_fields (to catch stuff like `select: p` and `select: [:derived]`

The PR is in a state where it can be reviewed to see if the idea/general direction are desirable. If it is there are some more things to do:

- improve documentation
- improve tests
- improve errors
- discuss how to handle `returning` for operations that don't use the planner (insert,update,delete). this part is the least straight forward

