### PR TITLE
Always keep map literal in `select_merge` if keys are distinct

### DIFF
--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -337,11 +337,10 @@ defmodule Ecto.Query.Builder.SelectTest do
           )
 
         assert Macro.to_string(query.select.expr) == """
-              merge(%{\
-              title: &0.archived_at(), \
-              maxdue: {:subquery, 0}, \
-              user_email: {:subquery, 1}\
-              }, %{\n\
+              %{\n\
+                user_email: {:subquery, 1},\n\
+                maxdue: {:subquery, 0},\n\
+                title: &0.archived_at(),\n\
                 template_name:\n\
                   fragment(\n\
                     {:raw, "CASE WHEN "},\n\
@@ -352,7 +351,7 @@ defmodule Ecto.Query.Builder.SelectTest do
                     {:expr, {:subquery, 2}},\n\
                     {:raw, " END"}\n\
                   )\n\
-              })\
+              }\
               """
 
         assert length(query.select.subqueries) == 3
@@ -398,18 +397,17 @@ defmodule Ecto.Query.Builder.SelectTest do
           )
 
         assert Macro.to_string(query.select.expr) == """
-              merge(%{\
-              title: &0.archived_at(), \
+              %{\
+              user_email: {:subquery, 1}, \
               maxdue: {:subquery, 0}, \
-              user_email: {:subquery, 1}\
-              }, %{\
+              title: &0.archived_at(), \
               template_name:\
                fragment({:raw, "CASE WHEN "},\
                {:expr, &0.from_template_id() == ^2},\
                {:raw, " THEN "}, {:expr, ""},\
                {:raw, " ELSE "}, {:expr, {:subquery, 2}},\
                {:raw, " END"})\
-              })\
+              }\
               """
 
         assert length(query.select.subqueries) == 3
@@ -506,7 +504,7 @@ defmodule Ecto.Query.Builder.SelectTest do
           select_merge: %{a: map(p, [:title]), b: ^0},
           select_merge: %{c: map(p, [:title, :body]), d: ^1}
 
-      assert Macro.to_string(query.select.expr) == "merge(%{a: &0, b: ^0}, %{c: &0, d: ^1})"
+      assert Macro.to_string(query.select.expr) == "%{b: ^0, a: &0, c: &0, d: ^1}"
       assert query.select.params == [{0, :any}, {1, :any}]
       assert query.select.take == %{0 => {:map, [:title, :body]}}
     end
@@ -518,7 +516,7 @@ defmodule Ecto.Query.Builder.SelectTest do
         |> select_merge([p], %{a: map(p, [:title]), b: ^0})
         |> select_merge([p], %{c: map(p, [:title, :body]), d: ^1})
 
-      assert Macro.to_string(query.select.expr) == "merge(%{a: &0, b: ^0}, %{c: &0, d: ^1})"
+      assert Macro.to_string(query.select.expr) == "%{b: ^0, a: &0, c: &0, d: ^1}"
       assert query.select.params == [{0, :any}, {1, :any}]
       assert query.select.take == %{0 => {:map, [:title, :body]}}
     end
@@ -700,6 +698,36 @@ defmodule Ecto.Query.Builder.SelectTest do
           select_merge: %{^:shared => :new, ^:merge => :merge}
 
       assert {:%{}, [], [shared: :new, merge: :merge]} = q.select.expr
+    end
+
+    test "merge map literals with no conflicting keys" do
+      # without inner interpolations/subqueries
+      query = from p in "posts", select: %{id: 1, title: "hi"}, select_merge: %{visits: ^2}
+      assert Macro.to_string(query.select.expr) == "%{id: 1, title: \"hi\", visits: ^0}"
+
+      # with inner interpolation
+      query = from p in "posts", select: %{id: ^1, title: "hi"}, select_merge: %{visits: ^2}
+      assert Macro.to_string(query.select.expr) == "%{title: \"hi\", id: ^0, visits: ^1}"
+
+      # with inner subquery
+      s = from p in "posts", select: p.title, limit: 1
+      query = from p in "posts", select: %{id: 1, title: subquery(s)}, select_merge: %{visits: ^2}
+      assert Macro.to_string(query.select.expr) == "%{title: {:subquery, 0}, id: 1, visits: ^1}"
+    end
+
+    test "merge map literals with conflicting keys" do
+      # without inner params
+      query = from p in "posts", select: %{id: 1, title: "hi"}, select_merge: %{id: ^2}
+      assert Macro.to_string(query.select.expr) == "%{title: \"hi\", id: ^0}"
+
+      # with inner params
+      query = from p in "posts", select: %{id: ^1, title: "hi"}, select_merge: %{id: ^2}
+      assert Macro.to_string(query.select.expr) == "merge(%{id: ^0, title: \"hi\"}, %{id: ^1})"
+
+      # with inner subqueries
+      s = from p in "posts", select: p.title, limit: 1
+      query = from p in "posts", select: %{id: 1, title: subquery(s)}, select_merge: %{id: ^2}
+      assert Macro.to_string(query.select.expr) == "merge(%{id: 1, title: {:subquery, 0}}, %{id: ^1})"
     end
   end
 end


### PR DESCRIPTION
Previously we discussed if `insert_all` can support `select_merge` with multiple map literals when one of the inner maps has interpolations. For example:

```elixir
from p in "posts", select: %{title: ^"title"}, select_merge: %{visits: 1}
```

Because the inner map has an interpolation, we don't know whether it will be wiped out and our query params will be incorrect. So we turn the select expression into `merge(%{...}, %{....})`.  And this merge expression doesn't work with `insert_all` due to difficulty extracting fields from `merge`. 

There is one condition we can be certain the interpolation won't be wiped out: when all the merges have distinct keys.  In this case we can keep the map literal and it will work with `insert_all`.  

This would give a lot more flexibility to user. If they have dynamic keys/values they want to turn into multiple merge statements, they can always remove duplication in Elixir before going to Ecto land.

For example this:

```elixir
conditions = [k1: v1, k2: v2, k3: v3, ...]
base = from p in "posts", select: %{k0: v0}

Enum.reduce(conditions, base, fn {k, v} -> from b in base, select_merge: %{^k => ^v}
```

They can ensure no duplications in `conditions` beforehand.

