### PR TITLE
feat: add telemetry event emission for repo process start

### DIFF
--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -213,4 +213,14 @@ defmodule Ecto.TestRepo do
   end
 end
 
+defmodule Ecto.TestRepoInitModify do
+  use Ecto.Repo, otp_app: :ecto, adapter: Ecto.TestAdapter
+
+  def init(_type, opts) do
+    opts = [url: "ecto://user:pass@local/hello"] ++ opts
+    opts = Keyword.drop(opts, [:telemetry_prefix])
+    {:ok, opts}
+  end
+end
+
 Ecto.TestRepo.start_link()


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/332

Some folks shared that it is not always "safe" to do what I proposed there. With this new telemetry event, we could add auto-instrumentation. Ideally, reducing the friction, forgetting to wire new repos, and have similar experience to other auto-instr ecosystems