### PR TITLE
Fix typo in associations example

### DIFF
--- a/guides/cheatsheets/associations.cheatmd
+++ b/guides/cheatsheets/associations.cheatmd
@@ -272,7 +272,7 @@ IO.inspect(movie.characters)
 #=>  %{name: "Red", age: 60}]
 
 characters =
-  Enum.map(characters, fn character ->
+  Enum.map(movie.characters, fn character ->
     update_in(character.age, &(&1 + 1)))
   end)
 


### PR DESCRIPTION
Fix typo in associations example