### PR TITLE
Fix misinfo in Repo.start_link/1 docs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -639,8 +639,8 @@ defmodule Ecto.Repo do
   @callback config() :: Keyword.t()
 
   @doc """
-  Starts any connection pooling or supervision and return `{:ok, pid}`
-  or just `:ok` if nothing needs to be done.
+  Starts any connection pooling or supervision tree required by
+  the Repo.
 
   Returns `{:error, {:already_started, pid}}` if the repo is already
   started or `{:error, term}` in case anything else goes wrong.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -639,8 +639,7 @@ defmodule Ecto.Repo do
   @callback config() :: Keyword.t()
 
   @doc """
-  Starts any connection pooling or supervision tree required by
-  the Repo.
+  Starts the Repo supervision tree.
 
   Returns `{:error, {:already_started, pid}}` if the repo is already
   started or `{:error, term}` in case anything else goes wrong.


### PR DESCRIPTION
Ecto never returns `:ok` there.
