### PR TITLE
drop :array_join join type

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -897,9 +897,7 @@ defmodule Ecto.Query do
     :right_join,
     :full_join,
     :inner_lateral_join,
-    :left_lateral_join,
-    :array_join,
-    :left_array_join
+    :left_lateral_join
   ]
 
   @doc """
@@ -948,8 +946,6 @@ defmodule Ecto.Query do
       Ecto.Query.exclude(query, :full_join)
       Ecto.Query.exclude(query, :inner_lateral_join)
       Ecto.Query.exclude(query, :left_lateral_join)
-      Ecto.Query.exclude(query, :array_join)
-      Ecto.Query.exclude(query, :left_array_join)
 
   However, keep in mind that if a join is removed and its bindings
   were referenced elsewhere, the bindings won't be removed, leading
@@ -1196,8 +1192,6 @@ defmodule Ecto.Query do
   defp join_qual(:cross_lateral_join), do: :cross_lateral
   defp join_qual(:left_lateral_join), do: :left_lateral
   defp join_qual(:inner_lateral_join), do: :inner_lateral
-  defp join_qual(:array_join), do: :array
-  defp join_qual(:left_array_join), do: :left_array
 
   defp collect_with_ties([{:with_ties, with_ties} | t], nil),
     do: collect_with_ties(t, with_ties)
@@ -1249,12 +1243,11 @@ defmodule Ecto.Query do
   Receives a source that is to be joined to the query and a condition for
   the join. The join condition can be any expression that evaluates
   to a boolean value. The qualifier must be one of `:inner`, `:left`,
-  `:right`, `:cross`, `:cross_lateral`, `:full`, `:inner_lateral`, `:left_lateral`,
-  `:array` or `:left_array`.
+  `:right`, `:cross`, `:cross_lateral`, `:full`, `:inner_lateral` or `:left_lateral`.
 
   For a keyword query the `:join` keyword can be changed to `:inner_join`,
-  `:left_join`, `:right_join`, `:cross_join`, `:cross_lateral_join`, `:full_join`, `:inner_lateral_join`,
-  `:left_lateral_join`, `:array_join` or `:left_array_join`. `:join` is equivalent to `:inner_join`.
+  `:left_join`, `:right_join`, `:cross_join`, `:cross_lateral_join`, `:full_join`, `:inner_lateral_join`
+  or `:left_lateral_join`. `:join` is equivalent to `:inner_join`.
 
   Currently it is possible to join on:
 
@@ -1403,18 +1396,6 @@ defmodule Ecto.Query do
   disclaimers about such functionality.
 
   Join hints must be static compile-time strings when they are specified as (list of) strings.
-
-  ## Array joins
-
-  The `:array` and `:left_array` qualifiers can be used to join with array
-  columns in [Clickhouse:](https://clickhouse.com/docs/en/sql-reference/statements/select/array-join)
-
-      from at in "arrays_test",
-        array_join: a in "arr",
-        select: %{s: at.s, arr: a}
-
-  Note that only the columns in the base table (i.e. the table referenced in `FROM`) can be used in the array join.
-
   """
   @join_opts [:on | @from_join_opts]
 

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -254,7 +254,7 @@ defmodule Ecto.Query.Builder.Join do
 
   defp ensure_on(on, _assoc, _qual, _source, _env) when on != nil, do: on
 
-  defp ensure_on(nil, _assoc = nil, qual, source, env) when qual not in [:cross, :cross_lateral, :array, :left_array] do
+  defp ensure_on(nil, _assoc = nil, qual, source, env) when qual not in [:cross, :cross_lateral] do
     maybe_source =
       with {source, alias} <- source,
         source when source != nil <- source || alias do
@@ -341,7 +341,7 @@ defmodule Ecto.Query.Builder.Join do
     end
   end
 
-  @qualifiers [:inner, :inner_lateral, :left, :left_lateral, :right, :full, :cross, :cross_lateral, :array, :left_array]
+  @qualifiers [:inner, :inner_lateral, :left, :left_lateral, :right, :full, :cross, :cross_lateral]
 
   @doc """
   Called at runtime to check dynamic qualifier.

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -369,8 +369,6 @@ defimpl Inspect, for: Ecto.Query do
   defp join_qual(:full), do: :full_join
   defp join_qual(:cross), do: :cross_join
   defp join_qual(:cross_lateral), do: :cross_lateral_join
-  defp join_qual(:array), do: :array_join
-  defp join_qual(:left_array), do: :left_array_join
 
   defp collect_sources(%{from: nil, joins: joins}) do
     ["query" | join_sources(joins)]

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -138,12 +138,6 @@ defmodule Ecto.Query.InspectTest do
     assert i(from(x in Post, cross_lateral_join: y in Comment, on: x.id == y.id)) ==
            ~s{from p0 in Inspect.Post, cross_lateral_join: c1 in Inspect.Comment, on: p0.id == c1.id}
 
-    assert i(from(x in Post, array_join: y in "arr")) ==
-           ~s{from p0 in Inspect.Post, array_join: a1 in "arr", on: true}
-
-    assert i(from(x in Post, left_array_join: y in "arr")) ==
-           ~s{from p0 in Inspect.Post, left_array_join: a1 in "arr", on: true}
-
     binding = :comments
     assert i(from(x in Post, left_join: y in assoc(x, ^binding), as: ^binding)) ==
            ~s{from p0 in Inspect.Post, left_join: c1 in assoc(p0, :comments), as: :comments}

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -769,8 +769,6 @@ defmodule Ecto.QueryTest do
       full_query          = from p in "posts", full_join: b in "blogs", on: true
       inner_lateral_query = from p in "posts", inner_lateral_join: b in "blogs", on: true
       left_lateral_query  = from p in "posts", left_lateral_join: b in "blogs", on: true
-      array_query         = from p in "posts", array_join: b in "blogs"
-      left_array_query    = from p in "posts", left_array_join: b in "blogs"
 
       refute inner_query.joins == base.joins
       refute cross_query.joins == base.joins
@@ -780,8 +778,6 @@ defmodule Ecto.QueryTest do
       refute full_query.joins == base.joins
       refute inner_lateral_query.joins == base.joins
       refute left_lateral_query.joins == base.joins
-      refute array_query.joins == base.joins
-      refute left_array_query.joins == base.joins
 
       excluded_inner_query = exclude(inner_query, :inner_join)
       assert excluded_inner_query.joins == base.joins
@@ -806,12 +802,6 @@ defmodule Ecto.QueryTest do
 
       excluded_left_lateral_query = exclude(left_lateral_query, :left_lateral_join)
       assert excluded_left_lateral_query.joins == base.joins
-
-      excluded_array_query = exclude(array_query, :array_join)
-      assert excluded_array_query.joins == base.joins
-
-      excluded_left_array_query = exclude(left_array_query, :left_array_join)
-      assert excluded_left_array_query.joins == base.joins
     end
 
     test "removes join qualifiers with named bindings" do
@@ -838,11 +828,7 @@ defmodule Ecto.QueryTest do
           as: :blogs_il,
           left_lateral_join: bll in "blogs",
           on: true,
-          as: :blogs_ll,
-          array_join: ba in "blogs",
-          as: :blogs_a,
-          left_array_join: bla in "blogs",
-          as: :blogs_la
+          as: :blogs_ll
 
       original_joins_number = length(query.joins)
       original_aliases_number = map_size(query.aliases)
@@ -894,18 +880,6 @@ defmodule Ecto.QueryTest do
       assert map_size(excluded_left_lateral_join_query.aliases) == original_aliases_number - 1
       refute Map.has_key?(excluded_left_lateral_join_query.aliases, :blogs_ll)
       assert Map.has_key?(excluded_left_lateral_join_query.aliases, :base)
-
-      excluded_array_join_query = exclude(query, :array_join)
-      assert length(excluded_array_join_query.joins) == original_joins_number - 1
-      assert map_size(excluded_array_join_query.aliases) == original_aliases_number - 1
-      refute Map.has_key?(excluded_array_join_query.aliases, :blogs_a)
-      assert Map.has_key?(excluded_array_join_query.aliases, :base)
-
-      excluded_left_array_join_query = exclude(query, :left_array_join)
-      assert length(excluded_left_array_join_query.joins) == original_joins_number - 1
-      assert map_size(excluded_left_array_join_query.aliases) == original_aliases_number - 1
-      refute Map.has_key?(excluded_left_array_join_query.aliases, :blogs_la)
-      assert Map.has_key?(excluded_left_array_join_query.aliases, :base)
 
       excluded_all_joins_query = exclude(query, :join)
       assert excluded_all_joins_query.joins == []


### PR DESCRIPTION
This PR removes the custom `:array` and `:left_array` join types  added in https://github.com/elixir-ecto/ecto/pull/4193 as they can be expressed via `join(..., hints: ...)` in the adapter (e.g. https://github.com/plausible/ecto_ch/pull/160) and are problematic to support fully. For example, some ARRAY JOINs in ClickHouse return scalar values but Ecto query expect the `join` binding to be "table-like" which leads to conflicts. Example of such query is

```elixir
from at in "arrays_test",
  array_join: a in "arr",
  select: %{s: at.s, arr: a}
```