### PR TITLE
ensure select statements in joined queries have access to parent bindings

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -669,6 +669,8 @@ defmodule Ecto.Query.Planner do
         distinct: nil,
         lock: nil
       } ->
+        join_query = put_in(join_query.aliases[@parent_as], query)
+
         join_query = rewrite_prefix(join_query, query.prefix)
         from = rewrite_prefix(join_query.from, prefix)
         {from, source} = plan_source(join_query, from, adapter, cte_names)


### PR DESCRIPTION
Ultimately, I don't fully understand how parent binding sources are managed well enough to really say if this is the most correct fix. Since `parent_as` works in other, non-select contexts using this formulation, it feels like there may be a more targeted/specific fix available?

Regardless, the newly added test will fail without the fix, and the fix does not cause any additional test failures. Open to adjusting it if as needed.