### PR TITLE
Respect late binding types

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1844,6 +1844,12 @@ defmodule Ecto.Query.Planner do
     {composite, type!(kind, query, expr, ix, field, allow_virtuals?)}
   end
 
+  defp field_type!(kind, query, expr, {{bind_kind, _, [_]} = bind_expr, field}, allow_virtuals?)
+       when bind_kind in [:as, :parent_as] do
+    {ix, _, ix_query} = get_ix!(bind_expr, kind, query)
+    type!(kind, ix_query, expr, ix, field, allow_virtuals?)
+  end
+
   defp field_type!(kind, query, expr, {ix, field}, allow_virtuals?) when is_integer(ix) do
     type!(kind, query, expr, ix, field, allow_virtuals?)
   end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1026,18 +1026,18 @@ defmodule Ecto.Query.PlannerTest do
   test "normalize: creating dynamic bindings with as" do
     as = {:posts}
 
-    query = from(Post, as: ^as, where: as(^as).code == ^"123") |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+    query = from(Post, as: ^as, where: as(^as).visits == ^"123") |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
 
-    query = from(Post, as: ^as, where: field(as(^as), :code) == ^"123") |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+    query = from(Post, as: ^as, where: field(as(^as), :visits) == ^"123") |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\{:posts\}\)`/, fn ->
-      from(Post, where: as(^as).code == ^"123") |> normalize()
+      from(Post, where: as(^as).visits == ^"123") |> normalize()
     end
 
-    query = from(Post, as: ^as, where: as(^as).code == ^"123") |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+    query = from(Post, as: ^as, where: as(^as).visits == ^"123") |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
   end
 
   test "normalize: late parent bindings with as" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -992,42 +992,51 @@ defmodule Ecto.Query.PlannerTest do
   end
 
   test "normalize: late bindings with as" do
-    query = from(Post, as: :posts, where: as(:posts).code == ^123) |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, where: as(:posts).visits == ^"123") |> normalize_with_params()
+
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
+    assert cast_params == [123]
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(:posts\)`/, fn ->
-      from(Post, where: as(:posts).code == ^123) |> normalize()
+      from(Post, where: as(:posts).visits == ^"123") |> normalize()
     end
   end
 
   test "normalize: late dynamic bindings with as" do
     as = :posts
 
-    query = from(Post, as: :posts, where: as(^as).code == ^123) |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, where: as(^as).visits == ^"123") |> normalize_with_params()
 
-    query = from(Post, as: :posts, where: field(as(^as), :code) == ^123) |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
+    assert cast_params == [123]
+
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, where: field(as(^as), :visits) == ^"123") |> normalize_with_params()
+
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
+    assert cast_params == [123]
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(:posts\)`/, fn ->
-      from(Post, where: as(^as).code == ^123) |> normalize()
+      from(Post, where: as(^as).visits == ^"123") |> normalize()
     end
   end
 
   test "normalize: creating dynamic bindings with as" do
     as = {:posts}
 
-    query = from(Post, as: ^as, where: as(^as).code == ^123) |> normalize()
+    query = from(Post, as: ^as, where: as(^as).code == ^"123") |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
 
-    query = from(Post, as: ^as, where: field(as(^as), :code) == ^123) |> normalize()
+    query = from(Post, as: ^as, where: field(as(^as), :code) == ^"123") |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\{:posts\}\)`/, fn ->
-      from(Post, where: as(^as).code == ^123) |> normalize()
+      from(Post, where: as(^as).code == ^"123") |> normalize()
     end
 
-    query = from(Post, as: ^as, where: as(^as).code == ^123) |> normalize()
+    query = from(Post, as: ^as, where: as(^as).code == ^"123") |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.code() == ^0"
   end
 
@@ -1039,6 +1048,14 @@ defmodule Ecto.Query.PlannerTest do
     child = from(c in Comment, select: %{map: parent_as(:posts).posted})
     query = from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize()
     assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
+
+    child = from(c in Comment, where: parent_as(:posts).visits == ^"123")
+
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize_with_params()
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).visits() == ^0"
+    assert cast_params == [123]
 
     assert_raise Ecto.SubQueryError, ~r/the parent_as in a subquery select used as a join can only access the `from` binding in query/, fn ->
       child = from(c in Comment, select: %{map: parent_as(:itself).posted})
@@ -1064,10 +1081,26 @@ defmodule Ecto.Query.PlannerTest do
     child = from(c in Comment, select: %{map: field(parent_as(^as), :posted)})
     query = from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize()
     assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
+
+    child = from(c in Comment, where: parent_as(^as).visits == ^"123")
+
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize_with_params()
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).visits() == ^0"
+    assert cast_params == [123]
+
+    child = from(c in Comment, where: field(parent_as(^as), :visits) == ^"123")
+
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize_with_params()
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).visits() == ^0"
+    assert cast_params == [123]
   end
 
   test "normalize: nested parent_as" do
-    child3 = from(c in Comment, where: parent_as(:posts).deleted == false, select: c.id)
+    child3 = from(c in Comment, where: parent_as(:posts).visits > 0, select: c.id)
     child2 = from(c in Comment, where: c.id in subquery(child3), select: c.id)
     child = from(c in Comment, where: parent_as(:posts).posted == c.posted and c.id in subquery(child2))
 
@@ -1078,7 +1111,7 @@ defmodule Ecto.Query.PlannerTest do
 
   test "normalize: nested dynamic parent_as" do
     as = :posts
-    child3 = from(c in Comment, where: parent_as(^as).deleted == false, select: c.id)
+    child3 = from(c in Comment, where: parent_as(^as).visits > 0, select: c.id)
     child2 = from(c in Comment, where: c.id in subquery(child3), select: c.id)
     child = from(c in Comment, where: field(parent_as(^as), :posted) == c.posted and c.id in subquery(child2))
 


### PR DESCRIPTION
I was reading Elixir Forum and came across a post that made it seem like as/parent_as types weren't being respected. Reference: https://elixirforum.com/t/ecto-types-and-named-bindiings/58370

When I looked into it I found that `as/parent_as` and `field(as/parent_as, _)` were having their types set to `:any`. When I fixed this I also noticed some tests started failing. So it actually uncovered some faulty tests:

1. Some of the late binding tests were comparing the `code` field to an integer when code is a binary. So casting should fail. When I made my changes the tests started failing. I updated the tests to cast to an integer field to make them pass and to ensure casting was being done properly.
2. Some of the parent_as tests were referencing a field that didn't exist on the parent. Namely, a `deleted` field on the posts schema. It wasn't failing before because the type of the field wasn't being looked up. Now that it's being looked up it failed. I fixed the test in a similar manner described above.