### PR TITLE
fix spacing in adapters table

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You need to add both Ecto and the database adapter as a dependency to your `mix.
 | MySQL      | Ecto.Adapters.MyXQL      | [ecto_sql][ecto_sql] + [myxql][myxql]            |
 | MSSQL      | Ecto.Adapters.Tds        | [ecto_sql][ecto_sql] + [tds][tds]                |
 | SQLite3    | Ecto.Adapters.SQLite3    | [ecto_sqlite3][ecto_sqlite3]                     |
-| ClickHouse | Ecto.Adapters.ClickHouse | [ecto_ch][ecto_ch]                               |
+| ClickHouse | Ecto.Adapters.ClickHouse | [ecto_ch][ecto_ch]                               |
 | ETS        | Etso                     | [etso][etso]                                     |
 
 [ecto_sql]: https://github.com/elixir-ecto/ecto_sql


### PR DESCRIPTION
It was a NO-BREAK SPACE for some reason which made GitHub render it strangely in Safari.

<img width="845" alt="Screenshot 2023-11-12 at 05 07 38" src="https://github.com/elixir-ecto/ecto/assets/67764432/2c9b04a3-fa05-469a-87bd-7a362b3c8678">
