### PR TITLE
docs/schemaless-changesets: common data structure

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -212,7 +212,8 @@ defmodule Ecto.Changeset do
   with the data and its types:
 
       user = %User{}
-      types = %{first_name: :string, last_name: :string, email: :string}
+      types = %{name: :string, email: :string, age: :integer}
+      params = %{name: "Callum", email: "callum@example.com", age: 27}
       changeset =
         {user, types}
         |> Ecto.Changeset.cast(params, Map.keys(types))
@@ -222,14 +223,14 @@ defmodule Ecto.Changeset do
   where the user struct refers to the definition in the following module:
 
       defmodule User do
-        defstruct [:name, :age]
+        defstruct [:name, :email, :age]
       end
 
   Changesets can also be used with data in a plain map, by following the same API:
 
       data  = %{}
-      types = %{name: :string}
-      params = %{name: "Callum"}
+      types = %{name: :string, email: :string, age: :integer}
+      params = %{name: "Callum", email: "callum@example.com", age: 27}
       changeset =
         {data, types}
         |> Ecto.Changeset.cast(params, Map.keys(types))


### PR DESCRIPTION
The documentation for schemaless changesets was confusing, because the struct had different fields than the types. This PR unifies the example to a common data structure, so it is more understandable by the reader.