### PR TITLE
Add support for :writable option on belongs_to

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1106,6 +1106,12 @@ defmodule Ecto.Schema do
     * `:where` - A filter for the association. See "Filtering associations"
       in `has_many/3`.
 
+    * `:writable` - Defines when the underlying field is allowed to modified, Must be
+      one of `:always`, `:insert`, or `:never`. If set to `:always`, the field can be
+      modified by any repo operation. If set to `:insert`, the field can be inserted
+      but cannot be further modified, even in an upsert. If set to `:never`, the field
+      becomes read only. Defaults to `:always`.
+
   ## Examples
 
       defmodule Comment do
@@ -2138,6 +2144,7 @@ defmodule Ecto.Schema do
     :defaults,
     :primary_key,
     :source,
+    :writable,
     :where
   ]
 

--- a/test/ecto/repo/belongs_to_test.exs
+++ b/test/ecto/repo/belongs_to_test.exs
@@ -35,6 +35,15 @@ defmodule Ecto.Repo.BelongsToTest do
     end
   end
 
+  defmodule RestrictedSchema do
+    use Ecto.Schema
+
+    schema "restricted_schema" do
+      belongs_to :unwritable, MyAssoc, writable: :never
+      belongs_to :non_updatable, MyAssoc, writable: :insert
+    end
+  end
+
   test "handles assocs on insert" do
     sample = %MyAssoc{x: "xyz"}
 
@@ -495,5 +504,30 @@ defmodule Ecto.Repo.BelongsToTest do
 
     assert updated_schema.assoc_id == 2
     assert %Ecto.Association.NotLoaded{} = updated_schema.assoc
+  end
+
+  test "handles writable: :never" do
+    schema =
+      %RestrictedSchema{}
+      |> Ecto.Changeset.cast(%{unwritable_id: 111}, [:unwritable_id])
+      |> TestRepo.insert!()
+
+    assert schema.unwritable_id == nil
+  end
+
+  test "handles writable: :insert" do
+    schema =
+      %RestrictedSchema{}
+      |> Ecto.Changeset.cast(%{non_updatable_id: 222}, [:non_updatable_id])
+      |> TestRepo.insert!()
+
+    assert schema.non_updatable_id == 222
+
+    schema =
+      schema
+      |> Ecto.Changeset.cast(%{non_updatable_id: 333}, [:non_updatable_id])
+      |> TestRepo.update!()
+
+    assert schema.non_updatable_id == 222
   end
 end


### PR DESCRIPTION
PR for my [proposal](https://groups.google.com/g/elixir-ecto/c/JDL69kx5nTA) to add `:writable` option to `belongs_to`.

This PR simply whitelists the `:writable` option in `@valid_belongs_to_options`, which has already been implemented in #4335 & #4472.

`cast_assoc` & `put_assoc` currently do not respect this option, so if it makes sense, I can send a follow-up PR for that.