### PR TITLE
Clarify the interaction between `reload` and associations

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -968,6 +968,8 @@ defmodule Ecto.Repo do
   to the same schema. Ordering is guaranteed to be kept. Results not found in
   the database will be returned as `nil`.
 
+  Preloaded association will be discarded and need to be preloaded again.
+
   ## Example
 
       MyRepo.reload(post)


### PR DESCRIPTION
I was pretty sure what the behavior was, went ahead and tested it but thought it may be helpful to add it to the docs as it could also be reasonable to assume that all preloaded associations are reloaded as well.

Thanks for all your work! :green_heart: 