### PR TITLE
has_one does not support preload_order option

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2096,7 +2096,7 @@ defmodule Ecto.Schema do
     :ok
   end
 
-  @valid_has_options [
+  @valid_has_many_options [
     :foreign_key,
     :references,
     :through,
@@ -2110,22 +2110,32 @@ defmodule Ecto.Schema do
   @doc false
   def __has_many__(mod, name, queryable, opts) do
     if is_list(queryable) and Keyword.has_key?(queryable, :through) do
-      check_options!(queryable, @valid_has_options, "has_many/3")
+      check_options!(queryable, @valid_has_many_options, "has_many/3")
       association(mod, :many, name, Ecto.Association.HasThrough, queryable)
     else
-      check_options!(opts, @valid_has_options, "has_many/3")
+      check_options!(opts, @valid_has_many_options, "has_many/3")
       struct = association(mod, :many, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
       Module.put_attribute(mod, :ecto_changeset_fields, {name, {:assoc, struct}})
     end
   end
 
+  @valid_has_one_options [
+    :foreign_key,
+    :references,
+    :through,
+    :on_delete,
+    :defaults,
+    :on_replace,
+    :where
+  ]
+
   @doc false
   def __has_one__(mod, name, queryable, opts) do
     if is_list(queryable) and Keyword.has_key?(queryable, :through) do
-      check_options!(queryable, @valid_has_options, "has_one/3")
+      check_options!(queryable, @valid_has_one_options, "has_one/3")
       association(mod, :one, name, Ecto.Association.HasThrough, queryable)
     else
-      check_options!(opts, @valid_has_options, "has_one/3")
+      check_options!(opts, @valid_has_one_options, "has_one/3")
       struct = association(mod, :one, name, Ecto.Association.Has, [queryable: queryable] ++ opts)
       Module.put_attribute(mod, :ecto_changeset_fields, {name, {:assoc, struct}})
     end


### PR DESCRIPTION
Currently `has_one` and `has_many` both validate against the same `@valid_has_options` allowing you to pass a `preload_order` option into `has_one` despite it not being supported.

There is a PR (https://github.com/elixir-ecto/ecto/pull/4505) that's been open for over a year with some discussion around `has_one` supporting `preload_order` but it would probably be good to clean this up in the meantime.