### PR TITLE
Fix planned values inspect

### DIFF
--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -140,7 +140,7 @@ defimpl Inspect, for: Ecto.Query do
   defp inspect_source(%{source: {nil, schema}}, _names), do: inspect(schema)
   defp inspect_source(%{source: {:fragment, _, _} = source} = part, names), do: "#{expr(source, names, part)}"
 
-  defp inspect_source(%{source: {:values, _, [types, _]}}, _names) do
+  defp inspect_source(%{source: {:values, _, [types | _]}}, _names) do
     fields = Keyword.keys(types)
     "values (#{Enum.join(fields, ", ")})"
   end

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -499,6 +499,7 @@ defmodule Ecto.Query.InspectTest do
   test "values lists" do
     query = from v in values([%{a: 1, b: 2, c: 3}], %{a: :integer, b: :integer, c: :integer})
     assert i(query) == "from v0 in values (a, b, c)"
+    assert i(plan(query)) == "from v0 in values (a, b, c)"
   end
 
   def plan(query) do


### PR DESCRIPTION
Before planning it is `{:values, [], [types, num_rows]}` after planning it is `{:values, [], [types, start_param_ix, num_rows]}`