### PR TITLE
Allow suppressing `association key is nil` warning when preloading data

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -1188,6 +1188,10 @@ defmodule Ecto.Repo do
     * `:on_preloader_spawn` - when preloads are done in parallel, this function
       will be called in the processes that perform the preloads. This can be useful
       for context propagation for traces.
+    * `:warn_if_nil_keys` - When set to `false`, suppresses the warning
+      when preloading associations where the parent's association key is nil.
+      Useful when working with unpersisted data (e.g., in changesets).
+      Defaults to `true`.
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.


### PR DESCRIPTION
Sometimes we want to preload data inside a changeset. (In our case, snapshotting values like "price" in an order item from product selections)

```elixir
changeset = struct
|> cast_assoc(:children)

changed_data = changeset
|> apply_changes()
|> Repo.preload([children: :nested_child])

changeset
|> put_computed_data(changed_data)
```

The data after apply_changes may have new children (with `id: nil`) like below. 

```elixir
%Child{
  id: nil, 
  nested_child_id: 123, 
  nested_child: %Ecto.Association.NotLoaded{}
}
  ```
  
Currently with the code above we get a warning message:


```
[warning] association `children` for `MyStruct` has a loaded value but its association key `id` is nil. This usually means one of:

  * `id` was not selected in a query
  * the struct was set with default values for `children` which now you want to override

If this is intentional, set force: true to disable this warning
```

We don't want to preload it with `force: true` in this case, because the data is changing and we don't want to override it, we just want a way to suppress this warning.