### PR TITLE
Add Repo.transaction_with/2

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -2275,4 +2275,52 @@ defmodule Ecto.Integration.RepoTest do
     defp uuid_module(Ecto.Adapters.Tds), do: Tds.Ecto.UUID
     defp uuid_module(_), do: Ecto.UUID
   end
+
+  describe "transaction_with/2" do
+    test "return ok" do
+      assert {:ok, [post1, post2]} =
+               TestRepo.transaction_with(fn ->
+                 post1 = TestRepo.insert!(%Post{title: "1"})
+                 post2 = TestRepo.insert!(%Post{title: "2"})
+                 {:ok, [post1, post2]}
+               end)
+
+      assert TestRepo.all(Post) |> Enum.sort() == [post1, post2]
+    end
+
+    test "return error" do
+      assert {:error, :oops} =
+               TestRepo.transaction_with(fn ->
+                 TestRepo.insert!(%Post{title: "1"})
+                 TestRepo.insert!(%Post{title: "2"})
+                 {:error, :oops}
+               end)
+
+      assert TestRepo.all(Post) == []
+    end
+
+    test "rollback" do
+      assert {:error, :oops} =
+               TestRepo.transaction_with(fn ->
+                 TestRepo.insert!(%Post{title: "1"})
+                 TestRepo.insert!(%Post{title: "2"})
+                 TestRepo.rollback(:oops)
+                 raise "unreachable"
+               end)
+
+      assert TestRepo.all(Post) == []
+    end
+
+    test "raise error" do
+      assert_raise RuntimeError, "oops", fn ->
+        TestRepo.transaction_with(fn ->
+          TestRepo.insert!(%Post{title: "1"})
+          TestRepo.insert!(%Post{title: "2"})
+          raise "oops"
+        end)
+      end
+
+      assert TestRepo.all(Post) == []
+    end
+  end
 end


### PR DESCRIPTION
References:
- https://tomkonidas.com/repo-transact/
- https://elixirforum.com/t/seeking-thoughts-on-advantages-of-the-repo-transact-pattern-vs-disadvantages-i-ve-read-about-ecto-multi/61733

I believe the interface and implementation are fairly uncontroversial and straightforward. I think the bigger undertaking is potentially revamping the docs, de-emphasizing Multi in favor of this, given that in a lot of (if not the vast majority of) cases, it achieves the same outcomes with less and simpler code. There are no plans to deprecate Multi.

The name of this function is not ideal, some other options considered were `Repo.transact` and `Repo.with_transaction`. I think `Repo.transaction_with` wins because basically:

```
iex(1)> Repo.transaction<tab>
transaction/1         transaction/2         transaction_with/1    transaction_with/2
```

That is, it will show up alongside `transaction` in docs, autocomplete, etc.