### PR TITLE
Don't duplicate fields with select_merge and map/2

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1455,6 +1455,11 @@ defmodule Ecto.Query.Planner do
     {{:source, :from}, fields, {{:source, :from}, expr, taken}}
   end
 
+  defp collect_fields({:&, _, [0]}, fields, from, _query, _take, _keep_literals?, _drop)
+       when from != :never do
+    {{:source, :from}, fields, from}
+  end
+
   defp collect_fields({:&, _, [ix]}, fields, from, query, take, _keep_literals?, drop) do
     {expr, taken} = source_take!(:select, query, take, ix, ix, drop)
     {expr, Enum.reverse(taken, fields), from}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1455,8 +1455,7 @@ defmodule Ecto.Query.Planner do
     {{:source, :from}, fields, {{:source, :from}, expr, taken}}
   end
 
-  defp collect_fields({:&, _, [0]}, fields, from, _query, _take, _keep_literals?, _drop)
-       when from != :never do
+  defp collect_fields({:&, _, [0]}, fields, from, _query, _take, _keep_literals?, _drop) do
     {{:source, :from}, fields, from}
   end
 


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4287

This is a bit involved but I'll try my best to explain the issue. To trigger this issue you need the following conditions:

1. To produce a `{:merge, [left, right]}` expression, i.e. when `map/2` is merged with `%{}`
2. To merge something that has a source expression into the result of (1), i.e. map/2 is given the expression `{:&, [], [0]}`

I'll describe below how the issue manifests referencing this query:

```elixir
from(s in "schema", select: %{id: s.id})
|> select_merge([s], map(s, [:x]))
|> select_merge([s], map(s, [:y])
```

1. When you go into `collect_fields` the first time, `from` is `:none`.
2. When collecting the fields from the merge of `%{id: s.id}` and `map(s, [:x])` two things happen:
    - from changes from `:none` to a complex tuple tagged by `:source`
    - `:x` and `:y` get added to the fields list because the `take` from both maps are merged before the planner
3. When collecting the fields from the merge of `map(s, [:y])` with the result of the above it hits this piece of code

```elixir
defp collect_fields({:&, _, [ix]}, fields, from, query, take, _keep_literals?, drop) do
  {expr, taken} = source_take!(:select, query, take, ix, ix, drop)
  {expr, Enum.reverse(taken, fields), from}
end
```
So now it's adding `:x` and `:y` to the fields again and we get the duplicates. The solution is to not touch the fields once you've processed a `{:&, [], [0]}` expression because it is already considering the merged fields.

The code I added actually was there before but removed here https://github.com/elixir-ecto/ecto/commit/75431735644309e20bb030da88743a9e623300e2.