### PR TITLE
Remove test code for compatibility with pre 1.13 elixir

### DIFF
--- a/test/ecto/changeset_test.exs
+++ b/test/ecto/changeset_test.exs
@@ -3,16 +3,9 @@ defmodule Ecto.ChangesetTest do
   import Ecto.Changeset
   require Ecto.Query
 
-  defmacrop assert_eq_macro_to_string(ast, post_1_13, pre_1_13) do
-    # AST is represented as string differently on versions pre 1.13
-    if Version.match?(System.version(), ">= 1.13.0-dev") do
-      quote do
-        assert Macro.to_string(unquote(ast)) == unquote(post_1_13)
-      end
-    else
-      quote do
-        assert Macro.to_string(unquote(ast)) == unquote(pre_1_13)
-      end
+  defmacrop assert_eq_macro_to_string(ast, string) do
+    quote do
+      assert Macro.to_string(unquote(ast)) == unquote(string)
     end
   end
 
@@ -2372,8 +2365,8 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: pk_expr}, %{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(pk_expr, "not (&0.id() == ^0)", "not(&0.id() == ^0)")
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(pk_expr, "not (&0.id() == ^0)")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for composite primary keys without query option for loaded schema" do
@@ -2386,13 +2379,9 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: pk_expr}, %{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(
-        pk_expr,
-        "not (&0.id() == ^0 and &0.token() == ^1)",
-        "not(&0.id() == ^0 and &0.token() == ^1)"
-      )
+      assert_eq_macro_to_string(pk_expr, "not (&0.id() == ^0 and &0.token() == ^1)")
 
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for single primary key with query option for loaded schema" do
@@ -2408,14 +2397,10 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: pk_expr}, %{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(
-        query_expr,
-        "is_nil(&0.published_at())",
-        "is_nil(&0.published_at())"
-      )
+      assert_eq_macro_to_string(query_expr, "is_nil(&0.published_at())")
 
-      assert_eq_macro_to_string(pk_expr, "not (&0.id() == ^0)", "not(&0.id() == ^0)")
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(pk_expr, "not (&0.id() == ^0)")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for composite primary keys with query option for loaded schema" do
@@ -2431,19 +2416,11 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: pk_expr}, %{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(
-        query_expr,
-        "is_nil(&0.published_at())",
-        "is_nil(&0.published_at())"
-      )
+      assert_eq_macro_to_string(query_expr, "is_nil(&0.published_at())")
 
-      assert_eq_macro_to_string(
-        pk_expr,
-        "not (&0.id() == ^0 and &0.token() == ^1)",
-        "not(&0.id() == ^0 and &0.token() == ^1)"
-      )
+      assert_eq_macro_to_string(pk_expr, "not (&0.id() == ^0 and &0.token() == ^1)")
 
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for single primary key without query option when schema wasn't loaded" do
@@ -2453,7 +2430,7 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for composite primary keys without query option when schema wasn't loaded" do
@@ -2463,7 +2440,7 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for single primary key with query option when schema wasn't loaded" do
@@ -2476,13 +2453,9 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(
-        query_expr,
-        "is_nil(&0.published_at())",
-        "is_nil(&0.published_at())"
-      )
+      assert_eq_macro_to_string(query_expr, "is_nil(&0.published_at())")
 
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "generates correct where clause for composite primary keys with query option when schema wasn't loaded" do
@@ -2495,13 +2468,9 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: query_expr}, %{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(
-        query_expr,
-        "is_nil(&0.published_at())",
-        "is_nil(&0.published_at())"
-      )
+      assert_eq_macro_to_string(query_expr, "is_nil(&0.published_at())")
 
-      assert_eq_macro_to_string(check_expr, "&0.body() == ^0", "&0.body() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.body() == ^0")
     end
 
     test "only queries the db when necessary" do
@@ -2555,7 +2524,7 @@ defmodule Ecto.ChangesetTest do
       assert_receive [MockRepo, function: :exists?, query: %Ecto.Query{wheres: wheres}, opts: []]
       assert [%{expr: check_expr}] = wheres
 
-      assert_eq_macro_to_string(check_expr, "&0.origin() == ^0", "&0.origin() == ^0")
+      assert_eq_macro_to_string(check_expr, "&0.origin() == ^0")
     end
   end
 
@@ -3696,7 +3665,13 @@ defmodule Ecto.ChangesetTest do
     end
 
     test "redacts all non-primary-key fields when schema sets @schema_redact :all_except_primary_keys" do
-      changeset = Ecto.Changeset.cast(%RedactAllExceptPrimaryKeysSchema{}, %{username: "Hunter", password: "hunter2"}, [:username, :password])
+      changeset =
+        Ecto.Changeset.cast(
+          %RedactAllExceptPrimaryKeysSchema{},
+          %{username: "Hunter", password: "hunter2"},
+          [:username, :password]
+        )
+
       assert inspect(changeset) =~ "id"
       refute inspect(changeset) =~ "hunter2"
       assert inspect(changeset) =~ "**redacted**"

--- a/test/ecto/query/builder/dynamic_test.exs
+++ b/test/ecto/query/builder/dynamic_test.exs
@@ -27,52 +27,25 @@ defmodule Ecto.Query.Builder.DynamicTest do
       assert params == [{1, {0, :foo}}]
     end
 
-    # TODO: AST is represented as string differently on versions pre 1.13
-    if Version.match?(System.version(), ">= 1.13.0-dev") do
-      test "with dynamic interpolation" do
-        dynamic = dynamic([p], p.bar == ^2)
-        dynamic = dynamic([p], p.foo == ^1 and ^dynamic or p.baz == ^3)
-        assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
-        assert Macro.to_string(expr) ==
-               "(&0.foo() == ^0 and &0.bar() == ^1) or &0.baz() == ^2"
-        assert params == [{1, {0, :foo}}, {2, {0, :bar}}, {3, {0, :baz}}]
-      end
-    else
-      test "with dynamic interpolation" do
-        dynamic = dynamic([p], p.bar == ^2)
-        dynamic = dynamic([p], p.foo == ^1 and ^dynamic or p.baz == ^3)
-        assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
-        assert Macro.to_string(expr) ==
-               "&0.foo() == ^0 and &0.bar() == ^1 or &0.baz() == ^2"
-        assert params == [{1, {0, :foo}}, {2, {0, :bar}}, {3, {0, :baz}}]
-      end
+    test "with dynamic interpolation" do
+      dynamic = dynamic([p], p.bar == ^2)
+      dynamic = dynamic([p], p.foo == ^1 and ^dynamic or p.baz == ^3)
+      assert {expr, _, params, [], _, _} = fully_expand(query(), dynamic)
+      assert Macro.to_string(expr) ==
+              "(&0.foo() == ^0 and &0.bar() == ^1) or &0.baz() == ^2"
+      assert params == [{1, {0, :foo}}, {2, {0, :bar}}, {3, {0, :baz}}]
     end
 
-    # TODO: AST is represented as string differently on versions pre 1.13
-    if Version.match?(System.version(), ">= 1.13.0-dev") do
-      test "with subquery and dynamic interpolation" do
-        dynamic = dynamic([p], p.sq in subquery(query()))
-        dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")
-        dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
-        assert {expr, binding, params, [_subquery], _, _} = fully_expand(query(), dynamic)
-        assert Macro.to_string(binding) == "[p]"
-        assert Macro.to_string(expr) ==
-              "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.sq() in {:subquery, 0} or &0.bar3() == ^3) and\n  &0.baz() == ^4"
-        assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {:subquery, 0},
-                          {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
-      end
-    else
-      test "with subquery and dynamic interpolation" do
-        dynamic = dynamic([p], p.sq in subquery(query()))
-        dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")
-        dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
-        assert {expr, binding, params, [_subquery], _, _} = fully_expand(query(), dynamic)
-        assert Macro.to_string(binding) == "[p]"
-        assert Macro.to_string(expr) ==
-              "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.sq() in {:subquery, 0} or &0.bar3() == ^3) and &0.baz() == ^4"
-        assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {:subquery, 0},
-                          {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
-      end
+    test "with subquery and dynamic interpolation" do
+      dynamic = dynamic([p], p.sq in subquery(query()))
+      dynamic = dynamic([p], p.bar1 == ^"bar1" or ^dynamic or p.bar3 == ^"bar3")
+      dynamic = dynamic([p], p.foo == ^"foo" and ^dynamic and p.baz == ^"baz")
+      assert {expr, binding, params, [_subquery], _, _} = fully_expand(query(), dynamic)
+      assert Macro.to_string(binding) == "[p]"
+      assert Macro.to_string(expr) ==
+            "&0.foo() == ^0 and (&0.bar1() == ^1 or &0.sq() in {:subquery, 0} or &0.bar3() == ^3) and\n  &0.baz() == ^4"
+      assert params == [{"foo", {0, :foo}}, {"bar1", {0, :bar1}}, {:subquery, 0},
+                        {"bar3", {0, :bar3}}, {"baz", {0, :baz}}]
     end
 
     test "with nested dynamic interpolation" do

--- a/test/ecto/query/builder/join_test.exs
+++ b/test/ecto/query/builder/join_test.exs
@@ -50,23 +50,12 @@ defmodule Ecto.Query.Builder.JoinTest do
     end
   end
 
-  # TODO: AST is represented as string differently on versions pre 1.13
-  if Version.match?(System.version(), ">= 1.13.0-dev") do
-    test "accepts keywords on :on" do
-      assert %{joins: [join]} =
-              join("posts", :inner, [p], c in "comments", on: [post_id: p.id, public: true])
-      assert Macro.to_string(join.on.expr) ==
-            "&1.post_id() == &0.id() and\n  &1.public() == %Ecto.Query.Tagged{tag: nil, type: {1, :public}, value: true}"
-      assert join.on.params == []
-    end
-  else
-    test "accepts keywords on :on" do
-      assert %{joins: [join]} =
-              join("posts", :inner, [p], c in "comments", on: [post_id: p.id, public: true])
-      assert Macro.to_string(join.on.expr) ==
-            "&1.post_id() == &0.id() and &1.public() == %Ecto.Query.Tagged{tag: nil, type: {1, :public}, value: true}"
-      assert join.on.params == []
-    end
+  test "accepts keywords on :on" do
+    assert %{joins: [join]} =
+            join("posts", :inner, [p], c in "comments", on: [post_id: p.id, public: true])
+    assert Macro.to_string(join.on.expr) ==
+          "&1.post_id() == &0.id() and\n  &1.public() == %Ecto.Query.Tagged{tag: nil, type: {1, :public}, value: true}"
+    assert join.on.params == []
   end
 
   test "accepts queries on interpolation" do

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -310,29 +310,15 @@ defmodule Ecto.Query.InspectTest do
              ~s{from p0 in Inspect.Post, lock: "FOOBAR"}
   end
 
-  # TODO: AST is represented as string differently on versions pre 1.13
-  if Version.match?(System.version(), ">= 1.13.0-dev") do
-    test "preload" do
-      assert i(from(x in Post, preload: :comments)) ==
-               ~s"from p0 in Inspect.Post, preload: [:comments]"
+  test "preload" do
+    assert i(from(x in Post, preload: :comments)) ==
+              ~s"from p0 in Inspect.Post, preload: [:comments]"
 
-      assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: y])) ==
-               ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: c1]"
+    assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: y])) ==
+              ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: c1]"
 
-      assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: {y, post: x}])) ==
-               ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: {c1, post: p0}]"
-    end
-  else
-    test "preload" do
-      assert i(from(x in Post, preload: :comments)) ==
-               ~s"from p0 in Inspect.Post, preload: [:comments]"
-
-      assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: y])) ==
-               ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: c1]"
-
-      assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: {y, post: x}])) ==
-               ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: {c1, [post: p0]}]"
-    end
+    assert i(from(x in Post, join: y in assoc(x, :comments), preload: [comments: {y, post: x}])) ==
+              ~s"from p0 in Inspect.Post, join: c1 in assoc(p0, :comments), preload: [comments: {c1, post: p0}]"
   end
 
   test "fragments" do
@@ -445,27 +431,14 @@ defmodule Ecto.Query.InspectTest do
            ) == string
   end
 
-  # TODO: AST is represented as string differently on versions pre 1.13
-  if Version.match?(System.version(), ">= 1.13.0-dev") do
-    test "container values" do
-      assert i(from(Post, select: <<1, 2, 3>>)) ==
-               "from p0 in Inspect.Post, select: \"\\x01\\x02\\x03\""
+  test "container values" do
+    assert i(from(Post, select: <<1, 2, 3>>)) ==
+              "from p0 in Inspect.Post, select: \"\\x01\\x02\\x03\""
 
-      foo = <<1, 2, 3>>
+    foo = <<1, 2, 3>>
 
-      assert i(from(p in Post, select: {p, ^foo})) ==
-               "from p0 in Inspect.Post, select: {p0, ^\"\\x01\\x02\\x03\"}"
-    end
-  else
-    test "container values" do
-      assert i(from(Post, select: <<1, 2, 3>>)) ==
-               "from p0 in Inspect.Post, select: <<1, 2, 3>>"
-
-      foo = <<1, 2, 3>>
-
-      assert i(from(p in Post, select: {p, ^foo})) ==
-               "from p0 in Inspect.Post, select: {p0, ^<<1, 2, 3>>}"
-    end
+    assert i(from(p in Post, select: {p, ^foo})) ==
+              "from p0 in Inspect.Post, select: {p0, ^\"\\x01\\x02\\x03\"}"
   end
 
   test "select" do


### PR DESCRIPTION
I don't think it's needed any more. The CI runs with 1.14 on the low end. 1.13 doesn't even get security patches any more, and we're removing _test execution_ support for versions before that even.

I had noticed this code due to a check annotation from github on my previous PR and it got me curios: https://github.com/elixir-ecto/ecto/pull/4607/files

Thanks for all your work! :green_heart: 