### PR TITLE
Proposal: Make `Ecto.Repo.transaction/2` overridable

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -288,6 +288,8 @@ defmodule Ecto.Repo do
           )
         end
 
+        defoverridable transaction: 2
+
         def in_transaction? do
           Ecto.Repo.Transaction.in_transaction?(get_dynamic_repo())
         end


### PR DESCRIPTION
## What?

Make `Ecto.Repo.transaction/2` overridable, allowing `App.Repo` to perform after-transaction success callbacks.

## Example (simplified)

```elixir
defmodule App.Repo do
  use Ecto.Repo

  def transaction(fun_or_multi, opts) do
    fun_or_multi
    |> super(opts)
    |> case do
      {:ok, results} ->
        {:ok, do_something_with_results(results)}

      error ->
        do_something_with_errors(error)
    end
  end
end
```

## Questions

Maybe there is a more mature way to wrap the transaction or built-in way to perform after-success callbacks, that I'm unaware of?

## Ideas

We could wrap `Ecto.Repo` in one more macro and override the callback in there, but this seems to be a problem when having multiple implementations as some of those can be `read_only` and not expose transaction function at all. So the best place to put this seems to be here...?
