### PR TITLE
Allow take with tuple fragment sources

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -782,6 +782,19 @@ defmodule Ecto.Integration.RepoTest do
     assert_raise Ecto.NoResultsError, fn -> query |> last |> TestRepo.one! end
   end
 
+  test "fragment source" do
+    query = from f in {fragment("select 1 as num"), Barebone}
+    assert %Barebone{num: 1} = TestRepo.one(query)
+  end
+
+  test "fragment source with take" do
+    query = from f in {fragment("select 1 as visits"), Post}, select: struct(f, [:visits])
+    assert %Post{visits: 1} = TestRepo.one(query)
+
+    query = from f in {fragment("select 1 as visits"), Post}, select: map(f, [:visits])
+    assert %{visits: 1} = TestRepo.one(query)
+  end
+
   test "exists?" do
     TestRepo.insert!(%Post{title: "1", visits: 2})
     TestRepo.insert!(%Post{title: "2", visits: 1})


### PR DESCRIPTION
This adds the ability to use `struct/2` and `map/2` with the fragment sources mapped to schemas. I moved the integration test from ecto sql to ecto. I'll submit a PR to ecto_sql to remove the test