### PR TITLE
Fragment constant/1 doesn't need adapter

### DIFF
--- a/lib/ecto/query/api.ex
+++ b/lib/ecto/query/api.ex
@@ -561,7 +561,7 @@ defmodule Ecto.Query.API do
 
   This would be transformed into
 
-      from p in Post, where: fragment(? in (?,?,?), p.id, constant(1), ^2, ^3)
+      from p in Post, where: fragment(? in (?,?,?), p.id, constant(^1), ^2, ^3)
   """
   def splice(list), do: doc!([list])
 

--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -781,8 +781,7 @@ defmodule Ecto.Query.Builder do
     case expr do
       {:^, _, [expr]} ->
         checked = quote do: Ecto.Query.Builder.constant!(unquote(expr))
-        escaped = {:{}, [], [:constant, [], [checked]]}
-        {escaped, params_acc}
+        {checked, params_acc}
 
       _ ->
         error!(

--- a/test/ecto/query_test.exs
+++ b/test/ecto/query_test.exs
@@ -1119,8 +1119,8 @@ defmodule Ecto.QueryTest do
 
       assert {:fragment, _, select_parts} = query.select.expr
       assert {:fragment, _, limit_parts} = query.limit.expr
-      assert [raw: "", expr: {:constant, _, ["hi"]}, raw: ""] = select_parts
-      assert [raw: "", expr: {:constant, _, [1]}, raw: ""] = limit_parts
+      assert [raw: "", expr: "hi", raw: ""] = select_parts
+      assert [raw: "", expr: 1, raw: ""] = limit_parts
 
       msg = "constant(^value) expects `value` to be a string or a number, got `%{}`"
 
@@ -1186,7 +1186,7 @@ defmodule Ecto.QueryTest do
                raw: ",",
                expr: 2,
                raw: ",",
-               expr: {:constant, _, [3]},
+               expr: 3,
                raw: ",",
                expr: {:^, _, [1]},
                raw: ")"


### PR DESCRIPTION
Right now we are passing `{:constant, [], [value]}` to the adapter and the adapter is taking care of the unpacking. But we can pass the constant value directly from Ecto and the existing adapter functionality can take care of it without the need for handling a `:constant` tuple.