### PR TITLE
Fix a few minor typos in docs / comments

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1332,7 +1332,7 @@ defmodule Ecto.Changeset do
     end
   end
 
-  # We check for the byte size to avoid creating unecessary large integers
+  # We check for the byte size to avoid creating unnecessary large integers
   # which would never map to a database key (u64 is 20 digits only).
   defp key_as_int({key, val}) when is_binary(key) and byte_size(key) < 32 do
     case Integer.parse(key) do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1724,7 +1724,7 @@ defmodule Ecto.Query do
 
   Dynamics can be part of a `select_merge` as values in a map that must be
   interpolated at the root level. The rules for merging detailed above apply.
-  This allows merging dynamic values into previsouly selected maps and structs.
+  This allows merging dynamic values into previously selected maps and structs.
   """
   defmacro select_merge(query, binding \\ [], expr) do
     Builder.Select.build(:merge, query, binding, expr, __CALLER__)

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -833,7 +833,7 @@ defmodule Ecto.Type do
     end
   end
 
-  # We check for the byte size to avoid creating unecessary large integers
+  # We check for the byte size to avoid creating unnecessary large integers
   # which would never map to a database key (u64 is 20 digits only).
   defp cast_integer(term) when is_binary(term) and byte_size(term) < 32 do
     case Integer.parse(term) do


### PR DESCRIPTION
While I was reading the docs & the source code I came across a few minor typos. This PR fixes them.