### PR TITLE
Fix nil map associations

### DIFF
--- a/integration_test/cases/preload.exs
+++ b/integration_test/cases/preload.exs
@@ -526,6 +526,51 @@ defmodule Ecto.Integration.PreloadTest do
     assert [] = sort_by_id(p3.comments)
   end
 
+  test "take with join nil maps (many association)" do
+    p = TestRepo.insert!(%Post{})
+
+    # many
+    query =
+      from p in Post,
+        left_join: c in Comment,
+        on: p.id == c.post_id,
+        select: map(p, [:id, comments: [:id, :post_id]]),
+        preload: [comments: c]
+
+    assert TestRepo.one(query) == %{id: p.id, comments: []}
+
+    query =
+      from p in Post,
+        left_join: c in Comment,
+        on: p.id == c.post_id,
+        select: map(p, [:id, comments: [:id, :post_id]]),
+        preload: [:comments]
+
+    assert TestRepo.one(query) == %{id: p.id, comments: []}
+  end
+
+  test "take with join nil maps (one association)" do
+    p = TestRepo.insert!(%Post{})
+
+    query =
+      from p in Post,
+        left_join: u in User,
+        on: p.author_id == u.id,
+        select: map(p, [:id, author: [:id, :name]]),
+        preload: [author: u]
+
+    assert TestRepo.one(query) == %{id: p.id, author: nil}
+
+    query =
+      from p in Post,
+        left_join: u in User,
+        on: p.author_id == u.id,
+        select: map(p, [:id, author: [:id, :name]]),
+        preload: [:author]
+
+    assert TestRepo.one(query) == %{id: p.id, author: nil}
+  end
+
   test "preload through with take" do
     %Post{id: pid1} = TestRepo.insert!(%Post{})
 


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4628

This one is kind of weird. When we fixed nil map joins it didn't take into account that joins can also be used for associations. So instead of `nil` being passed into the association processing it's  a map with all `nil` values.

There are 3 options I can see:

1. Revert and say everything should behave the same, preload or no preload.
2. Try to figure out if we should keep the maps or not during the postprocessing step.
3. Try to figure out if we should keep the maps or not doing the association processing.

For (1) I think there is enough of a semantic difference between preload and no preload to have both behaviours. The former is looking for things that are associated. The latter is saying just return whatever the query would normally return with no special behaviour.

For (2) it is pretty difficult to figure out if something is an association or not at that stage.

For (3) you know you are only looking at associations so that part is easier. But It's a bit expensive to see if every single value is `nil`. It's easier to check if every primary key value is `nil` and use that for a proxy to say the whole record is `nil`. I think that makes sense since primary key is the unique identifier for the record. If it's `nil` that should mean it's not there.

Note that I am making a distinction between the primary key actually being in the map or not. If it's not in the map then I am still raising. Because it means the user did not select it, which is a problem.