### PR TITLE
Revert "Allow numbers in literal/1 (#4562)" and add identifier/1 and constant/1 instead

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -493,6 +493,38 @@ defmodule Ecto.Query.API do
   def literal(binary), do: doc!([binary])
 
   @doc """
+  Allows a dynamic identifier to be injected into a fragment:
+
+      collation = "es_ES"
+      select("posts", [p], fragment("? COLLATE ?", p.title, identifier(^"es_ES")))
+
+  The example above will inject the value of `collation` directly
+  into the query instead of treating it as a query parameter. It will
+  generate a query such as `SELECT p0.title COLLATE "es_ES" FROM "posts" AS p0`
+  as opposed to `SELECT p0.title COLLATE $1 FROM "posts" AS p0`.
+
+  Note that each different value of `collation` will emit a different query,
+  which will be independently prepared and cached.
+  """
+  def identifier(binary), do: doc!([binary])
+
+  @doc """
+  Allows a dynamic string or number to be injected into a fragment:
+
+      limit = 10
+      "posts" |> select([p], p.title) |> limit(fragment("?", constant(^limit)))
+
+  The example above will inject the value of `limit` directly
+  into the query instead of treating it as a query parameter. It will
+  generate a query such as `SELECT p0.title FROM "posts" AS p0 LIMIT 1`
+  as opposed to `SELECT p0.title FROM "posts" AS p0` LIMIT $1`.
+
+  Note that each different value of `limit` will emit a different query,
+  which will be independently prepared and cached.
+  """
+  def constant(value), do: doc!([value])
+
+  @doc """
   Allows a list argument to be spliced into a fragment.
 
       from p in Post, where: fragment("? in (?)", p.id, splice(^[1, 2, 3]))
@@ -504,7 +536,7 @@ defmodule Ecto.Query.API do
   You may only splice runtime values. For example, this would not work because
   query bindings are compile-time constructs:
 
-      from p in Post, where: fragment("concat(?)", splice(^[p.count, " ", "count"])
+      from p in Post, where: fragment("concat(?)", splice(^[p.count, " ", "count"]))
   """
   def splice(list), do: doc!([list])
 

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -480,19 +480,6 @@ defmodule Ecto.Query.API do
   def fragment(fragments), do: doc!([fragments])
 
   @doc """
-  Allows a literal identifier to be injected into a fragment:
-
-      collation = "es_ES"
-      fragment("? COLLATE ?", ^name, literal(^collation))
-
-  The example above will inject `collation` into the query as
-  a literal identifier instead of a query parameter. Note that
-  each different value of `collation` will emit a different query,
-  which will be independently prepared and cached.
-  """
-  def literal(binary), do: doc!([binary])
-
-  @doc """
   Allows a dynamic identifier to be injected into a fragment:
 
       collation = "es_ES"

--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -480,20 +480,17 @@ defmodule Ecto.Query.API do
   def fragment(fragments), do: doc!([fragments])
 
   @doc """
-  Allows a literal identifier or number to be injected into a fragment:
+  Allows a literal identifier to be injected into a fragment:
 
       collation = "es_ES"
       fragment("? COLLATE ?", ^name, literal(^collation))
 
-      limit = 10
-      limit(query, fragment("?", literal(^limit)))
-
-  The example above will inject `collation` and `limit` into the queries as
-  literals instead of query parameters. Note that each different value passed
-  to `literal/1` will emit a different query, which will be independently prepared
-  and cached.
+  The example above will inject `collation` into the query as
+  a literal identifier instead of a query parameter. Note that
+  each different value of `collation` will emit a different query,
+  which will be independently prepared and cached.
   """
-  def literal(literal), do: doc!([literal])
+  def literal(binary), do: doc!([binary])
 
   @doc """
   Allows a list argument to be spliced into a fragment.

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -751,18 +751,15 @@ defmodule Ecto.Query.Builder do
     )
   end
 
-  defp escape_fragment({:literal, _meta, [expr]}, params_acc, _vars, _env) do
-    case expr do
-      {:^, _, [expr]} ->
-        checked = quote do: Ecto.Query.Builder.literal!(unquote(expr))
-        escaped = {:{}, [], [:literal, [], [checked]]}
-        {escaped, params_acc}
+  defp escape_fragment({:literal, meta, [expr]}, params_acc, vars, env) do
+    env = if {env, _fun} = env, do: env, else: env
 
-      _ ->
-        error!(
-          "literal/1 in fragment expects an interpolated value, such as literal(^value), got `#{Macro.to_string(expr)}`"
-        )
-    end
+    IO.warn(
+      "`literal/1` is deprecated. Please use `identifier/1` instead.",
+      Macro.Env.stacktrace(env)
+    )
+
+    escape_fragment({:identifier, meta, [expr]}, params_acc, vars, env)
   end
 
   defp escape_fragment({:identifier, _meta, [expr]}, params_acc, _vars, _env) do
@@ -1278,18 +1275,6 @@ defmodule Ecto.Query.Builder do
       kw
     else
       raise ArgumentError, bad_fragment_message(inspect(kw))
-    end
-  end
-
-  @doc """
-  Called by escaper at runtime to verify literal in fragments.
-  """
-  def literal!(literal) do
-    if is_binary(literal) do
-      literal
-    else
-      raise ArgumentError,
-            "literal(^value) expects `value` to be a string, got `#{inspect(literal)}`"
     end
   end
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -1256,12 +1256,13 @@ defmodule Ecto.Query.Builder do
   @doc """
   Called by escaper at runtime to verify literal in fragments.
   """
-  def literal!(literal) when is_binary(literal), do: literal
-  def literal!(literal) when is_number(literal), do: literal
-
   def literal!(literal) do
-    raise ArgumentError,
-          "literal(^value) expects `value` to be a string or a number, got `#{inspect(literal)}`"
+    if is_binary(literal) do
+      literal
+    else
+      raise ArgumentError,
+            "literal(^value) expects `value` to be a string, got `#{inspect(literal)}`"
+    end
   end
 
   @doc """

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -752,7 +752,11 @@ defmodule Ecto.Query.Builder do
   end
 
   defp escape_fragment({:literal, meta, [expr]}, params_acc, vars, env) do
-    env = if {env, _fun} = env, do: env, else: env
+    env =
+      case env do
+        {env, _fun} -> env
+        env -> env
+      end
 
     IO.warn(
       "`literal/1` is deprecated. Please use `identifier/1` instead.",

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -976,23 +976,6 @@ defmodule Ecto.QueryTest do
       end
     end
 
-    test "supports literals" do
-      query = from p in "posts", select: fragment("? COLLATE ?", p.name, literal(^"es_ES"))
-      assert {:fragment, _, parts} = query.select.expr
-
-      assert [
-               raw: "",
-               expr: {{:., _, [{:&, _, [0]}, :name]}, _, _},
-               raw: " COLLATE ",
-               expr: {:literal, _, ["es_ES"]},
-               raw: ""
-             ] = parts
-
-      assert_raise ArgumentError, "literal(^value) expects `value` to be a string, got `123`", fn ->
-        from p in "posts", select: fragment("? COLLATE ?", p.name, literal(^123))
-      end
-    end
-
     test "supports identifiers" do
       query = from p in "posts", select: fragment("? COLLATE ?", p.name, identifier(^"es_ES"))
       assert {:fragment, _, parts} = query.select.expr

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -988,20 +988,9 @@ defmodule Ecto.QueryTest do
                raw: ""
              ] = parts
 
-      query = from p in "posts", limit: fragment("?", literal(^1))
-      assert {:fragment, _, parts} = query.limit.expr
-
-      assert [
-               raw: "",
-               expr: {:literal, _, [1]},
-               raw: ""
-             ] = parts
-
-      assert_raise ArgumentError,
-                   "literal(^value) expects `value` to be a string or a number, got `%{}`",
-                   fn ->
-                     from p in "posts", select: fragment("? COLLATE ?", p.name, literal(^%{}))
-                   end
+      assert_raise ArgumentError, "literal(^value) expects `value` to be a string, got `123`", fn ->
+        from p in "posts", select: fragment("? COLLATE ?", p.name, literal(^123))
+      end
     end
 
     test "supports list splicing" do


### PR DESCRIPTION
Based on our discussions, it seems there is agreement that the old `literal/1` should be deprecated and we should make two new "functions": one for identifiers and one for constant values.

There was agreement by some people for `identifier/1` and `constant/1`. If you are not in favour of those names let me know! It won't affect the PR much.

Also, I'm not sure what is the normal deprecation procedure. I think we need to keep accepting `literal/1` to not break apps? If so should we remove it from the documentation or put some notes in the documentation about it being deprecated and replaced by these 2?

Companion Ecto SQL PR: https://github.com/elixir-ecto/ecto_sql/pull/652