### PR TITLE
Improve error message on invalid Ecto.Type.cast/1

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2537,9 +2537,17 @@ defmodule Ecto.Query.Planner do
       {:ok, v} ->
         {:ok, v}
 
-      _ ->
+      :error ->
         {:error,
          "value `#{inspect(v)}` in `#{kind}` cannot be cast to type #{Ecto.Type.format(type)}"}
+
+      {:error, _meta} ->
+        {:error,
+         "value `#{inspect(v)}` in `#{kind}` cannot be cast to type #{Ecto.Type.format(type)}"}
+
+      other ->
+        raise "expected #{inspect(type)}.cast/1 to return {:ok, v}, :error, or {:error, meta}" <>
+                ", got: #{inspect(other)}"
     end
   end
 

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1792,6 +1792,7 @@ defmodule Ecto.RepoTest do
       use Ecto.Type
       def type(), do: :binary_id
       def cast("foo-" <> _ = id), do: {:ok, id}
+      def cast("invalid"), do: :invalid
       def cast(id), do: {:ok, "foo-" <> id}
       def load(uuid), do: {:ok, "foo-" <> uuid}
       def dump("foo-" <> uuid), do: {:ok, uuid}
@@ -1817,6 +1818,15 @@ defmodule Ecto.RepoTest do
 
       assert {:ok, inserted} = TestRepo.insert(changeset)
       assert inserted.id == "foo-" <> id
+    end
+
+    test "invalid Ecto.Type.cast/1 implementation raises" do
+      e =
+        assert_raise RuntimeError, fn ->
+          TestRepo.all(from s in MySchemaCustomPK, where: s.id == ^"invalid")
+        end
+
+      assert e.message =~ "expected Ecto.RepoTest.PrefixedID.cast/1 to return {:ok, v},"
     end
   end
 


### PR DESCRIPTION
Ref: #4444

Another idea for implementation would be to raise from `Ecto.Type.cast/2`.