### PR TITLE
Update many-to-many docs

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1572,8 +1572,9 @@ defmodule Ecto.Schema do
         end
       end
 
-      # Then to create the association, pass in the ID's of an existing
-      # User and Organization to UserOrganization.changeset
+  To create the association, pass in the IDs of an existing `User` and
+  `Organization` to `UserOrganization.changeset/2`:
+
       changeset = UserOrganization.changeset(%UserOrganization{}, %{user_id: id, organization_id: id})
 
       case Repo.insert(changeset) do


### PR DESCRIPTION
I was reading this part of the docs and thought of submitting a small
improvement.

Turn documentation code comment into prose, fix typo and wrap code
references with backticks.
