### PR TITLE
Improve exception message for Jason.Encoder errors

### DIFF
--- a/lib/ecto/json.ex
+++ b/lib/ecto/json.ex
@@ -10,15 +10,16 @@ if Code.ensure_loaded?(Jason.Encoder) do
           Repo.preload(#{inspect(owner)}, #{inspect(field)})
 
       Or choose to not encode the association when converting the struct \
-      to JSON by explicitly listing the JSON fields in your schema, or by \
-      excluding it (commented out):
+      to JSON by explicitly listing the JSON fields in your schema:
 
           defmodule #{inspect(owner)} do
             # ...
 
             @derive {Jason.Encoder, only: [:name, :title, ...]}
-            # @derive {Jason.Encoder, except: [#{inspect(field)}]}
             schema ... do
+
+      You can also use the :except option instead of :only if you would \
+      prefer to skip some fields.
       """
     end
   end
@@ -31,15 +32,16 @@ if Code.ensure_loaded?(Jason.Encoder) do
       exposed externally.
 
       You can either map the schemas to remove the :__meta__ field before \
-      encoding to JSON (commented out), or explicitly list the JSON fields in \
-      your schema:
+      encoding or explicitly list the JSON fields in your schema:
 
           defmodule #{inspect(schema)} do
             # ...
 
             @derive {Jason.Encoder, only: [:name, :title, ...]}
-            # @derive {Jason.Encoder, except: [:__meta__]}
             schema ... do
+
+      You can also use the :except option instead of :only if you would \
+      prefer to skip some fields.
       """
     end
   end

--- a/lib/ecto/json.ex
+++ b/lib/ecto/json.ex
@@ -10,12 +10,14 @@ if Code.ensure_loaded?(Jason.Encoder) do
           Repo.preload(#{inspect(owner)}, #{inspect(field)})
 
       Or choose to not encode the association when converting the struct \
-      to JSON by explicitly listing the JSON fields in your schema:
+      to JSON by explicitly listing the JSON fields in your schema, or by \
+      excluding it (commented out):
 
           defmodule #{inspect(owner)} do
             # ...
 
             @derive {Jason.Encoder, only: [:name, :title, ...]}
+            # @derive {Jason.Encoder, except: [#{inspect(field)}]}
             schema ... do
       """
     end
@@ -29,12 +31,14 @@ if Code.ensure_loaded?(Jason.Encoder) do
       exposed externally.
 
       You can either map the schemas to remove the :__meta__ field before \
-      encoding to JSON, or explicitly list the JSON fields in your schema:
+      encoding to JSON (commented out), or explicitly list the JSON fields in \
+      your schema:
 
           defmodule #{inspect(schema)} do
             # ...
 
             @derive {Jason.Encoder, only: [:name, :title, ...]}
+            # @derive {Jason.Encoder, except: [:__meta__]}
             schema ... do
       """
     end


### PR DESCRIPTION
Thanks for all that you do, including continued maintenance of `ecto`, and now taking the time to consider this small pull request.

I decided it was too much to replicate the full contextual block that was already there just to add one alternative `@derive...` line, and thought maybe a commented out approach would be both simple and useful.