### PR TITLE
Pretty print given struct on relation error

### DIFF
--- a/lib/ecto/changeset/relation.ex
+++ b/lib/ecto/changeset/relation.ex
@@ -288,7 +288,9 @@ defmodule Ecto.Changeset.Relation do
     If you indeed want to replace the existing #{inspect name}, you have
     to change the foreign key field directly.
 
-    Got: #{inspect new}
+    Got:
+
+    #{inspect(new, pretty: true)}
     """
   end
 


### PR DESCRIPTION
Before:

```
** (RuntimeError) you have set that the relation :draft of Post
has `:on_replace` set to `:update` but you are giving it a struct/
changeset to put_assoc/put_change.

Since you have set `:on_replace` to `:update`, you are only allowed
to update the existing entry by giving updated fields as a map or
keyword list or set it to nil.

If you indeed want to replace the existing :draft, you have
to change the foreign key field directly.

Got: %PageContent{__meta__: #Ecto.Schema.Metadata<:built, "page_contents">, id: nil, really_long_field1: nil, really_long_field2: nil}

    (ecto 3.13.0-dev) lib/ecto/changeset/relation.ex:279: Ecto.Changeset.Relation.raise_if_updating_with_struct!/2
    (ecto 3.13.0-dev) lib/ecto/changeset/relation.ex:333: Ecto.Changeset.Relation.single_change/6
    (ecto 3.13.0-dev) lib/ecto/changeset/relation.ex:173: Ecto.Changeset.Relation.change/3
    (ecto 3.13.0-dev) lib/ecto/changeset.ex:1920: Ecto.Changeset.put_change/7
    (ecto 3.13.0-dev) lib/ecto/changeset.ex:2168: Ecto.Changeset.put_relation/5
    ecto_sql.exs:62: Main.main/0
    ecto_sql.exs:67: (file)

```

After:

```
** (RuntimeError) you have set that the relation :draft of Post
has `:on_replace` set to `:update` but you are giving it a struct/
changeset to put_assoc/put_change.

Since you have set `:on_replace` to `:update`, you are only allowed
to update the existing entry by giving updated fields as a map or
keyword list or set it to nil.

If you indeed want to replace the existing :draft, you have
to change the foreign key field directly.

Got:

%PageContent{
  __meta__: #Ecto.Schema.Metadata<:built, "page_contents">,
  id: nil,
  really_long_field1: nil,
  really_long_field2: nil
}

    (ecto 3.13.0-dev) lib/ecto/changeset/relation.ex:279: Ecto.Changeset.Relation.raise_if_updating_with_struct!/2
    (ecto 3.13.0-dev) lib/ecto/changeset/relation.ex:335: Ecto.Changeset.Relation.single_change/6
    (ecto 3.13.0-dev) lib/ecto/changeset/relation.ex:173: Ecto.Changeset.Relation.change/3
    (ecto 3.13.0-dev) lib/ecto/changeset.ex:1920: Ecto.Changeset.put_change/7
    (ecto 3.13.0-dev) lib/ecto/changeset.ex:2168: Ecto.Changeset.put_relation/5
    ecto_sql.exs:62: Main.main/0
    ecto_sql.exs:67: (file)

```