### PR TITLE
Add `Ecto.Type.parameterized?/2`

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -349,6 +349,8 @@ defmodule Ecto.Type do
       iex> type = Ecto.ParameterizedType.init(Ecto.Enum, values: [a: 1])
       iex> Ecto.Type.parameterized?(type, Ecto.Enum)
       true
+      iex> Ecto.Type.parameterized?(type, MyEnum)
+      false
 
   """
   @spec parameterized?(t, module) :: boolean

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -346,9 +346,9 @@ defmodule Ecto.Type do
   @doc """
   Checks if the given type is parameterized by the given module.
 
-    iex> type = Ecto.ParameterizedType.init(Ecto.Enum, values: [a: 1])
-    iex> Ecto.Type.parameterized?(type, Ecto.Enum)
-    true
+      iex> type = Ecto.ParameterizedType.init(Ecto.Enum, values: [a: 1])
+      iex> Ecto.Type.parameterized?(type, Ecto.Enum)
+      true
 
   """
   @spec parameterized?(t, module) :: boolean

--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -344,6 +344,18 @@ defmodule Ecto.Type do
   def primitive?(_), do: false
 
   @doc """
+  Checks if the given type is parameterized by the given module.
+
+    iex> type = Ecto.ParameterizedType.init(Ecto.Enum, values: [a: 1])
+    iex> Ecto.Type.parameterized?(type, Ecto.Enum)
+    true
+
+  """
+  @spec parameterized?(t, module) :: boolean
+  def parameterized?({:parameterized, {module, _}}, module), do: true
+  def parameterized?(_, _), do: false
+
+  @doc """
   Checks if the given atom can be used as composite type.
 
       iex> composite?(:array)


### PR DESCRIPTION
I think this makes sense to give library authors the ability to check if a type is parameterized. But let me know if you see any issues!

For reference, polymorphic embeds seems to want to check this: https://github.com/search?q=repo%3Amathieuprog%2Fpolymorphic_embed%20%7B%3Aparameterized&type=code