### PR TITLE
doc: add sentence about embed_as/1

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -106,6 +106,8 @@ defmodule Ecto.Type do
   >
   > When you `use Ecto.Type`, it will set `@behaviour Ecto.Type` and define
   > default, overridable implementations for `c:embed_as/1` and `c:equal?/2`.
+  > You must implement your own `c:embed_as/1` function if you want 
+  > your `c:dump/1` to be called when exporting from Ecto.
 
   ## Custom types and primary keys
 


### PR DESCRIPTION
Added a sentence letting the user know they need to implement their own embed_as/1 if they want their dump function to be called when exporting from Ecto e.g. when using Ecto.embedded_dump/2 .

I didn't realize the significance of the emed_as function until I looked at source and saw that it is called when dumping.  Hoping this saves time for someone else down the road.