### PR TITLE
Update put_assoc cheatsheet to use changesets

### DIFF
--- a/guides/cheatsheets/associations.cheatmd
+++ b/guides/cheatsheets/associations.cheatmd
@@ -268,12 +268,12 @@ movie =
   |> Repo.preload(:characters)
 
 IO.inspect(movie.characters)
-#=> [%{name: "Andy Dufresne", age: 50},
-#=>  %{name: "Red", age: 60}]
+#=> [%Character{name: "Andy Dufresne", age: 50},
+#=>  %Character{name: "Red", age: 60}]
 
 characters =
   Enum.map(movie.characters, fn character ->
-    update_in(character.age, &(&1 + 1)))
+    change(character, %{age: character.age + 1})
   end)
 
 {:ok, movie} =

--- a/guides/cheatsheets/associations.cheatmd
+++ b/guides/cheatsheets/associations.cheatmd
@@ -273,7 +273,7 @@ IO.inspect(movie.characters)
 
 characters =
   Enum.map(movie.characters, fn character ->
-    change(character, %{age: character.age + 1})
+    change(character, age: character.age + 1)
   end)
 
 {:ok, movie} =


### PR DESCRIPTION
The existing docs use update_in on a struct and pass that to put_assoc which doesn't actually perform any updates because:

"structs are not change tracked in any fashion.
In other words, if you change a comment struct and give it to put_assoc/4, the updates in the struct won't be persisted. You must use changesets instead."

This fixes the doc to use changesets instead so the example can be followed.