### PR TITLE
Allow schema fields to be set to read only

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -23,7 +23,7 @@ integration-test-base:
         apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
     ENV PATH="/opt/mssql-tools/bin:${PATH}"
 
-    GIT CLONE --branch read_only_migration https://github.com/greg-rychlewski/ecto_sql.git /src/ecto_sql
+    GIT CLONE https://github.com/elixir-ecto/ecto_sql.git /src/ecto_sql
     WORKDIR /src/ecto_sql
     RUN mix deps.get
 

--- a/Earthfile
+++ b/Earthfile
@@ -23,7 +23,7 @@ integration-test-base:
         apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
     ENV PATH="/opt/mssql-tools/bin:${PATH}"
 
-    GIT CLONE --single-branch --branch read_only_migration https://github.com/greg-rychlewski/ecto_sql.git /src/ecto_sql
+    GIT CLONE --branch read_only_migration https://github.com/greg-rychlewski/ecto_sql.git /src/ecto_sql
     WORKDIR /src/ecto_sql
     RUN mix deps.get
 

--- a/Earthfile
+++ b/Earthfile
@@ -23,7 +23,7 @@ integration-test-base:
         apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
     ENV PATH="/opt/mssql-tools/bin:${PATH}"
 
-    GIT CLONE --branch read_only_migration https://github.com/greg-rychlewski/ecto_sql.git /src/ecto_sql
+    GIT CLONE --single-branch --branch read_only_migration https://github.com/greg-rychlewski/ecto_sql.git /src/ecto_sql
     WORKDIR /src/ecto_sql
     RUN mix deps.get
 

--- a/Earthfile
+++ b/Earthfile
@@ -23,7 +23,7 @@ integration-test-base:
         apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
     ENV PATH="/opt/mssql-tools/bin:${PATH}"
 
-    GIT CLONE https://github.com/elixir-ecto/ecto_sql.git /src/ecto_sql
+    GIT CLONE --branch read_only_migration https://github.com/greg-rychlewski/ecto_sql.git /src/ecto_sql
     WORKDIR /src/ecto_sql
     RUN mix deps.get
 

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1308,7 +1308,9 @@ defmodule Ecto.Integration.RepoTest do
     test "select with read only field" do
       {1, _} = TestRepo.insert_all("posts", [%{title: "1", read_only: "readonly"}])
       query = from p in Post, where: p.read_only == ^"readonly", select: p.read_only
+
       assert "readonly" == TestRepo.one(query)
+      assert %{read_only: "readonly"} = TestRepo.one(Post)
     end
 
     test "update with read only field" do

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1369,6 +1369,7 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     @tag :with_conflict_target
+    @tag :upsert
     test "insert with read only field and conflict replace_all" do
       uuid = Ecto.UUID.generate()
       TestRepo.insert!(%Post{uuid: uuid, title: "1"})
@@ -1378,6 +1379,7 @@ defmodule Ecto.Integration.RepoTest do
 
     @tag :returning
     @tag :with_conflict_target
+    @tag :upsert
     test "insert with read only field and conflict replace_all and returning" do
       uuid = Ecto.UUID.generate()
       TestRepo.insert!(%Post{uuid: uuid, title: "1"})

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1332,7 +1332,7 @@ defmodule Ecto.Integration.RepoTest do
       TestRepo.insert!(%Post{title: "1"})
       update_query = from p in Post, where: p.title == "1", update: [set: [read_only: "nope"]]
 
-      assert_raise Ecto.QueryError,  ~r/`read_only` in `update` is an unwritable field/, fn ->
+      assert_raise Ecto.QueryError,  ~r/cannot update unwritable field `read_only` in query/, fn ->
         TestRepo.update_all(update_query, [])
       end
     end
@@ -1351,17 +1351,17 @@ defmodule Ecto.Integration.RepoTest do
     test "insert with read only field and conflict query" do
       on_conflict = from Post, update: [set: [read_only: "nope"]]
 
-      assert_raise Ecto.QueryError,  ~r/`read_only` in `update` is an unwritable field/, fn ->
+      assert_raise Ecto.QueryError,  ~r/cannot update unwritable field `read_only` in query/, fn ->
         TestRepo.insert!(%Post{title: "1"}, on_conflict: on_conflict)
       end
 
-      assert_raise Ecto.QueryError,  ~r/`read_only` in `update` is an unwritable field/, fn ->
+      assert_raise Ecto.QueryError,  ~r/cannot update unwritable field `read_only` in query/, fn ->
         TestRepo.insert!(%Post{title: "1"}, on_conflict: [set: [read_only: "nope"]])
       end
     end
 
     test "insert with read only field and conflict replace" do
-      msg = "cannot replace unwritable field `read_only` in :on_conflict option"
+      msg = "cannot replace unwritable field `:read_only` in :on_conflict option"
 
       assert_raise ArgumentError,  msg, fn ->
         TestRepo.insert!(%Post{title: "1"}, on_conflict: {:replace, [:read_only]})
@@ -1395,11 +1395,13 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     test "insert_all with read only field" do
-      msg = "cannot give unwritable field `read_only` to insert_all"
+      msg = ~r/Unwritable fields, such as virtual and read only fields are not supported./
 
       assert_raise ArgumentError, msg, fn ->
         TestRepo.insert_all(Post, [%{title: "1", read_only: "nope"}])
       end
+
+      msg = "cannot select unwritable field `read_only` for insert_all"
 
       assert_raise ArgumentError, msg, fn ->
         query = from p in Post, select: %{read_only: p.read_only}

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1304,6 +1304,104 @@ defmodule Ecto.Integration.RepoTest do
     assert TestRepo.get(Post, id).temp == "temp"
   end
 
+  describe "read only fields" do
+    test "select with read only field" do
+      {1, _} = TestRepo.insert_all("posts", [%{title: "1", read_only: "readonly"}])
+      query = from p in Post, where: p.read_only == ^"readonly", select: p.read_only
+      assert "readonly" == TestRepo.one(query)
+    end
+
+    test "update with read only field" do
+      %Post{id: id} = post = TestRepo.insert!(%Post{title: "1"})
+      cs = Ecto.Changeset.change(post, %{title: "2", read_only: "nope"})
+      TestRepo.update!(cs)
+      assert is_nil(TestRepo.get(Post, id).read_only)
+    end
+
+    @tag :returning
+    test "update with read only field and returning" do
+      post = TestRepo.insert!(%Post{title: "1"})
+      cs = Ecto.Changeset.change(post, %{title: "2", read_only: "nope"})
+      updated_post = TestRepo.update!(cs, returning: true)
+      assert is_nil(updated_post.read_only)
+    end
+
+    test "update_all with read only field" do
+      TestRepo.insert!(%Post{title: "1"})
+      update_query = from p in Post, where: p.title == "1", update: [set: [read_only: "nope"]]
+
+      assert_raise Ecto.QueryError,  ~r/cannot update read only field `read_only`/, fn ->
+        TestRepo.update_all(update_query, [])
+      end
+    end
+
+    test "insert with read only field" do
+      %Post{id: id} = TestRepo.insert!(%Post{title: "1", read_only: "nope"})
+      assert is_nil(TestRepo.get(Post, id).read_only)
+    end
+
+    @tag :returning
+    test "insert with read only field and returning" do
+      post = TestRepo.insert!(%Post{title: "1", read_only: "nope"}, returning: true)
+      assert is_nil(post.read_only)
+    end
+
+    test "insert with read only field and conflict query" do
+      on_conflict = from Post, update: [set: [read_only: "nope"]]
+
+      assert_raise Ecto.QueryError,  ~r/cannot update read only field `read_only`/, fn ->
+        TestRepo.insert!(%Post{title: "1"}, on_conflict: on_conflict)
+      end
+
+      assert_raise Ecto.QueryError,  ~r/cannot update read only field `read_only`/, fn ->
+        TestRepo.insert!(%Post{title: "1"}, on_conflict: [set: [read_only: "nope"]])
+      end
+    end
+
+    test "insert with read only field and conflict replace" do
+      msg = "cannot replace read only field `read_only` in :on_conflict option"
+
+      assert_raise ArgumentError,  msg, fn ->
+        TestRepo.insert!(%Post{title: "1"}, on_conflict: {:replace, [:read_only]})
+      end
+    end
+
+    @tag :with_conflict_target
+    test "insert with read only field and conflict replace_all" do
+      %Post{id: id} = TestRepo.insert!(%Post{id: 1, title: "1"})
+      TestRepo.insert!(%Post{id: 1, title: "2"}, conflict_target: [:id], on_conflict: :replace_all)
+      assert %{id: 1, title: "2", read_only: nil} = TestRepo.get(Post, id)
+    end
+
+    @tag :returning
+    @tag :with_conflict_target
+    test "insert with read only field and conflict replace_all and returning" do
+      TestRepo.insert!(%Post{id: 1, title: "1"})
+
+      post =
+        TestRepo.insert!(%Post{id: 1, title: "2", read_only: "nope"},
+          conflict_target: [:id],
+          on_conflict: :replace_all,
+          returning: true
+        )
+
+      assert %{id: 1, title: "2", read_only: nil} = post
+    end
+
+    test "insert_all with read only field" do
+      msg = "cannot give read only field `read_only` to insert_all"
+
+      assert_raise ArgumentError, msg, fn ->
+        TestRepo.insert_all(Post, [%{title: "1", read_only: "nope"}])
+      end
+
+      assert_raise ArgumentError, msg, fn ->
+        query = from p in Post, select: %{read_only: p.read_only}
+        TestRepo.insert_all(Post, query)
+      end
+    end
+  end
+
   ## Query syntax
 
   defmodule Foo do

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1370,24 +1370,26 @@ defmodule Ecto.Integration.RepoTest do
 
     @tag :with_conflict_target
     test "insert with read only field and conflict replace_all" do
-      %Post{id: id} = TestRepo.insert!(%Post{id: 1, title: "1"})
-      TestRepo.insert!(%Post{id: 1, title: "2"}, conflict_target: [:id], on_conflict: :replace_all)
-      assert %{id: 1, title: "2", read_only: nil} = TestRepo.get(Post, id)
+      uuid = Ecto.UUID.generate()
+      TestRepo.insert!(%Post{uuid: uuid, title: "1"})
+      %Post{id: id} = TestRepo.insert!(%Post{uuid: uuid, title: "2"}, conflict_target: [:uuid], on_conflict: :replace_all)
+      assert %{title: "2", read_only: nil} = TestRepo.get(Post, id)
     end
 
     @tag :returning
     @tag :with_conflict_target
     test "insert with read only field and conflict replace_all and returning" do
-      TestRepo.insert!(%Post{id: 1, title: "1"})
+      uuid = Ecto.UUID.generate()
+      TestRepo.insert!(%Post{uuid: uuid, title: "1"})
 
       post =
-        TestRepo.insert!(%Post{id: 1, title: "2", read_only: "nope"},
-          conflict_target: [:id],
+        TestRepo.insert!(%Post{uuid: uuid, title: "2", read_only: "nope"},
+          conflict_target: [:uuid],
           on_conflict: :replace_all,
           returning: true
         )
 
-      assert %{id: 1, title: "2", read_only: nil} = post
+      assert %{title: "2", read_only: nil} = post
     end
 
     test "insert_all with read only field" do

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1332,7 +1332,7 @@ defmodule Ecto.Integration.RepoTest do
       TestRepo.insert!(%Post{title: "1"})
       update_query = from p in Post, where: p.title == "1", update: [set: [read_only: "nope"]]
 
-      assert_raise Ecto.QueryError,  ~r/cannot update read only field `read_only`/, fn ->
+      assert_raise Ecto.QueryError,  ~r/`read_only` in `update` is an unwritable field/, fn ->
         TestRepo.update_all(update_query, [])
       end
     end
@@ -1351,17 +1351,17 @@ defmodule Ecto.Integration.RepoTest do
     test "insert with read only field and conflict query" do
       on_conflict = from Post, update: [set: [read_only: "nope"]]
 
-      assert_raise Ecto.QueryError,  ~r/cannot update read only field `read_only`/, fn ->
+      assert_raise Ecto.QueryError,  ~r/`read_only` in `update` is an unwritable field/, fn ->
         TestRepo.insert!(%Post{title: "1"}, on_conflict: on_conflict)
       end
 
-      assert_raise Ecto.QueryError,  ~r/cannot update read only field `read_only`/, fn ->
+      assert_raise Ecto.QueryError,  ~r/`read_only` in `update` is an unwritable field/, fn ->
         TestRepo.insert!(%Post{title: "1"}, on_conflict: [set: [read_only: "nope"]])
       end
     end
 
     test "insert with read only field and conflict replace" do
-      msg = "cannot replace read only field `read_only` in :on_conflict option"
+      msg = "cannot replace unwritable field `read_only` in :on_conflict option"
 
       assert_raise ArgumentError,  msg, fn ->
         TestRepo.insert!(%Post{title: "1"}, on_conflict: {:replace, [:read_only]})
@@ -1395,7 +1395,7 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     test "insert_all with read only field" do
-      msg = "cannot give read only field `read_only` to insert_all"
+      msg = "cannot give unwritable field `read_only` to insert_all"
 
       assert_raise ArgumentError, msg, fn ->
         TestRepo.insert_all(Post, [%{title: "1", read_only: "nope"}])

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -46,6 +46,7 @@ defmodule Ecto.Integration.Post do
     field :links, {:map, :string}
     field :intensities, {:map, :float}
     field :posted, :date
+    field :read_only, :string, mode: :readonly
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
     has_many :force_comments, Ecto.Integration.Comment, on_replace: :delete_if_exists
     has_many :ordered_comments, Ecto.Integration.Comment, preload_order: [:text]

--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -46,7 +46,7 @@ defmodule Ecto.Integration.Post do
     field :links, {:map, :string}
     field :intensities, {:map, :float}
     field :posted, :date
-    field :read_only, :string, mode: :readonly
+    field :read_only, :string, read_only: true
     has_many :comments, Ecto.Integration.Comment, on_delete: :delete_all, on_replace: :delete
     has_many :force_comments, Ecto.Integration.Comment, on_replace: :delete_if_exists
     has_many :ordered_comments, Ecto.Integration.Comment, preload_order: [:text]

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2040,7 +2040,7 @@ defmodule Ecto.Query.Planner do
 
             case dumper do
               %{^k => {_, _, false}} -> :ok
-              %{}-> error! query, "cannot update unwritable field `#{k}`"
+              %{} -> error! query, "cannot update unwritable field `#{k}`"
               nil -> :ok
             end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2027,8 +2027,7 @@ defmodule Ecto.Query.Planner do
   defp cte_fields([], [], _aliases), do: []
 
   defp assert_update!(%Ecto.Query{updates: updates} = query, operation) do
-    schema = schema_for_update(query)
-    dumper = schema && schema.__schema__(:dump)
+    dumper = dumper_for_update(query)
 
     changes =
       Enum.reduce(updates, %{}, fn update, acc ->
@@ -2079,10 +2078,13 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp schema_for_update(query) do
+  defp dumper_for_update(query) do
     case get_source!(:updates, query, 0) do
-      {source, schema, _} when is_binary(source) -> schema
-      _ -> nil
+      {source, schema, _} when is_binary(source) and schema != nil ->
+        schema.__schema__(:dump)
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2027,10 +2027,10 @@ defmodule Ecto.Query.Planner do
   defp cte_fields([], [], _aliases), do: []
 
   defp assert_update!(%Ecto.Query{updates: updates} = query, operation) do
-    modes =
+    read_only_fields =
       case get_source!(:updates, query, 0) do
         {source, schema, _} when is_binary(source) and schema != nil ->
-          schema.__schema__(:mode)
+          schema.__schema__(:read_only)
 
         _ ->
           %{}
@@ -2044,8 +2044,8 @@ defmodule Ecto.Query.Planner do
               error! query, "duplicate field `#{k}` for `#{operation}`"
             end
 
-            case modes do
-              %{^k => :readonly} ->
+            case read_only_fields do
+              %{^k => _} ->
                 error! query, "cannot update read only field `#{k}`"
 
               _ ->

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -171,7 +171,7 @@ defmodule Ecto.Repo.Schema do
 
   defp init_mapper(schema, dumper, adapter, placeholder_map) do
     fn {field, value}, acc ->
-      unless schema.__schema__(:writable_type, field) do
+      unless writable_field?(schema, field) do
         raise ArgumentError, "cannot give unwritable field `#{field}` to insert_all"
       end
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -768,7 +768,7 @@ defmodule Ecto.Repo.Schema do
   defp writable_field?(nil, _field), do: true
 
   defp writable_field?(schema, field) do
-    not is_nil(schema.__schema__(:writable_type, field))
+    schema.__schema__(:writable_type, field) != nil
   end
 
   defp field_source!(nil, field) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -143,11 +143,11 @@ defmodule Ecto.Repo.Schema do
     end
 
     if schema do
-      modes = schema.__schema__(:mode)
+      read_only_fields = schema.__schema__(:read_only)
 
       Enum.each(header, fn field ->
-        case modes do
-          %{^field => :readonly} ->
+        case read_only_fields do
+          %{^field => _} ->
             raise ArgumentError, "cannot give read only field `#{field}` to insert_all"
 
           _ ->
@@ -172,11 +172,11 @@ defmodule Ecto.Repo.Schema do
   end
 
   defp init_mapper(schema, dumper, adapter, placeholder_map) do
-    modes = schema.__schema__(:mode)
+    read_only_fields = schema.__schema__(:read_only)
 
     fn {field, value}, acc ->
-      case modes do
-        %{^field => :readonly} ->
+      case read_only_fields do
+        %{^field => _} ->
           raise ArgumentError, "cannot give read only field `#{field}` to insert_all"
 
         _ ->
@@ -735,12 +735,12 @@ defmodule Ecto.Repo.Schema do
         {{:nothing, [], conflict_target}, []}
 
       {:replace, keys} when is_list(keys) ->
-        modes = schema && schema.__schema__(:mode) || %{}
+        read_only_fields = schema && schema.__schema__(:read_only) || %{}
 
         fields =
           Enum.map(keys, fn key ->
-            case modes do
-              %{^key => :readonly} ->
+            case read_only_fields do
+              %{^key => _} ->
                 raise ArgumentError, "cannot replace read only field `#{key}` in :on_conflict option"
 
               _ ->

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -427,8 +427,9 @@ defmodule Ecto.Schema do
   * `__schema__(:virtual_fields)` - Returns a list of all virtual field names;
   * `__schema__(:field_source, field)` - Returns the alias of the given field;
 
-  * `__schema__(:type, field)` - Returns the type of the given non-virtual field;
+  * `__schema__(:type, field)` - Returns the type of the given non-virtual, non-read only field;
   * `__schema__(:virtual_type, field)` - Returns the type of the given virtual field;
+  * `__schema__(:mode, field)` - Returns the `:mode` of the field. Either `:readwrite` or `:readonly`;
 
   * `__schema__(:associations)` - Returns a list of all association field names;
   * `__schema__(:association, assoc)` - Returns the association reflection of the given assoc;
@@ -505,6 +506,7 @@ defmodule Ecto.Schema do
       Module.register_attribute(__MODULE__, :ecto_autogenerate, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_autoupdate, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_redact_fields, accumulate: true)
+      Module.register_attribute(__MODULE__, :ecto_field_modes, accumulate: true)
       Module.put_attribute(__MODULE__, :ecto_derive_inspect_for_redacted_fields, true)
       Module.put_attribute(__MODULE__, :ecto_autogenerate_id, nil)
     end
@@ -525,8 +527,12 @@ defmodule Ecto.Schema do
     :type,
     :where,
     :references,
-    :skip_default_validation
+    :skip_default_validation,
+    :mode
   ]
+
+  @default_mode :readwrite
+  @allowed_modes [:readwrite, :readonly]
 
   @doc """
   Defines an embedded schema with the given field definitions.
@@ -631,6 +637,7 @@ defmodule Ecto.Schema do
         assocs = @ecto_assocs |> Enum.reverse()
         embeds = @ecto_embeds |> Enum.reverse()
         redacted_fields = @ecto_redact_fields
+        field_modes = @ecto_field_modes |> Enum.reverse()
         loaded = Ecto.Schema.__loaded__(__MODULE__, @ecto_struct_fields)
 
         if redacted_fields != [] and not List.keymember?(@derive, Inspect, 0) and
@@ -658,6 +665,9 @@ defmodule Ecto.Schema do
         def __schema__(:redact_fields), do: unquote(redacted_fields)
         def __schema__(:virtual_fields), do: unquote(Enum.map(virtual_fields, &elem(&1, 0)))
 
+        def __schema__(:writable_fields),
+          do: unquote(for {name, mode} when mode != :readonly <- field_modes, do: name)
+
         def __schema__(:autogenerate_fields),
           do: unquote(Enum.flat_map(autogenerate, &elem(&1, 0)))
 
@@ -671,7 +681,7 @@ defmodule Ecto.Schema do
         end
 
         for clauses <-
-              Ecto.Schema.__schema__(fields, field_sources, assocs, embeds, virtual_fields),
+              Ecto.Schema.__schema__(fields, field_sources, assocs, embeds, virtual_fields, field_modes),
             {args, body} <- clauses do
           def __schema__(unquote_splicing(args)), do: unquote(body)
         end
@@ -745,6 +755,10 @@ defmodule Ecto.Schema do
 
     * `:skip_default_validation` - When true, it will skip the type validation
       step at compile time.
+
+    * `:mode` - Either `:readwrite` or `:readonly`. When `:readonly`, the field
+      can be selected from queries or `returning` clauses but can never be written to.
+      Defaults to `:readwrite`.
 
   """
   defmacro field(name, type \\ :string, opts \\ []) do
@@ -2007,6 +2021,7 @@ defmodule Ecto.Schema do
     # Check the field type before we check options because it is
     # better to raise unknown type first than unsupported option.
     type = check_field_type!(mod, name, type, opts)
+    mode = check_field_mode!(opts[:mode])
 
     if type == :any && !opts[:virtual] do
       raise ArgumentError,
@@ -2017,10 +2032,10 @@ defmodule Ecto.Schema do
     check_options!(type, opts, @field_opts, "field/3")
     Module.put_attribute(mod, :ecto_changeset_fields, {name, type})
     validate_default!(type, opts[:default], opts[:skip_default_validation])
-    define_field(mod, name, type, opts)
+    define_field(mod, name, type, mode, opts)
   end
 
-  defp define_field(mod, name, type, opts) do
+  defp define_field(mod, name, type, mode, opts) do
     virtual? = opts[:virtual] || false
     pk? = opts[:primary_key] || false
     put_struct_field(mod, name, Keyword.get(opts, :default))
@@ -2062,6 +2077,10 @@ defmodule Ecto.Schema do
         raise ArgumentError, "cannot mark the same field as autogenerate and read_after_writes"
       end
 
+      if mode == :readonly && gen do
+        raise ArgumentError, "cannot mark the same field as autogenerate and read only"
+      end
+
       if pk? do
         Module.put_attribute(mod, :ecto_primary_keys, name)
       end
@@ -2070,6 +2089,7 @@ defmodule Ecto.Schema do
         Module.put_attribute(mod, :ecto_query_fields, {name, type})
       end
 
+      Module.put_attribute(mod, :ecto_field_modes, {name, mode})
       Module.put_attribute(mod, :ecto_fields, {name, type})
     end
   end
@@ -2165,7 +2185,7 @@ defmodule Ecto.Schema do
 
     if Keyword.get(opts, :define_field, true) do
       Module.put_attribute(mod, :ecto_changeset_fields, {foreign_key_name, foreign_key_type})
-      define_field(mod, foreign_key_name, foreign_key_type, opts)
+      define_field(mod, foreign_key_name, foreign_key_type, @default_mode, opts)
     end
 
     struct =
@@ -2269,7 +2289,7 @@ defmodule Ecto.Schema do
   end
 
   @doc false
-  def __schema__(fields, field_sources, assocs, embeds, virtual_fields) do
+  def __schema__(fields, field_sources, assocs, embeds, virtual_fields, field_modes) do
     load =
       for {name, type} <- fields do
         if alias = field_sources[name] do
@@ -2282,6 +2302,11 @@ defmodule Ecto.Schema do
     dump =
       for {name, type} <- fields do
         {name, {field_sources[name] || name, type}}
+      end
+
+    modes_quoted =
+      for {name, mode} <- field_modes do
+        {[:mode, name], mode}
       end
 
     field_sources_quoted =
@@ -2315,6 +2340,7 @@ defmodule Ecto.Schema do
 
     single_arg = [
       {[:dump], dump |> Map.new() |> Macro.escape()},
+      {[:mode], field_modes |> Map.new() |> Macro.escape()},
       {[:load], load |> Macro.escape()},
       {[:associations], assoc_names},
       {[:embeds], embed_names}
@@ -2322,6 +2348,7 @@ defmodule Ecto.Schema do
 
     catch_all = [
       {[:field_source, quote(do: _)], nil},
+      {[:mode, quote(do: _)], nil},
       {[:type, quote(do: _)], nil},
       {[:virtual_type, quote(do: _)], nil},
       {[:association, quote(do: _)], nil},
@@ -2331,6 +2358,7 @@ defmodule Ecto.Schema do
     [
       single_arg,
       field_sources_quoted,
+      modes_quoted,
       types_quoted,
       virtual_types_quoted,
       assoc_quoted,
@@ -2347,7 +2375,7 @@ defmodule Ecto.Schema do
 
     Module.put_attribute(mod, :ecto_changeset_fields, {name, {:embed, struct}})
     Module.put_attribute(mod, :ecto_embeds, {name, struct})
-    define_field(mod, name, {:parameterized, Ecto.Embedded, struct}, opts)
+    define_field(mod, name, {:parameterized, Ecto.Embedded, struct}, @default_mode, opts)
   end
 
   defp put_struct_field(mod, name, assoc) do
@@ -2433,6 +2461,13 @@ defmodule Ecto.Schema do
       true ->
         raise ArgumentError, "unknown type #{inspect(type)} for field #{inspect(name)}"
     end
+  end
+
+  defp check_field_mode!(nil), do: @default_mode
+  defp check_field_mode!(mode) when mode in @allowed_modes, do: mode
+
+  defp check_field_mode!(other) do
+    raise ArgumentError, "invalid mode #{inspect(other)}. Expected `:readwrite` or `:readonly`"
   end
 
   defp composite?({composite, _} = type, name) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -505,7 +505,7 @@ defmodule Ecto.Schema do
       Module.register_attribute(__MODULE__, :ecto_autogenerate, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_autoupdate, accumulate: true)
       Module.register_attribute(__MODULE__, :ecto_redact_fields, accumulate: true)
-      Module.register_attribute(__MODULE__, :ecto_writable_fields, accumulate: true)
+      Module.register_attribute(__MODULE__, :ecto_read_only, accumulate: true)
       Module.put_attribute(__MODULE__, :ecto_derive_inspect_for_redacted_fields, true)
       Module.put_attribute(__MODULE__, :ecto_autogenerate_id, nil)
     end
@@ -633,7 +633,7 @@ defmodule Ecto.Schema do
         assocs = @ecto_assocs |> Enum.reverse()
         embeds = @ecto_embeds |> Enum.reverse()
         redacted_fields = @ecto_redact_fields
-        writable_fields = @ecto_writable_fields |> Enum.reverse()
+        read_only = @ecto_read_only |> Enum.reverse()
         loaded = Ecto.Schema.__loaded__(__MODULE__, @ecto_struct_fields)
 
         if redacted_fields != [] and not List.keymember?(@derive, Inspect, 0) and
@@ -660,7 +660,7 @@ defmodule Ecto.Schema do
         def __schema__(:loaded), do: unquote(Macro.escape(loaded))
         def __schema__(:redact_fields), do: unquote(redacted_fields)
         def __schema__(:virtual_fields), do: unquote(Enum.map(virtual_fields, &elem(&1, 0)))
-        def __schema__(:writable_fields), do: unquote(Enum.map(writable_fields, &elem(&1, 0)))
+        def __schema__(:writable_fields), do: unquote(for {name, false} <- read_only, do: name)
 
         def __schema__(:autogenerate_fields),
           do: unquote(Enum.flat_map(autogenerate, &elem(&1, 0)))
@@ -675,7 +675,7 @@ defmodule Ecto.Schema do
         end
 
         for clauses <-
-              Ecto.Schema.__schema__(fields, field_sources, assocs, embeds, virtual_fields, writable_fields),
+              Ecto.Schema.__schema__(fields, field_sources, assocs, embeds, virtual_fields, read_only),
             {args, body} <- clauses do
           def __schema__(unquote_splicing(args)), do: unquote(body)
         end
@@ -2081,10 +2081,7 @@ defmodule Ecto.Schema do
         Module.put_attribute(mod, :ecto_query_fields, {name, type})
       end
 
-      unless read_only? do
-        Module.put_attribute(mod, :ecto_writable_fields, {name, type})
-      end
-
+      Module.put_attribute(mod, :ecto_read_only, {name, read_only?})
       Module.put_attribute(mod, :ecto_fields, {name, type})
     end
   end
@@ -2284,7 +2281,7 @@ defmodule Ecto.Schema do
   end
 
   @doc false
-  def __schema__(fields, field_sources, assocs, embeds, virtual_fields, writable_fields) do
+  def __schema__(fields, field_sources, assocs, embeds, virtual_fields, read_only) do
     load =
       for {name, type} <- fields do
         if alias = field_sources[name] do
@@ -2296,7 +2293,7 @@ defmodule Ecto.Schema do
 
     dump =
       for {name, type} <- fields do
-        {name, {field_sources[name] || name, type}}
+        {name, {field_sources[name] || name, type, read_only[name]}}
       end
 
     field_sources_quoted =
@@ -2312,11 +2309,6 @@ defmodule Ecto.Schema do
     virtual_types_quoted =
       for {name, type} <- virtual_fields do
         {[:virtual_type, name], Macro.escape(type)}
-      end
-
-    writable_types_quoted =
-      for {name, type} <- writable_fields do
-        {[:writable_type, name], Macro.escape(type)}
       end
 
     assoc_quoted =
@@ -2344,7 +2336,6 @@ defmodule Ecto.Schema do
       {[:field_source, quote(do: _)], nil},
       {[:type, quote(do: _)], nil},
       {[:virtual_type, quote(do: _)], nil},
-      {[:writable_type, quote(do: _)], nil},
       {[:association, quote(do: _)], nil},
       {[:embed, quote(do: _)], nil}
     ]
@@ -2354,7 +2345,6 @@ defmodule Ecto.Schema do
       field_sources_quoted,
       types_quoted,
       virtual_types_quoted,
-      writable_types_quoted,
       assoc_quoted,
       embed_quoted,
       catch_all

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -427,7 +427,7 @@ defmodule Ecto.Schema do
   * `__schema__(:virtual_fields)` - Returns a list of all virtual field names;
   * `__schema__(:field_source, field)` - Returns the alias of the given field;
 
-  * `__schema__(:type, field)` - Returns the type of the given non-virtual, non-read only field;
+  * `__schema__(:type, field)` - Returns the type of the given non-virtual field;
   * `__schema__(:virtual_type, field)` - Returns the type of the given virtual field;
   * `__schema__(:mode, field)` - Returns the `:mode` of the field. Either `:readwrite` or `:readonly`;
 

--- a/lib/ecto/schema/loader.ex
+++ b/lib/ecto/schema/loader.ex
@@ -91,7 +91,7 @@ defmodule Ecto.Schema.Loader do
   Dumps the given data.
   """
   def safe_dump(struct, types, dumper) do
-    Enum.reduce(types, %{}, fn {field, {source, type}}, acc ->
+    Enum.reduce(types, %{}, fn {field, {source, type, _read_only?}}, acc ->
       value = Map.get(struct, field)
 
       case dumper.(type, value) do

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -97,6 +97,7 @@ defmodule Ecto.ChangesetTest do
       field :topics, {:array, :string}
       field :seo_metadata, :map
       field :virtual, :string, virtual: true
+      field :read_only, :string, mode: :readonly
       field :published_at, :naive_datetime
       field :source, :map
       field :permalink, :string, source: :url
@@ -120,7 +121,7 @@ defmodule Ecto.ChangesetTest do
   end
 
   defp changeset(schema \\ %Post{}, params) do
-    cast(schema, params, ~w(id token title author_email body upvotes decimal color topics seo_metadata virtual)a)
+    cast(schema, params, ~w(id token title author_email body upvotes decimal color topics seo_metadata virtual read_only)a)
   end
 
   defmodule CustomError do
@@ -1066,6 +1067,14 @@ defmodule Ecto.ChangesetTest do
     changeset =
       changeset(%{"virtual" => "hello"})
       |> validate_change(:virtual, fn :virtual, "hello" -> [] end)
+
+    assert changeset.valid?
+    assert changeset.errors == []
+
+    # When read only
+    changeset =
+      changeset(%{"read_only" => "hello"})
+      |> validate_change(:read_only, fn :read_only, "hello" -> [] end)
 
     assert changeset.valid?
     assert changeset.errors == []
@@ -2409,6 +2418,7 @@ defmodule Ecto.ChangesetTest do
       field :username, :string
       field :display_name, :string, redact: false
       field :virtual_pass, :string, redact: true, virtual: true
+      field :read_only_pass, :string, redact: true, mode: :readonly
     end
   end
 
@@ -2459,6 +2469,12 @@ defmodule Ecto.ChangesetTest do
 
     test "redacts virtual fields marked redact: true" do
       changeset = Ecto.Changeset.cast(%RedactedSchema{}, %{virtual_pass: "hunter2"}, [:virtual_pass])
+      refute inspect(changeset) =~ "hunter2"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+
+    test "redacts read only fields marked redact: true" do
+      changeset = Ecto.Changeset.cast(%RedactedSchema{}, %{read_only_pass: "hunter2"}, [:read_only_pass])
       refute inspect(changeset) =~ "hunter2"
       assert inspect(changeset) =~ "**redacted**"
     end

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -97,7 +97,7 @@ defmodule Ecto.ChangesetTest do
       field :topics, {:array, :string}
       field :seo_metadata, :map
       field :virtual, :string, virtual: true
-      field :read_only, :string, mode: :readonly
+      field :read_only, :string, read_only: true
       field :published_at, :naive_datetime
       field :source, :map
       field :permalink, :string, source: :url
@@ -2418,7 +2418,7 @@ defmodule Ecto.ChangesetTest do
       field :username, :string
       field :display_name, :string, redact: false
       field :virtual_pass, :string, redact: true, virtual: true
-      field :read_only_pass, :string, redact: true, mode: :readonly
+      field :read_only_pass, :string, redact: true, read_only: true
     end
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -630,8 +630,8 @@ defmodule Ecto.RepoTest do
         from s in MySchema,
           where: s.x > ^threshold,
           select: %{
-            foo: s.x,
-            bar: fragment("concat(?, ?, ?)", ^"one", ^"two", s.z)
+            x: s.x,
+            y: fragment("concat(?, ?, ?)", ^"one", ^"two", s.z)
           }
 
       TestRepo.insert_all(MySchema, query)
@@ -648,9 +648,9 @@ defmodule Ecto.RepoTest do
         from s in MySchema,
           where: s.x > ^threshold,
           select: %{
-            foo: s.x,
-            bar: "bar",
-            baz: nil
+            x: s.x,
+            y: "bar",
+            z: nil
           }
 
       TestRepo.insert_all(MySchema, query)
@@ -663,7 +663,7 @@ defmodule Ecto.RepoTest do
     test "takes query selecting on struct" do
       query =
         from s in MySchema,
-          select: struct(s, [:foo, :bar])
+          select: struct(s, [:x, :y])
 
       TestRepo.insert_all(MySchema, query)
 
@@ -673,7 +673,7 @@ defmodule Ecto.RepoTest do
     test "takes query selecting on map" do
       query =
         from s in MySchema,
-          select: map(s, [:foo, :bar])
+          select: map(s, [:x, :y])
 
       TestRepo.insert_all(MySchema, query)
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1658,7 +1658,7 @@ defmodule Ecto.RepoTest do
     end
 
     test "raises on non-existent fields on replace" do
-      msg = "cannot replace unwritable field `unknown` in :on_conflict option"
+      msg = "cannot replace unwritable field `:unknown` in :on_conflict option"
 
       assert_raise ArgumentError, msg, fn ->
         TestRepo.insert(

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1658,7 +1658,9 @@ defmodule Ecto.RepoTest do
     end
 
     test "raises on non-existent fields on replace" do
-      assert_raise ArgumentError, "unknown field for :on_conflict, got: :unknown", fn ->
+      msg = "cannot replace unwritable field `unknown` in :on_conflict option"
+
+      assert_raise ArgumentError, msg, fn ->
         TestRepo.insert(
           %MySchema{id: 1},
           on_conflict: {:replace, [:unknown]}

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -15,6 +15,7 @@ defmodule Ecto.SchemaTest do
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
       field :no_query_load, :string, load_in_query: false
+      field :read_only, :string, mode: :readonly
       belongs_to :comment, Comment
       belongs_to :permalink, Permalink, define_field: false
     end
@@ -25,13 +26,18 @@ defmodule Ecto.SchemaTest do
     assert Schema.__schema__(:prefix) == nil
 
     assert Schema.__schema__(:fields) ==
+             [:id, :name, :email, :password, :count, :array, :uuid, :no_query_load, :read_only, :comment_id]
+
+    assert Schema.__schema__(:writable_fields) ==
              [:id, :name, :email, :password, :count, :array, :uuid, :no_query_load, :comment_id]
 
     assert Schema.__schema__(:virtual_fields) == [:temp]
 
     assert Schema.__schema__(:query_fields) ==
-             [:id, :name, :email, :password, :count, :array, :uuid, :comment_id]
+             [:id, :name, :email, :password, :count, :array, :uuid, :read_only, :comment_id]
 
+    assert Schema.__schema__(:mode, :read_only) == :readonly
+    assert Schema.__schema__(:mode, :name) == :readwrite
     assert Schema.__schema__(:read_after_writes) == [:email, :count]
     assert Schema.__schema__(:primary_key) == [:id]
     assert Schema.__schema__(:autogenerate_id) == {:id, :id, :id}
@@ -68,7 +74,8 @@ defmodule Ecto.SchemaTest do
                temp: :any,
                id: :id,
                uuid: Ecto.UUID,
-               no_query_load: :string
+               no_query_load: :string,
+               read_only: :string
              }
   end
 
@@ -579,6 +586,18 @@ defmodule Ecto.SchemaTest do
 
                      schema "hello" do
                        field :x, Ecto.UUID, autogenerate: true, read_after_writes: true
+                     end
+                   end
+                 end
+
+    assert_raise ArgumentError,
+                 "cannot mark the same field as autogenerate and read only",
+                 fn ->
+                   defmodule AutogenerateFail do
+                     use Ecto.Schema
+
+                     schema "hello" do
+                       field :x, Ecto.UUID, autogenerate: true, mode: :readonly
                      end
                    end
                  end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -36,8 +36,8 @@ defmodule Ecto.SchemaTest do
     assert Schema.__schema__(:query_fields) ==
              [:id, :name, :email, :password, :count, :array, :uuid, :read_only, :comment_id]
 
-    assert Schema.__schema__(:read_only, :read_only) == true
-    assert Schema.__schema__(:read_only, :name) == false
+    assert Schema.__schema__(:writable_type, :read_only) == nil
+    assert Schema.__schema__(:writable_type, :name) == :string
     assert Schema.__schema__(:read_after_writes) == [:email, :count]
     assert Schema.__schema__(:primary_key) == [:id]
     assert Schema.__schema__(:autogenerate_id) == {:id, :id, :id}

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -15,7 +15,7 @@ defmodule Ecto.SchemaTest do
       field :array, {:array, :string}
       field :uuid, Ecto.UUID, autogenerate: true
       field :no_query_load, :string, load_in_query: false
-      field :read_only, :string, mode: :readonly
+      field :read_only, :string, read_only: true
       belongs_to :comment, Comment
       belongs_to :permalink, Permalink, define_field: false
     end
@@ -36,8 +36,8 @@ defmodule Ecto.SchemaTest do
     assert Schema.__schema__(:query_fields) ==
              [:id, :name, :email, :password, :count, :array, :uuid, :read_only, :comment_id]
 
-    assert Schema.__schema__(:mode, :read_only) == :readonly
-    assert Schema.__schema__(:mode, :name) == :readwrite
+    assert Schema.__schema__(:read_only, :read_only) == true
+    assert Schema.__schema__(:read_only, :name) == false
     assert Schema.__schema__(:read_after_writes) == [:email, :count]
     assert Schema.__schema__(:primary_key) == [:id]
     assert Schema.__schema__(:autogenerate_id) == {:id, :id, :id}
@@ -597,7 +597,7 @@ defmodule Ecto.SchemaTest do
                      use Ecto.Schema
 
                      schema "hello" do
-                       field :x, Ecto.UUID, autogenerate: true, mode: :readonly
+                       field :x, Ecto.UUID, autogenerate: true, read_only: true
                      end
                    end
                  end

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -36,8 +36,6 @@ defmodule Ecto.SchemaTest do
     assert Schema.__schema__(:query_fields) ==
              [:id, :name, :email, :password, :count, :array, :uuid, :read_only, :comment_id]
 
-    assert Schema.__schema__(:writable_type, :read_only) == nil
-    assert Schema.__schema__(:writable_type, :name) == :string
     assert Schema.__schema__(:read_after_writes) == [:email, :count]
     assert Schema.__schema__(:primary_key) == [:id]
     assert Schema.__schema__(:autogenerate_id) == {:id, :id, :id}


### PR DESCRIPTION
### Motivation

The `:mode` option will allow users to choose if a field should be read only or read-write. It is basically the same as adding a `:read_only` option only having a single field will let us add write only fields in the same place later on instead of creating a new field, if we want to add it.

Read only fields are useful for a few reasons:

1. We recently added the `generated` option to migrations. This allows users to put them into their schemas and have them just work™.
2. There are some workflows that benefit from having read only fields. For example, this option issue: https://github.com/elixir-ecto/ecto/issues/4251. The user would like two copies of the same field in their schema.
3. It solves part of the problems stated in this PR: https://github.com/elixir-ecto/ecto/pull/4261. Users can create generated fields in their migrations and utilize them in much the same way that was described in that issue. There are some limitations/differences but there is some overlap there.

### Changes

There were a lot of cases to consider. I will list them below:

**Casting**

- We allow casting read only fields the same way we do for virtual fields. The user might want to work with the changeset but not persist the field.

**Insert**

- When surfacing the changes, we silently filter read only fields, same as virtual fields. This is really the only way it can work because all fields are surfaced on insert so it doesn't make sense to raise.
- We want read only fields to be returned when `returning: true` is specified
- We don't want read only fields to be updated in `on_conflict`. They will be silently ignored for `replace_all` because the user is not specifying them. For `{:replace, fields}` and conflict queries an error will be raised because the user is going out of their way to specify them.

**Insert All**

- We raise immediately if a header contains a read only field. Both for lists of maps and insert queries.
- Same behaviour for `returning` and `on conflict` applies here as it did for `insert`

**Update**

- Same as `insert`, we silently ignore read only fields in the changeset. It might make sense to raise here but we don't do so for virtual fields. If we want to change one I think there's a case to change both.
- Same behaviour as `insert` for `returning`. There is no `on_conflict` to worry about.

**Update All**

- Raise if a read only field is given to the `:update` key in the query. 

**Select**

- The read only fields should be able to be selected
- The read only fields should be part of selecting the entire struct
- The read only fields should be allowed to be used as query parameters

**Delete**

- Read only fields don't come into play here

**Delete All**

- Same behaviour as select queries

