### PR TITLE
Remove `is_named_binding` test

### DIFF
--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1083,7 +1083,6 @@ defmodule Ecto.QueryTest do
 
       assert is_named_binding(named_binding_query, :posts)
       refute is_named_binding(no_binding_query, :posts)
-      refute is_named_binding("posts", :posts)
     end
   end
 


### PR DESCRIPTION
 I noticed the following warning when running this test:

```elixir
warning: incompatible types:

    map() !~ binary()

in expression:

    # test/ecto/query_test.exs:1086
    arg1.aliases

where "arg1" was given the type binary() in:

    # test/ecto/query_test.exs:1086
    {arg1, arg2} = {"posts", :posts}

where "arg1" was given the type map() (due to calling var.field) in:

    # test/ecto/query_test.exs:1086
    arg1.aliases

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  test/ecto/query_test.exs:1086: Ecto.QueryTest."test has_named_binding?/1 is_named_binding/2 guard"/1
````

It seems like this is a known behaviour: https://github.com/elixir-lang/elixir/issues/10485

Since it's not likely the guard will be changed in a way that breaks this test, maybe we can just remove it to avoid having the warnings while we develop?