### PR TITLE
Fix nil map merges

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1538,8 +1538,8 @@ defmodule Ecto.Integration.RepoTest do
                |> select_merge([_l, p], map(p, ^~w(title posted)a))
                |> TestRepo.all()
 
-      # left join record is not present
-      assert [%{url: "Q", title: "Z", posted: nil}] =
+      # left join record is not present, we consider it the same as being present with nils
+      assert [%{url: "Q", title: nil, posted: nil}] =
                Permalink
                |> join(:left, [l], p in Post, on: l.post_id == p.id and p.public == true)
                |> select([l, p], merge(l, map(p, ^~w(title posted)a)))

--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -1545,7 +1545,7 @@ defmodule Ecto.Integration.RepoTest do
                |> select([l, p], merge(l, map(p, ^~w(title posted)a)))
                |> TestRepo.all()
 
-      assert [%{url: "Q", title: "Z", posted: nil}] =
+      assert [%{url: "Q", title: nil, posted: nil}] =
                Permalink
                |> join(:left, [l], p in Post, on: l.post_id == p.id and p.public == true)
                |> select_merge([_l, p], map(p, ^~w(title posted)a))

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -310,7 +310,7 @@ defmodule Ecto.Repo.Queryable do
 
   defp process(row, {:merge, left, right}, from, adapter) do
     {left, row} = process(row, left, from, adapter)
-    {right, row} = process(row, right, from, adapter)
+    {right, row} = process_merge(row, right, from, adapter)
 
     data =
       case {left, right} do
@@ -425,6 +425,15 @@ defmodule Ecto.Repo.Queryable do
       {value, row} = process(row, value, from, adapter)
       {{key, value}, row}
     end)
+  end
+
+  defp process_merge(row, {:source, {source, schema}, prefix, types}, _from, adapter) do
+    struct = Ecto.Schema.Loader.load_struct(schema, prefix, source)
+    struct_load!(types, row, [], false, struct, adapter)
+  end
+
+  defp process_merge(row, process, from, adapter) do
+    process(row, process, from, adapter)
   end
 
   @compile {:inline, load!: 5}


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4598

The problem was actually more general than CTEs. Any map merging where the right side of the merge is a `{source, schema, prefix}` with a `nil` return value would do the same thing. For example, you can recreate the problem with this query

```elixir
TestRepo.insert!(%Post{title: "hi"})

from p in Post,
  left_join: s in Comment,
  on: p.id == s.post_id,
  select: %{title: p.title},
  select_merge: map(s, [:text])

Repo.all(query)
# [%{title: "hi"}]
```