### PR TITLE
Bubble up custom cast errors of the inner type for `{:map, type}` and `{:array, type}`

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1369,7 +1369,7 @@ defmodule Ecto.Type do
         :error
 
       {:error, custom_errors} ->
-        {:error, [{:index, index} | custom_errors]}
+        {:error, Keyword.update(custom_errors, :source, [index], &[index | &1])}
     end
   end
 
@@ -1402,7 +1402,7 @@ defmodule Ecto.Type do
         :error
 
       {:error, custom_errors} ->
-        {:error, [{:key, key} | custom_errors]}
+        {:error, Keyword.update(custom_errors, :source, [key], &[key | &1])}
     end
   end
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -539,8 +539,10 @@ defmodule Ecto.Type do
     end
   end
 
-  def dump({:array, {_, _, _} = type}, value, dumper), do: array(value, type, dumper, false, [])
-  def dump({:array, type}, value, dumper), do: array(value, type, dumper, true, [])
+  def dump({:array, {_, _, _} = type}, value, dumper),
+    do: array_with_type(value, type, dumper, false, [])
+
+  def dump({:array, type}, value, dumper), do: array_with_type(value, type, dumper, true, [])
   def dump({:map, type}, value, dumper), do: map(value, type, dumper, false, %{})
 
   def dump(:any, value, _dumper), do: {:ok, value}
@@ -633,8 +635,10 @@ defmodule Ecto.Type do
     end
   end
 
-  def load({:array, {_, _, _} = type}, value, loader), do: array(value, type, loader, false, [])
-  def load({:array, type}, value, loader), do: array(value, type, loader, true, [])
+  def load({:array, {_, _, _} = type}, value, loader),
+    do: array_with_type(value, type, loader, false, [])
+
+  def load({:array, type}, value, loader), do: array_with_type(value, type, loader, true, [])
   def load({:map, type}, value, loader), do: map(value, type, loader, false, %{})
 
   def load(:any, value, _loader), do: {:ok, value}
@@ -831,12 +835,12 @@ defmodule Ecto.Type do
 
   defp cast_fun({:array, {:parameterized, _, _} = type}) do
     fun = cast_fun(type)
-    &array(&1, fun, false, [])
+    &array_with_index(&1, fun, false, 0, [])
   end
 
   defp cast_fun({:array, type}) do
     fun = cast_fun(type)
-    &array(&1, fun, true, [])
+    &array_with_index(&1, fun, true, 0, [])
   end
 
   defp cast_fun({:map, {:parameterized, _, _} = type}) do
@@ -1352,23 +1356,28 @@ defmodule Ecto.Type do
   defp of_base_type?(:date, value), do: Kernel.match?(%Date{}, value)
   defp of_base_type?(_, _), do: false
 
-  defp array([nil | t], fun, true, acc) do
-    array(t, fun, true, [nil | acc])
+  defp array_with_index([nil | t], fun, true, index, acc) do
+    array_with_index(t, fun, true, index + 1, [nil | acc])
   end
 
-  defp array([h | t], fun, skip_nil?, acc) do
+  defp array_with_index([h | t], fun, skip_nil?, index, acc) do
     case fun.(h) do
-      {:ok, h} -> array(t, fun, skip_nil?, [h | acc])
-      :error -> :error
-      {:error, _custom_errors} -> :error
+      {:ok, h} ->
+        array_with_index(t, fun, skip_nil?, index + 1, [h | acc])
+
+      :error ->
+        :error
+
+      {:error, custom_errors} ->
+        {:error, [{:index, index} | custom_errors]}
     end
   end
 
-  defp array([], _fun, _skip_nil?, acc) do
+  defp array_with_index([], _fun, _skip_nil?, _index, acc) do
     {:ok, Enum.reverse(acc)}
   end
 
-  defp array(_, _, _, _) do
+  defp array_with_index(_, _, _, _, _) do
     :error
   end
 
@@ -1386,9 +1395,14 @@ defmodule Ecto.Type do
 
   defp map_each([{key, value} | t], fun, skip_nil?, acc) do
     case fun.(value) do
-      {:ok, value} -> map_each(t, fun, skip_nil?, Map.put(acc, key, value))
-      :error -> :error
-      {:error, _custom_errors} -> :error
+      {:ok, value} ->
+        map_each(t, fun, skip_nil?, Map.put(acc, key, value))
+
+      :error ->
+        :error
+
+      {:error, custom_errors} ->
+        {:error, [{:key, key} | custom_errors]}
     end
   end
 
@@ -1396,22 +1410,22 @@ defmodule Ecto.Type do
     {:ok, acc}
   end
 
-  defp array([nil | t], type, fun, true, acc) do
-    array(t, type, fun, true, [nil | acc])
+  defp array_with_type([nil | t], type, fun, true, acc) do
+    array_with_type(t, type, fun, true, [nil | acc])
   end
 
-  defp array([h | t], type, fun, skip_nil?, acc) do
+  defp array_with_type([h | t], type, fun, skip_nil?, acc) do
     case fun.(type, h) do
-      {:ok, h} -> array(t, type, fun, skip_nil?, [h | acc])
+      {:ok, h} -> array_with_type(t, type, fun, skip_nil?, [h | acc])
       :error -> :error
     end
   end
 
-  defp array([], _type, _fun, _skip_nil?, acc) do
+  defp array_with_type([], _type, _fun, _skip_nil?, acc) do
     {:ok, Enum.reverse(acc)}
   end
 
-  defp array(_, _, _, _, _) do
+  defp array_with_type(_, _, _, _, _) do
     :error
   end
 

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -432,7 +432,18 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(array_custom_error)a)
-    assert changeset.errors == [array_custom_error: {"is invalid", [type: {:array, Ecto.ChangesetTest.CustomError}, validation: :cast]}]
+
+    assert changeset.errors == [
+             array_custom_error:
+               {"custom error message",
+                [
+                  type: {:array, Ecto.ChangesetTest.CustomError},
+                  validation: :cast,
+                  reason: :foobar,
+                  source: [0]
+                ]}
+           ]
+
     refute changeset.valid?
   end
 
@@ -441,7 +452,18 @@ defmodule Ecto.ChangesetTest do
     struct = %CustomErrorTest{}
 
     changeset = cast(struct, params, ~w(map_custom_error)a)
-    assert changeset.errors == [map_custom_error: {"is invalid", [type: {:map, Ecto.ChangesetTest.CustomError}, validation: :cast]}]
+
+    assert changeset.errors == [
+      map_custom_error:
+        {"custom error message",
+         [
+           type: {:map, Ecto.ChangesetTest.CustomError},
+           validation: :cast,
+           reason: :foobar,
+           source: [:foo]
+         ]}
+    ]
+
     refute changeset.valid?
   end
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -20,6 +20,15 @@ defmodule Ecto.TypeTest do
     def cast(_),   do: {:ok, :cast}
   end
 
+  defmodule CustomWithCastError do
+    use Ecto.Type
+
+    def type,      do: :any
+    def load(_),   do: {:ok, :load}
+    def dump(_),   do: {:ok, :dump}
+    def cast(_),   do: {:error, foo: :bar}
+  end
+
   defmodule CustomParameterizedTypeWithFormat do
     use Ecto.ParameterizedType
 
@@ -88,10 +97,12 @@ defmodule Ecto.TypeTest do
     assert load(Custom, "foo") == {:ok, :load}
     assert dump(Custom, "foo") == {:ok, :dump}
     assert cast(Custom, "foo") == {:ok, :cast}
+    assert cast(CustomWithCastError, "foo") == {:error, foo: :bar}
 
     assert load(Custom, nil) == {:ok, nil}
     assert dump(Custom, nil) == {:ok, nil}
     assert cast(Custom, nil) == {:ok, nil}
+    assert cast(CustomWithCastError, nil) == {:ok, nil}
 
     assert match?(Custom, :any)
     assert match?(:any, Custom)
@@ -144,18 +155,22 @@ defmodule Ecto.TypeTest do
     assert load({:array, Custom}, ["foo"]) == {:ok, [:load]}
     assert dump({:array, Custom}, ["foo"]) == {:ok, [:dump]}
     assert cast({:array, Custom}, ["foo"]) == {:ok, [:cast]}
+    assert cast({:array, CustomWithCastError}, ["foo"]) == {:error, [index: 0, foo: :bar]}
 
     assert load({:array, Custom}, [nil]) == {:ok, [nil]}
     assert dump({:array, Custom}, [nil]) == {:ok, [nil]}
     assert cast({:array, Custom}, [nil]) == {:ok, [nil]}
+    assert cast({:array, CustomWithCastError}, [nil]) == {:ok, [nil]}
 
     assert load({:array, Custom}, nil) == {:ok, nil}
     assert dump({:array, Custom}, nil) == {:ok, nil}
     assert cast({:array, Custom}, nil) == {:ok, nil}
+    assert cast({:array, CustomWithCastError}, nil) == {:ok, nil}
 
     assert load({:array, Custom}, 1) == :error
     assert dump({:array, Custom}, 1) == :error
     assert cast({:array, Custom}, 1) == :error
+    assert cast({:array, CustomWithCastError}, 1) == :error
 
     assert load({:array, Custom}, [:unused], fn Custom, _ -> {:ok, :used} end) == {:ok, [:used]}
     assert dump({:array, Custom}, [:unused], fn Custom, _ -> {:ok, :used} end) == {:ok, [:used]}
@@ -165,18 +180,22 @@ defmodule Ecto.TypeTest do
     assert load({:map, Custom}, %{"x" => "foo"}) == {:ok, %{"x" => :load}}
     assert dump({:map, Custom}, %{"x" => "foo"}) == {:ok, %{"x" => :dump}}
     assert cast({:map, Custom}, %{"x" => "foo"}) == {:ok, %{"x" => :cast}}
+    assert cast({:map, CustomWithCastError}, %{"x" => "foo"}) == {:error, [key: "x", foo: :bar]}
 
     assert load({:map, Custom}, %{"x" => nil}) == {:ok, %{"x" => nil}}
     assert dump({:map, Custom}, %{"x" => nil}) == {:ok, %{"x" => nil}}
     assert cast({:map, Custom}, %{"x" => nil}) == {:ok, %{"x" => nil}}
+    assert cast({:map, CustomWithCastError}, %{"x" => nil}) == {:ok, %{"x" => nil}}
 
     assert load({:map, Custom}, nil) == {:ok, nil}
     assert dump({:map, Custom}, nil) == {:ok, nil}
     assert cast({:map, Custom}, nil) == {:ok, nil}
+    assert cast({:map, CustomWithCastError}, nil) == {:ok, nil}
 
     assert load({:map, Custom}, 1) == :error
     assert dump({:map, Custom}, 1) == :error
     assert cast({:map, Custom}, 1) == :error
+    assert cast({:map, CustomWithCastError}, 1) == :error
 
     assert load({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) == {:ok, %{"a" => :used}}
     assert dump({:map, Custom}, %{"a" => :unused}, fn Custom, _ -> {:ok, :used} end) == {:ok, %{"a" => :used}}


### PR DESCRIPTION
Take the following custom type as an example:
```elixir
  defmodule CustomWithCastError do
    use Ecto.Type

    def type,      do: :any
    def load(_),   do: {:ok, :load}
    def dump(_),   do: {:ok, :dump}
    def cast(_),   do: {:error, foo: :bar}
  end
```
When we attempt to cast this type wrapped in an `array` or a `map`, the current behaviour in Ecto is that we get:
```elixir
    assert cast({:array, CustomWithCastError}, ["foo", "bar", "baz"]) == :error

    assert cast({:map, CustomWithCastError}, %{"x" => "foo", "y" => "bar"}) == :error
```
Where as you can see, the custom errors returned by our custom type are lost. That, and we do not know what item of the array or the map made the cast fail. This PR aims to improve on both of these things.

With the changes in this PR, the behaviour above changes to:
```elixir
    assert cast({:array, CustomWithCastError}, ["foo", "bar", "baz"]) == {:error, [index: 0, foo: :bar]}

    assert cast({:map, CustomWithCastError}, %{"x" => "foo", "y" => "bar"}) == {:error, [key: "x", foo: :bar]}
```
So we do return the custom error, and we add a reference that indicates what item made the cast fail. We include an `index` integer for the array, and the `key` for the map.