### PR TITLE
Add Ecto migrations formatter config example to "Getting Started" guide

### DIFF
--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -155,7 +155,31 @@ defmodule Friends.Repo.Migrations.CreatePeople do
 end
 ```
 
-Let's add some code to this migration to create a new table called "people", with a few columns in it:
+To enable formatter support for our migrations (i.e. when running `mix format`), we can create a new formatter config file called `priv/repo/migrations/.formatter.exs` with the following content:
+
+```elixir
+[
+  import_deps: [:ecto_sql],
+  inputs: ["*.exs"]
+]
+```
+
+We will also need to add a line or two to our application's main formatter config so that the formatter knows where to find the new config file we just created. Let's update the application's main `.formatter.exs` file:
+
+```elixir
+[
+  # Add this line to enable Ecto formatter rules
+  import_deps: [:ecto, :ecto_sql],
+
+  # Add this line to enable the formatter in our new migrations directory
+  subdirectories: ["priv/*/migrations"],
+
+  # Default Elixir project rules
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]
+```
+
+Let's add some code to the new migration to create a new table called "people", with a few columns in it:
 
 ```elixir
 defmodule Friends.Repo.Migrations.CreatePeople do


### PR DESCRIPTION
After merging #4612, I took a look around to find instructions for adding the migration-specific formatter rules to a vanilla Ecto project.

Surprisingly, a few Google searches didn't turn up any instructions (that I could find)... so I figured it might just be easier to add the instructions to the part of the Getting Started guide that deals with migrations.

It does break the flow of the tutorial briefly, but I wasn't sure if there was a better place for it. Feel free to make any needed modifications.