### PR TITLE
Disable cache for values lists

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -521,6 +521,8 @@ defmodule Ecto.Query.API do
   Each field must be given a type or an error is raised. Any type that can be specified in
   a schema may be used.
 
+  Queries using a values list are not cacheable by Ecto.
+
   ## Select example
 
       values = [%{id: 1, text: "abc"}, %{id: 2, text: "xyz"}]

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1095,9 +1095,11 @@ defmodule Ecto.Query.Planner do
   defp source_cache(%{source: {bin, schema}, prefix: prefix}, params),
     do: {{bin, schema, schema.__schema__(:hash), prefix}, params}
 
-  defp source_cache(%{source: {kind, _, _} = source, prefix: prefix}, params)
-       when kind in [:fragment, :values],
-       do: {{source, prefix}, params}
+  defp source_cache(%{source: {:fragment, _, _} = source, prefix: prefix}, params),
+    do: {{source, prefix}, params}
+
+  defp source_cache(%{source: {:values, _, _}}, params),
+    do: {:nocache, params}
 
   defp source_cache(%{source: %Ecto.SubQuery{params: inner, cache: key}}, params),
     do: {key, Enum.reverse(inner, params)}

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -612,8 +612,6 @@ defmodule Ecto.Query.PlannerTest do
         lock: "foo",
         where: is_nil(nil),
         or_where: is_nil(nil),
-        join: v in values([%{num: 1}, %{num: 10}], %{num: :integer}),
-        on: true,
         join: c in Comment,
         on: true,
         hints: ["join hint"],
@@ -633,7 +631,6 @@ defmodule Ecto.Query.PlannerTest do
              {:where, [{:and, {:is_nil, [], [nil]}}, {:or, {:is_nil, [], [nil]}}]},
              {:join,
               [
-                {:inner, {{:values, [], [[num: :integer], 2]}, nil}, true, []},
                 {:inner, {"comments", Comment, 38_292_156, "world"}, true, ["join hint"]}
               ]},
              {:from, {"posts", Post, 50_009_106, "hello"}, ["hint"]},
@@ -660,6 +657,12 @@ defmodule Ecto.Query.PlannerTest do
       |> distinct(true)
 
     {_, _, key} = query1 |> union_all(^query2) |> Planner.plan(:all, Ecto.TestAdapter)
+    assert key == :nocache
+  end
+
+  test "plan: values lists are uncacheable" do
+    query = from(v in values([%{id: 1}], %{id: :integer}))
+    {_query, _params, key} = Planner.plan(query, :all, Ecto.TestAdapter)
     assert key == :nocache
   end
 


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4470

The cache key used to be like this `{:values, [], [[num: :integer], 2]}`. Basically we need the types (due to needing to cast the values) and the number of rows in order for the cache to work properly.

This has the potential to produce a lot of cache entries if the types or number of rows varies. In the attached issue we had a report of someone issuing many queries with 200-600 values in them. So each stored query string has the potential to be quite large. 