### PR TITLE
Add `Ecto.Query.prepend_order_by/3`

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1868,7 +1868,7 @@ defmodule Ecto.Query do
   end
 
   @doc """
-  Same as `order_by` except new expressions will be prepended to existing ones.
+  Same as `order_by/3` except new expressions will be prepended to existing ones.
   """
   defmacro prepend_order_by(query, binding \\ [], expr) do
     Builder.OrderBy.build(query, binding, expr, :prepend, __CALLER__)

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -736,7 +736,7 @@ defmodule Ecto.Query do
 
       windows: [ordered_names: [order_by: e.name]]
 
-  It works exactly as the keyword query version of `order_by/4`.
+  It works exactly as the keyword query version of `order_by/3`.
 
   ### :frame
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1809,19 +1809,11 @@ defmodule Ecto.Query do
   "nulls first" or "nulls last" is specific to each database implementation.
 
   `order_by` may be invoked or listed in a query many times. New expressions
-  can be appended or preprended to the existing ones. The behaviour is controlled
-  through the `:mode` option. By default, new expressions are appended.
+  are appended to the existing ones.
 
   `order_by` also accepts a list of atoms where each atom refers to a field in
   source or a keyword list where the direction is given as key and the field
   to order as value.
-
-  ## Options
-
-    * `:mode` - where to place the order expression relative to the
-      ones that already exist. Can be `:append`, to place it after the
-      current orderings, or `:prepend`, to place it before the current
-      orderings. Defaults to `:append`
 
   ## Keywords examples
 
@@ -1871,8 +1863,15 @@ defmodule Ecto.Query do
       City |> order_by(^order_by_param) # Keyword list
 
   """
-  defmacro order_by(query, binding \\ [], expr, opts \\ []) do
-    Builder.OrderBy.build(query, binding, expr, opts, __CALLER__)
+  defmacro order_by(query, binding \\ [], expr) do
+    Builder.OrderBy.build(query, binding, expr, :append, __CALLER__)
+  end
+
+  @doc """
+  Same as `order_by` except new expressions will be prepended to existing ones.
+  """
+  defmacro prepend_order_by(query, binding \\ [], expr) do
+    Builder.OrderBy.build(query, binding, expr, :prepend, __CALLER__)
   end
 
   @doc """

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -768,7 +768,7 @@ defmodule Ecto.Query.API do
   referencing it outside of select statements.
 
   This comes in handy when, for instance, you would like to use the calculated
-  value in `Ecto.Query.group_by/3` or `Ecto.Query.order_by/4`:
+  value in `Ecto.Query.group_by/3` or `Ecto.Query.order_by/3`:
 
       from p in Post,
         select: %{

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -340,7 +340,7 @@ defmodule Ecto.Repo.Preloader do
   defp add_preload_order([], query), do: query
 
   defp add_preload_order(order, query) when is_list(order) do
-    Ecto.Query.order_by(query, [q], ^order, mode: :prepend)
+    Ecto.Query.prepend_order_by(query, [q], ^order)
   end
 
   defp add_preload_order({m, f, a}, query) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -831,7 +831,7 @@ defmodule Ecto.Schema do
       For example, if you set `Post.has_many :comments, preload_order: [asc: :content]`,
       whenever the `:comments` associations is preloaded,
       the comments will be order by the `:content` field.
-      See `Ecto.Query.order_by/4` for more examples.
+      See `Ecto.Query.order_by/3` for more examples.
 
   ## Examples
 
@@ -1371,7 +1371,7 @@ defmodule Ecto.Schema do
 
     * `:preload_order` - Sets the default `order_by` when preloading the association.
       It may be a keyword list/list of fields or an MFA tuple, such as `{Mod, fun, []}`.
-      Both cases must resolve to a valid `order_by` expression. See `Ecto.Query.order_by/4`
+      Both cases must resolve to a valid `order_by` expression. See `Ecto.Query.order_by/3`
       to learn more about about ordering expressions.
       See the [preload order](#many_to_many/3-preload-order) section below to learn how
       this option can be utilized

--- a/test/ecto/query/builder/order_by_test.exs
+++ b/test/ecto/query/builder/order_by_test.exs
@@ -89,34 +89,14 @@ defmodule Ecto.Query.Builder.OrderByTest do
       end
     end
 
-    test "accepts :mode option" do
+    test "prepend_order_by" do
       query = order_by("q", [q], [:title])
-      opts = [mode: :prepend]
-      %{order_bys: prepend_order_bys} = order_by(query, [q], [:prepend], opts)
-      %{order_bys: append_order_bys} = order_by(query, [q], [:append], mode: :append)
-      %{order_bys: default_order_bys} = order_by(query, [q], [:append])
+      %{order_bys: order_bys} = prepend_order_by(query, [q], [:prepend])
 
       assert [
                %{expr: [asc: {{:., _, [_, :prepend]}, _, _}]},
                %{expr: [asc: {{:., _, [_, :title]}, _, _}]}
-             ] = prepend_order_bys
-
-      assert [
-               %{expr: [asc: {{:., _, [_, :title]}, _, _}]},
-               %{expr: [asc: {{:., _, [_, :append]}, _, _}]}
-             ] = append_order_bys
-
-      assert [
-               %{expr: [asc: {{:., _, [_, :title]}, _, _}]},
-               %{expr: [asc: {{:., _, [_, :append]}, _, _}]}
-             ] = default_order_bys
-
-
-      error_msg = "expected `:mode` to be `:append` or `:prepend`, got: :invalid"
-
-      assert_raise ArgumentError, error_msg, fn ->
-        order_by(query, [q], [:invalid], mode: :invalid)
-      end
+             ] = order_bys
     end
   end
 
@@ -128,36 +108,6 @@ defmodule Ecto.Query.Builder.OrderByTest do
       assert order_by("q", [q], [^key]).order_bys == order_by("q", [q], [asc: q.title]).order_bys
       assert order_by("q", [q], [desc: ^key]).order_bys == order_by("q", [q], [desc: q.title]).order_bys
       assert order_by("q", [q], [{^dir, ^key}]).order_bys == order_by("q", [q], [desc: q.title]).order_bys
-    end
-
-    test "accepts :mode option" do
-      query = order_by("q", [q], [:title])
-      opts = [mode: :prepend]
-      %{order_bys: prepend_order_bys} = order_by(query, [q], ^[:prepend], opts)
-      %{order_bys: append_order_bys} = order_by(query, [q], ^[:append], mode: :append)
-      %{order_bys: default_order_bys} = order_by(query, [q], ^[:append])
-
-      assert [
-               %{expr: [asc: {{:., _, [_, :prepend]}, _, _}]},
-               %{expr: [asc: {{:., _, [_, :title]}, _, _}]}
-             ] = prepend_order_bys
-
-      assert [
-               %{expr: [asc: {{:., _, [_, :title]}, _, _}]},
-               %{expr: [asc: {{:., _, [_, :append]}, _, _}]}
-             ] = append_order_bys
-
-      assert [
-               %{expr: [asc: {{:., _, [_, :title]}, _, _}]},
-               %{expr: [asc: {{:., _, [_, :append]}, _, _}]}
-             ] = default_order_bys
-
-
-      error_msg = "expected `:mode` to be `:append` or `:prepend`, got: :invalid"
-
-      assert_raise ArgumentError, error_msg, fn ->
-        order_by(query, [q], ^[:invalid], mode: :invalid)
-      end
     end
 
     test "supports dynamic expressions" do


### PR DESCRIPTION
Changes the `:mode` option to use a different macro to control ordering.