### PR TITLE
Allow strings in `field/2`

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -579,13 +579,42 @@ defmodule Ecto.Query.API do
   @doc """
   Allows a field to be dynamically accessed.
 
+  The field name can be given as either an atom or a string. In a schemaless
+  query, the two types of names behave the same. However, when referencing
+  a field from a schema the behaviours are different.
+
+  Using an atom to reference a schema field will inherit all the properties from
+  the schema. For example, the field name will be changed to the value of `:source`
+  before generating the final query and its type behaviour will be dictated by the
+  one specified in the schema.
+
+  Using a string to reference a schema field is equivalent to bypassing all of the
+  above and accessing the field directly from the source (i.e. the underlying table).
+  This means the name will not be changed to the value of `:source` and the type
+  behaviour will be dictated by the underlying driver (e.g. Postgrex or MyXQL).
+
+  Take the following schema and query:
+
+      defmodule Car do
+        use Ecto.Schema
+
+        schema "cars" do
+          field :doors, source: :num_doors
+          field :tires, source: :num_tires
+        end
+      end
+
       def at_least_four(doors_or_tires) do
         from c in Car,
           where: field(c, ^doors_or_tires) >= 4
       end
 
-  In the example above, both `at_least_four(:doors)` and `at_least_four(:tires)`
-  would be valid calls as the field is dynamically generated.
+  In the example above, `at_least_four(:doors)` and `at_least_four("num_doors")`
+  would be valid ways to return the set of cars having at least 4 doors.
+
+  String names can be particularly useful when your application is dynamically
+  generating many schemaless queries at runtime and you want to avoid creating
+  a large number of atoms.
   """
   def field(source, field), do: doc!([source, field])
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1119,7 +1119,7 @@ defmodule Ecto.Query.Builder do
   def quoted_atom_or_string!(other, used_ref),
     do:
       error!(
-        "expected literal atom or string or interpolated value in #{used_ref}, got: " <>
+        "expected literal atom/string or interpolated value in #{used_ref}, got: " <>
         "`#{Macro.to_string(other)}`"
       )
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1119,7 +1119,7 @@ defmodule Ecto.Query.Builder do
   def quoted_atom_or_string!(other, used_ref),
     do:
       error!(
-        "expected literal atom/string or interpolated value in #{used_ref}, got: " <>
+        "expected literal atom or string or interpolated value in #{used_ref}, got: " <>
         "`#{Macro.to_string(other)}`"
       )
 
@@ -1134,7 +1134,7 @@ defmodule Ecto.Query.Builder do
     do: error!("expected atom in #{used_ref}, got: `#{inspect(other)}`")
 
   @doc """
-  Called by escaper at runtime to verify that value is an atomor string.
+  Called by escaper at runtime to verify that value is an atom or string.
   """
   def atom_or_string!(atom, _used_ref) when is_atom(atom),
     do: atom

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -690,18 +690,18 @@ defmodule Ecto.Query.Builder do
 
   defp escape_field!({var, _, context}, field, vars)
        when is_atom(var) and is_atom(context) do
-    var   = escape_var!(var, vars)
+    var = escape_var!(var, vars)
     field = quoted_atom_or_string!(field, "field/2")
-    dot   = {:{}, [], [:., [], [var, field]]}
+    dot = {:{}, [], [:., [], [var, field]]}
     {:{}, [], [dot, [], []]}
   end
 
   defp escape_field!({kind, _, [value]}, field, _vars)
        when kind in [:as, :parent_as] do
     value = late_binding!(kind, value)
-    as    = {:{}, [], [kind, [], [value]]}
+    as = {:{}, [], [kind, [], [value]]}
     field = quoted_atom_or_string!(field, "field/2")
-    dot   = {:{}, [], [:., [], [as, field]]}
+    dot = {:{}, [], [:., [], [as, field]]}
     {:{}, [], [dot, [], []]}
   end
 

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -282,6 +282,12 @@ defimpl Inspect, for: Ecto.Query do
     binding_to_expr(ix, names, part)
   end
 
+  # Format field/2 with string name
+  defp postwalk({{:., _, [{_, _, _} = binding, field]}, meta, []}, _names, _part)
+       when is_binary(field) do
+    {:field, meta, [binding, field]}
+  end
+
   # Remove parens from field calls
   defp postwalk({{:., _, [_, _]} = dot, meta, []}, _names, _part) do
     {dot, [no_parens: true] ++ meta, []}

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2419,6 +2419,7 @@ defmodule Ecto.Query.Planner do
   defp type!(kind, query, expr, schema, field, allow_virtuals? \\ false)
 
   defp type!(_kind, _query, _expr, nil, _field, _allow_virtuals?), do: :any
+
   defp type!(_kind, _query, _expr, _ix, field, _allow_virtuals?) when is_binary(field), do: :any
 
   defp type!(kind, query, expr, ix, field, allow_virtuals?) when is_integer(ix) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2563,7 +2563,11 @@ defmodule Ecto.Query.Planner do
   defp field_source({source, schema, _}, field) when is_binary(source) and schema != nil do
     # If the field is not found we return the field itself
     # which will be checked and raise later.
-    schema.__schema__(:field_source, field) || field
+
+    case schema.__schema__(:field_source, field) do
+      nil -> if is_binary(field), do: String.to_existing_atom(field), else: field
+      field_source -> field_source
+    end
   end
 
   defp field_source(_, field) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2563,11 +2563,7 @@ defmodule Ecto.Query.Planner do
   defp field_source({source, schema, _}, field) when is_binary(source) and schema != nil do
     # If the field is not found we return the field itself
     # which will be checked and raise later.
-
-    case schema.__schema__(:field_source, field) do
-      nil -> if is_binary(field), do: String.to_existing_atom(field), else: field
-      field_source -> field_source
-    end
+    schema.__schema__(:field_source, field) || field
   end
 
   defp field_source(_, field) do

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2419,6 +2419,7 @@ defmodule Ecto.Query.Planner do
   defp type!(kind, query, expr, schema, field, allow_virtuals? \\ false)
 
   defp type!(_kind, _query, _expr, nil, _field, _allow_virtuals?), do: :any
+  defp type!(_kind, _query, _expr, _ix, field, _allow_virtuals?) when is_binary(field), do: :any
 
   defp type!(kind, query, expr, ix, field, allow_virtuals?) when is_integer(ix) do
     case get_source!(kind, query, ix) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -598,16 +598,11 @@ defmodule Ecto.Schema do
           end
         end
 
-        for clauses <-
-              Ecto.Schema.__schema__(fields, field_sources, assocs, embeds, virtual_fields, read_only),
-            clause <- clauses do
-          case clause do
-            {args, body} ->
-              def __schema__(unquote_splicing(args)), do: unquote(body)
+        def __schema__(:source), do: unquote(source)
+        def __schema__(:prefix), do: unquote(Macro.escape(prefix))
 
-            {args, when_expr, body} ->
-              def __schema__(unquote_splicing(args)) when(unquote(when_expr)), do: unquote(body)
-          end
+        for clauses <- bags_of_clauses, {args, body} <- clauses do
+          def __schema__(unquote_splicing(args)), do: unquote(body)
         end
 
         :ok

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -598,11 +598,16 @@ defmodule Ecto.Schema do
           end
         end
 
-        def __schema__(:source), do: unquote(source)
-        def __schema__(:prefix), do: unquote(Macro.escape(prefix))
+        for clauses <-
+              Ecto.Schema.__schema__(fields, field_sources, assocs, embeds, virtual_fields, read_only),
+            clause <- clauses do
+          case clause do
+            {args, body} ->
+              def __schema__(unquote_splicing(args)), do: unquote(body)
 
-        for clauses <- bags_of_clauses, {args, body} <- clauses do
-          def __schema__(unquote_splicing(args)), do: unquote(body)
+            {args, when_expr, body} ->
+              def __schema__(unquote_splicing(args)) when(unquote(when_expr)), do: unquote(body)
+          end
         end
 
         :ok

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -44,6 +44,12 @@ defmodule Ecto.Query.BuilderTest do
            |> Code.eval_quoted([], __ENV__)
            |> elem(0)
 
+    assert {{:., [], [{:&, [], [0]}, "z"]}, [], []} ==
+           escape(quote do field(x, "z") end, [x: 0], __ENV__)
+           |> elem(0)
+           |> Code.eval_quoted([], __ENV__)
+           |> elem(0)
+
     assert {Macro.escape(quote do -&0.y() end), []} ==
            escape(quote do -x.y() end, [x: 0], __ENV__)
   end
@@ -266,7 +272,7 @@ defmodule Ecto.Query.BuilderTest do
       escape(quote(do: x.y == 1), [], __ENV__)
     end
 
-    assert_raise Ecto.Query.CompileError, ~r"expected literal atom or interpolated value.*got: `var`", fn ->
+    assert_raise Ecto.Query.CompileError, ~r"expected literal atom or string or interpolated value.*got: `var`", fn ->
       escape(quote(do: field(x, var)), [x: 0], __ENV__) |> elem(0) |> Code.eval_quoted([], __ENV__)
     end
 
@@ -360,6 +366,9 @@ defmodule Ecto.Query.BuilderTest do
     assert validate_type!(quote do x.title end, [x: 0], env) == {0, :title}
     assert validate_type!(quote do field(x, :title) end, [x: 0], env) == {0, :title}
     assert validate_type!(quote do field(x, ^:title) end, [x: 0], env) == {0, :title}
+    assert validate_type!(quote do field(x, ^:title) end, [x: 0], env) == {0, :title}
+    assert validate_type!(quote do field(x, "title") end, [x: 0], env) == {0, "title"}
+    assert validate_type!(quote do field(x, ^"title") end, [x: 0], env) == {0, "title"}
 
     assert_raise Ecto.Query.CompileError, ~r"^type/2 expects an alias, atom", fn ->
       validate_type!(quote do "string" end, [x: 0], env)

--- a/test/ecto/query/builder_test.exs
+++ b/test/ecto/query/builder_test.exs
@@ -366,7 +366,6 @@ defmodule Ecto.Query.BuilderTest do
     assert validate_type!(quote do x.title end, [x: 0], env) == {0, :title}
     assert validate_type!(quote do field(x, :title) end, [x: 0], env) == {0, :title}
     assert validate_type!(quote do field(x, ^:title) end, [x: 0], env) == {0, :title}
-    assert validate_type!(quote do field(x, ^:title) end, [x: 0], env) == {0, :title}
     assert validate_type!(quote do field(x, "title") end, [x: 0], env) == {0, "title"}
     assert validate_type!(quote do field(x, ^"title") end, [x: 0], env) == {0, "title"}
 

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -574,6 +574,11 @@ defmodule Ecto.Query.InspectTest do
     assert i(plan(query)) == "from v0 in values (#{fields})"
   end
 
+  test "field/2 with string name" do
+    query = from p in Post, select: field(p, "visit")
+    assert i(query) == ~s<from p0 in Inspect.Post, select: field(p0, "visit")>
+  end
+
   def plan(query) do
     {query, _, _} = Ecto.Adapter.Queryable.plan_query(:all, Ecto.TestAdapter, query)
     query

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1449,6 +1449,14 @@ defmodule Ecto.Query.PlannerTest do
              "parent_as(:posts).visits() == ^0"
 
     assert cast_params == [123]
+
+    child = from(c in Comment, where: field(parent_as(^as), "visits") == ^"123")
+
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize_with_params()
+
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).visits() == ^0"
+    assert cast_params == [123]
   end
 
   test "normalize: nested parent_as" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1342,8 +1342,8 @@ defmodule Ecto.Query.PlannerTest do
     {query, cast_params, _, _} =
       from(Post, as: :posts, where: field(as(^as), "visits") == ^"123") |> normalize_with_params()
 
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
-    assert cast_params == [123]
+    assert Macro.to_string(hd(query.wheres).expr) == "&0 . \"visits\"() == ^0"
+    assert cast_params == ["123"]
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(:posts\)`/, fn ->
       from(Post, where: as(^as).visits == ^"123") |> normalize()
@@ -1360,7 +1360,7 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
 
     query = from(Post, as: ^as, where: field(as(^as), "visits") == ^"123") |> normalize()
-    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
+    assert Macro.to_string(hd(query.wheres).expr) == "&0 . \"visits\"() == ^0"
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\{:posts\}\)`/, fn ->
       from(Post, where: as(^as).visits == ^"123") |> normalize()
@@ -1428,7 +1428,7 @@ defmodule Ecto.Query.PlannerTest do
 
     child = from(c in Comment, select: %{map: field(parent_as(^as), "posted")})
     query = from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize()
-    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
+    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts) . \"posted\"()}"
 
     child = from(c in Comment, where: parent_as(^as).visits == ^"123")
 
@@ -1455,8 +1455,8 @@ defmodule Ecto.Query.PlannerTest do
     {query, cast_params, _, _} =
       from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize_with_params()
 
-    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts).visits() == ^0"
-    assert cast_params == [123]
+    assert Macro.to_string(hd(hd(query.joins).source.query.wheres).expr) == "parent_as(:posts) . \"visits\"() == ^0"
+    assert cast_params == ["123"]
   end
 
   test "normalize: nested parent_as" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -1339,6 +1339,12 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
     assert cast_params == [123]
 
+    {query, cast_params, _, _} =
+      from(Post, as: :posts, where: field(as(^as), "visits") == ^"123") |> normalize_with_params()
+
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
+    assert cast_params == [123]
+
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(:posts\)`/, fn ->
       from(Post, where: as(^as).visits == ^"123") |> normalize()
     end
@@ -1351,6 +1357,9 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
 
     query = from(Post, as: ^as, where: field(as(^as), :visits) == ^"123") |> normalize()
+    assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
+
+    query = from(Post, as: ^as, where: field(as(^as), "visits") == ^"123") |> normalize()
     assert Macro.to_string(hd(query.wheres).expr) == "&0.visits() == ^0"
 
     assert_raise Ecto.QueryError, ~r/could not find named binding `as\(\{:posts\}\)`/, fn ->
@@ -1416,6 +1425,10 @@ defmodule Ecto.Query.PlannerTest do
 
     assert Macro.to_string(hd(query.joins).source.query.select.expr) ==
              "%{map: parent_as(:posts).posted()}"
+
+    child = from(c in Comment, select: %{map: field(parent_as(^as), "posted")})
+    query = from(Post, as: :posts, join: c in subquery(child), on: true) |> normalize()
+    assert Macro.to_string(hd(query.joins).source.query.select.expr) == "%{map: parent_as(:posts).posted()}"
 
     child = from(c in Comment, where: parent_as(^as).visits == ^"123")
 


### PR DESCRIPTION
I'm worried I'm missing something obvious. But I think with these 2 simple changes to the schema functions we can allow string names in `field/2`. 

The `__schema__(:type, field)__` functions will now catch string names and get the right type. And the `__schema__(:field_source, field)__` functions will ensure the field is converted back into an atom during normalization so that the adapters don't have to change.