### PR TITLE
Add `Ecto.Multi.query/5`

### DIFF
--- a/lib/ecto/multi.ex
+++ b/lib/ecto/multi.ex
@@ -502,6 +502,10 @@ defmodule Ecto.Multi do
   This can be helpful, for example, when setting configuration
   parameters for a single transaction.
 
+  Your adapter must inject its query functions into the Ecto
+  repository in order for this function to be available. All of
+  the built-in adapters will work with this function.
+
   ## Example
 
       Ecto.Multi.new()

--- a/test/ecto/multi_test.exs
+++ b/test/ecto/multi_test.exs
@@ -210,6 +210,26 @@ defmodule Ecto.MultiTest do
     assert [{:comment, {:run, _fun}}] = multi.operations
   end
 
+  test "query/4 string" do
+    multi =
+      Multi.new()
+      |> Multi.query(:configure, "SET LOCAL lock_timeout TO '10s'", [])
+
+    assert multi.names == MapSet.new([:configure])
+    assert [{:configure, {:run, _fun}}] = multi.operations
+  end
+
+  test "query/4 fun" do
+    fun = fn _changes -> "SET LOCAL lock_timeout TO '10s'" end
+
+    multi =
+      Multi.new()
+      |> Multi.query(:configure, fun, [])
+
+    assert multi.names == MapSet.new([:configure])
+    assert [{:configure, {:run, _fun}}] = multi.operations
+  end
+
   test "error" do
     multi =
       Multi.new()


### PR DESCRIPTION
I was in a situation recently where this would have been handy. Setting special configuration parameters for a transaction.

Not completely sure if it's desirable to add it since `query` behaves differently than the other repo functions. i.e. an adapter might not even expose. But I thought I'd see what you thought because it's still useful to reduce the verbosity of some transactions.