### PR TITLE
Merge types during `Ecto.Changeset.merge/2`

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1523,10 +1523,10 @@ defmodule Ecto.Changeset do
 
   defp cast_merge(cs1, cs2) do
     new_params = (cs1.params || cs2.params) && Map.merge(cs1.params || %{}, cs2.params || %{})
+    new_types = (cs1.types || cs2.types) && Map.merge(cs1.types || %{}, cs2.types || %{})
     new_changes = Map.merge(cs1.changes, cs2.changes)
     new_errors = Enum.uniq(cs1.errors ++ cs2.errors)
     new_required = Enum.uniq(cs1.required ++ cs2.required)
-    new_types = cs1.types || cs2.types
     new_valid? = cs1.valid? and cs2.valid?
 
     %{

--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1523,7 +1523,7 @@ defmodule Ecto.Changeset do
 
   defp cast_merge(cs1, cs2) do
     new_params = (cs1.params || cs2.params) && Map.merge(cs1.params || %{}, cs2.params || %{})
-    new_types = (cs1.types || cs2.types) && Map.merge(cs1.types || %{}, cs2.types || %{})
+    new_types = Map.merge(cs1.types, cs2.types)
     new_changes = Map.merge(cs1.changes, cs2.changes)
     new_errors = Enum.uniq(cs1.errors ++ cs2.errors)
     new_required = Enum.uniq(cs1.required ++ cs2.required)

--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -661,6 +661,12 @@ defmodule Ecto.ChangesetTest do
     assert length(constraints(changeset)) == 2
   end
 
+  test "merge/2: merges types" do
+    cs1 = cast({%{}, %{title: :string}}, %{title: "foo"}, ~w(title)a)
+    cs2 = cast({%{}, %{body: :string}}, %{body: "foo"}, ~w(body)a)
+    assert merge(cs1, cs2).types == %{title: :string, body: :string}
+  end
+
   test "merge/2: merges parameters" do
     empty = cast(%Post{}, %{}, ~w(title)a)
     cs1 = cast(%Post{}, %{body: "foo"}, ~w(body)a)


### PR DESCRIPTION
This commit adds support for merging types when calling `Ecto.Changeset.merge/2`.

Closes #4424