### PR TITLE
Allow join preloads with subqueries

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -656,13 +656,15 @@ defmodule Ecto.Integration.JoinsTest do
 
     q =
       from p1 in Post,
+        left_join: u in User,
+        on: p1.author_id == u.id,
         inner_join: c in subquery(from c in Comment),
         on: p1.id == c.post_id,
         join: p2 in Post,
         on: c.post_id == p2.id,
-        preload: [comments: {c, post: p2}]
+        preload: [author: u, force_comments: {c, post: p2}]
 
-    assert [%Post{id: ^p_id, comments: comments}] = TestRepo.all(q)
+    assert [%Post{id: ^p_id, force_comments: comments}] = TestRepo.all(q)
     [comment1, comment2] = Enum.sort_by(comments, & &1.id)
     assert %Comment{id: ^c1_id, post: %Post{id: ^p_id}} = comment1
     assert %Comment{id: ^c2_id, post: %Post{id: ^p_id}} = comment2

--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -656,7 +656,7 @@ defmodule Ecto.Integration.JoinsTest do
 
     q =
       from p1 in Post,
-        inner_lateral_join: c in subquery(from c in Comment, order_by: c.id),
+        inner_join: c in subquery(from c in Comment, order_by: c.id),
         on: p1.id == c.post_id,
         join: p2 in Post,
         on: c.post_id == p2.id,

--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -656,13 +656,14 @@ defmodule Ecto.Integration.JoinsTest do
 
     q =
       from p1 in Post,
-        inner_join: c in subquery(from c in Comment, order_by: c.id),
+        inner_join: c in subquery(from c in Comment),
         on: p1.id == c.post_id,
         join: p2 in Post,
         on: c.post_id == p2.id,
         preload: [comments: {c, post: p2}]
 
-    assert [%Post{id: ^p_id, comments: [comment1, comment2]}] = TestRepo.all(q)
+    assert [%Post{id: ^p_id, comments: comments}] = TestRepo.all(q)
+    [comment1, comment2] = Enum.sort_by(comments, & &1.id)
     assert %Comment{id: ^c1_id, post: %Post{id: ^p_id}} = comment1
     assert %Comment{id: ^c2_id, post: %Post{id: ^p_id}} = comment2
   end

--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -669,7 +669,7 @@ defmodule Ecto.Integration.JoinsTest do
         on: c.post_id == p2.id,
         preload: [comments: {c, post: p2}]
 
-    assert [%Post{id: ^p_id, comments: [comment]}] = TestRepo.all(q, log: :error)
+    assert [%Post{id: ^p_id, comments: [comment]}] = TestRepo.all(q)
     assert %Comment{id: ^c2_id, post: %Post{id: ^p_id}} = comment
   end
 end


### PR DESCRIPTION
Following our discussion about lateral preloads, I took a stab at allowing subqueries to be both the parent and child of join preloads.

The main deterrent is that subqueries do not have a schema assigned to them, so it's not possible to directly obtain their primary keys or association metadata. These are both important when associating the parents/children once the information is retrieved from the database.

The workaround proposed here is to take the `related` schema from the owner association metadata and assume the subquery complies with it. This is similar but not 100% the same as how it works today. Today you could theoretically preload schema `A` while joining on schema `B` as long as `B` has its own primary key and has the fields needed for the association.

In this PR i took a stab only at joining in plain subqueries and not `assoc(...)`. I have to think a bit more about `assoc(...)` but I think we want to support this anyway....

