### PR TITLE
Add Changelog link to Hex package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,10 @@ defmodule Ecto.MixProject do
     [
       maintainers: ["Eric Meadows-Jönsson", "José Valim", "Felipe Stival", "Greg Rychlewski"],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => @source_url},
+      links: %{
+        "GitHub" => @source_url,
+        "Changelog" => "https://hexdocs.pm/ecto/changelog.html"
+      },
       files:
         ~w(.formatter.exs mix.exs README.md CHANGELOG.md lib) ++
           ~w(integration_test/cases integration_test/support)


### PR DESCRIPTION
Add Changelog link to package metadata using hexdocs URL for version-specific changelog access from hex.pm