### PR TITLE
Add Repo.select_all 

### DIFF
--- a/integration_test/cases/repo.exs
+++ b/integration_test/cases/repo.exs
@@ -98,6 +98,60 @@ defmodule Ecto.Integration.RepoTest do
     assert TestRepo.all_by(Post, title: "b") |> Enum.sort() == [post3]
   end
 
+  test "select_all" do
+    post1 = TestRepo.insert!(%Post{title: "a"})
+    post2 = TestRepo.insert!(%Post{title: "b"})
+    post3 = TestRepo.insert!(%Post{title: "c"})
+
+    # Test with full schema
+    {count, posts} = TestRepo.select_all(Post)
+    assert count == 3
+    assert Enum.sort(posts) == [post1, post2, post3]
+
+    # Test with query and select
+    query = from p in Post, where: p.title in ["a", "b"], select: p.title
+    {count, titles} = TestRepo.select_all(query)
+    assert count == 2
+    assert Enum.sort(titles) == ["a", "b"]
+
+    # Test with empty result
+    query = from p in Post, where: p.title == "nonexistent"
+    {count, posts} = TestRepo.select_all(query)
+    assert count == 0
+    assert posts == []
+
+    # Test without schema
+    {count, titles} =
+      TestRepo.select_all(from(p in "posts", order_by: p.title, select: p.title))
+    assert count == 3
+    assert titles == ["a", "b", "c"]
+  end
+
+  test "select_all_by" do
+    post1 = TestRepo.insert!(%Post{title: "a"})
+    post2 = TestRepo.insert!(%Post{title: "a"})
+    post3 = TestRepo.insert!(%Post{title: "b"})
+
+    {count, posts} = TestRepo.select_all_by(Post, title: "a")
+    assert count == 2
+    assert Enum.sort(posts) == [post1, post2]
+
+    {count, posts} = TestRepo.select_all_by(Post, title: "b")
+    assert count == 1
+    assert posts == [post3]
+
+    # Test with query
+    query = from p in Post
+    {count, posts} = TestRepo.select_all_by(query, title: "a")
+    assert count == 2
+    assert Enum.sort(posts) == [post1, post2]
+
+    # Test with empty result
+    {count, posts} = TestRepo.select_all_by(Post, title: "nonexistent")
+    assert count == 0
+    assert posts == []
+  end
+
   test "insert, update and delete" do
     post = %Post{title: "insert, update, delete", visits: 1}
     meta = post.__meta__

--- a/lib/ecto/repo.ex
+++ b/lib/ecto/repo.ex
@@ -546,6 +546,31 @@ defmodule Ecto.Repo do
           )
         end
 
+        def select_all(queryable, opts \\ []) do
+          validate_query_opts!(opts, :select_all)
+
+          repo = get_dynamic_repo()
+
+          Ecto.Repo.Queryable.select_all(
+            repo,
+            queryable,
+            Ecto.Repo.Supervisor.tuplet(repo, prepare_opts(:all, opts))
+          )
+        end
+
+        def select_all_by(queryable, clauses, opts \\ []) do
+          validate_query_opts!(opts, :select_all_by)
+
+          repo = get_dynamic_repo()
+
+          Ecto.Repo.Queryable.select_all_by(
+            repo,
+            queryable,
+            clauses,
+            Ecto.Repo.Supervisor.tuplet(repo, prepare_opts(:all, opts))
+          )
+        end
+
         def all_by(queryable, clauses, opts \\ []) do
           validate_query_opts!(opts, :all_by)
 
@@ -1484,6 +1509,76 @@ defmodule Ecto.Repo do
   """
   @doc group: "Query API"
   @callback all(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) :: [Ecto.Schema.t() | term]
+
+  @doc """
+  Fetches all entries from the data store matching the given query.
+
+  Similar to `c:all/2`, but returns a tuple with the count of rows and the list of results.
+
+  May raise `Ecto.QueryError` if query validation fails.
+
+  ## Options
+
+    * `:prefix` - The prefix to run the query on (such as the schema path
+      in Postgres or the database in MySQL). This will be applied to all `from`
+      and `join`s in the query that did not have a prefix previously given
+      either via the `:prefix` option on `join`/`from` or via `@schema_prefix`
+      in the schema. For more information see the ["Query Prefix"](`m:Ecto.Query#module-query-prefix`) section of the
+      `Ecto.Query` documentation.
+
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
+
+  ## Example
+
+      # Fetch all post titles with count
+      query = from p in Post,
+                select: p.title
+      {count, titles} = MyRepo.select_all(query)
+
+      # With returning the full struct
+      {count, posts} = from(p in Post, select: p) |> MyRepo.select_all()
+  """
+  @doc group: "Query API"
+  @callback select_all(queryable :: Ecto.Queryable.t(), opts :: Keyword.t()) ::
+              {non_neg_integer, [Ecto.Schema.t() | term]}
+
+  @doc """
+  Fetches all entries from the data store matching the given query and conditions.
+
+  Similar to `c:all_by/3`, but returns a tuple with the count of rows and the list of results.
+
+  May raise `Ecto.QueryError` if query validation fails.
+
+  This function is a shortcut for `c:select_all/2` when adjusting the given query with simple conditions.
+
+  See also `c:select_all/2`, `c:all_by/3`, and `c:get_by/3`.
+
+  ## Options
+
+    * `:prefix` - The prefix to run the query on (such as the schema path
+      in Postgres or the database in MySQL). This will be applied to all `from`
+      and `join`s in the query that did not have a prefix previously given
+      either via the `:prefix` option on `join`/`from` or via `@schema_prefix`
+      in the schema. For more information see the ["Query Prefix"](`m:Ecto.Query#module-query-prefix`) section of the
+      `Ecto.Query` documentation.
+
+  See the ["Shared options"](#module-shared-options) section at the module
+  documentation for more options.
+
+  ## Example
+
+      {count, posts} = MyRepo.select_all_by(Post, author_id: 1)
+
+      query = from p in Post
+      {count, posts} = MyRepo.select_all_by(query, author_id: 1)
+  """
+  @doc group: "Query API"
+  @callback select_all_by(
+              queryable :: Ecto.Queryable.t(),
+              clauses :: Keyword.t() | map,
+              opts :: Keyword.t()
+            ) :: {non_neg_integer, [Ecto.Schema.t() | term]}
 
   @doc """
   Fetches all entries from the data store matching the given query and conditions.

--- a/lib/ecto/repo/queryable.ex
+++ b/lib/ecto/repo/queryable.ex
@@ -10,22 +10,30 @@ defmodule Ecto.Repo.Queryable do
 
   require Ecto.Query
 
-  def all(name, queryable, tuplet) do
+  def select_all(name, queryable, tuplet) do
     query =
       queryable
       |> Ecto.Queryable.to_query()
       |> Ecto.Query.Planner.ensure_select(true)
 
-    execute(:all, name, query, tuplet) |> elem(1)
+    execute(:all, name, query, tuplet)
   end
 
-  def all_by(name, queryable, clauses, tuplet) do
+  def select_all_by(name, queryable, clauses, tuplet) do
     query =
       queryable
       |> Ecto.Query.where([], ^Enum.to_list(clauses))
       |> Ecto.Query.Planner.ensure_select(true)
 
-    execute(:all, name, query, tuplet) |> elem(1)
+    execute(:all, name, query, tuplet)
+  end
+
+  def all(name, queryable, tuplet) do
+    select_all(name, queryable, tuplet) |> elem(1)
+  end
+
+  def all_by(name, queryable, clauses, tuplet) do
+    select_all_by(name, queryable, clauses, tuplet) |> elem(1)
   end
 
   def stream(_name, queryable, {adapter_meta, opts}) do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2318,6 +2318,20 @@ defmodule Ecto.RepoTest do
       assert_received {:all, %{prefix: "rewritten"}}
     end
 
+    test "select_all" do
+      query = from p in MyParent, select: p
+
+      PrepareRepo.select_all(query, hello: :world)
+      assert_received {:all, ^query, [hello: :world]}
+      assert_received {:all, %{prefix: "rewritten"}}
+    end
+
+    test "select_all_by" do
+      PrepareRepo.select_all_by(MyParent, [id: 1], hello: :world)
+      assert_received {:all, _query, [hello: :world]}
+      assert_received {:all, %{prefix: "rewritten"}}
+    end
+
     test "update_all" do
       query = from p in MyParent, update: [set: [n: 1]]
       PrepareRepo.update_all(query, [], hello: :world)


### PR DESCRIPTION

```
{count, result} = Repo.select_all(query)
```

I proposed this on the Google Group but didn't receive any replies. This has been sitting on my disk, so I'll try to at least get it upstream.

I think this is a missing piece — we have `insert_all`, `delete_all`, and `update_all`, all of which return the count, but there's no equivalent for select. Currently, `Repo.all` has the count available internally but calls `elem(1)` on the tuple, so when we actually need the count we have two options:

1. Calling `Enum.count/1` on the results.
2. Running a separate `Repo.aggregate`.

I think this fits nicely inside the current api - you have either the long version `select_all` that gives you the full result with count, or the short version `all` that gives you only the result. 
The count is useful with pagination
Examples:
 https://github.com/duffelhq/paginator/blob/main/lib/paginator.ex#L329 uses Enum.count
 https://github.com/mojotech/scrivener_ecto/blob/main/lib/scrivener/paginater/ecto/query.ex#L71 uses sql count
 https://github.com/ash-project/ash/blob/main/lib/ash/actions/read/relationships.ex#L1617 uses Enum.split(limit) and checks if there is anything left