### PR TITLE
remove subquery parameter length check

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -370,11 +370,7 @@ defmodule Ecto.Query.Planner do
     {schema_or_source, expr, %{select: select} = query} =
       rewrite_subquery_select_expr(query, source?)
 
-    {expr, counter} = prewalk(expr, :select, query, select, 0, adapter)
-
-    if counter != length(select.params) do
-      error!(query, "subqueries cannot select_merge onto an existing field that has an interpolation")
-    end
+    {expr, _} = prewalk(expr, :select, query, select, 0, adapter)
 
     {{:map, types}, fields, _from} =
       collect_fields(expr, [], :none, query, select.take, true, %{})

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -563,14 +563,5 @@ defmodule Ecto.Query.SubqueryTest do
 
       assert Macro.to_string(planned_q.from.source.query.select.expr) == "%{id: ^0, text: ^1}"
     end
-
-    test "overlapping interpolations are allowed" do
-      msg = ~r"subqueries cannot select_merge onto an existing field that has an interpolation"
-
-      assert_raise Ecto.SubQueryError, msg, fn ->
-        q = from c in Comment, select: %{id: ^1}, select_merge: %{id: ^2}
-        from(s in subquery(q)) |> plan()
-      end
-    end
   end
 end


### PR DESCRIPTION
This comes from the check here:

```elixir
    {expr, counter} = prewalk(expr, :select, query, select, 0, adapter)

    if counter != length(select.params) do
      error!(query, "subqueries cannot select_merge onto an existing field that has an interpolation")
    end
```

https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/query/planner.ex#L375

I'm working on a fix, but I'm not actually sure what the heuristic here should be. It seems like each subquery "uses" a parameter slot, or something along those lines, which must be accounted for here. However, adding `+ length(select.subqueries)` can't be right, because it doesn't pass both tests.

This currently affects a portion of Ash users.