### PR TITLE
Upgrade ubuntu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   unit-test:
     name: unit test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       FORCE_COLOR: 1
       MIX_ENV: test
@@ -61,7 +61,7 @@ jobs:
 
   integration-test:
     name: integration test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       FORCE_COLOR: 1
     strategy:


### PR DESCRIPTION
Our CI started failing because ubuntu 20.04 is going away https://github.com/actions/runner-images/issues/11101