### PR TITLE
HOT optimization for upserts with :replace and :replace_all_except

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -754,6 +754,7 @@ defmodule Ecto.Repo.Schema do
         raise ArgumentError, ":on_conflict option with `{:replace, fields}` requires a non-empty list of fields"
 
       {:replace, keys} when is_list(keys) ->
+        keys = keys -- List.wrap(conflict_target)
         {{replace_fields!(dumper, keys), [], conflict_target}, []}
 
       :replace_all ->
@@ -764,7 +765,8 @@ defmodule Ecto.Repo.Schema do
         {{replace_all_fields!(:replace_all, schema, to_remove), [], conflict_target}, []}
 
       {:replace_all_except, fields} ->
-        {{replace_all_fields!(:replace_all_except, schema, fields), [], conflict_target}, []}
+        to_remove = List.wrap(conflict_target) ++ fields
+        {{replace_all_fields!(:replace_all_except, schema, to_remove), [], conflict_target}, []}
 
       [_ | _] = on_conflict ->
         from = if schema, do: {source, schema}, else: source

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -1904,6 +1904,25 @@ defmodule Ecto.RepoTest do
       assert_received {:insert, %{source: "my_schema", on_conflict: {^fields, [], []}}}
     end
 
+    test "includes conflict target in the field list given to :replace_all_except" do
+      fields = [:map, :z, :yyy, :x]
+      TestRepo.insert(%MySchema{id: 1}, on_conflict: {:replace_all_except, [:array]}, conflict_target: [:id])
+      assert_received {:insert, %{source: "my_schema", on_conflict: {^fields, [], [:id]}}}
+    end
+
+    test "excludes conflict target from the field list given to :replace" do
+      fields = [:id, :map, :z, :x]
+      TestRepo.insert(%MySchema{id: 1}, on_conflict: {:replace, fields}, conflict_target: [:id])
+      expected_fields = fields -- [:id]
+      assert_received {:insert, %{source: "my_schema", on_conflict: {^expected_fields, [], [:id]}}}
+    end
+
+    test "excludes conflict target from :replace_all" do
+      fields = [:map, :array, :z, :yyy, :x]
+      TestRepo.insert(%MySchema{id: 1}, on_conflict: :replace_all, conflict_target: [:id])
+      assert_received {:insert, %{source: "my_schema", on_conflict: {^fields, [], [:id]}}}
+    end
+
     test "converts keyword list into query" do
       TestRepo.insert(%MySchema{id: 1}, on_conflict: [set: [x: "123", y: "456"]])
       assert_received {:insert, %{source: "my_schema", on_conflict: {query, ["123", "456"], []}}}


### PR DESCRIPTION
Similar optimization as the one introduced in this PR: https://github.com/elixir-ecto/ecto/pull/4392

Essentially, we know that the `conflict_target` will have the same values because that's what's causing the conflict :), so there is no need to update them. This change could promote [heap-only tuple updates](https://www.postgresql.org/docs/current/storage-hot.html), reducing the overhead of updates in environments with high demand or concurrency.