### PR TITLE
Update docs formatting for `Ecto.Changeset.cast_assoc/3`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1119,7 +1119,7 @@ defmodule Ecto.Changeset do
       %{"name" => "john doe", "addresses" => %{...}, "addresses_sort" => [1, 0]}
 
   And that will internally sort the elements so 1 comes before 0. Note that
-  any index not present in "addresses_sort" will come _before_ any of the
+  any index not present in `"addresses_sort"` will come _before_ any of the
   sorted indexes. If an index is not found, an empty entry is added in its
   place.
 


### PR DESCRIPTION
The underscore in the string key is starting italicized formatting and messing up that section.

## Before

<img width="873" alt="Screenshot 2023-10-26 at 9 07 51 AM" src="https://github.com/elixir-ecto/ecto/assets/2897340/d82a5e7c-185c-4a23-bd66-ac1a7a4f6f45">

## After

<img width="878" alt="Screenshot 2023-10-26 at 9 07 12 AM" src="https://github.com/elixir-ecto/ecto/assets/2897340/c7566148-de7a-48f9-8017-a161a40279a5">
