### PR TITLE
Update Repo Documentation: Paranthesis on function calls

### DIFF
--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -774,15 +774,15 @@ defmodule Ecto.Repo do
 
   ## Examples
 
-      MyRepo.checked_out?
+      MyRepo.checked_out?()
       #=> false
 
       MyRepo.transact(fn ->
-        MyRepo.checked_out? #=> true
+        MyRepo.checked_out?() #=> true
       end)
 
       MyRepo.checkout(fn ->
-        MyRepo.checked_out? #=> true
+        MyRepo.checked_out?() #=> true
       end)
 
   """
@@ -1856,7 +1856,7 @@ defmodule Ecto.Repo do
   A typical example is calling `MyRepo.insert/1` with a struct
   and acting on the return value:
 
-      case MyRepo.insert %Post{title: "Ecto is great"} do
+      case MyRepo.insert(%Post{title: "Ecto is great"}) do
         {:ok, struct}       -> # Inserted with success
         {:error, changeset} -> # Something went wrong
       end
@@ -2055,8 +2055,8 @@ defmodule Ecto.Repo do
   ## Example
 
       post = MyRepo.get!(Post, 42)
-      post = Ecto.Changeset.change post, title: "New title"
-      case MyRepo.update post do
+      post = Ecto.Changeset.change(post, title: "New title")
+      case MyRepo.update(post) do
         {:ok, struct}       -> # Updated with success
         {:error, changeset} -> # Something went wrong
       end
@@ -2077,7 +2077,7 @@ defmodule Ecto.Repo do
   the database. So even if the struct exists, this won't work:
 
       struct = %Post{id: "existing_id", ...}
-      MyRepo.insert_or_update changeset
+      MyRepo.insert_or_update(changeset)
       # => {:error, changeset} # id already exists
 
   ## Options
@@ -2107,7 +2107,7 @@ defmodule Ecto.Repo do
           post -> post          # Post exists, let's use it
         end
         |> Post.changeset(changes)
-        |> MyRepo.insert_or_update
+        |> MyRepo.insert_or_update()
 
       case result do
         {:ok, struct}       -> # Inserted or updated with success
@@ -2166,7 +2166,7 @@ defmodule Ecto.Repo do
   ## Example
 
       post = MyRepo.get!(Post, 42)
-      case MyRepo.delete post do
+      case MyRepo.delete(post) do
         {:ok, struct}       -> # Deleted with success
         {:error, changeset} -> # Something went wrong
       end
@@ -2514,11 +2514,11 @@ defmodule Ecto.Repo do
 
   ## Examples
 
-      MyRepo.in_transaction?
+      MyRepo.in_transaction?()
       #=> false
 
       MyRepo.transact(fn ->
-        MyRepo.in_transaction? #=> true
+        MyRepo.in_transaction?() #=> true
       end)
 
   """


### PR DESCRIPTION
If any of these examples were in application code, calling `mix format` would add parenthesis.  So I think it makes sense to include the parenthesis in the examples to mimic how the usage would look in a code base.