### PR TITLE
FIX: Allow for HOT updates in replace_all

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -727,7 +727,15 @@ defmodule Ecto.Repo.Schema do
         {{replace_fields!(dumper, keys), [], conflict_target}, []}
 
       :replace_all ->
-        {{replace_all_fields!(:replace_all, schema, []), [], conflict_target}, []}
+        to_remove =
+          case conflict_target do
+            target when is_atom(target) or is_list(target) ->
+              List.wrap(target)
+
+            _ ->
+              []
+          end
+        {{replace_all_fields!(:replace_all, schema, to_remove), [], conflict_target}, []}
 
       {:replace_all_except, fields} ->
         {{replace_all_fields!(:replace_all_except, schema, fields), [], conflict_target}, []}

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -727,14 +727,10 @@ defmodule Ecto.Repo.Schema do
         {{replace_fields!(dumper, keys), [], conflict_target}, []}
 
       :replace_all ->
-        to_remove =
-          case conflict_target do
-            target when is_atom(target) or is_list(target) ->
-              List.wrap(target)
-
-            _ ->
-              []
-          end
+        # Remove the conflict targets from the replacing fields
+        # since the values don't change and this allows postgres to 
+        # possibly perform a HOT optimization: https://www.postgresql.org/docs/current/storage-hot.html
+        to_remove = List.wrap(conflict_target)
         {{replace_all_fields!(:replace_all, schema, to_remove), [], conflict_target}, []}
 
       {:replace_all_except, fields} ->


### PR DESCRIPTION
Hi, 

This is a small tweak for `:replace_all`. Currently `replace_all` will generate a query that will also replace the conflict targets with the same value:
```sql
insert into users (name, age) values ('elixir', 18) on conflict (name) do update
  SET name = EXCLUDED.name, age = EXCLUDED.age;
```

but this will prevent Postgres from using its [HOT optimization](https://www.postgresql.org/docs/current/storage-hot.html) because it modifies the name column. We can enable possible HOT optimization by not replacing the on conflict targets: 
```sql
insert into users (name, age) values ('elixir', 18) on conflict (name) do update SET age = EXCLUDED.age;
```

This can already be achieved by using `replace_all_except` but I was wondering if this should by default be the case for `replace_all` because I couldn't think of any reason/use case why someone would want to replace the on conflict columns with the same values.

I couldn't run the integration tests locally. I tried `earthly -P --ci --build-arg ELIXIR_BASE=1.15.6-erlang-26.1.2-alpine-3.16.7 +integration-test` but it failed for waiting that any DB comes along. I didn't have time to debug this further.
