### PR TITLE
docs: clarify index shifting in cast_assoc/3 when using drop_param

### DIFF
--- a/lib/ecto/changeset.ex
+++ b/lib/ecto/changeset.ex
@@ -1160,9 +1160,8 @@ defmodule Ecto.Changeset do
       changeset
       |> cast_assoc(:children, sort_param: ..., with: &child_changeset/3)
 
-  When using `:drop_param` without `:sort_param`, the remaining elements are
-  re-indexed sequentially starting from 0. For example, if you have the following
-  parameters:
+  When using `:drop_param`, the remaining elements are re-indexed sequentially
+  starting from 0. For example, if you have the following parameters:
 
       %{
         "addresses" => %{


### PR DESCRIPTION
While the behavior of `:drop_param` and `:sort_param` is documented, this PR adds a specific clarification regarding the index shifting that occurs when elements are dropped but not explicitly re-sorted.

### Context:

When using a map for many-style associations, Ecto compacts the remaining elements into a sequential list after applying `:drop_param`. As a result, the index passed to an arity-3 `:with` function reflects the final position in the list, which might differ from the original map key.

### Contribution:

- Explicitly mentions that remaining elements are re-indexed sequentially starting from 0.

- Adds a visual example to illustrate the difference between the original parameter key and the final position received by the changeset function.

This addition aims to help developers avoid subtle bugs when using the :with option to persist order (e.g., in a :position column), making the underlying list transformation more explicit.

**Note:** This is my first contribution to Ecto (and to an open-source project). I've found this specific case while working on a production system and thought it would be a valuable addition to the documentation for other developers. Feedback is more than welcome!