### PR TITLE
Ignore query prefix for CTE sources

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -197,15 +197,16 @@ defmodule Ecto.Query.Planner do
   This function is called by the backend before invoking
   any cache mechanism.
   """
-  @spec plan(Ecto.Query.t, atom, module) :: {planned_query :: Ecto.Query.t, parameters :: list, cache_key :: any}
-  def plan(query, operation, adapter) do
+  @spec plan(Ecto.Query.t(), atom(), module, map()) :: {planned_query :: Ecto.Query.t(), parameters :: list(), cache_key :: any()}
+  def plan(query, operation, adapter, cte_names \\ %{}) do
+    {query, cte_names} = plan_ctes(query, adapter, cte_names)
+
     query
-    |> plan_sources(adapter)
+    |> plan_sources(adapter, cte_names)
     |> plan_assocs()
-    |> plan_combinations(adapter)
-    |> plan_ctes(adapter)
-    |> plan_wheres(adapter)
-    |> plan_select(adapter)
+    |> plan_combinations(adapter, cte_names)
+    |> plan_wheres(adapter, cte_names)
+    |> plan_select(adapter, cte_names)
     |> plan_cache(operation, adapter)
   rescue
     e ->
@@ -216,58 +217,69 @@ defmodule Ecto.Query.Planner do
   @doc """
   Prepare all sources, by traversing and expanding from, joins, subqueries.
   """
-  def plan_sources(query, adapter) do
-    {from, source} = plan_from(query, adapter)
+  def plan_sources(query, adapter, cte_names) do
+    {from, source} = plan_from(query, adapter, cte_names)
 
     # Set up the initial source so we can refer
     # to the parent in subqueries in joins
     query = %{query | sources: {source}}
 
-    {joins, sources, tail_sources} = plan_joins(query, [source], length(query.joins), adapter)
+    {joins, sources, tail_sources} = plan_joins(query, [source], length(query.joins), adapter, cte_names)
 
     %{query | from: from,
               joins: joins |> Enum.reverse,
               sources: (tail_sources ++ sources) |> Enum.reverse |> List.to_tuple()}
   end
 
-  defp plan_from(%{from: nil} = query, _adapter) do
+  defp plan_from(%{from: nil} = query, _adapter, _cte_names) do
     error!(query, "query must have a from expression")
   end
 
-  defp plan_from(%{from: %{source: {kind, _, _}}, preloads: preloads, assocs: assocs} = query, _adapter)
+  defp plan_from(%{from: %{source: {kind, _, _}}, preloads: preloads, assocs: assocs} = query, _adapter, _cte_names)
        when kind in [:fragment, :values] and (assocs != [] or preloads != []) do
     error!(query, "cannot preload associations with a #{kind} source")
   end
 
-  defp plan_from(%{from: from} = query, adapter) do
-    plan_source(query, from, adapter)
+  defp plan_from(%{from: from} = query, adapter, cte_names) do
+    plan_source(query, from, adapter, cte_names)
   end
 
-  defp plan_source(query, %{source: %Ecto.SubQuery{} = subquery, prefix: prefix} = expr, adapter) do
-    subquery = plan_subquery(subquery, query, prefix, adapter, true)
+  defp plan_source(query, %{source: %Ecto.SubQuery{} = subquery, prefix: prefix} = expr, adapter, cte_names) do
+    subquery = plan_subquery(subquery, query, prefix, adapter, true, cte_names)
     {%{expr | source: subquery}, subquery}
   end
 
-  defp plan_source(query, %{source: {nil, schema}} = expr, _adapter)
+  defp plan_source(query, %{source: {nil, schema}} = expr, _adapter, _cte_names)
        when is_atom(schema) and schema != nil do
     source = schema.__schema__(:source)
     prefix = plan_source_schema_prefix(expr, schema) || query.prefix
     {%{expr | source: {source, schema}}, {source, schema, prefix}}
   end
 
-  defp plan_source(query, %{source: {source, schema}, prefix: prefix} = expr, _adapter)
+  defp plan_source(query, %{source: {source, nil}, prefix: prefix} = expr, _adapter, cte_names)
+       when is_binary(source) do
+    prefix =
+      case cte_names do
+        %{^source => _} -> prefix
+        _ -> prefix || query.prefix
+      end
+
+    {expr, {source, nil, prefix}}
+  end
+
+  defp plan_source(query, %{source: {source, schema}, prefix: prefix} = expr, _adapter, _cte_names)
        when is_binary(source) and is_atom(schema),
        do: {expr, {source, schema, prefix || query.prefix}}
 
-  defp plan_source(_query, %{source: {kind, _, _} = source, prefix: nil} = expr, _adapter)
+  defp plan_source(_query, %{source: {kind, _, _} = source, prefix: nil} = expr, _adapter, _cte_names)
        when kind in [:fragment, :values],
        do: {expr, source}
 
-  defp plan_source(query, %{source: {kind, _, _}, prefix: prefix} = expr, _adapter)
+  defp plan_source(query, %{source: {kind, _, _}, prefix: prefix} = expr, _adapter, _cte_names)
        when kind in [:fragment, :values],
        do: error!(query, expr, "cannot set prefix: #{inspect(prefix)} option for #{kind} sources")
 
-  defp plan_subquery(subquery, query, prefix, adapter, source?) do
+  defp plan_subquery(subquery, query, prefix, adapter, source?, cte_names) do
     %{query: inner_query} = subquery
 
     inner_query = %{
@@ -276,7 +288,7 @@ defmodule Ecto.Query.Planner do
         aliases: Map.put(inner_query.aliases, @parent_as, query)
     }
 
-    {inner_query, params, key} = plan(inner_query, :all, adapter)
+    {inner_query, params, key} = plan(inner_query, :all, adapter, cte_names)
     assert_no_subquery_assocs!(inner_query)
 
     {inner_query, select} =
@@ -460,12 +472,12 @@ defmodule Ecto.Query.Planner do
   defp valid_subquery_value?(arg) when is_atom(arg), do: is_boolean(arg)
   defp valid_subquery_value?(_), do: true
 
-  defp plan_joins(query, sources, offset, adapter) do
-    plan_joins(query.joins, query, [], sources, [], 1, offset, adapter)
+  defp plan_joins(query, sources, offset, adapter, cte_names) do
+    plan_joins(query.joins, query, [], sources, [], 1, offset, adapter, cte_names)
   end
 
   defp plan_joins([%JoinExpr{assoc: {ix, assoc}, qual: qual, on: on, prefix: prefix} = join|t],
-                     query, joins, sources, tail_sources, counter, offset, adapter) do
+                     query, joins, sources, tail_sources, counter, offset, adapter, cte_names) do
     source = fetch_source!(sources, ix)
     schema = schema_for_association_join!(query, join, source)
     refl = schema.__schema__(:association, assoc)
@@ -505,10 +517,10 @@ defmodule Ecto.Query.Planner do
     last_ix = length(child.joins)
     source_ix = counter
 
-    {_, child_from_source} = plan_source(child, child.from, adapter)
+    {_, child_from_source} = plan_source(child, child.from, adapter, cte_names)
 
     {child_joins, child_sources, child_tail} =
-      plan_joins(child, [child_from_source], offset + last_ix - 1, adapter)
+      plan_joins(child, [child_from_source], offset + last_ix - 1, adapter, cte_names)
 
     # Rewrite joins indexes as mentioned above
     child_joins = Enum.map(child_joins, &rewrite_join(&1, qual, ix, last_ix, source_ix, offset))
@@ -520,19 +532,19 @@ defmodule Ecto.Query.Planner do
     child_sources = child_tail ++ child_sources
 
     plan_joins(t, query, attach_on(child_joins, on) ++ joins, [current_source|sources],
-                  child_sources ++ tail_sources, counter + 1, offset + length(child_sources), adapter)
+                  child_sources ++ tail_sources, counter + 1, offset + length(child_sources), adapter, cte_names)
   end
 
   defp plan_joins([%JoinExpr{source: %Ecto.Query{} = join_query, qual: qual, on: on, prefix: prefix} = join|t],
-                      query, joins, sources, tail_sources, counter, offset, adapter) do
+                      query, joins, sources, tail_sources, counter, offset, adapter, cte_names) do
     case join_query do
       %{order_bys: [], limit: nil, offset: nil, group_bys: [], joins: [],
         havings: [], preloads: [], assocs: [], distinct: nil, lock: nil} ->
         join_query = rewrite_prefix(join_query, query.prefix)
         from = rewrite_prefix(join_query.from, prefix)
-        {from, source} = plan_source(join_query, from, adapter)
+        {from, source} = plan_source(join_query, from, adapter, cte_names)
         [join] = attach_on(query_to_joins(qual, from.source, join_query, counter), on)
-        plan_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter)
+        plan_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter, cte_names)
       _ ->
         error! query, join, """
         invalid query was interpolated in a join.
@@ -545,12 +557,12 @@ defmodule Ecto.Query.Planner do
   end
 
   defp plan_joins([%JoinExpr{} = join|t],
-                      query, joins, sources, tail_sources, counter, offset, adapter) do
-    {join, source} = plan_source(query, %{join | ix: counter}, adapter)
-    plan_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter)
+                      query, joins, sources, tail_sources, counter, offset, adapter, cte_names) do
+    {join, source} = plan_source(query, %{join | ix: counter}, adapter, cte_names)
+    plan_joins(t, query, [join|joins], [source|sources], tail_sources, counter + 1, offset, adapter, cte_names)
   end
 
-  defp plan_joins([], _query, joins, sources, tail_sources, _counter, _offset, _adapter) do
+  defp plan_joins([], _query, joins, sources, tail_sources, _counter, _offset, _adapter, _cte_names) do
     {joins, sources, tail_sources}
   end
 
@@ -638,15 +650,15 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  @spec plan_wheres(Ecto.Query.t, module) :: Ecto.Query.t
-  defp plan_wheres(query, adapter) do
+  @spec plan_wheres(Ecto.Query.t(), module, map()) :: Ecto.Query.t
+  defp plan_wheres(query, adapter, cte_names) do
     wheres =
       Enum.map(query.wheres, fn
         %{subqueries: []} = where ->
           where
 
         %{subqueries: subqueries} = where ->
-          %{where | subqueries: Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false))}
+          %{where | subqueries: Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false, cte_names))}
       end)
 
     havings =
@@ -655,17 +667,17 @@ defmodule Ecto.Query.Planner do
           having
 
         %{subqueries: subqueries} = having ->
-          %{having | subqueries: Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false))}
+          %{having | subqueries: Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false, cte_names))}
       end)
 
     %{query | wheres: wheres, havings: havings}
   end
 
-  @spec plan_select(Ecto.Query.t, module) :: Ecto.Query.t
-  defp plan_select(query, adapter) do
+  @spec plan_select(Ecto.Query.t(), module, map()) :: Ecto.Query.t
+  defp plan_select(query, adapter, cte_names) do
     case query do
       %{select: %{subqueries: [_ | _] = subqueries}} ->
-        subqueries = Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false))
+        subqueries = Enum.map(subqueries, &plan_subquery(&1, query, nil, adapter, false, cte_names))
         put_in(query.select.subqueries, subqueries)
 
       query -> query
@@ -921,10 +933,10 @@ defmodule Ecto.Query.Planner do
     end
   end
 
-  defp plan_combinations(query, adapter) do
+  defp plan_combinations(query, adapter, cte_names) do
     combinations =
       Enum.map query.combinations, fn {type, combination_query} ->
-        {prepared_query, _params, _key} = combination_query |> attach_prefix(query) |> plan(:all, adapter)
+        {prepared_query, _params, _key} = combination_query |> attach_prefix(query) |> plan(:all, adapter, cte_names)
         prepared_query = prepared_query |> ensure_select(true)
         {type, prepared_query}
       end
@@ -932,20 +944,21 @@ defmodule Ecto.Query.Planner do
     %{query | combinations: combinations}
   end
 
-  defp plan_ctes(%Ecto.Query{with_ctes: nil} = query, _adapter), do: query
-  defp plan_ctes(%Ecto.Query{with_ctes: %{queries: queries}} = query, adapter) do
-    queries =
-      Enum.map queries, fn
-        {name, opts, %Ecto.Query{} = cte_query} ->
-          {planned_query, _params, _key} = cte_query |> attach_prefix(query) |> plan(:all, adapter)
+  defp plan_ctes(%Ecto.Query{with_ctes: nil} = query, _adapter, cte_names), do: {query, cte_names}
+  defp plan_ctes(%Ecto.Query{with_ctes: %{queries: queries}} = query, adapter, cte_names) do
+    {queries, cte_names} =
+      Enum.map_reduce queries, cte_names, fn
+        {name, opts, %Ecto.Query{} = cte_query}, cte_names ->
+          cte_names = Map.put(cte_names, name, [])
+          {planned_query, _params, _key} = cte_query |> attach_prefix(query) |> plan(:all, adapter, cte_names)
           planned_query = planned_query |> ensure_select(true)
-          {name, opts, planned_query}
+          {{name, opts, planned_query}, cte_names}
 
-        {name, opts, other} ->
-          {name, opts, other}
+        {name, opts, other}, cte_names ->
+          {{name, opts, other}, cte_names}
       end
 
-    put_in(query.with_ctes.queries, queries)
+    {put_in(query.with_ctes.queries, queries), cte_names}
   end
 
   defp find_source_expr(query, 0) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -257,7 +257,7 @@ defmodule Ecto.Query.Planner do
     prefix =
       case cte_names do
         %{^source => _} -> source_prefix
-        _ -> source_prefix|| query.prefix
+        _ -> source_prefix || query.prefix
       end
 
     {%{expr | source: {source, schema}}, {source, schema, prefix}}

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -884,36 +884,37 @@ defmodule Ecto.Query.PlannerTest do
       assert cte_query.sources == {{"comments", Comment, nil}}
 
       {%{with_ctes: with_expr} = query, _, _, _} =
-        Comment
-        |> with_cte("pre-comment", as: ^from(c in "comment", select: c.title))
-        |> with_cte("comment", as: ^from(c in Comment))
-        |> with_cte("after-comment", as: ^from(c in "comment", select: c.title))
-        |> join(:inner, [c], c1 in "comment", on: true)
-        |> join(:inner, [c, c1], c2 in "comment", prefix: "global", on: true)
-        |> where([c, c1, c2], c.title == subquery(from c in "comment", select: c.title))
-        |> select([c, c1, c2], subquery(from c in "comment", select: c.title))
-        |> union(^from(c in "after-comment", select: c.title))
+        "comments"
+        |> with_cte("pre-comments", as: ^from(c in "comments", select: c.title))
+        |> with_cte("comments", as: ^from(c in Comment))
+        |> with_cte("after-comments", as: ^from(c in "comments", select: c.title))
+        |> join(:inner, [c], c1 in "comments", on: true)
+        |> join(:inner, [c, c1], c2 in "comments", prefix: "global", on: true)
+        |> join(:inner, [c, c1, c2], c3 in Comment, on: true)
+        |> where([c, c1, c2, c3], c.title == subquery(from c in "comments", select: c.title))
+        |> select([c, c1, c2, c3], subquery(from c in "comments", select: c.title))
+        |> union(^from(c in "after-comments", select: c.title))
         |> Map.put(:prefix, "global")
         |> plan()
 
       %{
         queries: [
-          {"pre-comment", %{}, pre_comment_cte_query},
-          {"comment", %{}, cte_query},
-          {"after-comment", %{}, after_comment_cte_query}
+          {"pre-comments", %{}, pre_comments_cte_query},
+          {"comments", %{}, comments_cte_query},
+          {"after-comments", %{}, after_comments_cte_query}
         ]
       } = with_expr
 
-      assert query.sources == {{"comments", Comment, "global"}, {"comment", nil, nil}, {"comment", nil, "global"}}
-      assert cte_query.sources == {{"comments", Comment, "global"}}
-      assert pre_comment_cte_query.sources == {{"comment", nil, "global"}}
-      assert after_comment_cte_query.sources == {{"comment", nil, nil}}
+      assert query.sources == {{"comments", nil, nil}, {"comments", nil, nil}, {"comments", nil, "global"}, {"comments", Comment, "global"}}
+      assert pre_comments_cte_query.sources == {{"comments", nil, "global"}}
+      assert comments_cte_query.sources == {{"comments", Comment, "global"}}
+      assert after_comments_cte_query.sources == {{"comments", nil, nil}}
       [%{subqueries: [%{query: where_subquery}]}] = query.wheres
-      assert where_subquery.sources == {{"comment", nil, nil}}
+      assert where_subquery.sources == {{"comments", nil, nil}}
       %{subqueries: [%{query: select_subquery}]} = query.select
-      assert select_subquery.sources == {{"comment", nil, nil}}
+      assert select_subquery.sources == {{"comments", nil, nil}}
       [{:union, union_query}] = query.combinations
-      assert union_query.sources == {{"after-comment", nil, nil}}
+      assert union_query.sources == {{"after-comments", nil, nil}}
 
       {%{with_ctes: with_expr} = query, _, _, _} = Comment |> with_cte("cte", as: ^(from(c in Comment) |> Map.put(:prefix, "cte"))) |> Map.put(:prefix, "global") |> plan()
       %{queries: [{"cte", %{}, cte_query}]} = with_expr

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -886,20 +886,25 @@ defmodule Ecto.Query.PlannerTest do
       {%{with_ctes: with_expr} = query, _, _, _} =
         Comment
         |> with_cte("comment", as: ^from(c in Comment))
+        |> with_cte("comment2", as: ^from(c in "comment", select: c.title))
         |> join(:inner, [c], c1 in "comment", on: true)
         |> join(:inner, [c, c1], c2 in "comment", prefix: "global", on: true)
         |> where([c, c1, c2], c.title == subquery(from c in "comment", select: c.title))
         |> select([c, c1, c2], subquery(from c in "comment", select: c.title))
+        |> union(^from(c in "comment2", select: c.title))
         |> Map.put(:prefix, "global")
         |> plan()
 
-      %{queries: [{"comment", %{}, cte_query}]} = with_expr
+      %{queries: [{"comment", %{}, cte_query}, {"comment2", %{}, cte_query2}]} = with_expr
       assert query.sources == {{"comments", Comment, "global"}, {"comment", nil, nil}, {"comment", nil, "global"}}
       assert cte_query.sources == {{"comments", Comment, "global"}}
+      assert cte_query2.sources == {{"comment", nil, nil}}
       [%{subqueries: [%{query: where_subquery}]}] = query.wheres
       assert where_subquery.sources == {{"comment", nil, nil}}
-      %{subqueries: [%{query: where_subquery}]} = query.select
-      assert where_subquery.sources == {{"comment", nil, nil}}
+      %{subqueries: [%{query: select_subquery}]} = query.select
+      assert select_subquery.sources == {{"comment", nil, nil}}
+      [{:union, union_query}] = query.combinations
+      assert union_query.sources == {{"comment2", nil, nil}}
 
       {%{with_ctes: with_expr} = query, _, _, _} = Comment |> with_cte("cte", as: ^(from(c in Comment) |> Map.put(:prefix, "cte"))) |> Map.put(:prefix, "global") |> plan()
       %{queries: [{"cte", %{}, cte_query}]} = with_expr

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -905,9 +905,9 @@ defmodule Ecto.Query.PlannerTest do
         ]
       } = with_expr
 
-      assert query.sources == {{"comments", nil, nil}, {"comments", nil, nil}, {"comments", nil, "global"}, {"comments", Comment, "global"}}
+      assert query.sources == {{"comments", nil, nil}, {"comments", nil, nil}, {"comments", nil, "global"}, {"comments", Comment, nil}}
       assert pre_comments_cte_query.sources == {{"comments", nil, "global"}}
-      assert comments_cte_query.sources == {{"comments", Comment, "global"}}
+      assert comments_cte_query.sources == {{"comments", Comment, nil}}
       assert after_comments_cte_query.sources == {{"comments", nil, nil}}
       [%{subqueries: [%{query: where_subquery}]}] = query.wheres
       assert where_subquery.sources == {{"comments", nil, nil}}


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/3387

I tried to figure out the exact scoping rules for the CTE names by playing around with Postgres and MySQL. For example these queries:

```sql
with 
     test as (select 1), 
     test2 as (select 2), 
     test3 as (with test as (select * from test2) select * from test) 
select * from test3;
 ?column? 
----------
        2
```

From what I see, it's basically the same as variable name scoping in regular programming languages. You can see CTE names at your own level or an outer level as long as it has been defined before it gets to you.