### PR TITLE
Allow fragment sources mapped to schemas

### DIFF
--- a/lib/ecto/query/builder/from.ex
+++ b/lib/ecto/query/builder/from.ex
@@ -59,7 +59,7 @@ defmodule Ecto.Query.Builder.From do
 
       ^query ->
         case query do
-          {left, right} -> {left, Macro.expand(right, env)}
+          {left, right} -> {escape_source(left, env), Macro.expand(right, env)}
           _ -> query
         end
 
@@ -117,6 +117,10 @@ defmodule Ecto.Query.Builder.From do
       {{:{}, _, [:fragment, _, _]} = fragment, params} ->
         {:ok, prefix} = prefix || {:ok, nil}
         {query(prefix, fragment, params, as, hints, env.file, env.line), binds, 1}
+
+      {{{:{}, _, [:fragment, _, _]} = fragment, params}, schema} when is_atom(schema) ->
+        {:ok, prefix} = prefix || {:ok, nil}
+        {query(prefix, {fragment, schema}, params, as, hints, env.file, env.line), binds, 1}
 
       {{:{}, _, [:values, _, _]} = values, prelude, params} ->
         {:ok, prefix} = prefix || {:ok, nil}

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -165,7 +165,8 @@ defimpl Inspect, for: Ecto.Query do
     "values (#{Enum.join(fields, ", ")})"
   end
 
-  defp inspect_source(%{source: {source, schema}}, _names) do
+  defp inspect_source(%{source: {source, schema}} = part, names) do
+    source = if is_binary(source), do: source, else: "#{expr(source, names, part)}"
     inspect(if source == schema.__schema__(:source), do: schema, else: {source, schema})
   end
 

--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -2219,7 +2219,7 @@ defmodule Ecto.Query.Planner do
       {{:ok, {:struct, _}}, {_, nil, _}} ->
         error!(query, "struct/2 in select expects a source with a schema")
 
-      {{:ok, {kind, fields}}, {source, schema, prefix}} ->
+      {{:ok, {kind, fields}}, {source, schema, prefix}} when is_binary(source) ->
         dumper = if schema, do: schema.__schema__(:dump), else: %{}
         schema = if kind == :map, do: nil, else: schema
         {types, fields} = select_dump(List.wrap(fields), dumper, ix, drop)

--- a/test/ecto/query/inspect_test.exs
+++ b/test/ecto/query/inspect_test.exs
@@ -81,6 +81,9 @@ defmodule Ecto.Query.InspectTest do
 
     assert i(from(subquery(Post), [])) ==
              ~s{from p0 in subquery(from p0 in Inspect.Post)}
+
+    assert i(from(x in {fragment("select generate_series(?::integer, ?::integer) as num", ^0, ^2), Inspect.Comment}, [])) ==
+             ~s[from c0 in {"fragment(\\"select generate_series(?::integer, ?::integer) as num\\", ^0, ^2)", Inspect.Comment}]
   end
 
   test "CTE" do

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -143,6 +143,15 @@ defmodule Ecto.Query.PlannerTest do
     end
   end
 
+  defmodule Barebone do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "barebone" do
+      field :num, :integer
+    end
+  end
+
   defp plan(query, operation \\ :all) do
     {query, params, key} = Planner.plan(query, operation, Ecto.TestAdapter)
     {cast_params, dump_params} = Enum.unzip(params)
@@ -937,6 +946,16 @@ defmodule Ecto.Query.PlannerTest do
                    ]
                  ]}}
              ]
+  end
+
+  test "plan: tuple source with fragment" do
+    {query, cast_params, dump_params, cache_key} =
+      plan(from {fragment("? as num", ^0), Barebone})
+
+    assert {{{:fragment, [], _}, Barebone, nil}} = query.sources
+    assert cast_params == [0]
+    assert dump_params == [0]
+    assert [:all, {:from, {{:fragment, _, _}, Barebone, _, _}, []}] = cache_key
   end
 
   describe "plan: CTEs" do
@@ -2570,6 +2589,16 @@ defmodule Ecto.Query.PlannerTest do
     assert_raise Ecto.QueryError, message, fn ->
       from(p in Post, order_by: p.title) |> normalize(:delete_all)
     end
+  end
+
+  test "normalize: tuple source with fragment" do
+    {query, _, _, select} =
+      normalize_with_params(from {fragment("? as num", ^0), Barebone})
+
+    %{from: {_, {:source, {{:fragment, _, _}, Barebone}, nil, types}}} = select
+    assert types == [num: :integer]
+    assert {{:fragment, _, _}, Barebone} = query.from.source
+    assert query.select.fields == [{{:., [writable: :always], [{:&, [], [0]}, :num]}, [], []}]
   end
 
   describe "normalize: subqueries in boolean expressions" do


### PR DESCRIPTION
This is similar to allowing `{string, Schema}` but allows for more use cases.

Companion Ecto SQL PR: https://github.com/elixir-ecto/ecto_sql/pull/691

There are some follow ups that I can make other PRs for if this seems alright to you:

- Allow it with `take`
- Allow it in joins
- Do the same stuff for Values