### PR TITLE
Allow `{fragment, Schema}` sources in joins

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -5,6 +5,7 @@ defmodule Ecto.Integration.JoinsTest do
   import Ecto.Query
 
   alias Ecto.Integration.Post
+  alias Ecto.Integration.Barebone
   alias Ecto.Integration.Comment
   alias Ecto.Integration.Permalink
   alias Ecto.Integration.User
@@ -160,6 +161,16 @@ defmodule Ecto.Integration.JoinsTest do
 
     assert p1.permalink == nil
     assert p2.permalink.id == plid1
+  end
+
+  test "joins with fragment source mapped to schema" do
+    query =
+      from f1  in {fragment("select 1 as num"), Barebone},
+        join: f2  in {fragment("select 1 as visits"), Post},
+        on: f1.num == f2.visits,
+        select: {f1, struct(f2, [:visits])}
+
+    assert {%Barebone{num: 1} = b1, %Post{visits: 1} = b2} = TestRepo.one(query)
   end
 
   ## Associations joins

--- a/lib/ecto/query/builder/join.ex
+++ b/lib/ecto/query/builder/join.ex
@@ -81,6 +81,18 @@ defmodule Ecto.Query.Builder.Join do
     end
   end
 
+  def escape({{:fragment, _, _} = fragment, schema} = join, vars, env) do
+    {_, expr, _, _, params} = escape(fragment, vars, env)
+
+    case Macro.expand(schema, env) do
+      schema when is_atom(schema) ->
+        {:_, {expr, schema}, nil, nil, params}
+
+      _ ->
+        Builder.error!("malformed join `#{Macro.to_string(join)}` in query expression")
+    end
+  end
+
   def escape({:assoc, _, [{var, _, context}, field]}, vars, _env)
       when is_atom(var) and is_atom(context) do
     ensure_field!(field)


### PR DESCRIPTION
Last PR allowed it in `from`. This one is for `join`