### PR TITLE
Support subqueries in order_by, group_by, distinct, and windows

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -433,7 +433,7 @@ defmodule Ecto.Query do
 
   defmodule ByExpr do
     @moduledoc false
-    defstruct [:expr, :file, :line, params: [], subqueries: [], aliases: %{}]
+    defstruct [:expr, :file, :line, params: [], subqueries: []]
   end
 
   defmodule BooleanExpr do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -431,6 +431,11 @@ defmodule Ecto.Query do
     defstruct [:expr, :file, :line, params: []]
   end
 
+  defmodule ByExpr do
+    @moduledoc false
+    defstruct [:expr, :file, :line, params: [], subqueries: [], aliases: %{}]
+  end
+
   defmodule BooleanExpr do
     @moduledoc false
     defstruct [:op, :expr, :file, :line, params: [], subqueries: []]
@@ -2866,7 +2871,7 @@ defmodule Ecto.Query do
     schema = assert_schema!(query)
     pks = schema.__schema__(:primary_key)
     expr = for pk <- pks, do: {dir, field(0, pk)}
-    %QueryExpr{expr: expr, file: __ENV__.file, line: __ENV__.line}
+    %ByExpr{expr: expr, file: __ENV__.file, line: __ENV__.line}
   end
 
   defp assert_schema!(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}})

--- a/lib/ecto/query/builder/distinct.ex
+++ b/lib/ecto/query/builder/distinct.ex
@@ -30,11 +30,21 @@ defmodule Ecto.Query.Builder.Distinct do
   Called at runtime to verify distinct.
   """
   def distinct!(query, distinct, file, line) when is_boolean(distinct) do
-    apply(query, %Ecto.Query.QueryExpr{expr: distinct, params: [], line: line, file: file})
+    apply(query, %Ecto.Query.ByExpr{expr: distinct, params: [], line: line, file: file})
   end
   def distinct!(query, distinct, file, line) do
-    {expr, params} = Builder.OrderBy.order_by_or_distinct!(:distinct, query, distinct, [])
-    expr = %Ecto.Query.QueryExpr{expr: expr, params: Enum.reverse(params), line: line, file: file}
+    {expr, params, subqueries, aliases} =
+      Builder.OrderBy.order_by_or_distinct!(:distinct, query, distinct, [])
+
+    expr = %Ecto.Query.ByExpr{
+      expr: expr,
+      params: Enum.reverse(params),
+      line: line,
+      file: file,
+      subqueries: subqueries,
+      aliases: aliases
+    }
+
     apply(query, expr)
   end
 
@@ -54,12 +64,14 @@ defmodule Ecto.Query.Builder.Distinct do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _acc}} = escape(expr, {[], %{}}, binding, env)
+    {expr, {params, acc}} = escape(expr, {[], %{subqueries: [], aliases: {:%{}, [], []}}}, binding, env)
     params = Builder.escape_params(params)
 
-    distinct = quote do: %Ecto.Query.QueryExpr{
+    distinct = quote do: %Ecto.Query.ByExpr{
                            expr: unquote(expr),
                            params: unquote(params),
+                           subqueries: unquote(acc[:subqueries]),
+                           aliases: unquote(acc[:aliases]),
                            file: unquote(env.file),
                            line: unquote(env.line)}
     Builder.apply_query(query, __MODULE__, [distinct], env)

--- a/lib/ecto/query/builder/distinct.ex
+++ b/lib/ecto/query/builder/distinct.ex
@@ -69,7 +69,7 @@ defmodule Ecto.Query.Builder.Distinct do
     distinct = quote do: %Ecto.Query.ByExpr{
                            expr: unquote(expr),
                            params: unquote(params),
-                           subqueries: unquote(acc[:subqueries]),
+                           subqueries: unquote(acc.subqueries),
                            file: unquote(env.file),
                            line: unquote(env.line)}
     Builder.apply_query(query, __MODULE__, [distinct], env)

--- a/lib/ecto/query/builder/distinct.ex
+++ b/lib/ecto/query/builder/distinct.ex
@@ -33,7 +33,7 @@ defmodule Ecto.Query.Builder.Distinct do
     apply(query, %Ecto.Query.ByExpr{expr: distinct, params: [], line: line, file: file})
   end
   def distinct!(query, distinct, file, line) do
-    {expr, params, subqueries, aliases} =
+    {expr, params, subqueries} =
       Builder.OrderBy.order_by_or_distinct!(:distinct, query, distinct, [])
 
     expr = %Ecto.Query.ByExpr{
@@ -41,8 +41,7 @@ defmodule Ecto.Query.Builder.Distinct do
       params: Enum.reverse(params),
       line: line,
       file: file,
-      subqueries: subqueries,
-      aliases: aliases
+      subqueries: subqueries
     }
 
     apply(query, expr)
@@ -64,14 +63,13 @@ defmodule Ecto.Query.Builder.Distinct do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, acc}} = escape(expr, {[], %{subqueries: [], aliases: {:%{}, [], []}}}, binding, env)
+    {expr, {params, acc}} = escape(expr, {[], %{subqueries: []}}, binding, env)
     params = Builder.escape_params(params)
 
     distinct = quote do: %Ecto.Query.ByExpr{
                            expr: unquote(expr),
                            params: unquote(params),
                            subqueries: unquote(acc[:subqueries]),
-                           aliases: unquote(acc[:aliases]),
                            file: unquote(env.file),
                            line: unquote(env.line)}
     Builder.apply_query(query, __MODULE__, [distinct], env)

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -99,7 +99,7 @@ defmodule Ecto.Query.Builder.GroupBy do
     group_by = quote do: %Ecto.Query.ByExpr{
                            expr: unquote(expr),
                            params: unquote(params),
-                           subqueries: unquote(acc[:subqueries]),
+                           subqueries: unquote(acc.subqueries),
                            file: unquote(env.file),
                            line: unquote(env.line)}
     Builder.apply_query(query, __MODULE__, [group_by], env)

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -49,21 +49,21 @@ defmodule Ecto.Query.Builder.GroupBy do
   Shared between group_by and partition_by.
   """
   def group_or_partition_by!(kind, query, exprs, params) do
-    {expr, {params, _, subqueries, aliases}} =
-      Enum.map_reduce(List.wrap(exprs), {params, length(params), [], %{}}, fn
+    {expr, {params, _, subqueries}} =
+      Enum.map_reduce(List.wrap(exprs), {params, length(params), []}, fn
         field, params_count when is_atom(field) ->
           {to_field(field), params_count}
 
-        %Ecto.Query.DynamicExpr{} = dynamic, {params, count, subqueries, aliases} ->
-          {expr, params, subqueries, aliases, count} = Builder.Dynamic.partially_expand(query, dynamic, params, subqueries, aliases, count)
-          {expr, {params, count, subqueries, aliases}}
+        %Ecto.Query.DynamicExpr{} = dynamic, {params, count, subqueries} ->
+          {expr, params, subqueries, _aliases, count} = Builder.Dynamic.partially_expand(query, dynamic, params, subqueries, %{}, count)
+          {expr, {params, count, subqueries}}
 
         other, _params_count ->
           raise ArgumentError,
                 "expected a list of fields and dynamics in `#{kind}`, got: `#{inspect other}`"
       end)
 
-    {expr, params, subqueries, aliases}
+    {expr, params, subqueries}
   end
 
   defp to_field(field), do: {{:., [], [{:&, [], [0]}, field]}, [], []}
@@ -72,8 +72,8 @@ defmodule Ecto.Query.Builder.GroupBy do
   Called at runtime to assemble group_by.
   """
   def group_by!(query, group_by, file, line) do
-    {expr, params, subqueries, aliases} = group_or_partition_by!(:group_by, query, group_by, [])
-    expr = %Ecto.Query.ByExpr{expr: expr, params: Enum.reverse(params), line: line, file: file, subqueries: subqueries, aliases: aliases}
+    {expr, params, subqueries} = group_or_partition_by!(:group_by, query, group_by, [])
+    expr = %Ecto.Query.ByExpr{expr: expr, params: Enum.reverse(params), line: line, file: file, subqueries: subqueries}
     apply(query, expr)
   end
 
@@ -93,14 +93,13 @@ defmodule Ecto.Query.Builder.GroupBy do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, acc}} = escape(:group_by, expr, {[], %{subqueries: [], aliases: {:%{}, [], []}}}, binding, env)
+    {expr, {params, acc}} = escape(:group_by, expr, {[], %{subqueries: []}}, binding, env)
     params = Builder.escape_params(params)
 
     group_by = quote do: %Ecto.Query.ByExpr{
                            expr: unquote(expr),
                            params: unquote(params),
                            subqueries: unquote(acc[:subqueries]),
-                           aliases: unquote(acc[:aliases]),
                            file: unquote(env.file),
                            line: unquote(env.line)}
     Builder.apply_query(query, __MODULE__, [group_by], env)

--- a/lib/ecto/query/builder/group_by.ex
+++ b/lib/ecto/query/builder/group_by.ex
@@ -49,21 +49,21 @@ defmodule Ecto.Query.Builder.GroupBy do
   Shared between group_by and partition_by.
   """
   def group_or_partition_by!(kind, query, exprs, params) do
-    {expr, {params, _}} =
-      Enum.map_reduce(List.wrap(exprs), {params, length(params)}, fn
+    {expr, {params, _, subqueries, aliases}} =
+      Enum.map_reduce(List.wrap(exprs), {params, length(params), [], %{}}, fn
         field, params_count when is_atom(field) ->
           {to_field(field), params_count}
 
-        %Ecto.Query.DynamicExpr{} = dynamic, {params, count} ->
-          {expr, params, count} = Builder.Dynamic.partially_expand(kind, query, dynamic, params, count)
-          {expr, {params, count}}
+        %Ecto.Query.DynamicExpr{} = dynamic, {params, count, subqueries, aliases} ->
+          {expr, params, subqueries, aliases, count} = Builder.Dynamic.partially_expand(query, dynamic, params, subqueries, aliases, count)
+          {expr, {params, count, subqueries, aliases}}
 
         other, _params_count ->
           raise ArgumentError,
                 "expected a list of fields and dynamics in `#{kind}`, got: `#{inspect other}`"
       end)
 
-    {expr, params}
+    {expr, params, subqueries, aliases}
   end
 
   defp to_field(field), do: {{:., [], [{:&, [], [0]}, field]}, [], []}
@@ -72,8 +72,8 @@ defmodule Ecto.Query.Builder.GroupBy do
   Called at runtime to assemble group_by.
   """
   def group_by!(query, group_by, file, line) do
-    {expr, params} = group_or_partition_by!(:group_by, query, group_by, [])
-    expr = %Ecto.Query.QueryExpr{expr: expr, params: Enum.reverse(params), line: line, file: file}
+    {expr, params, subqueries, aliases} = group_or_partition_by!(:group_by, query, group_by, [])
+    expr = %Ecto.Query.ByExpr{expr: expr, params: Enum.reverse(params), line: line, file: file, subqueries: subqueries, aliases: aliases}
     apply(query, expr)
   end
 
@@ -93,12 +93,14 @@ defmodule Ecto.Query.Builder.GroupBy do
 
   def build(query, binding, expr, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _acc}} = escape(:group_by, expr, {[], %{}}, binding, env)
+    {expr, {params, acc}} = escape(:group_by, expr, {[], %{subqueries: [], aliases: {:%{}, [], []}}}, binding, env)
     params = Builder.escape_params(params)
 
-    group_by = quote do: %Ecto.Query.QueryExpr{
+    group_by = quote do: %Ecto.Query.ByExpr{
                            expr: unquote(expr),
                            params: unquote(params),
+                           subqueries: unquote(acc[:subqueries]),
+                           aliases: unquote(acc[:aliases]),
                            file: unquote(env.file),
                            line: unquote(env.line)}
     Builder.apply_query(query, __MODULE__, [group_by], env)

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -143,9 +143,7 @@ defmodule Ecto.Query.Builder.OrderBy do
           {{dir, expr}, params}
 
         expr, params_count ->
-          {expr, params} =
-            dynamic_or_field!(kind, expr, query, params_count)
-
+          {expr, params} = dynamic_or_field!(kind, expr, query, params_count)
           {{:asc, expr}, params}
       end)
 

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -136,32 +136,50 @@ defmodule Ecto.Query.Builder.OrderBy do
   Shared between order_by and distinct.
   """
   def order_by_or_distinct!(kind, query, exprs, params) do
-    {expr, {params, _}} =
-      Enum.map_reduce(List.wrap(exprs), {params, length(params)}, fn
+    {expr, {params, _, subqueries, aliases}} =
+      Enum.map_reduce(List.wrap(exprs), {params, length(params), [], %{}}, fn
         {dir, expr}, params_count when dir in @directions ->
-          {expr, params} = dynamic_or_field!(kind, expr, query, params_count)
+          {expr, params} =
+            dynamic_or_field!(kind, expr, query, params_count)
+
           {{dir, expr}, params}
 
         expr, params_count ->
-          {expr, params} = dynamic_or_field!(kind, expr, query, params_count)
+          {expr, params} =
+            dynamic_or_field!(kind, expr, query, params_count)
+
           {{:asc, expr}, params}
       end)
 
-    {expr, params}
+    {expr, params, subqueries, aliases}
   end
 
   @doc """
   Called at runtime to assemble order_by.
   """
   def order_by!(query, exprs, op, file, line) do
-    {expr, params} = order_by_or_distinct!(:order_by, query, exprs, [])
-    expr = %Ecto.Query.QueryExpr{expr: expr, params: Enum.reverse(params), line: line, file: file}
+    {expr, params, subqueries, aliases} = order_by_or_distinct!(:order_by, query, exprs, [])
+    expr = %Ecto.Query.ByExpr{expr: expr, params: Enum.reverse(params), line: line, file: file, subqueries: subqueries, aliases: aliases}
     apply(query, expr, op)
   end
 
-  defp dynamic_or_field!(kind, %Ecto.Query.DynamicExpr{} = dynamic, query, {params, count}) do
-    {expr, params, count} = Builder.Dynamic.partially_expand(kind, query, dynamic, params, count)
-    {expr, {params, count}}
+  defp dynamic_or_field!(
+         _kind,
+         %Ecto.Query.DynamicExpr{} = dynamic,
+         query,
+         {params, count, subqueries, aliases}
+       ) do
+    {expr, params, subqueries, aliases, count} =
+      Ecto.Query.Builder.Dynamic.partially_expand(
+        query,
+        dynamic,
+        params,
+        subqueries,
+        aliases,
+        count
+      )
+
+    {expr, {params, count, subqueries, aliases}}
   end
 
   defp dynamic_or_field!(_kind, field, _query, params_count) when is_atom(field) do
@@ -196,13 +214,15 @@ defmodule Ecto.Query.Builder.OrderBy do
 
   def build(query, binding, expr, op, env) do
     {query, binding} = Builder.escape_binding(query, binding, env)
-    {expr, {params, _acc}} = escape(:order_by, expr, {[], %{}}, binding, env)
+    {expr, {params, acc}} = escape(:order_by, expr, {[], %{subqueries: [], aliases: {:%{}, [], []}}}, binding, env)
     params = Builder.escape_params(params)
 
     order_by =
-      quote do: %Ecto.Query.QueryExpr{
+      quote do: %Ecto.Query.ByExpr{
               expr: unquote(expr),
               params: unquote(params),
+              subqueries: unquote(acc[:subqueries]),
+              aliases: unquote(acc[:aliases]),
               file: unquote(env.file),
               line: unquote(env.line)
             }

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -217,7 +217,7 @@ defmodule Ecto.Query.Builder.OrderBy do
       quote do: %Ecto.Query.ByExpr{
               expr: unquote(expr),
               params: unquote(params),
-              subqueries: unquote(acc[:subqueries]),
+              subqueries: unquote(acc.subqueries),
               file: unquote(env.file),
               line: unquote(env.line)
             }

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -139,9 +139,7 @@ defmodule Ecto.Query.Builder.OrderBy do
     {expr, {params, _, subqueries}} =
       Enum.map_reduce(List.wrap(exprs), {params, length(params), []}, fn
         {dir, expr}, params_count when dir in @directions ->
-          {expr, params} =
-            dynamic_or_field!(kind, expr, query, params_count)
-
+          {expr, params} = dynamic_or_field!(kind, expr, query, params_count)
           {{dir, expr}, params}
 
         expr, params_count ->

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -125,24 +125,26 @@ defmodule Ecto.Query.Builder.Windows do
   end
 
   defp escape_window(vars, {name, expr}, env) do
-    {compile_acc, runtime_acc, {params, _acc}} = escape(expr, {[], %{}}, vars, env)
-    {name, compile_acc, runtime_acc, Builder.escape_params(params)}
+    {compile_acc, runtime_acc, {params, acc}} = escape(expr, {[], %{subqueries: [], aliases: {:%{}, [], []}}}, vars, env)
+    {name, compile_acc, runtime_acc, Builder.escape_params(params), acc}
   end
 
-  defp build_compile_window({name, compile_acc, _, params}, env) do
+  defp build_compile_window({name, compile_acc, _, params, acc}, env) do
     {name,
      quote do
-       %Ecto.Query.QueryExpr{
+       %Ecto.Query.ByExpr{
          expr: unquote(compile_acc),
          params: unquote(params),
+         subqueries: unquote(acc[:subqueries]),
+         aliases: unquote(acc[:aliases]),
          file: unquote(env.file),
          line: unquote(env.line)
        }
      end}
   end
 
-  defp build_runtime_window({name, compile_acc, runtime_acc, params}, _env) do
-    {:{}, [], [name, Enum.reverse(compile_acc), runtime_acc, Enum.reverse(params)]}
+  defp build_runtime_window({name, compile_acc, runtime_acc, params, acc}, _env) do
+    {:{}, [], [name, Enum.reverse(compile_acc), runtime_acc, Enum.reverse(params), {:%{}, [], [subqueries: acc[:subqueries], aliases: acc[:aliases]]}]}
   end
 
   @doc """
@@ -150,30 +152,32 @@ defmodule Ecto.Query.Builder.Windows do
   """
   def runtime!(query, runtime, file, line) do
     windows =
-      Enum.map(runtime, fn {name, compile_acc, runtime_acc, params} ->
-        {acc, params} = do_runtime_window!(runtime_acc, query, compile_acc, params)
-        expr = %Ecto.Query.QueryExpr{expr: Enum.reverse(acc), params: Enum.reverse(params), file: file, line: line}
+      Enum.map(runtime, fn {name, compile_acc, runtime_acc, params, escape_acc} ->
+        {{acc, subqueries, aliases}, params} = do_runtime_window!(runtime_acc, query, {compile_acc, escape_acc[:subqueries], escape_acc[:aliases]}, params)
+        expr = %Ecto.Query.ByExpr{expr: Enum.reverse(acc), params: Enum.reverse(params), file: file, line: line, subqueries: subqueries, aliases: aliases}
         {name, expr}
       end)
 
     apply(query, windows)
   end
 
-  defp do_runtime_window!([{:order_by, order_by} | kw], query, acc, params) do
-    {order_by, params} = OrderBy.order_by_or_distinct!(:order_by, query, order_by, params)
-    do_runtime_window!(kw, query, [{:order_by, order_by} | acc], params)
+  defp do_runtime_window!([{:order_by, order_by} | kw], query, {acc, subqueries_acc, aliases_acc}, params) do
+    {order_by, params, subqueries, aliases} = OrderBy.order_by_or_distinct!(:order_by, query, order_by, params)
+
+    do_runtime_window!(kw, query, {[{:order_by, order_by} | acc], subqueries_acc ++ subqueries, Map.merge(aliases_acc, aliases)}, params)
   end
 
-  defp do_runtime_window!([{:partition_by, partition_by} | kw], query, acc, params) do
-    {partition_by, params} = GroupBy.group_or_partition_by!(:partition_by, query, partition_by, params)
-    do_runtime_window!(kw, query, [{:partition_by, partition_by} | acc], params)
+  defp do_runtime_window!([{:partition_by, partition_by} | kw], query, {acc, subqueries_acc, aliases_acc}, params) do
+    {partition_by, params, subqueries, aliases} = GroupBy.group_or_partition_by!(:partition_by, query, partition_by, params)
+
+    do_runtime_window!(kw, query, {[{:partition_by, partition_by} | acc], subqueries_acc ++ subqueries, Map.merge(aliases_acc, aliases)}, params)
   end
 
-  defp do_runtime_window!([{:frame, frame} | kw], query, acc, params) do
+  defp do_runtime_window!([{:frame, frame} | kw], query, {acc, subqueries_acc, aliases_acc}, params) do
     case frame do
       %Ecto.Query.DynamicExpr{} ->
         {frame, params, _count} = Builder.Dynamic.partially_expand(:windows, query, frame, params, length(params))
-        do_runtime_window!(kw, query, [{:frame, frame} | acc], params)
+        do_runtime_window!(kw, query, {[{:frame, frame} | acc], subqueries_acc, aliases_acc}, params)
 
       _ ->
         raise ArgumentError,

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -135,7 +135,7 @@ defmodule Ecto.Query.Builder.Windows do
        %Ecto.Query.ByExpr{
          expr: unquote(compile_acc),
          params: unquote(params),
-         subqueries: unquote(acc[:subqueries]),
+         subqueries: unquote(acc.subqueries),
          file: unquote(env.file),
          line: unquote(env.line)
        }

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -152,7 +152,7 @@ defmodule Ecto.Query.Builder.Windows do
   def runtime!(query, runtime, file, line) do
     windows =
       Enum.map(runtime, fn {name, compile_acc, runtime_acc, params, escape_acc} ->
-        {{acc, subqueries}, params} = do_runtime_window!(runtime_acc, query, {compile_acc, escape_acc[:subqueries]}, params)
+        {{acc, subqueries}, params} = do_runtime_window!(runtime_acc, query, {compile_acc, escape_acc.subqueries}, params)
         expr = %Ecto.Query.ByExpr{expr: Enum.reverse(acc), params: Enum.reverse(params), file: file, line: line, subqueries: subqueries}
         {name, expr}
       end)

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -143,7 +143,7 @@ defmodule Ecto.Query.Builder.Windows do
   end
 
   defp build_runtime_window({name, compile_acc, runtime_acc, params, acc}, _env) do
-    {:{}, [], [name, Enum.reverse(compile_acc), runtime_acc, Enum.reverse(params), {:%{}, [], [subqueries: acc[:subqueries]]}]}
+    {:{}, [], [name, Enum.reverse(compile_acc), runtime_acc, Enum.reverse(params), {:%{}, [], Map.to_list(acc)}]}
   end
 
   @doc """

--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -312,7 +312,7 @@ defmodule Ecto.Repo.Preloader do
           query = add_preload_order(assoc.preload_order, query)
 
           update_in query.order_bys, fn order_bys ->
-            [%Ecto.Query.QueryExpr{expr: [asc: related_field_ast], params: [],
+            [%Ecto.Query.ByExpr{expr: [asc: related_field_ast], params: [],
                                    file: __ENV__.file, line: __ENV__.line}|order_bys]
           end
 

--- a/test/ecto/query/builder/distinct_test.exs
+++ b/test/ecto/query/builder/distinct_test.exs
@@ -77,7 +77,6 @@ defmodule Ecto.Query.Builder.DistinctTest do
       assert [_] = distinct.subqueries
     end
 
-
     test "raises on non-atoms" do
       message = "expected a field as an atom in `distinct`, got: `\"temp\"`"
       assert_raise ArgumentError, message, fn ->

--- a/test/ecto/query/builder/distinct_test.exs
+++ b/test/ecto/query/builder/distinct_test.exs
@@ -63,6 +63,21 @@ defmodule Ecto.Query.Builder.DistinctTest do
              [{1, {0, :foo}}, {"bar", {0, :bar}}, {2, {0, :baz}}, {"bat", {0, :bat}}]
     end
 
+    test "supports subqueries" do
+      distinct = [
+        asc: dynamic([p], exists(from other_post in "posts", where: other_post.id == parent_as(:p).id))
+      ]
+
+      %{distinct: distinct} = from p in "posts", as: :p, distinct: ^distinct
+      assert distinct.expr ==  [asc: {:exists, [], [subquery: 0]}]
+      assert [_] = distinct.subqueries
+
+      %{distinct: distinct} = from p in "posts", as: :p, distinct: [asc: exists(from other_post in "posts", where: other_post.id == parent_as(:p).id)]
+      assert distinct.expr ==  [asc: {:exists, [], [subquery: 0]}]
+      assert [_] = distinct.subqueries
+    end
+
+
     test "raises on non-atoms" do
       message = "expected a field as an atom in `distinct`, got: `\"temp\"`"
       assert_raise ArgumentError, message, fn ->

--- a/test/ecto/query/builder/group_by_test.exs
+++ b/test/ecto/query/builder/group_by_test.exs
@@ -53,6 +53,19 @@ defmodule Ecto.Query.Builder.GroupByTest do
       assert group_by("q", [q], ^[key]).group_bys == group_by("q", [q], [q.title]).group_bys
     end
 
+    test "accepts subqueries" do
+      key = dynamic([p], exists(from other_q in "q", where: other_q.title == parent_as(:q).title))
+      assert [group_by] = group_by("q", [q], ^key).group_bys
+
+      assert group_by.expr == [{:exists, [], [{:subquery, 0}]}]
+      assert [_] = group_by.subqueries
+
+      assert [group_by] = group_by("q", [q], exists(from other_q in "q", where: other_q.title == parent_as(:q).title)).group_bys
+
+      assert group_by.expr == [{:exists, [], [{:subquery, 0}]}]
+      assert [_] = group_by.subqueries
+    end
+
     test "raises when no a field or a list of fields" do
       message = "expected a field as an atom in `group_by`, got: `\"temp\"`"
       assert_raise ArgumentError, message, fn ->


### PR DESCRIPTION
So this seems to work without too much change required, but I do have one main misgiving: This requires a modification to `Ecto.QueryExpr`, which AFAIK is used in other places that won't be anticipate having subqueries in them.

I've got a test that shows this working as-is with `ecto_sql`: https://github.com/elixir-ecto/ecto_sql/pull/607