### PR TITLE
docs: add missing default_options/1 operation names

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1242,16 +1242,17 @@ defmodule Ecto.Repo do
   @callback default_options(operation) :: Keyword.t()
             when operation:
                    :all
-                   | :insert_all
-                   | :update_all
+                   | :delete
                    | :delete_all
+                   | :insert
+                   | :insert_all
+                   | :insert_or_update
+                   | :preload
+                   | :reload
                    | :stream
                    | :transaction
-                   | :insert
                    | :update
-                   | :delete
-                   | :insert_or_update
-
+                   | :update_all
   @doc """
   Fetches all entries from the data store matching the given query.
 


### PR DESCRIPTION
noticed the following operation names were missing:
- preload
- reload

i collected this list by grepping for literal invocations of `prepare_opts(:some_atom` and deduping the results

also sorted alphabetically as it was easier to think of what went where. happy to update to whatever ordering's preferred by maintainers though