### PR TITLE
Add utc_datetime examples to cast/2

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -760,6 +760,13 @@ defmodule Ecto.Type do
       iex> cast(:string, [1, 2, 3])
       :error
 
+      iex> cast(:utc_datetime, "2014-04-17T14:00:00Z")
+      {:ok, ~U[2014-04-17 14:00:00Z]}
+      iex> cast(:utc_datetime, "2014-04-17T14:00:00.030Z")
+      {:ok, ~U[2014-04-17 14:00:00Z]}
+      ex> cast(:utc_datetime, "2014-04-17T12:00:00-02:00")
+      {:ok, ~U[2014-04-17 14:00:00Z]}
+
   """
   @spec cast(t, term) :: {:ok, term} | {:error, keyword()} | :error
   def cast({:parameterized, type, params}, value), do: type.cast(value, params)


### PR DESCRIPTION
Was asked by someone integrating with an Ecto based API what formats are accepted for date times and I had a hard time tracking down docs to offer. In v2 we had https://hexdocs.pm/ecto/2.0.1/Ecto.DateTime.html#cast/1
