### PR TITLE
Improve the Repo.insert_all/3 docs on source query

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1491,7 +1491,8 @@ defmodule Ecto.Repo do
 
   A query can be given instead of a list with entries. This query needs to select
   into a map containing only keys that are available as writeable columns in the
-  schema.
+  schema. This will query and insert the values all inside one query, without
+  another round trip to the application.
 
   ## Examples
 


### PR DESCRIPTION
Hello everyone,

As usual thank you for all your hard work on my absolute favorite way to interact with the database :green_heart: 

Be more explicit about that it will be accomplished inside of just one query without a round trip of the data to the application, which can make a huge difference for data heavy operations.

I assumed this from the docs, but it also wasn't entirely clear and doubt was expressed that this was the behaviour. So, I tried out a (slightly adapted) version of the sample and low and behold it generates this SQL query:

```
INSERT INTO "author_stats" ("author_id","posts","interactions","inserted_at","updated_at") (SELECT p0."author_id", count(DISTINCT p0."id"), sum(c1."likes") + count(c1."id"), $1, $2 FROM "posts" AS p0 INNER JOIN "comments" AS c1 ON c1."post_id" = p0."id" GROUP BY p0."author_id") [~U[2024-07-11 12:40:53Z], ~U[2024-07-11 12:40:53Z]]
```

Which is what I expected.

So, I think this clarification helps. Feedback on how to make it even clearer appreciated :)