### PR TITLE
Remove soft deprecated literal warning

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -760,11 +760,6 @@ defmodule Ecto.Query.Builder do
         env -> env
       end
 
-    IO.warn(
-      "`literal/1` is deprecated. Please use `identifier/1` instead.",
-      Macro.Env.stacktrace(env)
-    )
-
     escape_fragment({:identifier, meta, [expr]}, params_acc, vars, env)
   end
 


### PR DESCRIPTION
Every use of `literal/1` generates a warning that directs people to use `identifier/1` instead. [According to the CHANGELOG](https://github.com/elixir-ecto/ecto/blob/master/CHANGELOG.md#soft-deprecations-no-warnings-emitted), this is a soft deprecation and it shouldn't generate so much noise.

Furthermore, this warning causes a great deal of noise for users of libraries that support multiple versions of Ecto.