### PR TITLE
Allow literal maps inside `dynamic/2`

### DIFF
--- a/lib/ecto/query/builder/dynamic.ex
+++ b/lib/ecto/query/builder/dynamic.ex
@@ -31,6 +31,10 @@ defmodule Ecto.Query.Builder.Dynamic do
     Select.escape(expr, vars, env)
   end
 
+  defp escape({:%{}, _, _} = expr, _params_acc, vars, env) do
+    Select.escape(expr, vars, env)
+  end
+
   defp escape(expr, params_acc, vars, env) do
     Builder.escape(expr, :any, params_acc, vars, {env, &escape_expansion/5})
   end

--- a/test/ecto/query/builder/select_test.exs
+++ b/test/ecto/query/builder/select_test.exs
@@ -494,6 +494,13 @@ defmodule Ecto.Query.Builder.SelectTest do
       q = from p in "posts", select: %{^:test_key => 1}
       assert {:%{}, [], [test_key: 1]} = q.select.expr
     end
+
+    test "supports literal maps inside dynamic" do
+      map = dynamic([p], %{id: p.id, title: p.title})
+      q = from p in "posts", select: ^map
+
+      assert Macro.to_string(q.select.expr) == "%{id: &0.id(), title: &0.title()}"
+    end
   end
 
   describe "select_merge" do


### PR DESCRIPTION
This is a small change to make life a little easier in certain situations. Right now you can generate a dynamic map like this

```elixir
select = 
  if something do
    %{a: dynamic(...), b: dynamic(....), ..., z: dynamic(....)}
  else
    %{aa: dynamic(....), ....}
  end
```

With this change you can put the dynamic on the outside and do what you have to do on the inside