### PR TITLE
Add mix ecto.query task

### DIFF
--- a/lib/ecto/adapter/transaction.ex
+++ b/lib/ecto/adapter/transaction.ex
@@ -11,6 +11,9 @@ defmodule Ecto.Adapter.Transaction do
   Returns `{:ok, value}` if the transaction was successful where `value`
   is the value returned by the function or `{:error, value}` if the transaction
   was rolled back where `value` is the value given to `rollback/1`.
+
+  If the `:read_only` option is true, the adapter must run the transaction
+  in read-only mode or raise if read-only transactions are not supported.
   """
   @callback transaction(adapter_meta, options :: Keyword.t(), function :: fun) ::
               {:ok, any} | {:error, any}

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -2348,6 +2348,9 @@ defmodule Ecto.Repo do
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.
+
+    * `:read_only` - when true, runs the transaction in read-only mode.
+      Adapters that do not support read-only transactions should raise.
   """
   @doc group: "Transaction API"
   @doc deprecated: "Use Repo.transact/2"
@@ -2533,6 +2536,9 @@ defmodule Ecto.Repo do
 
   See the ["Shared options"](#module-shared-options) section at the module
   documentation for more options.
+
+    * `:read_only` - when true, runs the transaction in read-only mode.
+      Adapters that do not support read-only transactions should raise.
 
   ## Examples
 

--- a/lib/mix/tasks/ecto.query.ex
+++ b/lib/mix/tasks/ecto.query.ex
@@ -1,0 +1,164 @@
+defmodule Mix.Tasks.Ecto.Query do
+  use Mix.Task
+  import Mix.Ecto
+
+  @shortdoc "Runs a query against the repository"
+
+  @switches [
+    limit: :integer,
+    repo: [:string, :keep],
+    no_compile: :boolean,
+    no_deps_check: :boolean
+  ]
+
+  @aliases [
+    r: :repo
+  ]
+
+  @moduledoc """
+  Runs the given query against the repository.
+
+  The query is evaluated as Elixir code after loading the current
+  `.iex.exs` file, if one exists, and importing `Ecto.Query`.
+
+  ## Examples
+
+      $ mix ecto.query "from p in Post, where: p.published"
+      $ mix ecto.query -r Custom.Repo "from p in Post, limit: 10"
+
+  ## Command line options
+
+    * `-r`, `--repo` - the repo to query
+    * `--limit` - limits the number of printed entries. Defaults to 100.
+
+  """
+
+  @default_limit 100
+
+  @impl true
+  def run(args) do
+    repos = parse_repo(args)
+    {opts, query_args} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
+
+    repo =
+      case repos do
+        [repo] -> repo
+        [] -> Mix.raise("ecto.query expects a repository to be configured or given as -r MyApp.Repo")
+        [_ | _] -> Mix.raise("ecto.query found multiple repositories, please pass one with -r")
+      end
+
+    query =
+      case query_args do
+        [query] -> query
+        [] -> Mix.raise("ecto.query expects a query to be given")
+        [_ | _] -> Mix.raise("ecto.query expects a single query to be given")
+      end
+
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    if limit < 0 do
+      Mix.raise("ecto.query expects --limit to be greater than or equal to zero")
+    end
+
+    Mix.Task.run("app.start", args)
+    ensure_repo(repo, args)
+
+    query = eval_query(query)
+
+    repo.transaction(
+      fn ->
+        query
+        |> repo.all()
+        |> Enum.take(limit)
+      end,
+      read_only: true
+    )
+    |> case do
+      {:ok, entries} ->
+        entries
+        |> clean_entries()
+        |> inspect(limit: :infinity, pretty: true)
+        |> Mix.shell().info()
+
+      {:error, reason} ->
+        Mix.raise("ecto.query failed: #{inspect(reason)}")
+    end
+  end
+
+  defp eval_query(query) do
+    code = [dot_iex(), "\nimport Ecto.Query\n", query]
+
+    {queryable, _binding} =
+      code
+      |> IO.iodata_to_binary()
+      |> Code.eval_string([], file: "ecto.query")
+
+    to_query!(queryable)
+  end
+
+  defp to_query!(queryable) do
+    Ecto.Queryable.to_query(queryable)
+  rescue
+    Protocol.UndefinedError ->
+      Mix.raise(
+        "Expected ecto.query to evaluate to a queryable expression, got: #{inspect(queryable)}"
+      )
+  end
+
+  defp dot_iex do
+    if File.regular?(".iex.exs") do
+      [File.read!(".iex.exs"), "\n"]
+    else
+      []
+    end
+  end
+
+  defp clean_entries(entries) do
+    Enum.map(entries, &clean_entry/1)
+  end
+
+  defp clean_entry(%{__struct__: schema} = struct) do
+    if function_exported?(schema, :__schema__, 1) do
+      drop_fields = [
+        :__meta__ | schema.__schema__(:associations) ++ schema.__schema__(:redact_fields)
+      ]
+
+      fields =
+        struct
+        |> Map.from_struct()
+        |> Map.drop(drop_fields)
+        |> Enum.map(fn {key, value} -> {key, clean_entry(value)} end)
+        |> Enum.sort()
+
+      struct(Mix.Tasks.Ecto.Query.Schema, schema: schema, fields: fields)
+    else
+      struct
+    end
+  end
+
+  defp clean_entry(entries) when is_list(entries), do: Enum.map(entries, &clean_entry/1)
+
+  defp clean_entry(%{} = entry),
+    do: Map.new(entry, fn {key, value} -> {key, clean_entry(value)} end)
+
+  defp clean_entry(entry), do: entry
+end
+
+defmodule Mix.Tasks.Ecto.Query.Schema do
+  @moduledoc false
+
+  defstruct [:schema, :fields]
+end
+
+defimpl Inspect, for: Mix.Tasks.Ecto.Query.Schema do
+  import Inspect.Algebra
+
+  def inspect(%{schema: schema, fields: fields}, opts) do
+    docs =
+      Enum.map(fields, fn {key, value} ->
+        concat([Atom.to_string(key), ": ", to_doc(value, opts)])
+      end)
+
+    container_doc("%#{inspect(schema)}{", docs, "}", opts, fn doc, _opts -> doc end)
+  end
+end

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2395,6 +2395,11 @@ defmodule Ecto.RepoTest do
       assert {:ok, TestRepo} = TestRepo.transaction(fun)
       assert_received {:transaction, _, _}
     end
+
+    test "passes read_only option to the adapter" do
+      assert {:ok, :ok} = TestRepo.transaction(fn -> :ok end, read_only: true)
+      assert_received {:transaction, _fun, read_only: true}
+    end
   end
 
   describe "all_running" do

--- a/test/mix/tasks/ecto.query_test.exs
+++ b/test/mix/tasks/ecto.query_test.exs
@@ -1,0 +1,146 @@
+defmodule Mix.Tasks.Ecto.QueryTest do
+  use ExUnit.Case
+
+  alias Mix.Tasks.Ecto.Query
+
+  defmodule Comment do
+    use Ecto.Schema
+
+    schema "comments" do
+      field :text, :string
+    end
+  end
+
+  defmodule Profile do
+    use Ecto.Schema
+
+    embedded_schema do
+      field :bio, :string
+      field :token, :string, redact: true
+    end
+  end
+
+  defmodule Post do
+    use Ecto.Schema
+
+    schema "posts" do
+      field :title, :string
+      field :secret, :string, redact: true
+      embeds_one :profile, Profile
+      has_many :comments, Comment
+    end
+  end
+
+  setup do
+    Process.delete(:test_repo_all_results)
+    Application.put_env(:ecto, :ecto_repos, [Ecto.TestRepo])
+    :ok
+  end
+
+  test "runs a query against the repo in a read-only transaction" do
+    Process.put(
+      :test_repo_all_results,
+      {2,
+       [
+         [1, "first", "hunter2", %{id: "profile-1", bio: "hello", token: "profile-token"}],
+         [2, "second", "swordfish", %{id: "profile-2", bio: "world", token: "profile-secret"}]
+       ]}
+    )
+
+    in_tmp("read_only", fn ->
+      File.write!(".iex.exs", "alias #{inspect(Post)}\n")
+
+      Query.run(["-r", "Ecto.TestRepo", "from(p in Post)"])
+
+      assert_received {:transaction, _fun, opts}
+      assert opts[:read_only]
+
+      assert_received {:all, %Ecto.Query{}}
+      assert_received {:mix_shell, :info, [output]}
+
+      assert output =~ "%Mix.Tasks.Ecto.QueryTest.Post{"
+      assert output =~ ~s(title: "first")
+      assert output =~ "%Mix.Tasks.Ecto.QueryTest.Profile{"
+      assert output =~ ~s(bio: "hello")
+      refute output =~ "__meta__"
+      refute output =~ "comments:"
+      refute output =~ "secret:"
+      refute output =~ "hunter2"
+      refute output =~ "token:"
+      refute output =~ "profile-token"
+    end)
+  end
+
+  test "uses the configured default repo" do
+    Process.put(:test_repo_all_results, {1, [[1, "first", "hunter2", nil]]})
+
+    in_tmp("default_repo", fn ->
+      File.write!(".iex.exs", "alias #{inspect(Post)}\n")
+
+      Query.run(["from(p in Post)"])
+
+      assert_received {:transaction, _fun, opts}
+      assert opts[:read_only]
+    end)
+  end
+
+  test "accepts a schema module queryable" do
+    Process.put(:test_repo_all_results, {1, [[1, "first", "hunter2", nil]]})
+
+    Query.run(["-r", "Ecto.TestRepo", inspect(Post)])
+
+    assert_received {:all, %Ecto.Query{}}
+    assert_received {:mix_shell, :info, [output]}
+    assert output =~ ~s(title: "first")
+  end
+
+  test "limits printed entries" do
+    Process.put(
+      :test_repo_all_results,
+      {2, [[1, "first", "hunter2", nil], [2, "second", "swordfish", nil]]}
+    )
+
+    in_tmp("limit", fn ->
+      File.write!(".iex.exs", "alias #{inspect(Post)}\n")
+
+      Query.run(["-r", "Ecto.TestRepo", "--limit", "1", "from(p in Post)"])
+
+      assert_received {:mix_shell, :info, [output]}
+      assert output =~ ~s(title: "first")
+      refute output =~ ~s(title: "second")
+    end)
+  end
+
+  test "raises when the evaluated expression is not queryable" do
+    for query <- ["1", "%{}", "[]", ":ok"] do
+      assert_raise Mix.Error,
+                   ~r/Expected ecto\.query to evaluate to a queryable expression, got:/,
+                   fn ->
+                     Query.run(["-r", "Ecto.TestRepo", query])
+                   end
+    end
+  end
+
+  test "raises when multiple repos are given" do
+    assert_raise Mix.Error,
+                 "ecto.query found multiple repositories, please pass one with -r",
+                 fn ->
+                   Query.run(["-r", "Ecto.TestRepo", "-r", "Ecto.TestRepo", "from(p in Post)"])
+                 end
+  end
+
+  test "raises when a query is not given" do
+    assert_raise Mix.Error, "ecto.query expects a query to be given", fn ->
+      Query.run(["-r", "Ecto.TestRepo"])
+    end
+  end
+
+  @tmp_path Path.expand("../../../tmp", __DIR__)
+
+  defp in_tmp(path, fun) do
+    path = Path.join(@tmp_path, path)
+    File.rm_rf!(path)
+    File.mkdir_p!(path)
+    File.cd!(path, fun)
+  end
+end

--- a/test/mix/tasks/ecto_test.exs
+++ b/test/mix/tasks/ecto_test.exs
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.EctoTest do
     assert_received {:mix_shell, :info, ["mix ecto.create" <> _]}
     assert_received {:mix_shell, :info, ["mix ecto.drop" <> _]}
     assert_received {:mix_shell, :info, ["mix ecto.gen.repo" <> _]}
+    assert_received {:mix_shell, :info, ["mix ecto.query" <> _]}
   end
 
   test "expects no arguments" do


### PR DESCRIPTION
Refs #4719
- adds mix ecto.query to evaluate an Ecto query expression, run it through the selected/default repo inside a read-only transaction, and print schema level data.