### PR TITLE
docs: fix single query preloading in associations cheatsheet

### DIFF
--- a/guides/cheatsheets/associations.cheatmd
+++ b/guides/cheatsheets/associations.cheatmd
@@ -167,7 +167,7 @@ query =
   from m in Movie,
   join: c in Character,
   on: m.id == c.movie_id,
-  preload: :characters
+  preload: [characters: c]
 Repo.all(query)
 ```
 
@@ -177,7 +177,7 @@ Repo.all(query)
 query =
   from m in Movie,
   join: c in assoc(m, :characters),
-  preload: :characters
+  preload: [characters: c]
 Repo.all(query)
 ```
 


### PR DESCRIPTION
Based on my testing and the [`preload/3` documentation](https://hexdocs.pm/ecto/Ecto.Query.html#preload/3), the associations cheatsheet contains invalid instructions for using join queries to preload associations in one query.