### PR TITLE
Improve prepend_order_by docs

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1946,7 +1946,7 @@ defmodule Ecto.Query do
   An order by query expression that is prepended to existing ones.
 
   Accepts the same input as `order_by/3` except the expression will
-  come before any previously defined `order_by` expression. This only
+  come before any previously defined order by expression. This only
   works with the macro-based query syntax and not the keyword-based
   query syntax.
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1943,7 +1943,22 @@ defmodule Ecto.Query do
   end
 
   @doc """
-  Same as `order_by/3` except new expressions will be prepended to existing ones.
+  An order by query expression that is prepended to existing ones.
+
+  Accepts the same input as `order_by/3` except the expression will
+  come before any previously defined `order_by` expression. This only
+  works with the macro-based query syntax and not the keyword-based
+  query syntax.
+
+  For example, the following will generate a query that orders by `human_popluation`
+  and then `name`:
+
+      City |> order_by([c], c.name) |> prepend_order_by([c], c.human_population)
+
+  The corresponding keyword-based syntax will raise an error:
+
+      from c in City, order_by: c.name, prepend_order_by: c.human_population
+
   """
   defmacro prepend_order_by(query, binding \\ [], expr) do
     Builder.OrderBy.build(query, binding, expr, :prepend, __CALLER__)


### PR DESCRIPTION
There was a PR a week or two ago where someone didn't realize this wouldn't work with the keyword syntax.