### PR TITLE
document fragment tuples + pretty print source on loaded struct

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -784,7 +784,8 @@ defmodule Ecto.Integration.RepoTest do
 
   test "fragment source mapped to schema" do
     query = from f in {fragment("select 1 as num"), Barebone}
-    assert %Barebone{num: 1} = TestRepo.one(query)
+    assert %Barebone{__meta__: meta, num: 1} = TestRepo.one(query)
+    assert meta.source == ~s[fragment("select 1 as num")]
   end
 
   test "fragment source mapped to schema with take" do

--- a/lib/ecto/query.ex
+++ b/lib/ecto/query.ex
@@ -1090,6 +1090,9 @@ defmodule Ecto.Query do
       # Fragment with built-in function and undefined columns
       from(f in fragment("select generate_series(?::integer, ?::integer) as x", ^0, ^10), select: f.x)
 
+      # Fragment with schema
+      from(f in {fragment("my_table_valued_function(arg)"), Schema})
+
   ## Expressions examples
 
       # Schema

--- a/lib/ecto/query/inspect.ex
+++ b/lib/ecto/query/inspect.ex
@@ -96,6 +96,11 @@ defimpl Inspect, for: Ecto.Query do
     end)
   end
 
+  @doc false
+  def inspect_fragment({:fragment, _, parts}) do
+    Macro.to_string({:fragment, [], unmerge_fragments(parts, "", [])})
+  end
+
   defp to_list(query) do
     names =
       query

--- a/lib/ecto/schema/loader.ex
+++ b/lib/ecto/schema/loader.ex
@@ -14,6 +14,12 @@ defmodule Ecto.Schema.Loader do
         struct
 
       %{__meta__: %Metadata{} = metadata} = struct ->
+        source =
+          case source do
+            {:fragment, _, _} = frag -> Inspect.Ecto.Query.inspect_fragment(frag)
+            other -> other
+          end
+
         Map.put(struct, :__meta__, %{metadata | source: source, prefix: prefix})
 
       %{} = struct ->


### PR DESCRIPTION
I forgot to document the new type of source `{fragment, Schema}`. Also I realized that after the results are loaded the `metadata.source` is not very easy on the eyes because it has all those `raw` and other stuff. So I re-used the logic from inspecting to pretty print it.