### PR TITLE
Support non-string prefix

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -882,7 +882,7 @@ defmodule Ecto.Query do
     subquery = wrap_in_subquery(query)
 
     case Keyword.fetch(opts, :prefix) do
-      {:ok, prefix} when is_binary(prefix) or is_nil(prefix) ->
+      {:ok, prefix} ->
         put_in(subquery.query.prefix, prefix)
 
       :error ->
@@ -909,11 +909,11 @@ defmodule Ecto.Query do
   @doc """
   Puts the given prefix in a query.
   """
-  def put_query_prefix(%Ecto.Query{} = query, prefix) when is_binary(prefix) do
+  def put_query_prefix(%Ecto.Query{} = query, prefix) do
     %{query | prefix: prefix}
   end
 
-  def put_query_prefix(other, prefix) when is_binary(prefix) do
+  def put_query_prefix(other, prefix) do
     other |> Ecto.Queryable.to_query() |> put_query_prefix(prefix)
   end
 

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -914,7 +914,8 @@ defmodule Ecto.Query do
   end
 
   def put_query_prefix(other, prefix) do
-    other |> Ecto.Queryable.to_query() |> put_query_prefix(prefix)
+    query = %Ecto.Query{} = Ecto.Queryable.to_query(other)
+    put_query_prefix(query, prefix)
   end
 
   @doc """

--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -77,7 +77,7 @@ defmodule Ecto.Query.Builder.From do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t(), Macro.Env.t(), atom, {:ok, String.t | nil} | nil, hints) ::
+  @spec build(Macro.t(), Macro.Env.t(), atom, {:ok, Ecto.Schema.prefix | nil} | nil, hints) ::
           {Macro.t(), Keyword.t(), non_neg_integer | nil}
   def build(query, env, as, prefix, hints) do
     hints = Enum.map(hints, &hint!(&1))
@@ -85,7 +85,7 @@ defmodule Ecto.Query.Builder.From do
     prefix = case prefix do
       nil -> nil
       {:ok, prefix} when is_binary(prefix) or is_nil(prefix) -> {:ok, prefix}
-      {:ok, {:^, _, [prefix]}} -> {:ok, quote(do: Ecto.Query.Builder.From.prefix!(unquote(prefix)))}
+      {:ok, {:^, _, [prefix]}} -> {:ok, prefix}
       {:ok, prefix} -> Builder.error!("`prefix` must be a compile time string or an interpolated value using ^, got: #{Macro.to_string(prefix)}")
     end
 
@@ -153,13 +153,6 @@ defmodule Ecto.Query.Builder.From do
   end
 
   @doc """
-  Validates a prefix at runtime.
-  """
-  @spec prefix!(any) :: nil | String.t()
-  def prefix!(prefix) when is_binary(prefix) or is_nil(prefix), do: prefix
-  def prefix!(prefix), do: raise("`prefix` must be a string, got: #{inspect(prefix)}")
-
-  @doc """
   Validates hints at compile time and runtime
   """
   def hint!(hint) when is_binary(hint), do: hint
@@ -187,7 +180,7 @@ defmodule Ecto.Query.Builder.From do
   @doc """
   The callback applied by `build/2` to build the query.
   """
-  @spec apply(Ecto.Queryable.t(), non_neg_integer, Macro.t(), {:ok, String.t} | nil, hints) :: Ecto.Query.t()
+  @spec apply(Ecto.Queryable.t(), non_neg_integer, Macro.t(), {:ok, Ecto.Schema.prefix} | nil, hints) :: Ecto.Query.t()
   def apply(query, binds, as, prefix, hints) do
     query =
       query

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -128,7 +128,7 @@ defmodule Ecto.Query.Builder.Join do
   If possible, it does all calculations at compile time to avoid
   runtime work.
   """
-  @spec build(Macro.t, atom, [Macro.t], Macro.t, Macro.t, Macro.t, atom, nil | {:ok, String.t | nil}, nil | String.t | [String.t], Macro.Env.t) ::
+  @spec build(Macro.t, atom, [Macro.t], Macro.t, Macro.t, Macro.t, atom, nil | {:ok, Ecto.Schema.prefix}, nil | String.t | [String.t], Macro.Env.t) ::
               {Macro.t, Keyword.t, non_neg_integer | nil}
   def build(query, qual, binding, expr, count_bind, on, as, prefix, maybe_hints, env) do
     {:ok, prefix} = prefix || {:ok, nil}
@@ -144,7 +144,7 @@ defmodule Ecto.Query.Builder.Join do
     prefix = case prefix do
       nil -> nil
       prefix when is_binary(prefix) -> prefix
-      {:^, _, [prefix]} -> quote(do: Ecto.Query.Builder.From.prefix!(unquote(prefix)))
+      {:^, _, [prefix]} -> prefix
       prefix -> Builder.error!("`prefix` must be a compile time string or an interpolated value using ^, got: #{Macro.to_string(prefix)}")
     end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2310,11 +2310,7 @@ defmodule Ecto.Query.Planner do
   """
   def attach_prefix(%{prefix: nil} = query, opts) when is_list(opts) do
     case Keyword.fetch(opts, :prefix) do
-      {:ok, prefix} when is_binary(prefix) or is_nil(prefix) ->
-        %{query | prefix: prefix}
-
-      {:ok, prefix} when is_atom(prefix) ->
-        IO.warn("atom prefixes are deprecated. Please use a string instead.")
+      {:ok, prefix} ->
         %{query | prefix: prefix}
 
       :error ->

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -478,7 +478,7 @@ defmodule Ecto.Schema do
   alias Ecto.Schema.Metadata
 
   @type source :: String.t()
-  @type prefix :: String.t() | nil
+  @type prefix :: any()
   @type schema :: %{optional(atom) => any, __struct__: atom, __meta__: Metadata.t()}
   @type embedded_schema :: %{optional(atom) => any, __struct__: atom}
   @type t :: schema | embedded_schema
@@ -662,7 +662,7 @@ defmodule Ecto.Schema do
           %{unquote_splicing(Macro.escape(@ecto_changeset_fields))}
         end
 
-        def __schema__(:prefix), do: unquote(prefix)
+        def __schema__(:prefix), do: unquote(Macro.escape(prefix))
         def __schema__(:source), do: unquote(source)
         def __schema__(:fields), do: unquote(Enum.map(fields, &elem(&1, 0)))
         def __schema__(:query_fields), do: unquote(Enum.map(query_fields, &elem(&1, 0)))
@@ -690,7 +690,7 @@ defmodule Ecto.Schema do
             %Ecto.Query{
               from: %Ecto.Query.FromExpr{
                 source: {unquote(source), __MODULE__},
-                prefix: unquote(prefix)
+                prefix: unquote(Macro.escape(prefix))
               }
             }
           end

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -817,6 +817,12 @@ defmodule Ecto.Query.PlannerTest do
       |> plan()
 
     assert query.sources == {{"comments", Comment, "global"}, {"comments", Comment, "local"}}
+
+    # Non-string schema prefix is supported
+    {query, _, _, _} =
+      from(c in Comment, join: Post, on: true) |> Map.put(:prefix, %{key: :global}) |> plan()
+
+    assert query.sources == {{"comments", Comment, %{key: :global}}, {"posts", Post, "my_prefix"}}
   end
 
   test "plan: combination queries" do

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -242,6 +242,11 @@ defmodule Ecto.QueryTest do
       assert put_query_prefix(from("posts"), "hello").prefix == "hello"
       assert put_query_prefix(Schema, "hello").prefix == "hello"
     end
+
+    test "stores non-string prefix in query" do
+      assert put_query_prefix(from("posts"), %{key: :hello}).prefix == %{key: :hello}
+      assert put_query_prefix(Schema, %{key: :hello}).prefix == %{key: :hello}
+    end
   end
 
   describe "trailing bindings (...)" do
@@ -500,24 +505,15 @@ defmodule Ecto.QueryTest do
       assert hd(query.joins).prefix == join_prefix
     end
 
-    test "variables are validated at runtime" do
-      prefix = 123
-
-      assert_raise RuntimeError, ~r/`prefix` must be a string/, fn ->
-        from p in "posts", prefix: ^prefix
-      end
-
-      assert_raise RuntimeError, ~r/`prefix` must be a string/, fn ->
-        from p in "posts", join: "comments", on: true, prefix: ^prefix
-      end
-    end
-
     test "are supported and overridden from schemas" do
       query = from(Post)
       assert query.from.prefix == "another"
 
       query = from(Post, prefix: "hello")
       assert query.from.prefix == "hello"
+
+      query = from(Post, prefix: ^123)
+      assert query.from.prefix == 123
 
       query = from(Post, prefix: nil)
       assert query.from.prefix == nil

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -341,6 +341,15 @@ defmodule Ecto.SchemaTest do
     end
   end
 
+  defmodule SchemaWithNonStringPrefix do
+    use Ecto.Schema
+
+    @schema_prefix %{key: :tenant}
+    schema "company" do
+      field :name
+    end
+  end
+
   test "schema prefix metadata" do
     assert SchemaWithPrefix.__schema__(:source) == "company"
     assert SchemaWithPrefix.__schema__(:prefix) == "tenant"
@@ -364,6 +373,31 @@ defmodule Ecto.SchemaTest do
     from = {"another_company", SchemaWithPrefix}
     query = from(from, select: 1)
     assert query.from.prefix == "tenant"
+  end
+
+  test "schema non-string prefix metadata" do
+    assert SchemaWithNonStringPrefix.__schema__(:source) == "company"
+    assert SchemaWithNonStringPrefix.__schema__(:prefix) == %{key: :tenant}
+    assert %SchemaWithNonStringPrefix{}.__meta__.source == "company"
+    assert %SchemaWithNonStringPrefix{}.__meta__.prefix == %{key: :tenant}
+  end
+
+  test "schema non-string prefix in queries from" do
+    import Ecto.Query
+
+    query = from(SchemaWithNonStringPrefix, select: 1)
+    assert query.from.prefix == %{key: :tenant}
+
+    query = from({"another_company", SchemaWithNonStringPrefix}, select: 1)
+    assert query.from.prefix == %{key: :tenant}
+
+    from = SchemaWithNonStringPrefix
+    query = from(from, select: 1)
+    assert query.from.prefix == %{key: :tenant}
+
+    from = {"another_company", SchemaWithNonStringPrefix}
+    query = from(from, select: 1)
+    assert query.from.prefix == %{key: :tenant}
   end
 
   ## Schema context


### PR DESCRIPTION
Discussed in elixir-ecto/ecto#4496

These changes allow an adapter to support a `:prefix` and `@schema_prefix` of any type, rather than being restricted to String.t().

1. At compile time, `from` and `join` query portions still require either string literal or interpolated value. The interpolated value can be anything. Additional literals can be supported here if desired. (from.ex:87 and join.ex:146)
2. Happy to add more tests, let me know if you see gaps
3. I also verified ecto_sql's tests still pass

Thanks!