### PR TITLE
Fix inspecting fields from sources with take

### DIFF
--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -477,6 +477,9 @@ defmodule Ecto.Query.InspectTest do
 
     assert i(from(p in Post, select: merge(p, %{foo: p.foo}))) ==
              ~s"from p0 in Inspect.Post, select: merge(p0, %{foo: p0.foo})"
+
+    assert i(from(p in Post, select: %{title: p.title}, select_merge: map(p, [:visits]))) ==
+             ~s"from p0 in Inspect.Post, select: merge(%{title: p0.title}, map(p0, [:visits]))"
   end
 
   test "select after planner" do


### PR DESCRIPTION
There is an issue when using inspect on a query that selects a field from a source that also has `take`. The traversal only looks for `{:&, _, [ix]}` and prints out `map(...)` or `struct(...)` if take is present without considering the context `{:&, _, [ix]}` is being used in.

The change here is to catch during the pre-order traversal when it is being used  as part of a field expression. Because in this case it does not make sense to consider `take`. 

Without this change the test I added would print ` "from p0 in Inspect.Post, select: merge(%{title: map(p0, [:visits]).title}, map(p0, [:visits]))"`