### PR TITLE
Fix compilation error when using prepend_order_by

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1103,7 +1103,7 @@ defmodule Ecto.Query do
 
   @from_join_opts [:as, :prefix, :hints]
   @no_binds [:union, :union_all, :except, :except_all, :intersect, :intersect_all]
-  @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
+  @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :prepend_order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge, :with_ctes]
 
   defp from([{type, expr} | t], env, count_bind, quoted, binds) when type in @binds do


### PR DESCRIPTION
If you are trying to use `Ecto.Query.prepend_order_by/3` it fails during compilation with 
```
** (Ecto.Query.CompileError) unsupported :prepend_order_by in keyword query expression
    (ecto 3.11.1) expanding macro: Ecto.Query.from/2
```
This is happening because `prepend_order_by` is not added to the `from` building function guard.