### PR TITLE
Small doc improvement on c:equal?/2

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -272,6 +272,8 @@ defmodule Ecto.Type do
 
   This callback is used for determining equality of types in
   `Ecto.Changeset`.
+
+  By default the terms are compared with the equal operator `==/2`.
   """
   @callback equal?(term, term) :: boolean
 


### PR DESCRIPTION
To make it clear how the terms are compared by default, as defined at https://github.com/elixir-ecto/ecto/blob/8fac7068ed28cbb63c9844bb4cfba09fb48b9a09/lib/ecto/type.ex#L171