### PR TITLE
Proposal: Add native support to bitstring

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -2,12 +2,13 @@ VERSION 0.6
 
 all:
     BUILD \
-        --build-arg ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.16.7 \
-        --build-arg ELIXIR_BASE=1.15.6-erlang-24.3.4.14-alpine-3.16.7 \
+        --build-arg ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.18.4 \
+        --build-arg ELIXIR_BASE=1.15.6-erlang-24.3.4.14-alpine-3.18.4 \
         +integration-test
 
 integration-test-base:
-    ARG ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.16.7
+    ARG ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.18.4
+    ARG TARGETARCH 
     FROM hexpm/elixir:$ELIXIR_BASE
     RUN apk add --no-progress --update git build-base
     RUN mix local.rebar --force
@@ -17,13 +18,13 @@ integration-test-base:
     RUN apk add --no-progress --update docker docker-compose git postgresql-client mysql-client
 
     RUN apk add --no-cache curl gnupg --virtual .build-dependencies -- && \
-        curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.5.2.1-1_amd64.apk && \
-        curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.5.2.1-1_amd64.apk && \
-        echo y | apk add --allow-untrusted msodbcsql17_17.5.2.1-1_amd64.apk mssql-tools_17.5.2.1-1_amd64.apk && \
+        curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.2.1-1_${TARGETARCH}.apk && \
+        curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/mssql-tools18_18.3.1.1-1_${TARGETARCH}.apk && \
+        echo y | apk add --allow-untrusted msodbcsql18_18.3.2.1-1_${TARGETARCH}.apk mssql-tools18_18.3.1.1-1_${TARGETARCH}.apk && \
         apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
-    ENV PATH="/opt/mssql-tools/bin:${PATH}"
+    ENV PATH="/opt/mssql-tools18/bin:${PATH}"
 
-    GIT CLONE https://github.com/elixir-ecto/ecto_sql.git /src/ecto_sql
+    GIT CLONE --branch feature/bitstring-support https://github.com/Gigitsu/ecto_sql.git /src/ecto_sql
     WORKDIR /src/ecto_sql
     RUN mix deps.get
 
@@ -44,7 +45,7 @@ integration-test:
     ARG MYSQL_IMG="mysql:5.7"
 
     # then run the tests
-    WITH DOCKER --pull "$PG_IMG" --pull "$MCR_IMG" --pull "$MYSQL_IMG"
+    WITH DOCKER --pull "$PG_IMG" --pull "$MCR_IMG" --pull "$MYSQL_IMG" --platform linux/amd64
         RUN set -e; \
             timeout=$(expr $(date +%s) + 60); \
 
@@ -54,7 +55,7 @@ integration-test:
             docker run --name mysql --network=host -d -e MYSQL_ROOT_PASSWORD=root "$MYSQL_IMG"; \
 
             # wait for mssql to start
-            while ! sqlcmd -S tcp:127.0.0.1,1433 -U sa -P 'some!Password' -Q "SELECT 1" >/dev/null 2>&1; do \
+            while ! sqlcmd -C -S tcp:127.0.0.1,1433 -U sa -P 'some!Password' -Q "SELECT 1" >/dev/null 2>&1; do \
                 test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for mysql"; exit 1); \
                 echo "waiting for mssql"; \
                 sleep 1; \

--- a/Earthfile
+++ b/Earthfile
@@ -24,7 +24,7 @@ integration-test-base:
         apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
     ENV PATH="/opt/mssql-tools18/bin:${PATH}"
 
-    GIT CLONE --branch feature/bitstring-support https://github.com/Gigitsu/ecto_sql.git /src/ecto_sql
+    GIT CLONE https://github.com/elixir-ecto/ecto_sql.git /src/ecto_sql
     WORKDIR /src/ecto_sql
     RUN mix deps.get
 

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -11,11 +11,12 @@ defmodule Ecto.Integration.TypeTest do
     integer  = 1
     float    = 0.1
     blob     = <<0, 1>>
+    bitstring = <<2::3>>
     uuid     = "00010203-0405-4607-8809-0a0b0c0d0e0f"
     datetime = ~N[2014-01-16 20:26:51]
 
     TestRepo.insert!(%Post{blob: blob, public: true, visits: integer, uuid: uuid,
-                           counter: integer, inserted_at: datetime, intensity: float})
+                           counter: integer, inserted_at: datetime, intensity: float, token: bitstring})
 
     # nil
     assert [nil] = TestRepo.all(from Post, select: nil)
@@ -41,6 +42,9 @@ defmodule Ecto.Integration.TypeTest do
     # Binaries
     assert [^blob] = TestRepo.all(from p in Post, where: p.blob == <<0, 1>>, select: p.blob)
     assert [^blob] = TestRepo.all(from p in Post, where: p.blob == ^blob, select: p.blob)
+
+    # Bitstrings
+    assert [^bitstring] = TestRepo.all(from p in Post, where: p.token == ^bitstring, select: p.token)
 
     # UUID
     assert [^uuid] = TestRepo.all(from p in Post, where: p.uuid == ^uuid, select: p.uuid)

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -1,7 +1,7 @@
 defmodule Ecto.Integration.TypeTest do
   use Ecto.Integration.Case, async: Application.compile_env(:ecto, :async_integration_tests, true)
 
-  alias Ecto.Integration.{Comment, Custom, Item, ItemColor, Order, Post, User, Tag, Usec}
+  alias Ecto.Integration.{Bitstring, Comment, Custom, Item, ItemColor, Order, Post, User, Tag, Usec}
   alias Ecto.Integration.TestRepo
   import Ecto.Query
 
@@ -11,12 +11,11 @@ defmodule Ecto.Integration.TypeTest do
     integer  = 1
     float    = 0.1
     blob     = <<0, 1>>
-    bitstring = <<2::3>>
     uuid     = "00010203-0405-4607-8809-0a0b0c0d0e0f"
     datetime = ~N[2014-01-16 20:26:51]
 
     TestRepo.insert!(%Post{blob: blob, public: true, visits: integer, uuid: uuid,
-                           counter: integer, inserted_at: datetime, intensity: float, token: bitstring})
+                           counter: integer, inserted_at: datetime, intensity: float})
 
     # nil
     assert [nil] = TestRepo.all(from Post, select: nil)
@@ -69,6 +68,19 @@ defmodule Ecto.Integration.TypeTest do
     TestRepo.insert!(%Usec{naive_datetime_usec: naive_datetime, utc_datetime_usec: datetime})
     assert [^naive_datetime] = TestRepo.all(from u in Usec, where: u.naive_datetime_usec == ^naive_datetime, select: u.naive_datetime_usec)
     assert [^datetime] = TestRepo.all(from u in Usec, where: u.utc_datetime_usec == ^datetime, select: u.utc_datetime_usec)
+  end
+
+  @tag :bitstring_type
+  test "bitstring type" do
+    bitstring = <<2::3>>
+
+    TestRepo.insert!(%Bitstring{bs: bitstring, bs_with_size: <<5::10>>})
+
+    # Bitstrings
+    assert [^bitstring] = TestRepo.all(from p in Bitstring, where: p.bs == ^bitstring, select: p.bs)
+    assert [^bitstring] = TestRepo.all(from p in Bitstring, where: p.bs == <<2::3>>, select: p.bs)
+
+    assert [<<42::6>>] = TestRepo.all(from p in Bitstring, limit: 1, select: p.bs_with_default)
   end
 
   @tag :select_not

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -42,9 +42,6 @@ defmodule Ecto.Integration.TypeTest do
     assert [^blob] = TestRepo.all(from p in Post, where: p.blob == <<0, 1>>, select: p.blob)
     assert [^blob] = TestRepo.all(from p in Post, where: p.blob == ^blob, select: p.blob)
 
-    # Bitstrings
-    assert [^bitstring] = TestRepo.all(from p in Post, where: p.token == ^bitstring, select: p.token)
-
     # UUID
     assert [^uuid] = TestRepo.all(from p in Post, where: p.uuid == ^uuid, select: p.uuid)
 

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -75,6 +75,7 @@ defmodule Ecto.Integration.TypeTest do
 
     # Bitstrings
     assert [^bitstring] = TestRepo.all(from p in Bitstring, where: p.bs == ^bitstring, select: p.bs)
+    assert [^bitstring] = TestRepo.all(from p in Bitstring, where: p.bs == <<2::3>>, select: p.bs)
 
     assert [<<42::6>>] = TestRepo.all(from p in Bitstring, limit: 1, select: p.bs_with_default)
   end

--- a/integration_test/cases/type.exs
+++ b/integration_test/cases/type.exs
@@ -75,7 +75,6 @@ defmodule Ecto.Integration.TypeTest do
 
     # Bitstrings
     assert [^bitstring] = TestRepo.all(from p in Bitstring, where: p.bs == ^bitstring, select: p.bs)
-    assert [^bitstring] = TestRepo.all(from p in Bitstring, where: p.bs == <<2::3>>, select: p.bs)
 
     assert [<<42::6>>] = TestRepo.all(from p in Bitstring, limit: 1, select: p.bs_with_default)
   end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -400,7 +400,7 @@ defmodule Ecto.Integration.Bitstring do
 
   schema "bitstrings" do
     field :bs,  :bitstring
-    field :bs_with_default, :bitstring, default: <<42::6>>
+    field :bs_with_default, :bitstring
     field :bs_with_size, :bitstring
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -401,6 +401,6 @@ defmodule Ecto.Integration.Bitstring do
   schema "bitstrings" do
     field :bs,  :bitstring
     field :bs_with_default, :bitstring, default: <<42::6>>
-    field :bs_with_size, :bitstring, size: 10
+    field :bs_with_size, :bitstring
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -47,7 +47,6 @@ defmodule Ecto.Integration.Post do
     field :intensities, {:map, :float}
     field :posted, :date
     field :read_only, :string, read_only: true
-    field :token, :bitstring
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
     has_many :force_comments, Ecto.Integration.Comment, on_replace: :delete_if_exists
     has_many :ordered_comments, Ecto.Integration.Comment, preload_order: [:text]
@@ -387,5 +386,21 @@ defmodule Ecto.Integration.ArrayLogging do
   schema "array_loggings" do
     field :uuids, {:array, Ecto.Integration.TestRepo.uuid()}
     timestamps()
+  end
+end
+
+defmodule Ecto.Integration.Bitstring do
+  @moduledoc """
+  This module is used to test:
+
+    * Bitstring type
+
+  """
+  use Ecto.Integration.Schema
+
+  schema "bitstrings" do
+    field :bs,  :bitstring
+    field :bs_with_default, :bitstring, default: <<42::6>>
+    field :bs_with_size, :bitstring, size: 10
   end
 end

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -47,6 +47,7 @@ defmodule Ecto.Integration.Post do
     field :intensities, {:map, :float}
     field :posted, :date
     field :read_only, :string, read_only: true
+    field :token, :bitstring
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
     has_many :force_comments, Ecto.Integration.Comment, on_replace: :delete_if_exists
     has_many :ordered_comments, Ecto.Integration.Comment, preload_order: [:text]

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1228,9 +1228,8 @@ defmodule Ecto.Query.Builder do
   defp get_env({env, _}), do: env
   defp get_env(env), do: env
 
-  defp normalize_type(value, :binary) do
-    {:||, [], [{:&&, [], [{:is_binary, [], [value]}, :binary]}, :bitstring]}
-  end
+  defp normalize_type(value, :binary),
+    do: quote(do: is_binary(unquote(value)) && :binary || :bitstring)
 
   @doc """
   Raises a query building error.

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -122,7 +122,7 @@ defmodule Ecto.Query.Builder do
   end
 
   def escape({:type, _, [{bitwise_op, _, [_, _]} = op_expr, type]}, _type, params_acc, vars, env)
-      when bitwise_op in ~w(&&& |||)a do
+      when bitwise_op in ~w(&&& ||| <<< >>>)a do
     escape_with_type(op_expr, type, params_acc, vars, env)
   end
 
@@ -153,7 +153,7 @@ defmodule Ecto.Query.Builder do
           * fields, such as p.foo or field(p, :foo)
           * fragments, such as fragment("foo(?)", value)
           * an arithmetic expression (+, -, *, /)
-          * a bitwise expression (&&&, |||)
+          * a bitwise expression (&&&, |||, <<<, >>>)
           * an aggregation or window expression (avg, count, min, max, sum, over, filter)
           * a conditional expression (coalesce)
           * access/json paths (p.column[0].field)
@@ -348,7 +348,7 @@ defmodule Ecto.Query.Builder do
 
   # bitwise operators
   def escape({bitwise_op, _, [left, right]}, type, params_acc, vars, env)
-      when bitwise_op in ~w(&&& |||)a do
+      when bitwise_op in ~w(&&& ||| <<< >>>)a do
     {left,  params_acc} = escape(left, type, params_acc, vars, env)
     {right, params_acc} = escape(right, type, params_acc, vars, env)
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -777,7 +777,7 @@ defmodule Ecto.Query.Builder do
     do: do_literal(value, expected, quoted_type(value, vars))
 
   defp do_literal(value, _, current) when current in @always_tagged,
-    do: {:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: value, type: current]}]}
+    do: {:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: value, type: normalize_type(value, current)]}]}
   defp do_literal(value, :any, _current),
     do: value
   defp do_literal(value, expected, expected),
@@ -1227,6 +1227,10 @@ defmodule Ecto.Query.Builder do
 
   defp get_env({env, _}), do: env
   defp get_env(env), do: env
+
+  defp normalize_type(value, :binary) do
+    {:||, [], [{:&&, [], [{:is_binary, [], [value]}, :binary]}, :bitstring]}
+  end
 
   @doc """
   Raises a query building error.

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -795,6 +795,10 @@ defmodule Ecto.Query.Builder do
   @doc """
   Validates the type with the given vars.
   """
+  def validate_type!([{_, _} = type], vars, env),
+    do: validate_type!(type, vars, env)
+  def validate_type!({type, size}, vars, env) when is_number(size),
+    do: {validate_type!(type, vars, env), size}
   def validate_type!({composite, type}, vars, env),
     do: {composite, validate_type!(type, vars, env)}
   def validate_type!({:^, _, [type]}, _vars, _env),
@@ -816,7 +820,7 @@ defmodule Ecto.Query.Builder do
     do: {find_var!(var, vars), field}
 
   def validate_type!(type, _vars, _env) do
-    error! "type/2 expects an alias, atom, initialized parameterized type or " <>
+    error! "type/2 expects an alias, atom, a pari {atom, number}, initialized parameterized type or " <>
            "source.field as second argument, got: `#{Macro.to_string(type)}`"
   end
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -346,13 +346,20 @@ defmodule Ecto.Query.Builder do
     {{:{}, [], [math_op, [], [left, right]]}, params_acc}
   end
 
-  # bitwise operators
+  # binary bitwise operators
   def escape({bitwise_op, _, [left, right]}, type, params_acc, vars, env)
       when bitwise_op in ~w(&&& ||| <<< >>>)a do
     {left,  params_acc} = escape(left, type, params_acc, vars, env)
     {right, params_acc} = escape(right, type, params_acc, vars, env)
 
     {{:{}, [], [bitwise_op, [], [left, right]]}, params_acc}
+  end
+
+  # unary bitwise operators
+  def escape({:~~~, _, [bitstring]}, type, params_acc, vars, env) do
+    {bitstring,  params_acc} = escape(bitstring, type, params_acc, vars, env)
+
+    {{:{}, [], [:~~~, [], [bitstring]]}, params_acc}
   end
 
   # in operator

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -795,10 +795,6 @@ defmodule Ecto.Query.Builder do
   @doc """
   Validates the type with the given vars.
   """
-  def validate_type!([{_, _} = type], vars, env),
-    do: validate_type!(type, vars, env)
-  def validate_type!({type, size}, vars, env) when is_number(size),
-    do: {validate_type!(type, vars, env), size}
   def validate_type!({composite, type}, vars, env),
     do: {composite, validate_type!(type, vars, env)}
   def validate_type!({:^, _, [type]}, _vars, _env),
@@ -820,7 +816,7 @@ defmodule Ecto.Query.Builder do
     do: {find_var!(var, vars), field}
 
   def validate_type!(type, _vars, _env) do
-    error! "type/2 expects an alias, atom, a pari {atom, number}, initialized parameterized type or " <>
+    error! "type/2 expects an alias, atom, initialized parameterized type or " <>
            "source.field as second argument, got: `#{Macro.to_string(type)}`"
   end
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -126,6 +126,10 @@ defmodule Ecto.Query.Builder do
     escape_with_type(op_expr, type, params_acc, vars, env)
   end
 
+  def escape({:type, _, [{:~~~, _, [_]} = op_expr, type]}, _type, params_acc, vars, env) do
+    escape_with_type(op_expr, type, params_acc, vars, env)
+  end
+
   def escape({:type, _, [{fun, _, args} = expr, type]}, _type, params_acc, vars, env)
       when is_list(args) and fun in ~w(fragment avg count max min sum over filter)a do
     escape_with_type(expr, type, params_acc, vars, env)

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -256,6 +256,7 @@ defmodule Ecto.Schema do
   `:boolean`              | `boolean`               | true, false
   `:string`               | UTF-8 encoded `string`  | "hello"
   `:binary`               | `binary`                | `<<int, int, int, ...>>`
+  `:bitstring`            | `bitstring`             | `<<_::size>>
   `{:array, inner_type}`  | `list`                  | `[value, value, value, ...]`
   `:map`                  | `map` |
   `{:map, inner_type}`    | `map` |

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -208,6 +208,7 @@ defmodule Ecto.Type do
           | :float
           | :boolean
           | :string
+          | :bitstring
           | :map
           | :binary
           | :decimal
@@ -227,7 +228,7 @@ defmodule Ecto.Type do
   @typep private_composite :: {:maybe, t} | {:in, t} | {:param, :any_datetime}
 
   @base ~w(
-    integer float decimal boolean string map binary id binary_id any
+    integer float decimal boolean string bitstring map binary id binary_id any
     utc_datetime naive_datetime date time
     utc_datetime_usec naive_datetime_usec time_usec
   )a
@@ -550,6 +551,7 @@ defmodule Ecto.Type do
   def dump(:map, value, _dumper), do: same_map(value)
   def dump(:string, value, _dumper), do: same_binary(value)
   def dump(:binary, value, _dumper), do: same_binary(value)
+  def dump(:bitstring, value, _dumper), do: same_bitstring(value)
   def dump(:id, value, _dumper), do: same_integer(value)
   def dump(:binary_id, value, _dumper), do: same_binary(value)
   def dump(:decimal, value, _dumper), do: same_decimal(value)
@@ -644,6 +646,7 @@ defmodule Ecto.Type do
   def load(:map, value, _loader), do: same_map(value)
   def load(:string, value, _loader), do: same_binary(value)
   def load(:binary, value, _loader), do: same_binary(value)
+  def load(:bitstring, value, _loader), do: same_bitstring(value)
   def load(:id, value, _loader), do: same_integer(value)
   def load(:binary_id, value, _loader), do: same_binary(value)
   def load(:decimal, value, _loader), do: same_decimal(value)
@@ -814,6 +817,7 @@ defmodule Ecto.Type do
   defp cast_fun(:map), do: &cast_map/1
   defp cast_fun(:string), do: &cast_binary/1
   defp cast_fun(:binary), do: &cast_binary/1
+  defp cast_fun(:bitstring), do: &cast_bitstring/1
   defp cast_fun(:id), do: &cast_integer/1
   defp cast_fun(:binary_id), do: &cast_binary/1
   defp cast_fun(:any), do: &{:ok, &1}
@@ -897,6 +901,9 @@ defmodule Ecto.Type do
   defp cast_binary(term) when is_binary(term), do: {:ok, term}
   defp cast_binary(_), do: :error
 
+  defp cast_bitstring(term) when is_bitstring(term), do: {:ok, term}
+  defp cast_bitstring(_), do: :error
+
   defp cast_map(term) when is_map(term), do: {:ok, term}
   defp cast_map(_), do: :error
 
@@ -911,6 +918,9 @@ defmodule Ecto.Type do
 
   defp same_binary(term) when is_binary(term), do: {:ok, term}
   defp same_binary(_), do: :error
+
+  defp same_bitstring(term) when is_bitstring(term), do: {:ok, term}
+  defp same_bitstring(_), do: :error
 
   defp same_map(term) when is_map(term), do: {:ok, term}
   defp same_map(_), do: :error

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -217,6 +217,9 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do type(bnot(&0.y()), :bitstring) end), []} ==
            escape(quote do type(bnot(x.y()), :bitstring) end, [x: 0, y: 1], __ENV__)
 
+    assert {Macro.escape(quote do type(bnot(&0.y()), {:bitstring, 5}) end), []} ==
+           escape(quote do type(bnot(x.y()), bitstring: 5) end, [x: 0, y: 1], __ENV__)
+
     import Kernel, except: [>: 2]
     assert {Macro.escape(quote do type(filter(sum(&0.y()), &0.y() > &0.z()), :decimal) end), []} ==
           escape(quote do type(filter(sum(x.y()), x.y() > x.z()), :decimal) end, [x: 0], {__ENV__, %{}})

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -187,6 +187,9 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do type(&0.y() &&& &1.z(), :decimal) end), []} ==
            escape(quote do type(x.y() &&& y.z(), :decimal) end, [x: 0, y: 1], __ENV__)
 
+    assert {Macro.escape(quote do type(~~~&0.y(), :decimal) end), []} ==
+           escape(quote do type(~~~x.y(), :decimal) end, [x: 0, y: 1], __ENV__)
+
     assert {Macro.escape(quote do type(&0.y(), :decimal) end), []} ==
           escape(quote do type(field(x, :y), :decimal) end, [x: 0], __ENV__)
 

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -32,7 +32,7 @@ defmodule Ecto.Query.BuilderTest do
     assert {quote(do: ~s"123"), []} ==
            escape(quote do ~s"123" end, [], __ENV__)
 
-    assert {{:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: {:<<>>, [], [0, 1, 2]}, type: :binary]}]}, []} ==
+    assert {{:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: {:<<>>, [], [0, 1, 2]}, type: {:||, [], [{:&&, [], [{:is_binary, [], [{:<<>>, [], [0, 1, 2]}]}, :binary]}, :bitstring]}]}]}, []} ==
            escape(quote do <<0, 1, 2>> end, [], __ENV__)
 
     assert {:some_atom, []} ==

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -32,7 +32,7 @@ defmodule Ecto.Query.BuilderTest do
     assert {quote(do: ~s"123"), []} ==
            escape(quote do ~s"123" end, [], __ENV__)
 
-    assert {{:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: {:<<>>, [], [0, 1, 2]}, type: {:||, [], [{:&&, [], [{:is_binary, [], [{:<<>>, [], [0, 1, 2]}]}, :binary]}, :bitstring]}]}]}, []} ==
+    assert {{:%, [], [Ecto.Query.Tagged, {:%{}, [], [value: {:<<>>, [], [0, 1, 2]}, type: {:||, _, [{:&&, _, [{:is_binary, _, [{:<<>>, [], [0, 1, 2]}]}, :binary]}, :bitstring]}]}]}, []} =
            escape(quote do <<0, 1, 2>> end, [], __ENV__)
 
     assert {:some_atom, []} ==

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -26,15 +26,6 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do &0.y() + &1.z() end), []} ==
            escape(quote do x.y() + y.z() end, [x: 0, y: 1], __ENV__)
 
-    assert {Macro.escape(quote do &0.y() &&& &1.z() end), []} ==
-           escape(quote do x.y() &&& y.z() end, [x: 0, y: 1], __ENV__)
-
-    assert {Macro.escape(quote do band(&0.y(), &1.z()) end), []} ==
-           escape(quote do band(x.y(), y.z()) end, [x: 0, y: 1], __ENV__)
-
-    assert {Macro.escape(quote do bnot(&0.y()) end), []} ==
-           escape(quote do bnot(x.y()) end, [x: 0], __ENV__)
-
     assert {Macro.escape(quote do avg(0) end), []} ==
            escape(quote do avg(0) end, [], __ENV__)
 
@@ -55,9 +46,6 @@ defmodule Ecto.Query.BuilderTest do
 
     assert {Macro.escape(quote do -&0.y() end), []} ==
            escape(quote do -x.y() end, [x: 0], __ENV__)
-
-    assert {Macro.escape(quote do ~~~&0.y() end), []} ==
-           escape(quote do ~~~x.y() end, [x: 0], __ENV__)
   end
 
   test "escape json_extract_path" do
@@ -190,12 +178,6 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do type(&0.y() + &1.z(), :decimal) end), []} ==
            escape(quote do type(x.y() + y.z(), :decimal) end, [x: 0, y: 1], __ENV__)
 
-    assert {Macro.escape(quote do type(&0.y() &&& &1.z(), :decimal) end), []} ==
-           escape(quote do type(x.y() &&& y.z(), :decimal) end, [x: 0, y: 1], __ENV__)
-
-    assert {Macro.escape(quote do type(~~~&0.y(), :decimal) end), []} ==
-           escape(quote do type(~~~x.y(), :decimal) end, [x: 0, y: 1], __ENV__)
-
     assert {Macro.escape(quote do type(&0.y(), :decimal) end), []} ==
           escape(quote do type(field(x, :y), :decimal) end, [x: 0], __ENV__)
 
@@ -210,12 +192,6 @@ defmodule Ecto.Query.BuilderTest do
 
     assert {Macro.escape(quote do type(count(), :decimal) end), []} ==
           escape(quote do type(count(), :decimal) end, [x: 0], {__ENV__, %{}})
-
-    assert {Macro.escape(quote do type(band(&0.y(), &1.z()), :bitstring) end), []} ==
-           escape(quote do type(band(x.y(), y.z()), :bitstring) end, [x: 0, y: 1], __ENV__)
-
-    assert {Macro.escape(quote do type(bnot(&0.y()), :bitstring) end), []} ==
-           escape(quote do type(bnot(x.y()), :bitstring) end, [x: 0, y: 1], __ENV__)
 
     import Kernel, except: [>: 2]
     assert {Macro.escape(quote do type(filter(sum(&0.y()), &0.y() > &0.z()), :decimal) end), []} ==

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -49,6 +49,9 @@ defmodule Ecto.Query.BuilderTest do
 
     assert {Macro.escape(quote do -&0.y() end), []} ==
            escape(quote do -x.y() end, [x: 0], __ENV__)
+
+    assert {Macro.escape(quote do ~~~&0.y() end), []} ==
+           escape(quote do ~~~x.y() end, [x: 0], __ENV__)
   end
 
   test "escape json_extract_path" do

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -29,6 +29,12 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do &0.y() &&& &1.z() end), []} ==
            escape(quote do x.y() &&& y.z() end, [x: 0, y: 1], __ENV__)
 
+    assert {Macro.escape(quote do band(&0.y(), &1.z()) end), []} ==
+           escape(quote do band(x.y(), y.z()) end, [x: 0, y: 1], __ENV__)
+
+    assert {Macro.escape(quote do bnot(&0.y()) end), []} ==
+           escape(quote do bnot(x.y()) end, [x: 0], __ENV__)
+
     assert {Macro.escape(quote do avg(0) end), []} ==
            escape(quote do avg(0) end, [], __ENV__)
 
@@ -204,6 +210,12 @@ defmodule Ecto.Query.BuilderTest do
 
     assert {Macro.escape(quote do type(count(), :decimal) end), []} ==
           escape(quote do type(count(), :decimal) end, [x: 0], {__ENV__, %{}})
+
+    assert {Macro.escape(quote do type(band(&0.y(), &1.z()), :bitstring) end), []} ==
+           escape(quote do type(band(x.y(), y.z()), :bitstring) end, [x: 0, y: 1], __ENV__)
+
+    assert {Macro.escape(quote do type(bnot(&0.y()), :bitstring) end), []} ==
+           escape(quote do type(bnot(x.y()), :bitstring) end, [x: 0, y: 1], __ENV__)
 
     import Kernel, except: [>: 2]
     assert {Macro.escape(quote do type(filter(sum(&0.y()), &0.y() > &0.z()), :decimal) end), []} ==

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -217,9 +217,6 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do type(bnot(&0.y()), :bitstring) end), []} ==
            escape(quote do type(bnot(x.y()), :bitstring) end, [x: 0, y: 1], __ENV__)
 
-    assert {Macro.escape(quote do type(bnot(&0.y()), {:bitstring, 5}) end), []} ==
-           escape(quote do type(bnot(x.y()), bitstring: 5) end, [x: 0, y: 1], __ENV__)
-
     import Kernel, except: [>: 2]
     assert {Macro.escape(quote do type(filter(sum(&0.y()), &0.y() > &0.z()), :decimal) end), []} ==
           escape(quote do type(filter(sum(x.y()), x.y() > x.z()), :decimal) end, [x: 0], {__ENV__, %{}})

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -26,6 +26,9 @@ defmodule Ecto.Query.BuilderTest do
     assert {Macro.escape(quote do &0.y() + &1.z() end), []} ==
            escape(quote do x.y() + y.z() end, [x: 0, y: 1], __ENV__)
 
+    assert {Macro.escape(quote do &0.y() &&& &1.z() end), []} ==
+           escape(quote do x.y() &&& y.z() end, [x: 0, y: 1], __ENV__)
+
     assert {Macro.escape(quote do avg(0) end), []} ==
            escape(quote do avg(0) end, [], __ENV__)
 
@@ -177,6 +180,9 @@ defmodule Ecto.Query.BuilderTest do
     import Kernel, except: [+: 2, +: 1]
     assert {Macro.escape(quote do type(&0.y() + &1.z(), :decimal) end), []} ==
            escape(quote do type(x.y() + y.z(), :decimal) end, [x: 0, y: 1], __ENV__)
+
+    assert {Macro.escape(quote do type(&0.y() &&& &1.z(), :decimal) end), []} ==
+           escape(quote do type(x.y() &&& y.z(), :decimal) end, [x: 0, y: 1], __ENV__)
 
     assert {Macro.escape(quote do type(&0.y(), :decimal) end), []} ==
           escape(quote do type(field(x, :y), :decimal) end, [x: 0], __ENV__)


### PR DESCRIPTION
Recently, I had the need to store a variable-size bitstring in a PostgreSQL database. I was surprised to find that there isn't native support in Ecto for this data type, and the `:string` type doesn't work for me since I need to store a string where the number of bits is not a multiple of 8.

This PR is currently just a draft, but if this could be a desired feature, I would be happy to implement the entire feature set, including an `Ecto.Query` set of bitwise operators to work with bits and a corresponding `Ecto` schema type.
