### PR TITLE
Don't send dynamic map keys to the database

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1959,7 +1959,8 @@ defmodule Ecto.Query do
   >
   > When selecting a literal atom, its value must be the same across
   > all queries. Otherwise, the value from the parent query will be
-  > applied to all other queries.
+  > applied to all other queries. This also holds true for selecting
+  > maps with atom keys.
 
   Union expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2011,7 +2012,8 @@ defmodule Ecto.Query do
   >
   > When selecting a literal atom, its value must be the same across
   > all queries. Otherwise, the value from the parent query will be
-  > applied to all other queries.
+  > applied to all other queries. This also holds true for selecting
+  > maps with atom keys.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the union. `order_by` must
@@ -2058,7 +2060,8 @@ defmodule Ecto.Query do
   >
   > When selecting a literal atom, its value must be the same across
   > all queries. Otherwise, the value from the parent query will be
-  > applied to all other queries.
+  > applied to all other queries. This also holds true for selecting
+  > maps with atom keys.
 
   Except expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2110,7 +2113,8 @@ defmodule Ecto.Query do
   >
   > When selecting a literal atom, its value must be the same across
   > all queries. Otherwise, the value from the parent query will be
-  > applied to all other queries.
+  > applied to all other queries. This also holds true for selecting
+  > maps with atom keys.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`
@@ -2157,7 +2161,8 @@ defmodule Ecto.Query do
   >
   > When selecting a literal atom, its value must be the same across
   > all queries. Otherwise, the value from the parent query will be
-  > applied to all other queries.
+  > applied to all other queries. This also holds true for selecting
+  > maps with atom keys.
 
   Intersect expression returns only unique rows as if each query returned
   distinct results. This may cause a performance penalty. If you need
@@ -2209,7 +2214,8 @@ defmodule Ecto.Query do
   >
   > When selecting a literal atom, its value must be the same across
   > all queries. Otherwise, the value from the parent query will be
-  > applied to all other queries.
+  > applied to all other queries. This also holds true for selecting
+  > maps with atom keys.
 
   Note that the operations `order_by`, `limit` and `offset` of the
   current `query` apply to the result of the set difference. `order_by`

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -188,7 +188,7 @@ defmodule Ecto.Query.Builder.Select do
   def map_key!(key) when is_atom(key), do: key
 
   def map_key!(other) do
-    Builder.error(
+    Builder.error!(
       "interpolated map keys in `:select` can only be atoms, strings or numbers, got: #{inspect(other)}"
     )
   end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -187,6 +187,12 @@ defmodule Ecto.Query.Builder.Select do
   def map_key!(key) when is_float(key), do: key
   def map_key!(key) when is_atom(key), do: key
 
+  def map_key!(other) do
+    Builder.error(
+      "interpolated map keys in `:select` can only be atoms, strings or numbers, got: #{inspect(other)}"
+    )
+  end
+
   # atom list sigils
   defp take?({name, _, [_, modifiers]}) when name in ~w(sigil_w sigil_W)a do
     ?a in modifiers

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -140,6 +140,11 @@ defmodule Ecto.Query.Builder.Select do
     {k, params_acc}
   end
 
+  defp escape_key({:^, _, [{var, _, context} = k]}, params_acc, _vars, _env)
+       when is_atom(var) and is_atom(context) do
+    {k, params_acc}
+  end
+
   defp escape_key(k, params_acc, vars, env) do
     escape(k, params_acc, vars, env)
   end

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -140,8 +140,13 @@ defmodule Ecto.Query.Builder.Select do
     {k, params_acc}
   end
 
-  defp escape_key({:^, _, [k]}, params_acc, _vars, _env) do
+  defp escape_key({:^, _, [{var, _, context} = k]}, params_acc, _vars, _env)
+       when is_atom(var) and is_atom(context) do
     {k, params_acc}
+  end
+
+  defp escape_key({:^, _, [k]}, params_acc, vars, env) do
+    escape_key(k, params_acc, vars, env)
   end
 
   defp escape_key(k, params_acc, vars, env) do

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -140,8 +140,7 @@ defmodule Ecto.Query.Builder.Select do
     {k, params_acc}
   end
 
-  defp escape_key({:^, _, [{var, _, context} = k]}, params_acc, _vars, _env)
-       when is_atom(var) and is_atom(context) do
+  defp escape_key({:^, _, [k]}, params_acc, _vars, _env) do
     {k, params_acc}
   end
 

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -140,13 +140,9 @@ defmodule Ecto.Query.Builder.Select do
     {k, params_acc}
   end
 
-  defp escape_key({:^, _, [{var, _, context} = k]}, params_acc, _vars, _env)
-       when is_atom(var) and is_atom(context) do
-    {k, params_acc}
-  end
-
-  defp escape_key({:^, _, [k]}, params_acc, vars, env) do
-    escape_key(k, params_acc, vars, env)
+  defp escape_key({:^, _, [k]}, params_acc, _vars, _env) do
+    checked = quote do: Ecto.Query.Builder.Select.map_key!(unquote(k))
+    {checked, params_acc}
   end
 
   defp escape_key(k, params_acc, vars, env) do
@@ -182,6 +178,14 @@ defmodule Ecto.Query.Builder.Select do
         "expected a list of fields in `#{tag}/2` inside `select`, got: `#{inspect fields}`"
     end
   end
+
+  @doc """
+  Called at runtime to verify a map key
+  """
+  def map_key!(key) when is_binary(key), do: key
+  def map_key!(key) when is_integer(key), do: key
+  def map_key!(key) when is_float(key), do: key
+  def map_key!(key) when is_atom(key), do: key
 
   # atom list sigils
   defp take?({name, _, [_, modifiers]}) when name in ~w(sigil_w sigil_W)a do

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -489,7 +489,11 @@ defmodule Ecto.Query.Builder.SelectTest do
 
     test "supports interpolated map keys" do
       key = :test_key
+
       q = from p in "posts", select: %{^key => 1}
+      assert {:%{}, [], [test_key: 1]} = q.select.expr
+
+      q = from p in "posts", select: %{^:test_key => 1}
       assert {:%{}, [], [test_key: 1]} = q.select.expr
     end
   end
@@ -687,6 +691,13 @@ defmodule Ecto.Query.Builder.SelectTest do
         from p in "posts",
           select: %{^shared_key => :old},
           select_merge: %{^shared_key => :new, ^merge_key => :merge}
+
+      assert {:%{}, [], [shared: :new, merge: :merge]} = q.select.expr
+
+      q =
+        from p in "posts",
+          select: %{^:shared => :old},
+          select_merge: %{^:shared => :new, ^:merge => :merge}
 
       assert {:%{}, [], [shared: :new, merge: :merge]} = q.select.expr
     end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -486,6 +486,12 @@ defmodule Ecto.Query.Builder.SelectTest do
         %Ecto.Query{} |> select([], 1) |> select([], 2)
       end
     end
+
+    test "supports interpolated map keys" do
+      key = :test_key
+      q = from p in "posts", select: %{^key => 1}
+      assert {:%{}, [], [test_key: 1]} = q.select.expr
+    end
   end
 
   describe "select_merge" do
@@ -574,7 +580,7 @@ defmodule Ecto.Query.Builder.SelectTest do
         end)
 
       assert Macro.to_string(query.select.expr) ==
-               "merge(merge(%{comments: count(&2.id())}, %{^0 => &0.name()}), %{^1 => &1.author()})"
+               "%{comments: count(&2.id()), name: &0.name(), author: &1.author()}"
     end
 
     test "supports '...' in binding list with no prior select" do
@@ -671,6 +677,18 @@ defmodule Ecto.Query.Builder.SelectTest do
           select: %{t: {p.title, ^0}},
           select_merge: %{t: p.title, b: p.body}
       assert Macro.to_string(query.select.expr) =~ "merge"
+    end
+
+    test "supports interpolated map keys" do
+      shared_key = :shared
+      merge_key = :merge
+
+      q =
+        from p in "posts",
+          select: %{^shared_key => :old},
+          select_merge: %{^shared_key => :new, ^merge_key => :merge}
+
+      assert {:%{}, [], [shared: :new, merge: :merge]} = q.select.expr
     end
   end
 end


### PR DESCRIPTION
I was reading over the issue from this morning about seeing dynamic map keys (https://github.com/elixir-ecto/ecto/issues/4326). I think I have a decent way to solve it.

The idea is that any interpolated map key doesn't need to be sent to the database because it won't affect the query:
- For subqueries/CTEs, only atom map key are allowed and those are never sent to the database
- For outer queries literals are never sent to the database

This means instead of making map keys query parameters we can simply validate them on the spot and save them into the query struct.

There is a limitation where we can really only interpolate map keys for basic literals like atoms, strings and numbers. Composite literals like tuples and maps would require recursive escaping, which we lose the ability to do because we are at runtime.

I'm also restricting this proposal to just map keys even though I think there might be a case to extend it to anywhere in select. But it is more complicated (i.e. the distinction between outer and inner query becomes important) and more tests break, so I thought I would save it for later.