### PR TITLE
Select with map update syntax and dynamic values

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1461,6 +1461,13 @@ defmodule Ecto.Integration.RepoTest do
       assert [%Post{title: "new title", visits: 13}] =
         TestRepo.all(from p in Post, select: %Post{p | title: "new title"})
 
+
+      assert [%Post{:title => "1", visits: -1}] =
+             TestRepo.all(from p in Post, select: %{p | visits: ^"-1"})
+
+      assert [%Post{title: "1", visits: -1}] =
+        TestRepo.all(from p in Post, select: %Post{p | visits: ^"-1"})
+
       assert_raise KeyError, fn ->
         TestRepo.all(from p in Post, select: %{p | unknown: "new title"})
       end

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1461,7 +1461,6 @@ defmodule Ecto.Integration.RepoTest do
       assert [%Post{title: "new title", visits: 13}] =
         TestRepo.all(from p in Post, select: %Post{p | title: "new title"})
 
-
       assert [%Post{:title => "1", visits: -1}] =
              TestRepo.all(from p in Post, select: %{p | visits: ^"-1"})
 


### PR DESCRIPTION
I am almost certain we can support https://github.com/elixir-ecto/ecto/issues/4464 but first we need to make some small changes to how selecting with map update syntax works with dynamic values. 

Today we are not trying to infer the type so it gets set to `:any`. Then adapters like Postgrex default to assuming it's a binary type. So for instance if your dynamic value is an integer you will get an error.

This change makes it so that we look for dynamic values with the map update syntax and wrap it in `type/2`. We don't want to do this for literals because then it will make the literals part of the query instead of a post processing update.