### PR TITLE
Improve error message for `select_merge` with `insert_all`

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -134,6 +134,17 @@ defmodule Ecto.Repo.Schema do
           end
         end)
 
+      %Ecto.Query.SelectExpr{expr: {:merge, _, _}} ->
+        raise ArgumentError, """
+        the source query given to `insert_all` has selected both `map/2` and
+        a literal map:
+
+          #{inspect query}
+
+        when using `select_merge` with `insert_all`, you must always use literal
+        maps or always use `map/2`. The two cannot be combined.
+        """
+
       _ ->
         raise ArgumentError, """
         cannot generate a fields list for insert_all from the given source query


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/pull/4431
Closes https://github.com/elixir-ecto/ecto/issues/4430

I can't see a great way to fix this so going with your suggestion to improve the error message. Maybe with the `map/1` improvements we discussed last year it can help this.