### PR TITLE
Handle empty list argument without raising error

### DIFF
--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -90,6 +90,8 @@ defmodule Ecto.Repo.Queryable do
     one!(name, query_for_get_by(queryable, clauses), opts)
   end
 
+  def reload(_name, [], _opts), do: []
+
   def reload(name, [head | _] = structs, opts) when is_list(structs) do
     results = all(name, query_for_reload(structs), opts)
 
@@ -104,6 +106,8 @@ defmodule Ecto.Repo.Queryable do
   def reload(name, struct, opts) do
     one(name, query_for_reload([struct]), opts)
   end
+
+  def reload!(_name, [], _opts), do: []
 
   def reload!(name, [head | _] = structs, opts) when is_list(structs) do
     query = query_for_reload(structs)

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -350,6 +350,14 @@ defmodule Ecto.RepoTest do
       TestRepo.reload(struct_with_custom_source)
       assert_received {:all, %{from: %{source: {"custom_schema", MySchema}}}}
     end
+
+    test "returns empty list when given empty list" do
+      assert TestRepo.reload([]) == []
+    end
+
+    test "reload! returns empty list when given empty list" do
+      assert TestRepo.reload!([]) == []
+    end
   end
 
   defmodule DefaultOptionRepo do


### PR DESCRIPTION
I discovering this when our app called `Repo.reload[]` and a error was raised, causing an unknown bug.

Also, the typespecs for those functions are:

https://github.com/elixir-ecto/ecto/blob/8f1ef299a81ea9a5719838d4ce9e3b59b381450d/lib/ecto/repo.ex#L1059-L1062

which means and empty list `[ ]` is an expeted input and output.