### PR TITLE
Expand macros in window frames

### DIFF
--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -72,8 +72,21 @@ defmodule Ecto.Query.Builder.Windows do
   defp escape_frame({:fragment, _, _} = fragment, params_acc, vars, env) do
     Builder.escape(fragment, :any, params_acc, vars, env)
   end
-  defp escape_frame(other, _, _, _) do
-    Builder.error!("expected a dynamic or fragment in `:frame`, got: `#{inspect other}`")
+
+  defp escape_frame(other, params_acc, vars, env) do
+    macro_env =
+      case env do
+        {env, _} -> env
+        env -> env
+      end
+
+    case Macro.expand_once(other, macro_env) do
+      ^other ->
+        Builder.error!("expected a dynamic or fragment in `:frame`, got: `#{inspect other}`")
+
+      expanded ->
+        escape_frame(expanded, params_acc, vars, env)
+    end
   end
 
   defp error!(other) do

--- a/test/ecto/query/builder/windows_test.exs
+++ b/test/ecto/query/builder/windows_test.exs
@@ -6,6 +6,18 @@ defmodule Ecto.Query.Builder.WindowsTest do
 
   import Ecto.Query
 
+  defmacrop rows_between_preceding(count) do
+    quote do
+      fragment(unquote("ROWS BETWEEN #{count} PRECEDING AND CURRENT ROW"))
+    end
+  end
+
+  defmacro invalid_frame do
+    quote do
+      [rows: -3, exclude: :current]
+    end
+  end
+
   describe "escape" do
     test "handles expressions and params" do
       assert {Macro.escape(quote(do: [partition_by: [&0.y()]])), [], {[], %{}}} ==
@@ -62,6 +74,26 @@ defmodule Ecto.Query.Builder.WindowsTest do
     test "defines frame" do
       query = "q" |> windows([p], w: [frame: fragment("FOOBAR")])
       assert query.windows[:w].expr[:frame] == {:fragment, [], [raw: "FOOBAR"]}
+    end
+
+    test "defines frame with macro that expands to fragment" do
+      query = "q" |> windows([p], w: [frame: rows_between_preceding(6)])
+
+      assert query.windows[:w].expr[:frame] ==
+               {:fragment, [], [raw: "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW"]}
+    end
+
+    test "raises on frame macro that does not expand to fragment" do
+      assert_raise Ecto.Query.CompileError, ~r"expected a dynamic or fragment in `:frame`", fn ->
+        Code.eval_quoted(
+          quote do
+            import Ecto.Query
+            import unquote(__MODULE__)
+
+            "q" |> windows([p], w: [frame: invalid_frame()])
+          end
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Allow `:frame` to expand macros before validating that the result is a fragment.

Today this works:

```elixir
windows: [
  recent: [
    order_by: result.date,
    frame: fragment(
      "RANGE BETWEEN INTERVAL 10 DAYS PRECEDING AND INTERVAL 10 DAYS FOLLOWING EXCLUDE CURRENT ROW"
    )
  ]
]
```

but an equivalent helper is rejected before expansion:

```elixir
defmacro range_between(start_boundary, end_boundary, opts \\ []) do
  exclude = Keyword.get(opts, :exclude, :no_others)

  quote do
    fragment(
      unquote("RANGE BETWEEN #{start_boundary} AND #{end_boundary} EXCLUDE #{exclude}")
    )
  end
end

windows: [
  recent: [
    order_by: result.date,
    frame:
      range_between(
        "INTERVAL 10 DAYS PRECEDING",
        "INTERVAL 10 DAYS FOLLOWING",
        exclude: "CURRENT ROW"
      )
  ]
]
```

I ran into this while working on [QuackDB](https://github.com/elixir-vibe/quackdb), a new DuckDB adapter for Elixir. DuckDB supports richer frame clauses such as `ROWS`, `RANGE`, `GROUPS`, and `EXCLUDE`, and QuackDB could expose reusable helpers for those clauses instead of requiring users to write frame fragments inline.

The validation stays the same: after expansion, the frame still has to be a fragment. Non-fragment expansions continue to raise the existing error.
