### PR TITLE
Consider only sort_param if the assoc param is not provided, not the drop_param.

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1290,7 +1290,7 @@ defmodule Ecto.Changeset do
     drop = opts_key_from_params(:drop_param, opts, params)
 
     changeset =
-      if is_map_key(params, param_key) or is_list(sort) or is_list(drop) do
+      if is_map_key(params, param_key) or is_list(sort) do
         value = Map.get(params, param_key)
         original = Map.get(data, key)
         current = Relation.load!(data, original)

--- a/test/ecto/changeset/embedded_test.exs
+++ b/test/ecto/changeset/embedded_test.exs
@@ -463,6 +463,9 @@ defmodule Ecto.Changeset.EmbeddedTest do
     changeset = cast(%Author{}, %{sort: ["new"]}, :posts, opts)
     assert Enum.map(changeset.changes.posts, & &1.changes[:title]) == [nil]
 
+    changeset = cast(%Author{}, %{drop: [0]}, :posts, opts)
+    assert Enum.map(changeset.changes.posts, & &1.changes[:title]) == [nil]
+
     changeset = cast(%Author{}, %{posts: posts, sort: [2, 3, 1]}, :posts, opts)
     assert Enum.map(changeset.changes.posts, & &1.changes[:title]) == ~w(two three one)
 


### PR DESCRIPTION
1. The following commit message says it should consider the sort_param, without mentioning the drop_param: https://github.com/elixir-ecto/ecto/commit/afc694ce723f047e9fe7828ad16cea2de82eb217

2. The tests still pass when removing the check `is_list(drop)`

3. Adding the last 2 lines in the tests:
```elixir
changeset = cast(%Author{}, %{sort: ["new"]}, :posts, opts)
assert Enum.map(changeset.changes.posts, & &1.changes[:title]) == [nil] # passes

changeset = cast(%Author{}, %{drop: [0]}, :posts, opts)
assert Enum.map(changeset.changes.posts, & &1.changes[:title]) == [nil] # doesn't pass
```
raises with message
> ** (KeyError) key :posts not found in: %{}

Based on these 3 observations, I suspect the check `is_list(drop)` shouldn't be there.