### PR TITLE
Convert structs that implement the Enumerable protocol to lists

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -135,8 +135,9 @@ defmodule Ecto.Query.API do
 
       from p in Post, where: p.id in [1, 2, 3]
 
-  The right side may either be a list, a literal list, a struct that implements
-  the `Enumerable` protocol, or even a column in the database with array type:
+  The right side may either be a literal list, an interpolated list,
+  any struct that implements the `Enumerable` protocol, or even a
+  column in the database with array type:
 
       from p in Post, where: "elixir" in p.tags
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -135,8 +135,8 @@ defmodule Ecto.Query.API do
 
       from p in Post, where: p.id in [1, 2, 3]
 
-  The right side may either be a list, a literal list
-  or even a column in the database with array type:
+  The right side may either be a list, a literal list, a struct that implements
+  the `Enumerable` protocol, or even a column in the database with array type:
 
       from p in Post, where: "elixir" in p.tags
 

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1387,6 +1387,13 @@ defmodule Ecto.Type do
     {:ok, Enum.reverse(acc)}
   end
 
+  defp array_with_index(%_{} = struct, fun, skip_nil?, index, acc) do
+    case Enumerable.impl_for(struct) do
+      nil -> :error
+      _ -> struct |> Enum.to_list() |> array_with_index(fun, skip_nil?, index, acc)
+    end
+  end
+
   defp array_with_index(_, _, _, _, _) do
     :error
   end

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -243,6 +243,8 @@ defmodule Ecto.TypeTest do
 
   test "in" do
     assert cast({:in, :integer}, ["1", "2", "3"]) == {:ok, [1, 2, 3]}
+    assert {:ok, list} = cast({:in, :integer}, MapSet.new(~w(1 2 3)))
+    assert [1, 2, 3] = Enum.sort(list)
     assert cast({:in, :integer}, nil) == :error
   end
 


### PR DESCRIPTION
I found it surprising that I could not use a `MapSet` or another `Enum` when using `in` in a query as I expected it to function similarly to `Kernel.in/2`.
```elixir
ids = MapSet.new([1, 2, 3])
where(Comment, [c], c.id in ^ids) 
```

This PR checks for an implementation of the `Enumerable` protocol and converts it to a list when casting, returning an error if there is none.

If this isn't the direction you want Ecto to go, I'm happy to have this closed. Otherwise, let me know anything else I should be mindful of or any documentation I should update.

Thanks!