### PR TITLE
Add anchors in documentation

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1027,7 +1027,8 @@ defmodule Ecto.Changeset do
 
     * If there is an associated child with an ID and its ID is not given
       as parameter, the `:on_replace` callback for that association will
-      be invoked (see the "On replace" section on the module documentation)
+      be invoked (see the ["On replace" section](#module-the-on_replace-option)
+      on the module documentation)
 
   If two or more addresses have the same IDs, Ecto will consider that an
   error and add an error to the changeset saying that there are duplicate

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -870,7 +870,8 @@ defmodule Ecto.Query do
       )
 
   If you need to refer to a parent binding which is not known when writing the subquery,
-  you can use `parent_as` as shown in the examples under "Named bindings" in this module doc.
+  you can use `parent_as` as shown in the examples under ["Named bindings"](#module-named-bindings)
+  in this module doc.
 
   You can also use subquery directly in `select` and `select_merge`:
 
@@ -2885,7 +2886,8 @@ defmodule Ecto.Query do
   @doc """
   Returns `true` if the query has a binding with the given name, otherwise `false`.
 
-  For more information on named bindings see "Named bindings" in this module doc.
+  For more information on named bindings see ["Named bindings"](#module-named-bindings)
+  in this module doc.
   """
   def has_named_binding?(%Ecto.Query{aliases: aliases}, key) do
     Map.has_key?(aliases, key)
@@ -2923,7 +2925,8 @@ defmodule Ecto.Query do
         join(query, :left, [p], a in assoc(p, ^binding), as: ^binding)
       end)
 
-  For more information on named bindings see "Named bindings" in this module doc or `has_named_binding?/2`.
+  For more information on named bindings see ["Named bindings"](#module-named-bindings)
+  in this module doc or `has_named_binding?/2`.
   """
   def with_named_binding(%Ecto.Query{} = query, key, fun) do
     if has_named_binding?(query, key) do

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -822,7 +822,8 @@ defmodule Ecto.Schema do
       association, defaults to the primary key on the schema
 
     * `:through` - Allow this association to be defined in terms of existing
-      associations. Read the section on `:through` associations for more info
+      associations. Read the [section on `:through` associations](#has_many/3-has_many-has_one-through)
+      for more info
 
     * `:on_delete` - The action taken on associations when parent record
       is deleted. May be `:nothing` (default), `:nilify_all` and `:delete_all`.


### PR DESCRIPTION
Hello! I've stumbled upon a few places in the docs that could use anchors instead of having to search through the module page. Feel free to change the formatting! Thank you!