### PR TITLE
Documentation: Include map and keyword list data as an option for change tracking in `put_assoc` 

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2003,7 +2003,7 @@ defmodule Ecto.Changeset do
       update or delete them). Different to passing changesets, structs are not
       change tracked in any fashion. In other words, if you change a comment
       struct and give it to `put_assoc/4`, the updates in the struct won't be
-      persisted. You must use changesets, keyword lists, or a map instead. `put_assoc/4` with structs
+      persisted. You must use changesets, keyword lists, or maps instead. `put_assoc/4` with structs
       only takes care of guaranteeing that the comments and the parent data
       are associated. This is extremely useful when associating existing data,
       as we will see in the "Example: Adding tags to a post" section.

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -2003,7 +2003,7 @@ defmodule Ecto.Changeset do
       update or delete them). Different to passing changesets, structs are not
       change tracked in any fashion. In other words, if you change a comment
       struct and give it to `put_assoc/4`, the updates in the struct won't be
-      persisted. You must use changesets instead. `put_assoc/4` with structs
+      persisted. You must use changesets, keyword lists, or a map instead. `put_assoc/4` with structs
       only takes care of guaranteeing that the comments and the parent data
       are associated. This is extremely useful when associating existing data,
       as we will see in the "Example: Adding tags to a post" section.


### PR DESCRIPTION
Currently the documentation mentions that when using structs in `put_assoc` they are not change tracked. In case you do want to change track the data then it says "You **must** use changesets instead."

I believe that maps and keyword lists could be used as well so I wanted to amend that sentence.

## Example I ran into

I wasn't aware of structs not being change tracked. Changing things to a map instead of a struct still fixed things.

## Non Change Tracked Code

```elixir
    changes =
      intervals_to_change
      |> Enum.reduce([], fn interval, interval_acc ->
        new_start = DateTime.add(interval.start, minutes, :minute)
        new_end = DateTime.add(interval.end, minutes, :minute)
        [%Interval{interval | start: new_start, end: new_end} | interval_acc]
      end)

    Ecto.Changeset.put_embed(changeset, :intervals, changes)
```

This will result in no changes
```elixir
 #Ecto.Changeset<action: nil, changes: %{}, errors: [],
 data: #Alpen.Intervals.IntervalList<>, valid?: true>

```

### Change Tracked Code with Maps

After just changing the struct to a map, changes were tracked

```elixir
    changes =
      intervals_to_change
      |> Enum.reduce([], fn interval, interval_acc ->
        new_start = DateTime.add(interval.start, minutes, :minute)
        new_end = DateTime.add(interval.end, minutes, :minute)
        [%{id: interval.id, start: new_start, end: new_end} | interval_acc]
      end)
    Ecto.Changeset.put_embed(changeset, :intervals, changes)
```

The output was the following 
```elixir
#Ecto.Changeset<
  action: nil,
  changes: %{
    intervals: [
      #Ecto.Changeset<
        action: :update,
        changes: %{
          start: ~U[2024-05-24 08:30:00Z],
          end: ~U[2024-05-24 09:00:00Z]
        },
        errors: [],
        data: #Alpen.Intervals.Interval<>,
        valid?: true
      >,
      #Ecto.Changeset<
        action: :update,
        changes: %{
          start: ~U[2024-05-24 09:00:00Z],
          end: ~U[2024-05-24 09:30:00Z]
        },
        errors: [],
        data: #Alpen.Intervals.Interval<>,
        valid?: true
      >
    ]
  },
  errors: [],
  data: #Alpen.Intervals.IntervalList<>,
  valid?: true
>


```