### PR TITLE
Allow map/2 and struct/2 to take subsets of embed fields

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1425,6 +1425,7 @@ defmodule Ecto.Integration.RepoTest do
       assert p3 == %{id: pid3}
     end
 
+    @tag :json_extract_path
     test "take with embed" do
       today = Date.utc_today()
 

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1443,7 +1443,7 @@ defmodule Ecto.Integration.RepoTest do
       [o1, o2, o3] =
         Order
         |> select([o], map(o, [:metadata, item: [:price, primary_color: [:name]]]))
-        |> order_by([o], o.item["price"])
+        |> order_by([o], o.id)
         |> TestRepo.all()
 
       assert o1 == %{metadata: %{"test" => "test"}, item: %Item{price: 1, primary_color: %ItemColor{name: "1"}}}


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4536

The general idea is to select the fields individually and then combine them in Elixir after they are retrieved from the database. There are more corner cases than I was anticipating. Here are some points for consideration:

1. I am using `json_extract_path` to select the individual fields from the embed assuming this abstraction is meant to work for most databases. If it's not mean to be, then is it better to create a general expression for embed fields and have the adapter convert it?
2. Right now this only works for `embeds_one` and not `embeds_many` because of the way extractions are being done. There is a similar limitation on `json_extract_path`. There is a chance it can be extended to `embeds_many` but I am not sure there is a simple operator to extract the same key from every object in a json array. So if we want to keep this we might have to be ok with it only working for `embeds_one`
3. Right now taking associations inside of embeds is not supported. I think this can be done but if it's not a big deal would prefer to do it in a follow-up PR. I think there are enough complications with the current PR to consider.
4. There is a current inconsistency, maybe intentional, between taking associations and taking embeds that is carrying over to this PR. If doing `map(p, [assoc_field: [:assoc_sub_field])` the `:assoc_field` will also be a map. But if it's an embed field it will be a struct. This happens with or without the current PR. I kept the current behaviour but wanted to highlight it in case we want to make these consistent in a different PR. It will probably be a larger change to see why it behaves this way today.