### PR TITLE
[codex] Redact repo child start args

### DIFF
--- a/lib/ecto/repo/supervisor.ex
+++ b/lib/ecto/repo/supervisor.ex
@@ -1,7 +1,17 @@
+defmodule Ecto.Repo.Supervisor.Start do
+  @moduledoc false
+  defstruct [:mfa]
+end
+
+defimpl Inspect, for: Ecto.Repo.Supervisor.Start do
+  def inspect(_, _opts), do: "#Ecto.Repo.Supervisor.Start<redacted>"
+end
+
 defmodule Ecto.Repo.Supervisor do
   @moduledoc false
   use Supervisor
   require Logger
+  alias Ecto.Repo.Supervisor.Start
 
   @defaults [timeout: 15000, pool_size: 10]
   @integer_url_query_params ["timeout", "pool_size", "idle_interval"]
@@ -209,7 +219,9 @@ defmodule Ecto.Repo.Supervisor do
     end
   end
 
-  def start_child({mod, fun, args}, name, adapter, meta) do
+  def start_child(start, name, adapter, meta) do
+    {mod, fun, args} = unwrap_start(start)
+
     case apply(mod, fun, args) do
       {:ok, pid} ->
         meta = Map.merge(meta, %{pid: pid, adapter: adapter})
@@ -221,7 +233,10 @@ defmodule Ecto.Repo.Supervisor do
     end
   end
 
+  defp unwrap_start(%Start{mfa: mfa}), do: mfa
+  defp unwrap_start(mfa), do: mfa
+
   defp wrap_child_spec(%{start: start} = spec, args) do
-    %{spec | start: {__MODULE__, :start_child, [start | args]}}
+    %{spec | start: {__MODULE__, :start_child, [%Start{mfa: start} | args]}}
   end
 end

--- a/test/ecto/repo/supervisor_test.exs
+++ b/test/ecto/repo/supervisor_test.exs
@@ -3,6 +3,31 @@ defmodule Ecto.Repo.SupervisorTest do
 
   import Ecto.Repo.Supervisor
 
+  defmodule LeakyAdapter do
+    @behaviour Ecto.Adapter
+
+    defmacro __before_compile__(_opts), do: :ok
+    def ensure_all_started(_, _), do: {:ok, []}
+
+    def init(_opts) do
+      child = %{
+        id: __MODULE__,
+        start: {Task, :start_link, [fn -> :timer.sleep(:infinity) end, [password: "secret"]]}
+      }
+
+      {:ok, child, %{}}
+    end
+
+    def checkout(_repo, _opts, fun), do: fun.()
+    def checked_out?(_repo), do: false
+    def loaders(_primitive, type), do: [type]
+    def dumpers(_primitive, type), do: [type]
+  end
+
+  defmodule LeakyRepo do
+    use Ecto.Repo, otp_app: :ecto, adapter: LeakyAdapter
+  end
+
   defp put_env(env) do
     Application.put_env(:ecto, __MODULE__, env)
   end
@@ -50,6 +75,16 @@ defmodule Ecto.Repo.SupervisorTest do
     assert opts[:name] == :telemetry_test
 
     :telemetry.detach(:telemetry_test)
+  end
+
+  test "redacts adapter child start args in supervisor reports" do
+    {:ok, {_sup_flags, [child]}} =
+      Ecto.Repo.Supervisor.init({LeakyRepo, LeakyRepo, :ecto, LeakyAdapter, []})
+
+    inspected = inspect(child, limit: :infinity)
+
+    assert inspected =~ "#Ecto.Repo.Supervisor.Start<redacted>"
+    refute inspected =~ "secret"
   end
 
   test "reads otp app configuration" do


### PR DESCRIPTION
## Summary
- wrap adapter child start MFA values in a small redacted struct before storing them in the repo supervisor child spec
- keep Ecto.Repo.Supervisor.start_child/4 compatible with the old raw MFA tuple shape
- add regression coverage proving sensitive adapter start args do not appear when the generated child spec is inspected

Fixes #4718

## Validation
- mix format --check-formatted lib/ecto/repo/supervisor.ex test/ecto/repo/supervisor_test.exs
- mix test test/ecto/repo/supervisor_test.exs
- mix test