### PR TITLE
Improve `insert_all` select expression message

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -370,7 +370,11 @@ defmodule Ecto.Query.Planner do
     {schema_or_source, expr, %{select: select} = query} =
       rewrite_subquery_select_expr(query, source?)
 
-    {expr, _} = prewalk(expr, :select, query, select, 0, adapter)
+    {expr, counter} = prewalk(expr, :select, query, select, 0, adapter)
+
+    if counter != length(select.params) do
+      error!(query, "subqueries cannot select_merge onto an existing field that has an interpolation")
+    end
 
     {{:map, types}, fields, _from} =
       collect_fields(expr, [], :none, query, select.take, true, %{})

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -142,32 +142,22 @@ defmodule Ecto.Repo.Schema do
         %Ecto.Query.SelectExpr{expr: {:&, _, [_ix]}, fields: fields} ->
           Enum.map(fields, &insert_all_select_dump!(&1))
 
-        %Ecto.Query.SelectExpr{expr: {:merge, _, _}} ->
-          raise ArgumentError, """
-          the source query given to `insert_all` has selected both `map/2` and
-          a literal map:
-
-            #{inspect(query)}
-
-          when using `select_merge` with `insert_all`, you must always use literal
-          maps or always use `map/2`. The two cannot be combined.
-          """
-
         _ ->
           raise ArgumentError, """
-          cannot generate a fields list for insert_all from the given source query
-          because it does not have a select clause that uses a map:
+          cannot generate a fields list for insert_all from the given source query:
 
             #{inspect(query)}
 
-          Please add a select clause that selects into a map, like this:
+          The select clause must be one of the following:
 
-            from x in Source,
-              ...,
-              select: %{
-                field_a: x.bar,
-                field_b: x.foo
-              }
+            * A single `map/2` or several `map/2` expressions combined with `select_merge`
+            * A single `struct/2` or several `struct/2` expressions combined with `select_merge`
+            * A source such as `p` in the query `from p in Post`
+            * A single literal map or several literal maps combined with `select_merge`. If
+              combining several literal maps, there cannot be any query interpolations
+              except in the last `select_merge`. Consider using `Ecto.Query.exclude(:select)`
+              to rebuild the select expression from scratch if you need multiple `select_merge`
+              statements with interpolations
 
           All keys must exist in the schema that is being inserted into
           """

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -155,7 +155,7 @@ defmodule Ecto.Repo.Schema do
             * A source such as `p` in the query `from p in Post`
             * A single literal map or several literal maps combined with `select_merge`. If
               combining several literal maps, there cannot be any query interpolations
-              except in the last `select_merge`. Consider using `Ecto.Query.exclude(:select)`
+              except in the last `select_merge`. Consider using `Ecto.Query.exclude/2`
               to rebuild the select expression from scratch if you need multiple `select_merge`
               statements with interpolations
 


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4474

You're right there are too many issues trying to make this work At minimum we'd have to traverse through the select expressions again to find any parameters, even if there are none.

It's not as obvious how to catch the subquery case so will look into that and follow up.