### PR TITLE
Plan sources before creating plan_subquery closure

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -221,10 +221,10 @@ defmodule Ecto.Query.Planner do
           {planned_query :: Ecto.Query.t(), parameters :: list(), cache_key :: any()}
   def plan(query, operation, adapter, cte_names \\ %{}) do
     {query, cte_names} = plan_ctes(query, adapter, cte_names)
+    query = plan_sources(query, adapter, cte_names)
     plan_subquery = &plan_subquery(&1, query, nil, adapter, false, cte_names)
 
     query
-    |> plan_sources(adapter, cte_names)
     |> plan_assocs()
     |> plan_combinations(adapter, cte_names)
     |> plan_expr_subqueries(:wheres, plan_subquery)

--- a/test/ecto/query/subquery_test.exs
+++ b/test/ecto/query/subquery_test.exs
@@ -481,6 +481,12 @@ defmodule Ecto.Query.SubqueryTest do
       assert dump_params == ["foo"]
     end
 
+    test "in query with exists" do
+      c = from(c in "comments", where: ^"title" == parent_as(:p).title, select: 1)
+      s = from(p in "posts", as: :p, where: exists(c), select: count())
+      normalize(s)
+    end
+
     test "in dynamic" do
       c = from(c in Comment, where: c.text == ^"foo", select: c.post_id)
       d = dynamic([p], p.id in subquery(c))


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4547

Because `where` and friends might need to cast parameters to field types, we need to be able to cast the sources first. This way `query.sources` is populated.