### PR TITLE
Raise if user tries to query embedded schema

### DIFF
--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -33,12 +33,15 @@ defimpl Ecto.Queryable, for: Atom do
       UndefinedFunctionError ->
         message =
           if :code.is_loaded(module) do
-            "the given module does not provide a schema"
+            "the given module either does not provide a schema"
           else
             "the given module does not exist"
           end
 
         raise Protocol.UndefinedError, protocol: @protocol, value: module, description: message
+
+      FunctionClauseError ->
+        raise Protocol.UndefinedError, protocol: @protocol, value: module, description: "the given module is an embedded schema"
     end
   end
 end

--- a/lib/ecto/queryable.ex
+++ b/lib/ecto/queryable.ex
@@ -33,7 +33,7 @@ defimpl Ecto.Queryable, for: Atom do
       UndefinedFunctionError ->
         message =
           if :code.is_loaded(module) do
-            "the given module either does not provide a schema"
+            "the given module does not provide a schema"
           else
             "the given module does not exist"
           end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -666,13 +666,15 @@ defmodule Ecto.Schema do
         def __schema__(:autogenerate_fields),
           do: unquote(Enum.flat_map(autogenerate, &elem(&1, 0)))
 
-        def __schema__(:query) do
-          %Ecto.Query{
-            from: %Ecto.Query.FromExpr{
-              source: {unquote(source), __MODULE__},
-              prefix: unquote(prefix)
+        if meta? do
+          def __schema__(:query) do
+            %Ecto.Query{
+              from: %Ecto.Query.FromExpr{
+                source: {unquote(source), __MODULE__},
+                prefix: unquote(prefix)
+              }
             }
-          }
+          end
         end
 
         for clauses <-

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -86,4 +86,10 @@ defmodule Ecto.EmbeddedTest do
     assert not Map.has_key?(author1, :__struct__)
     assert not Map.has_key?(author1, :__meta__)
   end
+
+  test "embedded schemas are not queryable" do
+    assert_raise Protocol.UndefinedError,
+                   ~r"the given module is an embedded schema",
+                   fn -> Ecto.Queryable.to_query(Post) end
+  end
 end


### PR DESCRIPTION
There are some edge cases around embedded schemas that I think can be cleaned up a little. This one happens when you try to query an embedded schema. Currently, you'll get  an error like this:

> (Postgrex.Error) ERROR 42P01 (undefined_table) relation "nil" does not exist


With this change you'll get this

>  ** (Protocol.UndefinedError) protocol Ecto.Queryable not implemented for Ecto.Integration.Item of type Atom, the given module is an embedded schema. This protocol is implemented for the following type(s): Atom, BitString, Ecto.Query, Ecto.SubQuery, Tuple
