### PR TITLE
Fix mssql 2017 integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
   integration-test:
     name: integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FORCE_COLOR: 1
     strategy:


### PR DESCRIPTION
There is an issue with the mssql 2017 docker image working on the latest ubuntu. The current fix is to use ubuntu 20.04

Reference: https://github.com/microsoft/mssql-docker/issues/899