### PR TITLE
Add Qlty code coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,13 @@ jobs:
         run: mix compile --warning-as-errors
         if: ${{ matrix.lint }}
       - name: Run tests
-        run: mix test
+        run: mix test ${{ matrix.lint && '--cover' || '' }}
+      - name: Upload coverage to Qlty
+        if: ${{ matrix.lint }}
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: cover/lcov.info
 
   integration-test:
     name: integration test

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,9 @@ defmodule Ecto.MixProject do
       description: "A toolkit for data mapping and language integrated query for Elixir",
       package: package(),
 
+      # Coverage
+      test_coverage: [tool: LcovEx],
+
       # Docs
       name: "Ecto",
       docs: docs()
@@ -35,7 +38,8 @@ defmodule Ecto.MixProject do
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:decimal, "~> 2.0"},
       {:jason, "~> 1.0", optional: true},
-      {:ex_doc, "~> 0.38", only: :docs}
+      {:ex_doc, "~> 0.38", only: :docs},
+      {:lcov_ex, "~> 0.3", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
## Summary
- Added `lcov_ex` dependency to generate LCOV coverage data during tests
- Configured `mix test --cover` to run on the latest Elixir/OTP matrix entry (1.19.5/28.4)
- Added Qlty coverage upload step using the official GitHub Action with token authentication

## Manual steps required
1. Add the `QLTY_COVERAGE_TOKEN` secret to this repository's GitHub Settings → Secrets and variables → Actions
   - Generate the token from your Qlty Cloud workspace: Settings → Coverage Tokens
2. Ensure the project is set up in Qlty Cloud at https://qlty.sh

## Test plan
- [ ] Verify CI passes on all matrix entries
- [ ] Confirm coverage data is uploaded to Qlty Cloud after adding the `QLTY_COVERAGE_TOKEN` secret
- [ ] Check coverage report appears in Qlty Cloud project settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)