### PR TITLE
Reset belongs_to association if foreign key update results in a mismatch

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -592,6 +592,8 @@ defmodule Ecto do
 
   """
   @spec reset_fields(Ecto.Schema.t(), list()) :: Ecto.Schema.t()
+  def reset_fields(struct, []), do: struct
+
   def reset_fields(%{__struct__: schema} = struct, fields) do
     default_struct = schema.__struct__()
     default_fields = Map.take(default_struct, fields)

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -903,8 +903,7 @@ defmodule Ecto.Repo.Schema do
          %{^field => %{^related_key => related_value}} when owner_value != related_value <- data do
       true
     else
-      _ ->
-        false
+      _ -> false
     end
   end
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -439,8 +439,8 @@ defmodule Ecto.Repo.Schema do
         assoc_opts = assoc_opts(assocs, opts)
         user_changeset = run_prepare(changeset, prepare)
 
-        {changeset, parents, children, unchanged_parents} = pop_assocs(user_changeset, assocs)
-        changeset = process_parents(changeset, user_changeset, parents, unchanged_parents, adapter, assoc_opts)
+        {changeset, parents, children, reset_parents} = pop_assocs(user_changeset, assocs)
+        changeset = process_parents(changeset, user_changeset, parents, reset_parents, adapter, assoc_opts)
 
         if changeset.valid? do
           embeds = Ecto.Embedded.prepare(changeset, embeds, adapter, :update)
@@ -868,31 +868,44 @@ defmodule Ecto.Repo.Schema do
     {changeset, [], [], []}
   end
 
-  defp pop_assocs(%{changes: changes, types: types} = changeset, assocs) do
-    {changes, parent, child, unchanged_parent} =
-      Enum.reduce assocs, {changes, [], [], []}, fn assoc, {changes, parent, child, unchanged_parent} ->
+  defp pop_assocs(%{changes: changes, types: types, data: data} = changeset, assocs) do
+    {changes, parent, child, reset} =
+      Enum.reduce(assocs, {changes, [], [], []}, fn assoc, {changes, parent, child, reset} ->
         case changes do
           %{^assoc => value} ->
             changes = Map.delete(changes, assoc)
 
             case types do
               %{^assoc => {:assoc, %{relationship: :parent} = refl}} ->
-                {changes, [{refl, value} | parent], child, unchanged_parent}
+                {changes, [{refl, value} | parent], child, reset}
+
               %{^assoc => {:assoc, %{relationship: :child} = refl}} ->
-                {changes, parent, [{refl, value} | child], unchanged_parent}
+                {changes, parent, [{refl, value} | child], reset}
             end
 
           %{} ->
-            case types do
-              %{^assoc => {:assoc, %{relationship: :parent} = refl}} ->
-                {changes, parent, child, [refl | unchanged_parent]}
-              _ ->
-                {changes, parent, child, unchanged_parent}
+            with %{^assoc => {:assoc, %{relationship: :parent} = refl}} <- types,
+                 true <- reset_parent?(changes, data, refl) do
+              {changes, parent, child, [assoc | reset]}
+            else
+              _ -> {changes, parent, child, reset}
             end
         end
-      end
+      end)
 
-    {%{changeset | changes: changes}, parent, child, unchanged_parent}
+    {%{changeset | changes: changes}, parent, child, reset}
+  end
+
+  defp reset_parent?(changes, data, assoc) do
+    %{field: field, owner_key: owner_key, related_key: related_key} = assoc
+
+    with %{^owner_key => owner_value} <- changes,
+         %{^field => %{^related_key => related_value}} when owner_value != related_value <- data do
+      true
+    else
+      _ ->
+        false
+    end
   end
 
   # Don't mind computing options if there are no assocs
@@ -902,7 +915,7 @@ defmodule Ecto.Repo.Schema do
     Keyword.take(opts, [:timeout, :log, :telemetry_event, :prefix])
   end
 
-  defp process_parents(changeset, user_changeset, assocs, unchanged_assocs, adapter, opts) do
+  defp process_parents(changeset, user_changeset, assocs, reset_assocs, adapter, opts) do
     %{changes: changes, valid?: valid?} = changeset
 
     # Even if the changeset is invalid, we want to run parent callbacks
@@ -910,7 +923,7 @@ defmodule Ecto.Repo.Schema do
     case Ecto.Association.on_repo_change(changeset, assocs, adapter, opts) do
       {:ok, struct} when valid? ->
         changes = change_parents(changes, struct, assocs)
-        struct = reset_parents(changes, struct, unchanged_assocs)
+        struct = Ecto.reset_fields(struct, reset_assocs)
         %{changeset | changes: changes, data: struct}
 
       {:ok, _} ->
@@ -937,26 +950,6 @@ defmodule Ecto.Repo.Schema do
           Map.put(acc, owner_key, value)
       end
     end
-  end
-
-  defp reset_parents(changes, struct, assocs) do
-    Enum.reduce(assocs, struct, fn assoc, struct ->
-      %{field: field, owner_key: owner_key, related_key: related_key} = assoc
-
-      case changes do
-        %{^owner_key => owner_value} ->
-          case struct do
-            %{^field => %{^related_key => related_value}} when owner_value != related_value ->
-              Ecto.reset_fields(struct, [field])
-
-            _ ->
-              struct
-          end
-
-        _ ->
-          struct
-      end
-    end)
   end
 
   defp process_children(changeset, user_changeset, assocs, adapter, opts) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -347,8 +347,8 @@ defmodule Ecto.Repo.Schema do
       assoc_opts = assoc_opts(assocs, opts)
       user_changeset = run_prepare(changeset, prepare)
 
-      {changeset, parents, children, unchanged_parents} = pop_assocs(user_changeset, assocs)
-      changeset = process_parents(changeset, user_changeset, parents, unchanged_parents, adapter, assoc_opts)
+      {changeset, parents, children, _} = pop_assocs(user_changeset, assocs)
+      changeset = process_parents(changeset, user_changeset, parents, [], adapter, assoc_opts)
 
       if changeset.valid? do
         embeds = Ecto.Embedded.prepare(changeset, embeds, adapter, :insert)
@@ -886,7 +886,7 @@ defmodule Ecto.Repo.Schema do
             case types do
               %{^assoc => {:assoc, %{relationship: :parent} = refl}} ->
                 {changes, parent, child, [refl | unchanged_parent]}
-              %{^assoc => {:assoc, %{relationship: :child}}} ->
+              _ ->
                 {changes, parent, child, unchanged_parent}
             end
         end

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -484,6 +484,7 @@ defmodule Ecto.Repo.BelongsToTest do
 
   test "reset assoc when foreign key update results in a mismatch" do
     schema = TestRepo.insert!(%MySchema{assoc_id: 1, assoc: %MyAssoc{id: 1}})
+    assert schema.assoc_id == 1
     assert %MyAssoc{id: 1} = schema.assoc
 
     updated_schema =
@@ -491,6 +492,8 @@ defmodule Ecto.Repo.BelongsToTest do
       |> Ecto.Changeset.change(%{assoc_id: 2})
       |> TestRepo.update!()
 
+
+    assert updated_schema.assoc_id == 2;
     assert %Ecto.Association.NotLoaded{} = updated_schema.assoc
   end
 end

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -481,4 +481,16 @@ defmodule Ecto.Repo.BelongsToTest do
     loaded = put_in schema.__meta__.state, :loaded
     TestRepo.insert!(loaded)
   end
+
+  test "reset assoc when foreign key update results in a mismatch" do
+    schema = TestRepo.insert!(%MySchema{assoc_id: 1, assoc: %MyAssoc{id: 1}})
+    assert %MyAssoc{id: 1} = schema.assoc
+
+    updated_schema =
+      schema
+      |> Ecto.Changeset.change(%{assoc_id: 2})
+      |> TestRepo.update!()
+
+    assert %Ecto.Association.NotLoaded{} = updated_schema.assoc
+  end
 end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4256

Some callouts:

1. This can only take effect if the foreign key is changed and the assoc field is not. If both are changed then mismatches are handled here: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/schema.ex#L925
2. Given the above, the reset doesn't actually trigger any change in the database. It's only a post-processing cleanup to ensure the returned struct doesn't have any inconsistencies. So the cleanup can be handled in the post-process step.
3. We only have to consider the update operation. During insert everything is surfaced as a change so it is handled by point 1