### PR TITLE
Add sslmode=verify-full connection string expansion.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Ecto.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :crypto, :eex],
+      extra_applications: [:logger, :crypto, :eex, :public_key],
       mod: {Ecto.Application, []}
     ]
   end


### PR DESCRIPTION
This query param is used by postgres and cockroachdb to verify to force a secure connection,
verify that the server certificate is signed by a known CA, and verify that the server address matches that specified in the certificate.

This requires setting various complex ssl options that we can do for the user automatically.

mysql also uses the sslMode terminology for their ssl options, so I believe this can also align there as well.