### PR TITLE
Remove directional escapes from `Builder.Select`

### DIFF
--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -56,9 +56,6 @@ defmodule Ecto.Query.Builder.OrderBy do
     |> Enum.map_reduce(params_acc, &do_escape(&1, &2, kind, vars, env))
   end
 
-  defp get_env({env, _}), do: env
-  defp get_env(env), do: env
-
   defp do_escape({dir, {:^, _, [expr]}}, params_acc, kind, _vars, _env) do
     {{quoted_dir!(kind, dir),
       quote(do: Ecto.Query.Builder.OrderBy.field!(unquote(kind), unquote(expr)))}, params_acc}
@@ -86,6 +83,9 @@ defmodule Ecto.Query.Builder.OrderBy do
     {ast, params_acc} = Builder.escape(expr, :any, params_acc, vars, env)
     {{:asc, ast}, params_acc}
   end
+
+  defp get_env({env, _}), do: env
+  defp get_env(env), do: env
 
   @doc """
   Checks the variable is a quoted direction at compilation time or

--- a/lib/ecto/query/builder/order_by.ex
+++ b/lib/ecto/query/builder/order_by.ex
@@ -51,10 +51,13 @@ defmodule Ecto.Query.Builder.OrderBy do
           {Macro.t(), {list, term}}
   def escape(kind, expr, params_acc, vars, env) do
     expr
-    |> Macro.expand_once(env)
+    |> Macro.expand_once(get_env(env))
     |> List.wrap()
     |> Enum.map_reduce(params_acc, &do_escape(&1, &2, kind, vars, env))
   end
+
+  defp get_env({env, _}), do: env
+  defp get_env(env), do: env
 
   defp do_escape({dir, {:^, _, [expr]}}, params_acc, kind, _vars, _env) do
     {{quoted_dir!(kind, dir),

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -98,12 +98,6 @@ defmodule Ecto.Query.Builder.Select do
   end
 
   # List
-  defp escape([{dir, _} | _] = expr, params_acc, vars, env)
-       when dir in ~w(asc asc_nulls_last asc_nulls_first desc desc_nulls_last desc_nulls_first)a do
-    Builder.escape(expr, :any, params_acc, vars, {env, &escape_expansion/5})
-  end
-
-  # List
   defp escape(list, params_acc, vars, env) when is_list(list) do
     Enum.map_reduce(list, params_acc, &escape(&1, &2, vars, env))
   end


### PR DESCRIPTION
We can remove this because the window function eventually call the escape functions from `Builder.OrderBy`.

While playing around with this I also found that we can't rely on env being the struct.