### PR TITLE
Add Ecto formatter config example to "Getting Started" guide

### DIFF
--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -46,10 +46,8 @@ against our database. If we didn't do this step, we wouldn't be able to do any
 querying at all.
 
 That's the first two steps taken now. We have installed Ecto and Postgrex as
-dependencies of our application.
-
-Now, we can change our `.formatter.exs` file so that Ecto's custom formatter
-rules will be applied when we run `mix format`:
+dependencies of our application. Next let's update the `.formatter.exs`
+file so that Ecto's rules will be applied on `mix format`:
 
 ```elixir
 [

--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -46,9 +46,24 @@ against our database. If we didn't do this step, we wouldn't be able to do any
 querying at all.
 
 That's the first two steps taken now. We have installed Ecto and Postgrex as
-dependencies of our application. We now need to setup some configuration for
-Ecto so that we can perform actions on a database from within the
-application's code.
+dependencies of our application.
+
+Now, we can change our `.formatter.exs` file so that Ecto's custom formatter
+rules will be applied when we run `mix format`:
+
+```elixir
+[
+  # Add these lines to enable Ecto formatter rules
+  import_deps: [:ecto, :ecto_sql],
+  subdirectories: ["priv/*/migrations"],
+
+  # Default Elixir project rules
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]
+```
+
+We now need to setup some configuration for Ecto so that we can perform actions
+on a database from within the application's code.
 
 We can set up this configuration by running this command:
 

--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -60,9 +60,8 @@ file so that Ecto's rules will be applied on `mix format`:
 ```
 
 We now need to setup some configuration for Ecto so that we can perform actions
-on a database from within the application's code.
-
-We can set up this configuration by running this command:
+on a database from within the application's code. We can set up this
+configuration by running this command:
 
 ```
 mix ecto.gen.repo -r Friends.Repo

--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -53,9 +53,8 @@ rules will be applied when we run `mix format`:
 
 ```elixir
 [
-  # Add these lines to enable Ecto formatter rules
+  # Add this line to enable Ecto formatter rules
   import_deps: [:ecto, :ecto_sql],
-  subdirectories: ["priv/*/migrations"],
 
   # Default Elixir project rules
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]


### PR DESCRIPTION
I was following through the Getting Started guide, and noticed that the formatter config was not present in there, so I added a brief section on adding it. Now, I have no more ugly brackets in my Ecto migrations when I follow the guide!