### PR TITLE
Fix edge case for insert_all with selecting a source with updates

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -125,7 +125,10 @@ defmodule Ecto.Repo.Schema do
                 do: insert_all_select_dump!(expr)
 
           updated_fields = args |> Keyword.keys() |> Enum.map(&insert_all_select_dump!(&1, dumper))
-          unchanged_fields ++ updated_fields
+          # If the user updates a field with another field from the same source, it will get
+          # moved to the end of `select.fields` but still have the same select expression.
+          # To maintain the order of the fields, we have to de-duplicate and keep the last one.
+          (unchanged_fields ++ updated_fields) |> Enum.reverse() |> Enum.uniq() |> Enum.reverse()
 
         %Ecto.Query.SelectExpr{expr: {:%{}, _ctx, args}} ->
           Enum.map(args, fn {field, _} -> insert_all_select_dump!(field, dumper) end)

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -121,9 +121,7 @@ defmodule Ecto.Repo.Schema do
       case query.select do
         %Ecto.Query.SelectExpr{expr: {:%{}, [], [{:|, _, [{:&, _, [ix]}, args]}]}, fields: fields} ->
           {updated_fields, updated_set} =
-            args
-            |> Keyword.keys()
-            |> Enum.map_reduce(MapSet.new(), fn field, set ->
+            Enum.map_reduce(args, MapSet.new(), fn {field, _}, set ->
               dumped_field = insert_all_select_dump!(field, dumper)
               {dumped_field, MapSet.put(set, dumped_field)}
             end)

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -120,14 +120,17 @@ defmodule Ecto.Repo.Schema do
     header =
       case query.select do
         %Ecto.Query.SelectExpr{expr: {:%{}, [], [{:|, _, [{:&, _, [ix]}, args]}]}, fields: fields} ->
-          updated_fields =
-            args |> Keyword.keys() |> Enum.map(&insert_all_select_dump!(&1, dumper))
-
-          updated_fields_set = MapSet.new(updated_fields)
+          {updated_fields, updated_set} =
+            args
+            |> Keyword.keys()
+            |> Enum.map_reduce(MapSet.new(), fn field, set ->
+              dumped_field = insert_all_select_dump!(field, dumper)
+              {dumped_field, MapSet.put(set, dumped_field)}
+            end)
 
           unchanged_fields =
             for {{:., _, [{:&, _, [^ix]}, field]}, [], []} = expr <- fields,
-                not MapSet.member?(updated_fields_set, field),
+                not MapSet.member?(updated_set, field),
                 do: insert_all_select_dump!(expr)
 
           unchanged_fields ++ updated_fields

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -746,6 +746,49 @@ defmodule Ecto.RepoTest do
       assert query.select.fields == select_fields(unchanged_fields, 0) ++ updated_values
     end
 
+    test "takes query selecting on source with update from same source" do
+      # no join
+      query = from s in MySchema, select: %{s | x: s.y, y: s.x}
+      TestRepo.insert_all(MySchema, query)
+
+      assert_received {:insert_all, %{source: "my_schema", header: header},
+                       {%Ecto.Query{} = query, _params}}
+
+      unchanged_fields = [:id, :z, :array, :map]
+      updated_fields = [:x, :yyy]
+
+      updated_values = [
+        {{:., [type: :binary], [{:&, [], [0]}, :yyy]}, [], []},
+        {{:., [type: :string], [{:&, [], [0]}, :x]}, [], []}
+      ]
+
+      assert header == unchanged_fields ++ updated_fields
+      assert query.select.fields == select_fields(unchanged_fields, 0) ++ updated_values
+
+      # join
+      query =
+        from s in MySchema,
+          join: a in MySchemaWithAssoc,
+          on: true,
+          select: %{a | n: a.parent_id, parent_id: a.n}
+
+      TestRepo.insert_all(MySchemaWithAssoc, query)
+
+      assert_received {:insert_all, %{source: "my_schema", header: header},
+                       {%Ecto.Query{} = query, _params}}
+
+      unchanged_fields = [:id]
+      updated_fields = [:n, :parent_id]
+
+      updated_values = [
+        {{:., [type: :id], [{:&, [], [1]}, :parent_id]}, [], []},
+        {{:., [type: :integer], [{:&, [], [1]}, :n]}, [], []}
+      ]
+
+      assert header == unchanged_fields ++ updated_fields
+      assert query.select.fields == select_fields(unchanged_fields, 1) ++ updated_values
+    end
+
     test "takes query selecting on map/2 with update" do
       query = from s in MySchema, select: %{map(s, [:id, :x, :z]) | x: "x"}
       TestRepo.insert_all(MySchema, query)


### PR DESCRIPTION
I missed an edge case yesterday.

If the user updates with a field from the same source we have to worry about duplicate headers. What happens is the updated field gets moved to the bottom of `select.fields` but keeps its expression. So the for comprehension we are using to filter out updates won't know it's an update. 