### PR TITLE
fix: autogenerated uuid pk syntax when passing a list

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -1596,7 +1596,7 @@ defmodule Ecto.Schema do
       section for more info). Primary keys are automatically set up for embedded
       schemas as well, defaulting to `{:id,  :binary_id, autogenerate: true}`.
       This will generate the default UUID v4. You can use UUID v7 instead by setting
-      the primary key to `{:id, :binary_id, autogenerate: [version: 7]}`
+      the primary key to `{:id, Ecto.UUID, autogenerate: [version: 7]}`
       Note `:primary_key`s are not automatically read back on `insert/2`,
       unless one of `autogenerate: true` or `read_after_writes: true` is set.
 

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -14,12 +14,12 @@ defmodule Ecto.UUID do
   To use UUID v7 (time-ordered) instead:
 
       use Ecto.Schema
-      @primary_key {:id, :binary_id, autogenerate: [version: 7]}
+      @primary_key {:id, Ecto.UUID, autogenerate: [version: 7]}
 
   To use UUID v7 (time-ordered) monotonic:
 
       use Ecto.Schema
-      @primary_key {:id, :binary_id, autogenerate: [version: 7, monotonic: true]}
+      @primary_key {:id, Ecto.UUID, autogenerate: [version: 7, monotonic: true]}
 
   According to [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562#name-monotonicity-and-counters):
   "Monotonicity (each subsequent value being greater than the last) is the


### PR DESCRIPTION
I tried it in my project but the following provided syntax was not working:
@primary_key {:id, :binary_id, autogenerate: [version: 7, monotonic: true]}

I realized that changing :binary_id to Ecto.UUID fixed it:
@primary_key {:id, Ecto.UUID, autogenerate: [version: 7, monotonic: true]}

This PR just changes the documented syntax when passing list to autogenerate