### PR TITLE
Load context into struct metadata

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -69,8 +69,8 @@ defmodule Ecto.Repo.Schema do
     for row <- rows, do: Map.new(Enum.zip(fields, row))
   end
 
-  defp postprocess(rows, types, adapter, schema, %{prefix: prefix, source: source}) do
-    struct = Ecto.Schema.Loader.load_struct(schema, prefix, source)
+  defp postprocess(rows, types, adapter, schema, schema_meta) do
+    struct = Ecto.Schema.Loader.load_struct(schema, schema_meta)
 
     for row <- rows do
       {loaded, _} = Ecto.Repo.Queryable.struct_load!(types, row, [], false, struct, adapter)
@@ -705,7 +705,7 @@ defmodule Ecto.Repo.Schema do
   defp metadata(schema, prefix, source, autogen_id, context, opts) do
     %{
       autogenerate_id: autogen_id,
-      context: context,
+      context: Keyword.get(opts, :context, context),
       schema: schema,
       source: source,
       prefix: Keyword.get(opts, :prefix, prefix)
@@ -910,8 +910,8 @@ defmodule Ecto.Repo.Schema do
     Enum.reduce(autogen, data, fn {k, v}, acc -> %{acc | k => v} end)
   end
 
-  defp apply_metadata(%{__meta__: meta} = data, state, %{source: source, prefix: prefix}) do
-    %{data | __meta__: %{meta | state: state, source: source, prefix: prefix}}
+  defp apply_metadata(%{__meta__: meta} = data, state, %{source: source, prefix: prefix, context: context}) do
+    %{data | __meta__: %{meta | state: state, source: source, prefix: prefix, context: context}}
   end
 
   defp load_each(struct, [{_, value} | kv], [{key, type} | types], adapter) do

--- a/lib/ecto/schema/loader.ex
+++ b/lib/ecto/schema/loader.ex
@@ -6,15 +6,19 @@ defmodule Ecto.Schema.Loader do
   @doc """
   Loads a struct to be used as a template in further operations.
   """
-  def load_struct(nil, _prefix, _source), do: %{}
+  def load_struct(nil, _schema_meta), do: %{}
 
-  def load_struct(schema, prefix, source) do
+  def load_struct(schema, schema_meta) do
+    source = schema_meta[:source]
+    prefix = schema_meta[:prefix]
+    context = schema_meta[:context]
+
     case schema.__schema__(:loaded) do
-      %{__meta__: %Metadata{prefix: ^prefix, source: ^source}} = struct ->
+      %{__meta__: %Metadata{prefix: ^prefix, source: ^source, context: ^context}} = struct ->
         struct
 
       %{__meta__: %Metadata{} = metadata} = struct ->
-        Map.put(struct, :__meta__, %{metadata | source: source, prefix: prefix})
+        Map.put(struct, :__meta__, %{metadata | source: source, prefix: prefix, context: context})
 
       %{} = struct ->
         struct

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1322,6 +1322,18 @@ defmodule Ecto.RepoTest do
                    end
     end
 
+    test "insert and delete sets schema context with struct" do
+      valid = %MySchema{id: 1}
+
+      ref = make_ref()
+
+      assert {:ok, schema} = TestRepo.insert(valid, context: ref)
+      assert schema.__meta__.context == ref
+
+      assert {:ok, schema} = TestRepo.delete(valid, context: ref)
+      assert schema.__meta__.context == ref
+    end
+
     test "insert!, update!, insert_or_update! and delete!" do
       valid = Ecto.Changeset.cast(%MySchema{id: 1}, %{}, [])
       assert %MySchema{} = TestRepo.insert!(valid)
@@ -1488,6 +1500,22 @@ defmodule Ecto.RepoTest do
 
     assert [schema] = TestRepo.all(MySchemaWithPrefix, prefix: "public")
     assert schema.__meta__.prefix == "private"
+  end
+
+  test "get, get_by, one and all sets schema context" do
+    ref = make_ref()
+
+    assert schema = TestRepo.get(MySchema, 123, context: ref)
+    assert schema.__meta__.context == ref
+
+    assert schema = TestRepo.get_by(MySchema, [id: 123], context: ref)
+    assert schema.__meta__.context == ref
+
+    assert schema = TestRepo.one(MySchema, context: ref)
+    assert schema.__meta__.context == ref
+
+    assert [schema] = TestRepo.all(MySchema, context: ref)
+    assert schema.__meta__.context == ref
   end
 
   describe "changeset prepare" do

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -96,8 +96,23 @@ defmodule Ecto.TestAdapter do
     {1, nil}
   end
 
-  def insert(_, %{context: nil, prefix: prefix} = meta, fields, on_conflict, returning, _opts) do
-    meta = Map.merge(meta, %{fields: fields, on_conflict: on_conflict, returning: returning, prefix: prefix})
+  def insert(
+        _,
+        %{context: nil_or_ref, prefix: prefix} = meta,
+        fields,
+        on_conflict,
+        returning,
+        _opts
+      )
+      when is_nil(nil_or_ref) or is_reference(nil_or_ref) do
+    meta =
+      Map.merge(meta, %{
+        fields: fields,
+        on_conflict: on_conflict,
+        returning: returning,
+        prefix: prefix
+      })
+
     send(self(), {:insert, meta})
     {:ok, Enum.zip(returning, 1..length(returning))}
   end
@@ -107,7 +122,8 @@ defmodule Ecto.TestAdapter do
   end
 
   # Notice the list of changes is never empty.
-  def update(_, %{context: nil} = meta, [_ | _] = changes, filters, returning, _opts) do
+  def update(_, %{context: nil_or_ref} = meta, [_ | _] = changes, filters, returning, _opts)
+      when is_nil(nil_or_ref) or is_reference(nil_or_ref) do
     meta = Map.merge(meta, %{changes: changes, filters: filters, returning: returning})
     send(self(), {:update, meta})
     {:ok, Enum.zip(returning, 1..length(returning))}
@@ -117,7 +133,8 @@ defmodule Ecto.TestAdapter do
     context
   end
 
-  def delete(_, %{context: nil} = meta, filters, returning, _opts) do
+  def delete(_, %{context: nil_or_ref} = meta, filters, returning, _opts)
+      when is_nil(nil_or_ref) or is_reference(nil_or_ref) do
     meta = Map.merge(meta, %{filters: filters, returning: returning})
     send(self(), {:delete, meta})
     {:ok, Enum.zip(returning, 1..length(returning))}


### PR DESCRIPTION
The goal of the change is to have the :context track along with the schema metadata so that it can be used by an adapter for its own purposes.

The :prefix option already has good semantics for this, except that it is restricted to String.t() and subjected to is_binary guards. We can certainly duplicate the way prefix is treated with the context field, but this would result in a large changeset (particularly because we would need `%Query{context: ...}` or similar.

As is, this PR is a bit of a compromise in that it loads the context onto the schema on the basic operations, but does not attempt to duplicate all of the Query's prefix semantics. (subqueries, etc)