### PR TITLE
insert_all with query was not using field source

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -961,6 +961,13 @@ defmodule Ecto.Integration.RepoTest do
 
       assert %Post{title: ^expected_title} = TestRepo.get(Post, expected_id)
     end
+
+    test "insert_all with query and source field" do
+      TestRepo.insert!(%Permalink{url: "url", title: "title"})
+
+      source = from p in Permalink, select: %{url: p.title}
+      assert {1, _} = TestRepo.insert_all(Permalink, source)
+    end
   end
 
   @tag :invalid_prefix

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -963,9 +963,10 @@ defmodule Ecto.Integration.RepoTest do
     end
 
     test "insert_all with query and source field" do
+      %{id: post_id} = TestRepo.insert!(%Post{})
       TestRepo.insert!(%Permalink{url: "url", title: "title"})
 
-      source = from p in Permalink, select: %{url: p.title}
+      source = from p in Permalink, select: %{url: p.title, post_id: ^post_id}
       assert {1, _} = TestRepo.insert_all(Permalink, source)
     end
   end

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -119,7 +119,7 @@ defmodule Ecto.Repo.Schema do
       %Ecto.Query.SelectExpr{expr: {:%{}, _ctx, args}} ->
         Enum.map(args, fn {field, _} ->
           case dumper do
-            %{^field => {_, _, false}} -> field
+            %{^field => {source, _, false}} -> source
             %{} -> raise ArgumentError, "cannot select unwritable field `#{field}` for insert_all"
             nil -> field
           end
@@ -128,7 +128,7 @@ defmodule Ecto.Repo.Schema do
       %Ecto.Query.SelectExpr{take: %{^ix => {_fun, fields}}} ->
         Enum.map(fields, fn field ->
           case dumper do
-            %{^field => {_, _, false}} -> field
+            %{^field => {source, _, false}} -> source
             %{} -> raise ArgumentError, "cannot select unwritable field `#{field}` for insert_all"
             nil -> field
           end


### PR DESCRIPTION
The issue is that when a query is used as the data for `insert_all`, the map keys are not converted into the field source names.  This is in contrast to when a list of maps/kw lists are given, [which use the field source name](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/schema.ex#L176).

I believe we want to standardize this so it's the same behaviour both ways but it would be good to confirm you agree. Thanks.

