### PR TITLE
Fix typos

### DIFF
--- a/guides/howtos/Dynamic queries.md
+++ b/guides/howtos/Dynamic queries.md
@@ -44,7 +44,7 @@ end
 
 The examples above show you can build and compose queries at a high-level: by composing each call to `where`, `order_by`, and so on. However, sometimes you want the contents of the `where` or the `order_by` themselves to be defined dynamically. For example, a web application that provides search functionality on top of existing posts. The user should be able to specify multiple criteria, such as the author name, the post category, publishing interval, etc.
 
-Futhermore, while many developers prefer the pipe-based syntax, having to repeat the binding `p` made it quite verbose compared to the keyword one.
+Furthermore, while many developers prefer the pipe-based syntax, having to repeat the binding `p` made it quite verbose compared to the keyword one.
 
 To solve those problems, Ecto also provides a data-structure centric API to build queries as well as a very powerful mechanism for dynamic queries. Let's take a look.
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -789,7 +789,7 @@ defmodule Ecto.Query.API do
 
   `type/2` is all about Ecto types. Therefore, you can perform `type(expr, :string)`
   but not `type(expr, :text)`, because `:text` is not an actual Ecto type. If you want
-  to peform casting exclusively at the database level, you can use fragment. For example,
+  to perform casting exclusively at the database level, you can use fragment. For example,
   in PostgreSQL, you might do `fragment("?::text", p.column)`.
   """
   def type(interpolated_value, type), do: doc!([interpolated_value, type])

--- a/lib/ecto/query/builder/preload.ex
+++ b/lib/ecto/query/builder/preload.ex
@@ -302,7 +302,7 @@ defmodule Ecto.Query.Builder.Preload do
     raise ArgumentError,
       "invalid preload for key `#{inspect(key)}`: #{inspect(other)}. " <>
       "Preloads can be a query, a function (arity 1), or a dynamic that " <>
-      "evalutes to a single binding."
+      "evaluates to a single binding."
   end
 
   defp assert_assoc!(mode, _atom) when mode in [:both, :assoc], do: :ok

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -576,7 +576,7 @@ defmodule Ecto.Repo.Queryable do
     end
 
     unless Enum.all?(structs, &(&1.__struct__ == head.__struct__)) do
-      raise ArgumentError, "expected an homogenous list, received different struct types"
+      raise ArgumentError, "expected an homogeneous list, received different struct types"
     end
 
     :ok

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1761,7 +1761,7 @@ defmodule Ecto.Schema do
   Ecto provides this guarantee for all built-in types.
 
   When decoding, if a key exists in the database not defined in the
-  schema, it'll be ignored. If a field exists in the schema thats not
+  schema, it'll be ignored. If a field exists in the schema that's not
   in the database, it's value will be `nil`.
   """
   defmacro embeds_one(name, schema, opts \\ [])

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -296,7 +296,7 @@ defmodule Ecto.RepoTest do
     end
 
     test "raises when receives multiple struct types" do
-      message = ~r"expected an homogenous list"
+      message = ~r"expected an homogeneous list"
 
       assert_raise ArgumentError, message, fn ->
         TestRepo.reload([%MySchemaWithAssoc{id: 1}, %MySchema{id: 2}])


### PR DESCRIPTION
Found via `codespell -L reenable -S deps`