### PR TITLE
Fix docs: example in `Repo.transaction`

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -2079,8 +2079,8 @@ defmodule Ecto.Repo do
       end)
 
   If the changeset is valid, but the insert operation fails due to a database constraint,
-  the subsequent `repo.insert(%Failure{})` operation will raise an exception because the
-  database has already aborted the transaction and thus making the operation invalid.
+  the subsequent `repo.insert(%Status{value: "failure"})` operation will raise an exception
+  because the database has already aborted the transaction and thus making the operation invalid.
   In Postgres, the exception would look like this:
 
       ** (Postgrex.Error) ERROR 25P02 (in_failed_sql_transaction) current transaction is aborted, commands ignored until end of transaction block
@@ -2098,7 +2098,7 @@ defmodule Ecto.Repo do
 
   Another alternative is to handle this operation outside of the transaction.
   For example, you can choose to perform an explicit `repo.rollback` call in the
-  `{:error, changeset}` clause and then perform the `repo.insert(%Failure{})` outside
+  `{:error, changeset}` clause and then perform the `repo.insert(%Status{value: "failure"})` outside
   of the transaction. You might also consider using `Ecto.Multi`, as they automatically
   rollback whenever an operation fails.
 


### PR DESCRIPTION
In the [Aborted Transactions](https://hexdocs.pm/ecto/Ecto.Repo.html#c:transaction/2-aborted-transactions) section of the documentation for `Repo.transaction/2`, I believe that:

> the subsequent `repo.insert(%Failure{})` operation

Should instead read:

> the subsequent `repo.insert(%Status{value: "failure"})` operation

To match the example code provided above (reproduced here for clarity):

```elixir
Repo.transaction(fn repo ->
  case repo.insert(changeset) do
    {:ok, post} ->
      repo.insert(%Status{value: "success"})
    {:error, changeset} ->
      repo.insert(%Status{value: "failure"})    # <- I think this is the line referred to
  end
end)
```