### PR TITLE
Fix `Ecto.Type.type/1` not working for parameterized types

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -413,7 +413,7 @@ defmodule Ecto.Type do
   def type({:parameterized, type, params}), do: type.type(params)
   def type({:array, type}), do: {:array, type(type)}
   def type({:map, type}), do: {:map, type(type)}
-  def type({:maybe, type}), do: type
+  def type({:maybe, type}), do: type(type)
   def type(type) when type in @base, do: type
   def type(type) when is_atom(type), do: type.type()
   def type(type), do: type

--- a/test/ecto/parameterized_type_test.exs
+++ b/test/ecto/parameterized_type_test.exs
@@ -50,6 +50,7 @@ defmodule Ecto.ParameterizedTypeTest do
   test "operations" do
     assert Ecto.Type.type(@p_self_type) == :custom
     assert Ecto.Type.type(@p_dump_type) == :custom
+    assert Ecto.Type.type({:maybe, @p_self_type}) == :custom
 
     assert Ecto.Type.embed_as(@p_self_type, :foo) == :self
     assert Ecto.Type.embed_as(@p_dump_type, :foo) == :dump


### PR DESCRIPTION
As pointed out here: https://github.com/elixir-ecto/ecto/issues/4262#issuecomment-1686402046