### PR TITLE
Fix through association nested preloads

### DIFF
--- a/integration_test/support/schemas.exs
+++ b/integration_test/support/schemas.exs
@@ -98,6 +98,7 @@ defmodule Ecto.Integration.Comment do
     belongs_to :post, Ecto.Integration.Post
     belongs_to :author, Ecto.Integration.User
     has_one :post_permalink, through: [:post, :permalink]
+    has_one :author_permalink, through: [:author, :permalink]
   end
 
   def changeset(schema, params) do
@@ -124,6 +125,7 @@ defmodule Ecto.Integration.Permalink do
     belongs_to :update_post, Ecto.Integration.Post, on_replace: :update, foreign_key: :post_id, define_field: false
     belongs_to :user, Ecto.Integration.User
     has_many :post_comments_authors, through: [:post, :comments_authors]
+    has_many :user_posts, through: [:user, :posts]
   end
 
   def changeset(schema, params) do

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1137,14 +1137,7 @@ defmodule Ecto.Repo do
 
     * `:force` - By default, Ecto won't preload associations that
       are already loaded. By setting this option to true, any existing
-      association will be discarded and reloaded. This behaviour only
-      applies to non-through associations. For through associations,
-      see the `:force_through` option.
-    * `:force_through` - By default, Ecto will preload through associations
-      even if they have already been loaded. By setting this option to false,
-      any existing through association will be kept instead of reloaded. The
-      chain of associations comprising the through association will still be
-      preloaded according to the `:force` option.
+      association will be discarded and reloaded.
     * `:in_parallel` - If the preloads must be done in parallel. It can
       only be performed when we have more than one preload and the
       repository is not in a transaction. Defaults to `true`.

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1137,7 +1137,14 @@ defmodule Ecto.Repo do
 
     * `:force` - By default, Ecto won't preload associations that
       are already loaded. By setting this option to true, any existing
-      association will be discarded and reloaded.
+      association will be discarded and reloaded. This behaviour only
+      applies to non-through associations. For through associations,
+      see the `:force_through` option.
+    * `:force_through` - By default, Ecto will preload through associations
+      even if they have already been loaded. By setting this option to false,
+      any existing through association will be kept instead of reloaded. The
+      chain of associations comprising the through association will still be
+      preloaded according to the `:force` option.
     * `:in_parallel` - If the preloads must be done in parallel. It can
       only be performed when we have more than one preload and the
       repository is not in a transaction. Defaults to `true`.

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -12,14 +12,14 @@ defmodule Ecto.Repo.Preloader do
   Transforms a result set based on query preloads, loading
   the associations onto their parent schema.
   """
-  @spec query([list], Ecto.Repo.t, list, Access.t, fun, {adapter_meta :: map, opts :: Keyword.t}) :: [list]
-  def query([], _repo_name, _preloads, _take, _fun, _tuplet), do: []
-  def query(rows, _repo_name, [], _take, fun, _tuplet), do: Enum.map(rows, fun)
+  @spec query([list], Ecto.Repo.t, list, Access.t, list, fun, {adapter_meta :: map, opts :: Keyword.t}) :: [list]
+  def query([], _repo_name, _preloads, _take, _assocs, _fun, _tuplet), do: []
+  def query(rows, _repo_name, [], _take, _assocs, fun, _tuplet), do: Enum.map(rows, fun)
 
-  def query(rows, repo_name, preloads, take, fun, tuplet) do
+  def query(rows, repo_name, preloads, take, assocs, fun, tuplet) do
     rows
     |> extract()
-    |> normalize_and_preload_each(repo_name, preloads, take, tuplet)
+    |> normalize_and_preload_each(repo_name, preloads, take, assocs, tuplet)
     |> unextract(rows, fun)
   end
 
@@ -41,16 +41,17 @@ defmodule Ecto.Repo.Preloader do
   end
 
   def preload(structs, repo_name, preloads, {_adapter_meta, opts} = tuplet) when is_list(structs) do
-    normalize_and_preload_each(structs, repo_name, preloads, opts[:take], tuplet)
+    normalize_and_preload_each(structs, repo_name, preloads, opts[:take], [], tuplet)
   end
 
   def preload(struct, repo_name, preloads, {_adapter_meta, opts} = tuplet) when is_map(struct) do
-    normalize_and_preload_each([struct], repo_name, preloads, opts[:take], tuplet) |> hd()
+    normalize_and_preload_each([struct], repo_name, preloads, opts[:take], [], tuplet) |> hd()
   end
 
-  defp normalize_and_preload_each(structs, repo_name, preloads, take, tuplet) do
+  defp normalize_and_preload_each(structs, repo_name, preloads, take, query_assocs, tuplet) do
     preloads = normalize(preloads, take, preloads)
-    preload_each(structs, repo_name, preloads, tuplet)
+    query_assocs = normalize_query_assocs(query_assocs)
+    preload_each(structs, repo_name, preloads, query_assocs, tuplet)
   rescue
     e ->
       # Reraise errors so we ignore the preload inner stacktrace
@@ -59,22 +60,21 @@ defmodule Ecto.Repo.Preloader do
 
   ## Preloading
 
-  defp preload_each(structs, _repo_name, [], _tuplet),   do: structs
-  defp preload_each([], _repo_name, _preloads, _tuplet), do: []
-  defp preload_each(structs, repo_name, preloads, tuplet) do
+  defp preload_each(structs, _repo_name, [], _query_assocs, _tuplet),   do: structs
+  defp preload_each([], _repo_name, _preloads, _query_assocs, _tuplet), do: []
+  defp preload_each(structs, repo_name, preloads, query_assocs, tuplet) do
     if sample = Enum.find(structs, & &1) do
       module = sample.__struct__
       prefix = preload_prefix(tuplet, sample)
-      {assocs, throughs, embeds} = expand(module, preloads, {%{}, [], []})
+      {assocs, throughs, embeds} = expand(module, preloads, query_assocs, {%{}, [], []})
       structs = preload_embeds(structs, embeds, repo_name, tuplet)
-      structs = preload_throughs(structs, throughs, repo_name, tuplet)
+      structs = preload_throughs(structs, throughs, repo_name, query_assocs, tuplet)
 
       {fetched_assocs, to_fetch_queries} =
         prepare_queries(structs, module, assocs, prefix, repo_name, tuplet)
 
       fetched_queries = maybe_pmap(to_fetch_queries, repo_name, tuplet)
-      assocs = preload_assocs(fetched_assocs, fetched_queries, repo_name, tuplet)
-      throughs = Enum.map(throughs, &elem(&1, 0))
+      assocs = preload_assocs(fetched_assocs, fetched_queries, repo_name, query_assocs, tuplet)
 
       for struct <- structs do
         struct = Enum.reduce assocs, struct, &load_assoc/2
@@ -149,20 +149,22 @@ defmodule Ecto.Repo.Preloader do
 
   # Then we unpack the query results, merge them, and preload recursively
   defp preload_assocs(
-         [{assoc, query?, loaded_ids, loaded_structs, preloads} | assocs],
+         [{assoc, query?, loaded_ids, loaded_structs, sub_preloads} | assocs],
          queries,
          repo_name,
+         query_assocs,
          tuplet
        ) do
     {fetch_ids, fetch_structs, queries} = maybe_unpack_query(query?, queries)
-    all = preload_each(Enum.reverse(loaded_structs, fetch_structs), repo_name, preloads, tuplet)
+    sub_query_assocs = Keyword.get(query_assocs, assoc.field, [])
+    all = preload_each(Enum.reverse(loaded_structs, fetch_structs), repo_name, sub_preloads, sub_query_assocs, tuplet)
     entry = {:assoc, assoc, assoc_map(assoc.cardinality, Enum.reverse(loaded_ids, fetch_ids), all)}
-    [entry | preload_assocs(assocs, queries, repo_name, tuplet)]
+    [entry | preload_assocs(assocs, queries, repo_name, query_assocs, tuplet)]
   end
 
-  defp preload_assocs([], [], _repo_name, _tuplet), do: []
+  defp preload_assocs([] = _assocs, [] = _queries, _, _, _), do: []
 
-  defp preload_embeds(structs, [], _repo_name, _tuplet), do: structs
+  defp preload_embeds(structs, [] = _embeds, _, _), do: structs
 
   defp preload_embeds(structs, [embed | embeds], repo_name, tuplet) do
     {%{field: field, cardinality: card}, sub_preloads} = embed
@@ -176,33 +178,43 @@ defmodule Ecto.Repo.Preloader do
         struct, _counts -> raise ArgumentError, "expected #{inspect(struct)} to contain embed `#{field}`"
       end)
 
-    embed_structs = preload_each(embed_structs, repo_name, sub_preloads, tuplet)
+    # It is not possible for an embed to preload through a join
+    # Therefore, we don't consider associations coming from queries
+    embed_structs = preload_each(embed_structs, repo_name, sub_preloads, [], tuplet)
     structs = put_through_or_embed(card, field, structs, embed_structs, Enum.reverse(counts), [])
     preload_embeds(structs, embeds, repo_name, tuplet)
   end
 
-  defp preload_throughs(structs, [], _repo_name, _tuplet), do: structs
+  defp preload_throughs(structs, [] = _throughs, _, _, _), do: structs
 
-  defp preload_throughs(structs, [through | throughs], repo_name, tuplet) do
-    {{_, %{field: field, cardinality: card}, _}, sub_preloads} = through
+  defp preload_throughs(
+         structs,
+         [{_, _, false = _from_query?} | throughs],
+         repo_name,
+         query_assocs,
+         tuplet
+       ) do
+    # We only preload through associations directly if they were previously loaded by a query.
+    # Otherwise, we preload the association chain.
+    preload_throughs(structs, throughs, repo_name, query_assocs, tuplet)
+  end
+
+  defp preload_throughs(structs, [through | throughs], repo_name, query_assocs, tuplet) do
+    {{_, %{field: field, cardinality: card}, _}, sub_preloads, true} = through
+    sub_query_assocs = Keyword.get(query_assocs, field, [])
 
     {through_structs, counts} =
       Enum.flat_map_reduce(structs, [], fn
         %{^field => throughs}, counts when is_list(throughs) -> {throughs, [length(throughs) | counts]}
         %{^field => nil}, counts -> {[], [0 | counts]}
-        %{^field => through}, counts ->
-          if Ecto.assoc_loaded?(through) do
-            {[through], [1 | counts]}
-          else
-            {[], [0 | counts]}
-          end
+        %{^field => through}, counts -> {[through], [1 | counts]}
         nil, counts -> {[], [0 | counts]}
         struct, _counts -> raise ArgumentError, "expected #{inspect(struct)} to contain through association `#{field}`"
       end)
 
-    through_structs = preload_each(through_structs, repo_name, sub_preloads, tuplet)
+    through_structs = preload_each(through_structs, repo_name, sub_preloads, sub_query_assocs, tuplet)
     structs = put_through_or_embed(card, field, structs, through_structs, Enum.reverse(counts), [])
-    preload_throughs(structs, throughs, repo_name, tuplet)
+    preload_throughs(structs, throughs, repo_name, query_assocs, tuplet)
   end
 
   defp put_through_or_embed(_card, _field, [], [], [], acc), do: Enum.reverse(acc)
@@ -464,15 +476,14 @@ defmodule Ecto.Repo.Preloader do
     Map.put(struct, field, loaded)
   end
 
-  defp load_through({:through, _assoc, _throughs}, nil) do
+  defp load_through({_, _, _}, nil) do
     nil
   end
 
-  defp load_through({:through, assoc, throughs}, struct) do
+  defp load_through({{:through, assoc, throughs}, _, from_query?}, struct) do
     %{cardinality: cardinality, field: field, owner: owner} = assoc
-    %{^field => value} = struct
 
-    if Ecto.assoc_loaded?(value) do
+    if from_query? do
       struct
     else
       {loaded, _} = Enum.reduce(throughs, {[struct], owner}, &recur_through/2)
@@ -604,9 +615,19 @@ defmodule Ecto.Repo.Preloader do
                          "preload expects an atom, a (nested) keyword or a (nested) list of atoms"
   end
 
+  defp normalize_query_assocs([]), do: []
+
+  defp normalize_query_assocs(assocs) when is_list(assocs) do
+    Enum.reduce(assocs, [], &normalize_each_query_assoc(&1, &2))
+  end
+
+  defp normalize_each_query_assoc({field, {_idx, sub_assocs}}, acc) do
+    [{field, normalize_query_assocs(sub_assocs)} | acc]
+  end
+
   ## Expand
 
-  def expand(schema, preloads, acc) do
+  def expand(schema, preloads, query_assocs, acc) do
     Enum.reduce(preloads, acc, fn {preload, {fields, query, sub_preloads}},
                                   {assocs, throughs, embeds} ->
       assoc_or_embed = association_or_embed!(schema, preload)
@@ -620,13 +641,17 @@ defmodule Ecto.Repo.Preloader do
           {assocs, throughs, embeds}
 
         {:through, _, through} ->
-          through =
-            through
-            |> Enum.reverse()
-            |> Enum.reduce({fields, query, sub_preloads}, &{nil, nil, [{&1, &2}]})
-            |> elem(2)
+          if Keyword.has_key?(query_assocs, preload) do
+            {assocs, [{info, sub_preloads, true} | throughs], embeds}
+          else
+            through =
+              through
+              |> Enum.reverse()
+              |> Enum.reduce({fields, query, sub_preloads}, &{nil, nil, [{&1, &2}]})
+              |> elem(2)
 
-          expand(schema, through, {assocs, [{info, sub_preloads} | throughs], embeds})
+            expand(schema, through, query_assocs, {assocs, [{info, sub_preloads, false} | throughs], embeds})
+          end
 
         :embed ->
           if sub_preloads == [] do

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -479,19 +479,13 @@ defmodule Ecto.Repo.Preloader do
     Map.put(struct, field, loaded)
   end
 
-  defp load_through({_, _, _}, nil) do
-    nil
-  end
+  defp load_through({_, _, _}, nil), do: nil
+  defp load_through({_, _, true = _from_query?}, struct), do: struct
 
-  defp load_through({{:through, assoc, throughs}, _, from_query?}, struct) do
+  defp load_through({{:through, assoc, throughs}, _, false = _from_query?}, struct) do
     %{cardinality: cardinality, field: field, owner: owner} = assoc
-
-    if from_query? do
-      struct
-    else
-      {loaded, _} = Enum.reduce(throughs, {[struct], owner}, &recur_through/2)
-      Map.put(struct, field, maybe_first(loaded, cardinality))
-    end
+    {loaded, _} = Enum.reduce(throughs, {[struct], owner}, &recur_through/2)
+    Map.put(struct, field, maybe_first(loaded, cardinality))
   end
 
   defp maybe_first(list, :one), do: List.first(list)

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -644,11 +644,10 @@ defmodule Ecto.Repo.Preloader do
           if Keyword.has_key?(query_assocs, preload) do
             {assocs, [{info, sub_preloads, true} | throughs], embeds}
           else
-            through =
+            {_, _, through} =
               through
               |> Enum.reverse()
               |> Enum.reduce({fields, query, sub_preloads}, &{nil, nil, [{&1, &2}]})
-              |> elem(2)
 
             expand(schema, through, query_assocs, {assocs, [{info, sub_preloads, false} | throughs], embeds})
           end

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -17,9 +17,15 @@ defmodule Ecto.Repo.Preloader do
   def query(rows, _repo_name, [], _take, fun, _tuplet), do: Enum.map(rows, fun)
 
   def query(rows, repo_name, preloads, take, fun, tuplet) do
+    # Don't reload through associations when they have already
+    # been loaded from a query. Otherwise nested associations
+    # from the query may be lost.
+    {adapter_meta, opts} = tuplet
+    opts = Keyword.put(opts, :force_through, false)
+
     rows
     |> extract()
-    |> normalize_and_preload_each(repo_name, preloads, take, tuplet)
+    |> normalize_and_preload_each(repo_name, preloads, take, {adapter_meta, opts})
     |> unextract(rows, fun)
   end
 
@@ -63,11 +69,18 @@ defmodule Ecto.Repo.Preloader do
   defp preload_each([], _repo_name, _preloads, _tuplet), do: []
   defp preload_each(structs, repo_name, preloads, tuplet) do
     if sample = Enum.find(structs, & &1) do
+      {_, opts} = tuplet
       module = sample.__struct__
       prefix = preload_prefix(tuplet, sample)
+      force_through? = opts[:force_through] || true
       {assocs, throughs, embeds} = expand(module, preloads, {%{}, [], []})
       structs = preload_embeds(structs, embeds, repo_name, tuplet)
-      structs = preload_throughs(structs, throughs, repo_name, tuplet)
+
+      # If forcing through associations, let the association chain overwrite it
+      structs =
+        if force_through?,
+          do: structs,
+          else: preload_loaded_throughs(structs, throughs, repo_name, tuplet)
 
       {fetched_assocs, to_fetch_queries} =
         prepare_queries(structs, module, assocs, prefix, repo_name, tuplet)
@@ -78,7 +91,7 @@ defmodule Ecto.Repo.Preloader do
 
       for struct <- structs do
         struct = Enum.reduce assocs, struct, &load_assoc/2
-        struct = Enum.reduce throughs, struct, &load_through/2
+        struct = Enum.reduce throughs, struct, &load_through(&1, &2, force_through?)
         struct
       end
     else
@@ -181,28 +194,33 @@ defmodule Ecto.Repo.Preloader do
     preload_embeds(structs, embeds, repo_name, tuplet)
   end
 
-  defp preload_throughs(structs, [], _repo_name, _tuplet), do: structs
+  defp preload_loaded_throughs(structs, [], _repo_name, _tuplet), do: structs
 
-  defp preload_throughs(structs, [through | throughs], repo_name, tuplet) do
+  defp preload_loaded_throughs(structs, [through | throughs], repo_name, tuplet) do
     {{_, %{field: field, cardinality: card}, _}, sub_preloads} = through
 
     {through_structs, counts} =
       Enum.flat_map_reduce(structs, [], fn
-        %{^field => throughs}, counts when is_list(throughs) -> {throughs, [length(throughs) | counts]}
-        %{^field => nil}, counts -> {[], [0 | counts]}
+        %{^field => throughs}, counts when is_list(throughs) ->
+          {throughs, [length(throughs) | counts]}
+
         %{^field => through}, counts ->
-          if Ecto.assoc_loaded?(through) do
+          if through != nil and Ecto.assoc_loaded?(through) do
             {[through], [1 | counts]}
           else
             {[], [0 | counts]}
           end
-        nil, counts -> {[], [0 | counts]}
-        struct, _counts -> raise ArgumentError, "expected #{inspect(struct)} to contain through association `#{field}`"
+
+        nil, counts ->
+          {[], [0 | counts]}
+
+        struct, _counts ->
+          raise ArgumentError, "expected #{inspect(struct)} to contain through association `#{field}`"
       end)
 
     through_structs = preload_each(through_structs, repo_name, sub_preloads, tuplet)
     structs = put_through_or_embed(card, field, structs, through_structs, Enum.reverse(counts), [])
-    preload_throughs(structs, throughs, repo_name, tuplet)
+    preload_loaded_throughs(structs, throughs, repo_name, tuplet)
   end
 
   defp put_through_or_embed(_card, _field, [], [], [], acc), do: Enum.reverse(acc)
@@ -464,15 +482,16 @@ defmodule Ecto.Repo.Preloader do
     Map.put(struct, field, loaded)
   end
 
-  defp load_through({:through, _assoc, _throughs}, nil) do
+  defp load_through({:through, _assoc, _throughs}, nil, _force?) do
     nil
   end
 
-  defp load_through({:through, assoc, throughs}, struct) do
+  defp load_through({:through, assoc, throughs}, struct, force?) do
     %{cardinality: cardinality, field: field, owner: owner} = assoc
     %{^field => value} = struct
+    loaded? = Ecto.assoc_loaded?(value) and not force?
 
-    if Ecto.assoc_loaded?(value) do
+    if loaded? do
       struct
     else
       {loaded, _} = Enum.reduce(throughs, {[struct], owner}, &recur_through/2)

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -235,7 +235,7 @@ defmodule Ecto.Repo.Queryable do
         {count,
          rows
          |> Ecto.Repo.Assoc.query(assocs, sources, preprocessor)
-         |> Ecto.Repo.Preloader.query(name, preloads, take, postprocessor, tuplet)}
+         |> Ecto.Repo.Preloader.query(name, preloads, take, assocs, postprocessor, tuplet)}
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4112

I didn't add tests yet because I wanted to see what you thought about the solution presented here and the alternative solution. This one is really tricky.

## Background

When using `Repo.preload`, it is possible for through associations to lose their nested preloads like this

```elixir
  from c in Comment, 
    join: t in ThroughAssoc,
    on: c.through_id == t.id, 
    join: u in User,
    on: t.user_id == u.id, 
    preload: [through_assoc: {t, [:some_other_assoc, user: u]}]
```

What happens is this:

1. The join preloads put User into ThroughAssoc and ThroughAssoc into Comment
2. The separate query preload puts :some_other_assoc into ThroughAssoc. However, it does this by generating the association chain and then putting it into the through field. This association chain does not have User inside of ThroughAssoc so that nested preload is lost.

## Solution

The solution in this PR is pretty simple. If the through association is already loaded then we preload directly into it. The same way we do for embeds. When determining whether to put the association chain into the through field, we simply don't put the association chain into the through field if it has already been loaded. However, the chain is still calculated and put into the "regular" association fields. 

The drawback of this method is that we are adding additional queries for the loaded through associations. Taking into account nested associations, this could end up with a decent amount of extra queries.

## Alternative Solution

The alternative solution is to not preload the association chain if the through association has been loaded. I tried this out first but it gets quite complex to the point where I'm not sure there is any sane way to do it. There are two main issues:

1. Different through associations can overlap in their association chains. For example:

- posts => author => location
- posts => author => company => department
- posts => author => company => manager => director

Depending on which of these 3  through fields are already loaded, we would have to keep track of which sub-preloads at each nested layer are to be kept.

2. Building off of point (1), the chain of preloads is dependent on which struct you are looking at. Since each struct can have different fields loaded/unloaded, not every one will have the same chain of nested preloads. This goes against the current flow in the code which assumes each struct in a give layer has the same sub-preloads. 

It also means we have to carry over information several layers deep. For example, a field on `post` might control whether `manager` is preloaded. But by the time we get to manager we've lost all the post information because we preload recursively.

