### PR TITLE
Pass parent aliases to combination queries

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1096,13 +1096,16 @@ defmodule Ecto.Query.Planner do
     {Enum.reverse(exprs), counter}
   end
 
-  defp validate_and_increment(:combination, _query, combinations, counter, operation, adapter) do
+  defp validate_and_increment(:combination, query, combinations, counter, operation, adapter) do
     fun = &validate_and_increment(&1, &2, &3, &4, operation, adapter)
+    parent_aliases = query.aliases[@parent_as]
 
     {combinations, counter} =
       Enum.reduce combinations, {[], counter}, fn {type, combination_query}, {combinations, counter} ->
+        combination_query = put_in(combination_query.aliases[@parent_as], parent_aliases)
         {combination_query, counter} = traverse_exprs(combination_query, operation, counter, fun)
         {combination_query, _} = combination_query |> normalize_select(true)
+        {_, combination_query} = pop_in(combination_query.aliases[@parent_as])
         {[{type, combination_query} | combinations], counter}
       end
 
@@ -1167,23 +1170,9 @@ defmodule Ecto.Query.Planner do
   end
   defp prewalk_source(%Ecto.SubQuery{query: inner_query} = subquery, kind, query, _expr, counter, adapter) do
     try do
-      combinations =
-        Enum.map(inner_query.combinations, fn {type, combination_query} ->
-          {type, put_in(combination_query.aliases[@parent_as], query)}
-        end)
-
-      inner_query = put_in(inner_query.combinations, combinations)
       inner_query = put_in(inner_query.aliases[@parent_as], query)
       {inner_query, counter} = normalize_query(inner_query, :all, adapter, counter)
       {inner_query, _} = normalize_select(inner_query, true)
-
-      combinations =
-        Enum.map(inner_query.combinations, fn {type, combination_query} ->
-          {_, combination_query} = pop_in(combination_query.aliases[@parent_as])
-          {type, combination_query}
-        end)
-
-      inner_query = put_in(inner_query.combinations, combinations)
       {_, inner_query} = pop_in(inner_query.aliases[@parent_as])
 
       inner_query =

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -534,5 +534,12 @@ defmodule Ecto.Query.SubqueryTest do
         from(c in Comment, where: c.post_id in subquery(p)) |> normalize()
       end
     end
+
+    test "with combinations and parent_as/1" do
+      right_query = from(c in Comment, where: c.id == parent_as(:c).id, select: c.id)
+      left_query = from(c in Comment, where: c.id == parent_as(:c).id, select: c.id)
+      union_query = union(left_query, ^right_query)
+      from(c in Comment, as: :c, where: c.id in subquery(union_query)) |> normalize()
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4281

The issue is that the right hand side of combinations queries are stored in the `:combinations` list of the main query and they weren't being passed the parent aliases.

This only matters during normalization because that is when the parent index is checked. Then after the query is normalized the parent alias is popped out again and is handled later in Ecto SQL. 

Companion Ecto SQL PR: https://github.com/elixir-ecto/ecto_sql/pull/561