### PR TITLE
remove compile dependency on `:preload_order` MFA in `has_many`

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1035,6 +1035,7 @@ defmodule Ecto.Schema do
   """
   defmacro has_many(name, schema, opts \\ []) do
     schema = expand_literals(schema, __CALLER__)
+    opts = expand_literals(opts, __CALLER__)
 
     quote do
       Ecto.Schema.__has_many__(__MODULE__, unquote(name), unquote(schema), unquote(opts))


### PR DESCRIPTION
Expand AST on `has_many` opts. This is already done on `many_to_many` so I figured it shouldn't cause any problem.

Fixes #4466

