### PR TITLE
Accidental backtick in @moduledoc compromising docs layout for Ecto.Schema

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -295,7 +295,7 @@ defmodule Ecto.Schema do
       where casting has to be done explicitly and is never performed
       implicitly when loading from or dumping to the database.
 
-    * For `the `:duration` type, you may need to enable `Duration` support in
+    * For the `:duration` type, you may need to enable `Duration` support in
       your adapter. For information on how to enable it in Postgrex, see their
       [HexDocs page](https://hexdocs.pm/postgrex/readme.html#data-representation).
 


### PR DESCRIPTION
Feel free to just correct it instead of merging, this is not worth a PR.

Note that `ex_doc` warns about that : 

```
➜  ecto git:(patch-1) MIX_ENV=docs mix docs
Compiling 1 file (.ex)
Generating docs...
warning: Closing unclosed backquotes ` at end of input
  lib/ecto/schema.ex:462: (file)

View "html" docs at "doc/index.html"
warning: Closing unclosed backquotes ` at end of input
  lib/ecto/schema.ex:462: (file)
```

<img width="1440" alt="Capture d’écran 2024-08-12 à 10 55 54" src="https://github.com/user-attachments/assets/e95093cf-9ab5-47d6-bfa3-bad015d6a748">
