### PR TITLE
Correctly extract passwords with colons from URL

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -111,7 +111,7 @@ defmodule Ecto.Repo.Supervisor do
       raise Ecto.InvalidURLError, url: url, message: "path should be a database name"
     end
 
-    destructure [username, password], info.userinfo && String.split(info.userinfo, ":")
+    destructure [username, password], info.userinfo && String.split(info.userinfo, ":", parts: 2)
     "/" <> database = info.path
 
     url_opts = [

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -152,6 +152,12 @@ defmodule Ecto.Repo.SupervisorTest do
       refute Keyword.has_key?(url, :password)
     end
 
+    test "parses password containing colons" do
+      url = parse_url("ecto://user:top:secret@host:12345/mydb")
+      assert {:password, "top:secret"} in url
+      assert {:username, "user"} in url
+    end
+
     test "parses multiple query string options" do
       encoded_url = URI.encode("ecto://eric:it+й@host:12345/mydb?ssl=true&timeout=1515")
       url = parse_url(encoded_url)


### PR DESCRIPTION
```elixir
iex(1)> Ecto.Repo.Supervisor.parse_url("ecto://user:top:secret@host:12345/mydb")
[
  hostname: "host",
  scheme: "ecto",
  username: "user",
  password: "top",
  database: "mydb",
  port: 12345
]
```

It correctly works if the password is URL encoded, but since passwords with colon are very common it is better to support them directly as well. 

Surprisingly I noticed that **`mix format` does not work in the repo** and there is no CI check for formatted code. The reason is that `.formatter.exs` is missing `:inputs`. Is this intentional?