### PR TITLE
Document usage of ParametrizedType inside of a composite type

### DIFF
--- a/lib/ecto/parameterized_type.ex
+++ b/lib/ecto/parameterized_type.ex
@@ -64,6 +64,13 @@ defmodule Ecto.ParameterizedType do
         field :bar, MyApp.MyType, opt1: :baz, opt2: :boo
       end
 
+  To use this type in a schema field with a composite type, specify the type in a tuple
+  and opts afterwards.
+
+      schema "foo" do
+        field :bars, {:array, MyApp.MyType}, opt1: :baz, opt2: :boo
+      end
+
   To use this type in places where you need it to be initialized (for example,
   schemaless changesets), you can use `init/2`.
 


### PR DESCRIPTION
Hi!

I was recently struggling with finding how to use a parametrized type inside of an array.
https://elixirforum.com/t/syntax-for-an-array-of-parameterized-types-in-ecto/68114
@wojtekmach suggested adding that to the documentation.

Let me know if that is OK or if I should improve anything!