### PR TITLE
dk-query comments

### DIFF
--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -397,6 +397,7 @@ defmodule Ecto.Query do
   """
   defstruct prefix: nil,
             sources: nil,
+            comments: [],
             from: nil,
             joins: [],
             aliases: %{},
@@ -424,6 +425,11 @@ defmodule Ecto.Query do
   defmodule DynamicExpr do
     @moduledoc false
     defstruct [:fun, :binding, :file, :line]
+  end
+
+  defmodule CommentExpr do
+    @moduledoc false
+    defstruct [:expr, :file, :line, params: []]
   end
 
   defmodule QueryExpr do
@@ -939,6 +945,7 @@ defmodule Ecto.Query do
       Ecto.Query.exclude(query, :distinct)
       Ecto.Query.exclude(query, :select)
       Ecto.Query.exclude(query, :combinations)
+      Ecto.Query.exclude(query, :comments)
       Ecto.Query.exclude(query, :with_ctes)
       Ecto.Query.exclude(query, :limit)
       Ecto.Query.exclude(query, :offset)
@@ -980,6 +987,7 @@ defmodule Ecto.Query do
   defp do_exclude(%Ecto.Query{} = query, :order_by), do: %{query | order_bys: []}
   defp do_exclude(%Ecto.Query{} = query, :group_by), do: %{query | group_bys: []}
   defp do_exclude(%Ecto.Query{} = query, :combinations), do: %{query | combinations: []}
+  defp do_exclude(%Ecto.Query{} = query, :comments), do: %{query | comments: []}
   defp do_exclude(%Ecto.Query{} = query, :with_ctes), do: %{query | with_ctes: nil}
   defp do_exclude(%Ecto.Query{} = query, :having), do: %{query | havings: []}
   defp do_exclude(%Ecto.Query{} = query, :distinct), do: %{query | distinct: nil}
@@ -1109,7 +1117,7 @@ defmodule Ecto.Query do
   end
 
   @from_join_opts [:as, :prefix, :hints]
-  @no_binds [:union, :union_all, :except, :except_all, :intersect, :intersect_all]
+  @no_binds [:union, :union_all, :except, :except_all, :intersect, :intersect_all, :comment]
   @binds [:lock, :where, :or_where, :select, :distinct, :order_by, :group_by, :windows] ++
            [:having, :or_having, :limit, :offset, :preload, :update, :select_merge, :with_ctes]
 
@@ -1732,6 +1740,10 @@ defmodule Ecto.Query do
   """
   defmacro select_merge(query, binding \\ [], expr) do
     Builder.Select.build(:merge, query, binding, expr, __CALLER__)
+  end
+
+  defmacro comment(query, comment) do
+    Builder.Comment.build(query, comment, __CALLER__)
   end
 
   @doc """

--- a/lib/ecto/query/builder/comment.ex
+++ b/lib/ecto/query/builder/comment.ex
@@ -1,0 +1,62 @@
+import Kernel, except: [apply: 2]
+
+defmodule Ecto.Query.Builder.Comment do
+  @moduledoc false
+
+  alias Ecto.Query.Builder
+  alias Ecto.Query.CommentExpr
+
+  @spec escape(Macro.t(), Macro.Env.t()) :: Macro.t()
+  def escape(comment, _env) when is_binary(comment), do: comment
+
+  def escape(expr, env) do
+    {expr, {_params, _acc}} =
+      Builder.escape(expr, :any, {[], %{}}, [], env)
+
+    expr
+  end
+
+  @doc """
+  Called at runtime to assemble comment.
+  """
+  def comment!(query, comment, file, line) do
+    comment = %CommentExpr{
+      expr: comment,
+      line: line,
+      file: file
+    }
+
+    apply(query, comment)
+  end
+
+  def build(query, {:^, _, [var]}, env) do
+    quote do
+      Ecto.Query.Builder.Comment.comment!(
+        unquote(query),
+        unquote(var),
+        unquote(env.file),
+        unquote(env.line)
+      )
+    end
+  end
+
+  def build(query, comment, env) do
+    Builder.apply_query(query, __MODULE__, [escape(comment, env)], env)
+  end
+
+  def build(query, comment, _file, _line) do
+    apply(query, comment)
+  end
+
+  @doc """
+  The callback applied by `build/4` to build the query.
+  """
+  @spec apply(Ecto.Queryable.t(), String.t() | CommentExpr.t()) :: Ecto.Query.t()
+  def apply(%Ecto.Query{comments: comments} = query, comment) do
+    %{query | comments: comments ++ [comment]}
+  end
+
+  def apply(query, comment) do
+    apply(Ecto.Queryable.to_query(query), comment)
+  end
+end

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -1,7 +1,7 @@
 import Inspect.Algebra
 import Kernel, except: [to_string: 1]
 
-alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr, WithExpr, LimitExpr}
+alias Ecto.Query.{DynamicExpr, JoinExpr, QueryExpr, WithExpr, LimitExpr, CommentExpr}
 
 defimpl Inspect, for: Ecto.Query.DynamicExpr do
   def inspect(%DynamicExpr{binding: binding} = dynamic, opts) do
@@ -49,6 +49,11 @@ defimpl Inspect, for: Ecto.Query do
       end)
 
     result = container_doc("#Ecto.Query<", list, ">", opts, fn str, _ -> str end)
+
+    result =
+      if query.comments == [],
+        do: result,
+        else: concat([comment(query.comments), "\n", result])
 
     case query.with_ctes do
       %WithExpr{recursive: recursive, queries: [_ | _] = queries} ->
@@ -159,6 +164,13 @@ defimpl Inspect, for: Ecto.Query do
 
   defp inspect_source(%{source: {source, schema}}, _names) do
     inspect(if source == schema.__schema__(:source), do: schema, else: {source, schema})
+  end
+
+  defp comment(comments) do
+    Enum.map_join(comments, "\n", fn
+      comment when is_binary(comment) -> "# #{comment}"
+      %CommentExpr{expr: comment} -> "# #{comment}"
+    end)
   end
 
   defp joins(joins, names) do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -571,6 +571,61 @@ defmodule Ecto.Query.InspectTest do
     assert i(plan(query)) == "from v0 in values (#{fields})"
   end
 
+  test "with static comments" do
+    query = from(p in "posts") |> comment("foo") |> comment("bar")
+    i = inspect(query, safe: false)
+
+    assert i == """
+           # foo
+           # bar
+           #Ecto.Query<from p0 in "posts">\
+           """
+
+    i = inspect(plan(query), safe: false)
+
+    assert i == """
+           # foo
+           # bar
+           #Ecto.Query<from p0 in "posts">\
+           """
+  end
+
+  test "with dynamic comments" do
+    query = from(p in "posts") |> comment(^"foo #{"bar"}")
+    i = inspect(query, safe: false)
+
+    assert i == """
+           # foo bar
+           #Ecto.Query<from p0 in "posts">\
+           """
+
+    i = inspect(plan(query), safe: false)
+
+    assert i == """
+           # foo bar
+           #Ecto.Query<from p0 in "posts">\
+           """
+  end
+
+  test "comments in keyword query" do
+    query = from(p in "posts", comment: "foo", comment: ^"bar #{"baz"}")
+    i = inspect(query, safe: false)
+
+    assert i == """
+           # foo
+           # bar baz
+           #Ecto.Query<from p0 in "posts">\
+           """
+
+    i = inspect(plan(query), safe: false)
+
+    assert i == """
+           # foo
+           # bar baz
+           #Ecto.Query<from p0 in "posts">\
+           """
+  end
+
   def plan(query) do
     {query, _, _} = Ecto.Adapter.Queryable.plan_query(:all, Ecto.TestAdapter, query)
     query

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -666,6 +666,26 @@ defmodule Ecto.Query.PlannerTest do
     assert key == :nocache
   end
 
+  test "plan: dynamic comments are uncacheable" do
+    {_query, _params, key} =
+      Post
+      |> select([p], p.id)
+      |> comment(^"uncache#{"able"}")
+      |> Planner.plan(:all, Ecto.TestAdapter)
+
+    assert key == :nocache
+  end
+
+  test "plan: static comments are cacheable" do
+    {_query, _params, key} =
+      Post
+      |> select([p], p.id)
+      |> comment("cacheable")
+      |> Planner.plan(:all, Ecto.TestAdapter)
+
+    assert key != :nocache
+  end
+
   test "plan: normalizes prefixes" do
     # No schema prefix in from
     {query, _, _, _} = from(Comment, select: 1) |> plan()

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1137,4 +1137,23 @@ defmodule Ecto.QueryTest do
       assert inspect(reverse_order(q)) == inspect(order_by(q, desc: :id))
     end
   end
+
+
+  describe "query comments" do
+    test "allows compile time strings" do
+      query =
+        from(p in "posts")
+        |> comment("called from test")
+
+      assert ["called from test"] == query.comments
+    end
+
+    test "allows interpolated strings" do
+      query =
+        from(p in "posts")
+        |> comment(^"called from #{"test"}")
+
+      assert "called from test" == hd(query.comments).expr
+    end
+  end
 end


### PR DESCRIPTION
This is continuation of the work that I started in [postgrex repo](https://github.com/elixir-ecto/postgrex/pull/709) - I think ecto will better benefit from it. For completnes I think an alternative to this pr may be to provide a callback that will receive the query generated query and allow to modify it with comment, but then we don't know if it could be cached and use as prepared query.

It adds a new field in Ecto.Query that aggregates comments.
The comments are then added to the generated query:
`/*comment1*/ /*comment2*/ SELECT s0."x" FROM (/*subquery comment*/ SELECT ss0."x" AS "x" FROM "schema" AS ss0) AS s0`
comments can be inspected:
```
           # foo
           # bar
           #Ecto.Query<from p0 in "posts">
``` 
Currently a comment can be a:
- compile time string - this does not change and query with only such comments can be cached and a query can be prepared - we are not sacrificing any performance benefits of ecto in this case.
 examples: module, function, app name, repo name, job name, host.
- interpolated string or a variable - these are not cached and the query should not be prepared (not implemented yet).
examples traces and spans, ip
This may be slower when compiling a query and also require more resources to parse the query in the db. 
But not everyone is running db with 80% load. Also traces can be sampled and only a small percent could include the additional data.
I need it for sqlcommenter mostly and [libraries in other languages](https://github.com/google/sqlcommenter) do it similarly, [rails has it built in](https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-enabled).

What next:
- disable prepared queries when the comment is not a compile time string  - I'm not sure how to best do that, if it's enough to extend the build_meta functions or if the db libraries also need a new param or maybe a new field in query struct that the query should not be prepared ?
- validate for sql injection - currently in postgrex there is a transaction comment that raises when  `*/` is included in comment.  I think that it's better to replace any occurence of `*/` with `* /` to have any sql injection attempt logged and the data saved.
- add [changes to ecto_sql](https://github.com/elixir-ecto/ecto_sql/pull/645) to add the comments to actual query
- add config option to specify if the comment should be prepended or appended to the query:
  by default the comments will be in front but [sqlcommenter specification](https://google.github.io/sqlcommenter/spec/) requires comments a the end.
- add a default comment `comment()` configured similar as logger format with access to compile time env struct. 
  this would allow to add metadata to a composed query from multiple files
  format: `$line: $module.$function` will create a compile time comment that can be cached and prepared and the resulting sql would look like:
   `/*22: MyApp.QueryBuilder.build*/ /*33: MyApp.QueryBuilder.filter*/ SELECT s0."x" FROM  "schema" where z = ? AS s0`
- add a `comment(:sqlcommenter, keyword)` that will accept create a sqlcommenter comment or require the use an external library to do the escaping and just accept the comment as string or iolist. The escaping logic is pretty simple and I think it could be included in ecto. This will require to specify in config `ecto: comment_position: :append`
This may require flushing previous comments or merging them into one - sqlcommenter specification says that there should be only one. But we can for example aggrgate key value pairs and the build it all at the end into a single comment, additional config option may be required. 
- comment(atom) - when you follow the rules to not create atoms dynamically then we can use atoms from variables similarly as compile time strings and cache queries built from strings with atoms, example :
```
method = :get
query |> comment("method: #{method}")
or 
query |> comment({:safe, "method: #{method}"})
```
- implement for insert_all and delete_all
- implement for other adapters
- add TracedRepo module that would be a drop in replacement for Repo with macros and calling TracedRepo.all(query) would use the work done here and inject comments with static metadata. Again - I'm not sure if it should be in ecto or just in ecto documentation as an example ?
- documentation - I wan't some feedback first before I do that.
