### PR TITLE
Add warning about unspecified join condition behaviour

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1279,7 +1279,7 @@ defmodule Ecto.Query do
   after the join. In the expression syntax, the options are given as
   the fifth argument.
 
-   > ### Unspecified join condition {: .warning}
+  > ### Unspecified join condition {: .warning}
   >
   > Leaving the `on` option unspecified will trigger
   > a warning when not performing a cross join. This

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1281,12 +1281,13 @@ defmodule Ecto.Query do
 
   > ### Unspecified join condition {: .warning}
   >
-  > Leaving the `on` option unspecified will trigger
-  > a warning when not performing a cross join. This
-  > is to help users avoid performing expensive cross
-  > joins when they don't mean to. To remove the warning,
-  > change the join type to a cross join or explicitly set
-  > `on: true`.
+  > Leaving the `:on` option unspecified while performing a join
+  > that is not a cross join will trigger a warning. This is to
+  > help users avoid performing expensive cross joins when they don't
+  > mean to. If the behaviour is desired, you may remove the warning by
+  > changing to a cross join or explicitly setting `on: true`. If
+  > the behaviour is not desired, you should specify the appropriate
+  > join condition.
 
   ## Keywords examples
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1279,6 +1279,15 @@ defmodule Ecto.Query do
   after the join. In the expression syntax, the options are given as
   the fifth argument.
 
+   > ### Unspecified join condition {: .warning}
+  >
+  > Leaving the `on` option unspecified will trigger
+  > a warning when not performing a cross join. This
+  > is to help users avoid performing expensive cross
+  > joins when they don't mean to. To remove the warning,
+  > change the join type to a cross join or explicitly set
+  > `on: true`.
+
   ## Keywords examples
 
       from c in Comment,


### PR DESCRIPTION
I saw some confusion around this on Elixir Forum so tried to improve the docs

ref: https://elixirforum.com/t/why-does-a-missing-on-option-in-ecto-query-join-5-trigger-this-warning/58197