### PR TITLE
Pass allow_stale opt to assocs

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1660,9 +1660,9 @@ defmodule Ecto.Repo do
     * `:stale_error_message` - The message to add to the configured
       `:stale_error_field` when stale errors happen, defaults to "is stale".
 
-    * `:allow_stale` - Doesn't error if insert is stale. Defaults to `false`.
+    * `:allow_stale` - Doesn't error when structs are stale. Defaults to `false`.
       This may happen if there are rules or triggers in the database that
-      rejects the insert operation.
+      rejects the insert operation. This option cascades to associations.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.
@@ -1863,7 +1863,7 @@ defmodule Ecto.Repo do
     * `:allow_stale` - Doesn't error if update is stale. Defaults to `false`.
       This may happen if the struct has been deleted from the database before
       the update or if there is a rule or a trigger on the database that rejects
-      the update operation.
+      the update operation. This option cascades to associations.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.
@@ -1909,8 +1909,8 @@ defmodule Ecto.Repo do
     * `:stale_error_message` - The message to add to the configured
       `:stale_error_field` when stale errors happen, defaults to "is stale".
       Only applies to updates.
-    * `:allow_stale` - Doesn't error if delete is stale. Defaults to `false`.
-      Only applies to updates.
+    * `:allow_stale` - Doesn't error when structs are stale. Defaults to `false`.
+      This option cascades to associations.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -977,7 +977,7 @@ defmodule Ecto.Repo.Schema do
   defp assoc_opts([], _opts), do: []
 
   defp assoc_opts(_assocs, opts) do
-    Keyword.take(opts, [:timeout, :log, :telemetry_event, :prefix])
+    Keyword.take(opts, [:timeout, :log, :telemetry_event, :prefix, :allow_stale])
   end
 
   defp process_parents(changeset, user_changeset, assocs, reset_assocs, adapter, opts) do


### PR DESCRIPTION
When implementing the soft delete detailed [here](https://dashbit.co/blog/soft-deletes-with-ecto) I ran into errors when soft deleting assocs, it seems we just need to pass the allow_stale option on to the assocs to allow this