### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,53 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: unit test
+    runs-on: ubuntu-20.04
+    env:
+      FORCE_COLOR: 1
+      MIX_ENV: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: 1.11.4
+            otp: 21.3.8.24
+          - elixir: 1.15.6
+            otp: 24.3.4.13
+          - elixir: 1.15.6
+            otp: 25.3.2.6
+            lint: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Elixir and Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+      - name: Restore deps and _build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Compile deps
+        run: mix deps.compile
+      - name: Check unused dependencies
+        run: mix deps.unlock --check-unused
+        if: ${{ matrix.lint }}
+      - name: Compile lint
+        run: mix compile --warning-as-errors
+        if: ${{ matrix.lint }}
+      - name: Run tests
+        run: mix test
+
   integration-test:
     name: integration test
     runs-on: ubuntu-latest
@@ -18,43 +65,11 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.13.4-erlang-24.3.4.2-alpine-3.16.0"
-          - "1.13.4-erlang-22.3.4.20-alpine-3.14.0"
+          - "1.15.6-erlang-25.3.2.6-alpine-3.16.7"
+          - "1.15.6-erlang-24.3.4.14-alpine-3.16.7"
           - "1.11.4-erlang-21.3.8.24-alpine-3.13.3"
     steps:
       - uses: earthly/actions-setup@v1
       - uses: actions/checkout@v3
       - name: ecto integration-test under ${{matrix.elixirbase}}
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +integration-test
-  unit-test:
-    name: unit test
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-    strategy:
-      fail-fast: false
-      matrix:
-        elixirbase:
-          - "1.13.4-erlang-24.3.4.2-alpine-3.16.0"
-          - "1.13.4-erlang-22.3.4.20-alpine-3.14.0"
-          - "1.11.4-erlang-21.3.8.24-alpine-3.13.3"
-    steps:
-      - uses: earthly/actions-setup@v1
-      - uses: actions/checkout@v3
-      - name: ecto test under ${{matrix.elixirbase}}
-        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +test
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-    strategy:
-      fail-fast: false
-      matrix:
-        elixirbase:
-          - "1.13.4-erlang-24.3.4.2-alpine-3.16.0"
-    steps:
-      - uses: earthly/actions-setup@v1
-      - uses: actions/checkout@v3
-      - name: ecto lint under ${{matrix.elixirbase}}
-        run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.11.4
-            otp: 21.3.8.24
-          - elixir: 1.15.6
-            otp: 24.3.4.13
           - elixir: 1.15.6
             otp: 25.3.2.6
             lint: lint
+          - elixir: 1.15.6
+            otp: 24.3.4.13
+          - elixir: 1.11.4
+            otp: 21.3.8.24
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  unit-test:
     name: unit test
     runs-on: ubuntu-20.04
     env:

--- a/Earthfile
+++ b/Earthfile
@@ -1,58 +1,19 @@
 VERSION 0.5
 
 all:
-    BUILD +all-test
-    BUILD +all-integration-test
-    BUILD +lint
-
-
-all-test:
     BUILD \
-        --build-arg ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0 \
-        --build-arg ELIXIR_BASE=1.13.4-erlang-22.3.4.20-alpine-3.14.0 \
-        --build-arg ELIXIR_BASE=1.11.4-erlang-21.3.8.24-alpine-3.13.3 \
-        +test
-
-
-test:
-    FROM +setup-base
-    COPY mix.exs mix.lock .formatter.exs ./
-    RUN mix deps.get
-
-    RUN MIX_ENV=test mix deps.compile
-    COPY --dir lib integration_test examples test ./
-
-    RUN mix deps.get --only test
-    RUN mix deps.compile
-    RUN mix test
-
-
-lint:
-    FROM +test
-    RUN mix deps.get
-    RUN mix deps.unlock --check-unused
-    RUN mix compile --warnings-as-errors
-
-
-all-integration-test:
-    BUILD \
-        --build-arg ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0 \
-        --build-arg ELIXIR_BASE=1.13.4-erlang-22.3.4.20-alpine-3.14.0 \
+        --build-arg ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.16.7 \
+        --build-arg ELIXIR_BASE=1.15.6-erlang-24.3.4.14-alpine-3.16.7 \
         +integration-test
 
-
-setup-base:
-    ARG ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0
+integration-test-base:
+    ARG ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.16.7
     FROM hexpm/elixir:$ELIXIR_BASE
     RUN apk add --no-progress --update git build-base
     RUN mix local.rebar --force
     RUN mix local.hex --force
     ENV ELIXIR_ASSERT_TIMEOUT=10000
     WORKDIR /src/ecto
-
-
-integration-test-base:
-    FROM +setup-base
     RUN apk add --no-progress --update docker docker-compose git postgresql-client mysql-client
 
     RUN apk add --no-cache curl gnupg --virtual .build-dependencies -- && \


### PR DESCRIPTION
- use earthly for integration tests only
- update to elixir 1.15 and otp 25

I need to work up the will power to fix the map orderings for otp 26 