### PR TITLE
Add expression to nil comparison error message

### DIFF
--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -70,7 +70,7 @@ defmodule Ecto.QueryTest do
       end
 
       assert_raise ArgumentError,
-                   ~r"comparison with nil in `p.id == \^id` is forbidden as it is unsafe", fn ->
+                   ~r"comparing `p.id` with `nil` is forbidden as it is unsafe", fn ->
         from p in "posts", where: p.id == ^id
       end
     end

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -56,16 +56,22 @@ defmodule Ecto.QueryTest do
 
     test "does not allow nils in comparison at compile time" do
       assert_raise Ecto.Query.CompileError,
-                   ~r"comparison with nil is forbidden as it is unsafe", fn ->
+                   ~r"comparison with nil in `p.id == nil` is forbidden as it is unsafe", fn ->
         quote_and_eval from p in "posts", where: p.id == nil
       end
     end
 
     test "does not allow interpolated nils at runtime" do
+      id = nil
+
       assert_raise ArgumentError,
-                   ~r"comparison with nil is forbidden as it is unsafe", fn ->
-        id = nil
+                   ~r"nil given for `id`. comparison with nil is forbidden as it is unsafe", fn ->
         from p in "posts", where: [id: ^id]
+      end
+
+      assert_raise ArgumentError,
+                   ~r"comparison with nil in `p.id == \^id` is forbidden as it is unsafe", fn ->
+        from p in "posts", where: p.id == ^id
       end
     end
 


### PR DESCRIPTION
Was reading Elixir Forum and found this: https://elixirforum.com/t/ecto-argumenterror-comparison-with-nil-is-forbidden-when-querying-for-null-field-in-phoenix-elixir/68343/3

This should help make the issue easier to identify.