### PR TITLE
Introduce is_named_binding guard

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.5
+VERSION 0.6
 
 all:
     BUILD \

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -529,6 +529,15 @@ defmodule Ecto.Query do
     end
   end
 
+  @doc """
+  Returns `true` if `query` has named binding `name`; otherwise returns `false`.
+
+  For more information on named bindings see "Named bindings" in this module doc.
+  """
+  @doc guard: true
+  defguard is_named_binding(query, name)
+           when is_struct(query, Ecto.Query) and is_map_key(query.aliases, name)
+
   @type t :: %__MODULE__{}
   @type dynamic_expr :: %DynamicExpr{}
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -529,15 +529,6 @@ defmodule Ecto.Query do
     end
   end
 
-  @doc """
-  Returns `true` if `query` has named binding `name`; otherwise returns `false`.
-
-  For more information on named bindings see "Named bindings" in this module doc.
-  """
-  @doc guard: true
-  defguard is_named_binding(query, name)
-           when is_struct(query, Ecto.Query) and is_map_key(query.aliases, name)
-
   @type t :: %__MODULE__{}
   @type dynamic_expr :: %DynamicExpr{}
 
@@ -2846,6 +2837,13 @@ defmodule Ecto.Query do
     raise RuntimeError,
           "callback function for with_named_binding/3 should return an Ecto.Query struct, got: #{inspect(other)}"
   end
+
+  @doc """
+  The same as `has_named_binding?/2` but allowed in guards.
+  """
+  @doc guard: true
+  defguard is_named_binding(query, name)
+           when is_struct(query, Ecto.Query) and is_map_key(query.aliases, name)
 
   @doc """
   Reverses the ordering of the query.

--- a/mix.exs
+++ b/mix.exs
@@ -59,6 +59,9 @@ defmodule Ecto.MixProject do
       source_url: @source_url,
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: extras(),
+      groups_for_docs: [
+        Guards: & &1[:guard] == true
+      ],
       groups_for_extras: groups_for_extras(),
       groups_for_functions: [
         group_for_function("Query API"),

--- a/mix.exs
+++ b/mix.exs
@@ -59,9 +59,6 @@ defmodule Ecto.MixProject do
       source_url: @source_url,
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: extras(),
-      groups_for_docs: [
-        Guards: & &1[:guard] == true
-      ],
       groups_for_extras: groups_for_extras(),
       groups_for_functions: [
         group_for_function("Query API"),

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1076,6 +1076,15 @@ defmodule Ecto.QueryTest do
                    ~r"protocol Ecto.Queryable not implemented for \[\]",
                    fn -> has_named_binding?([], :posts) end
     end
+
+    test "is_named_binding/2 guard" do
+      named_binding_query = from p in "posts", as: :posts
+      no_binding_query = from p in "posts"
+
+      assert is_named_binding(named_binding_query, :posts)
+      refute is_named_binding(no_binding_query, :posts)
+      refute is_named_binding("posts", :posts)
+    end
   end
 
   describe "with_named_binding/3" do


### PR DESCRIPTION
What do you think about adding this as a convenience? i.e. instead of

```elixir
def modify_query(query) do
  if has_named_binding?(query, :name) do
    ... do something ...
  else
    ... do something else ...
  end
end
```

you can do

```elixir
def modify_query(query) when is_named_binding(query, :name) do
  ... do something ...
end

def modify_query(query) do
  .. do something else...
end
```