### PR TITLE
Add missing anchors in docs

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1926,7 +1926,7 @@ defmodule Ecto.Changeset do
   if a Post has many Comments, it allows you to add, remove or change all
   comments at once. If your goal is to simply add a new comment to a post,
   then it is preferred to do so manually, as we will describe later in the
-  "Example: Adding a comment to a post" section.
+  ["Example: Adding a comment to a post" section](#put_assoc/4-example-adding-a-comment-to-a-post).
 
   This function requires the associated data to have been preloaded, except
   when the parent changeset has been newly built and not yet persisted.
@@ -1991,7 +1991,7 @@ defmodule Ecto.Changeset do
       persisted. You must use changesets, keyword lists, or maps instead. `put_assoc/4` with structs
       only takes care of guaranteeing that the comments and the parent data
       are associated. This is extremely useful when associating existing data,
-      as we will see in the "Example: Adding tags to a post" section.
+      as we will see in the ["Example: Adding tags to a post" section](#put_assoc/4-example-adding-tags-to-a-post).
 
   Once the parent changeset is given to an `Ecto.Repo` function, all entries
   will be inserted/updated/deleted within the same transaction.

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -799,7 +799,7 @@ defmodule Ecto.Query.API do
   @doc """
   Refer to a named atom binding.
 
-  See the "Named binding" section in `Ecto.Query` for more information.
+  See the "Named bindings" section in `Ecto.Query` for more information.
   """
   def as(binding), do: doc!([binding])
 
@@ -808,7 +808,7 @@ defmodule Ecto.Query.API do
 
   This is available only inside subqueries.
 
-  See the "Named binding" section in `Ecto.Query` for more information.
+  See the "Named bindings" section in `Ecto.Query` for more information.
   """
   def parent_as(binding), do: doc!([binding])
 

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1482,7 +1482,7 @@ defmodule Ecto.Repo do
       `ON CONFLICT (coalesce(firstname, ''), coalesce(lastname, '')) WHERE middlename IS NULL` SQL query.
 
     * `:placeholders` - A map with placeholders. This feature is not supported
-      by all databases. See the "Placeholders" section for more information.
+      by all databases. See the ["Placeholders" section](#c:insert_all/3-placeholders) for more information.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for remaining options.


### PR DESCRIPTION
Hello, this is just fixing a couple of missing anchors in the docs and a section name missing an `s`, that's it! 🤏 