### PR TITLE
remove Query.exclude(:order_by) in exists?

### DIFF
--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -142,7 +142,6 @@ defmodule Ecto.Repo.Queryable do
     queryable =
       Query.exclude(queryable, :select)
       |> Query.exclude(:preload)
-      |> Query.exclude(:order_by)
       |> Query.exclude(:distinct)
       |> Query.select(1)
       |> Query.limit(1)

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -543,12 +543,12 @@ defmodule Ecto.RepoTest do
                "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
     end
 
-    test "removes order by from query without distinct/limit/offset" do
+    test "keeps order by from query" do
       from(MySchema, order_by: :id) |> TestRepo.exists?()
       assert_received {:all, query}
 
       assert inspect(query) ==
-               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, limit: 1, select: 1>"
+               "#Ecto.Query<from m0 in Ecto.RepoTest.MySchema, order_by: [asc: m0.id], limit: 1, select: 1>"
     end
 
     test "overrides any select" do


### PR DESCRIPTION
`select(1)` with `limit(1)` is sufficient for databases to optimize away the order_by. In some cases removing the `order_by` clause will change the query-plan leading to seq-scans instead of index usage.