### PR TITLE
Fix join_count conflicts

### DIFF
--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -165,11 +165,9 @@ defmodule Ecto.Query.Builder.Join do
       if is_nil(count_bind) do
         query =
           quote do
-            query = Ecto.Queryable.to_query(unquote(query))
-            join_count = Builder.count_binds(query)
-            query
+            Ecto.Queryable.to_query(unquote(query))
           end
-        {quote(do: join_count), query}
+        {quote(do: Builder.count_binds(unquote(query))), query}
       else
         {count_bind, query}
       end

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -202,4 +202,17 @@ defmodule Ecto.Query.Builder.JoinTest do
       end, [], __ENV__)
     end
   end
+
+  test "join count is incremented correctly for runtime sources" do
+    users_table = "users"
+    source_query = fn -> from p in "posts", join: c in "comments", on: true end
+
+    q =
+      from s in source_query.(),
+        join: j in subquery(from u in users_table, join: p in "profiles", on: true, select: u.id),
+        on: true,
+        select: {s.id, j.id}
+
+    assert {:{}, _, [_, {{:., [], [{:&, [], [2]}, :id]}, [], []}]} = q.select.expr
+  end
 end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4591

To me it looks like this is happening:

1. The `from` source can only be determined at runtime, so we don't know the starting join count. We quote the expression used to evaluate the join count.
2. The count from (1) is stored in a variable `join_count` in the join builder module.
3. Now let's say we have a subquery that also has a `from` source that can only be determined at runtime. This is setting the variable `join_count` to what makes sense for it. And this is conflicting with (2)

So the solution I made is to not set a `join_count` variable and instead evaluate the `Builder.count_binds` function each time.