### PR TITLE
Do not reflect changes ignored due to :writable in returned struct

### DIFF
--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -456,8 +456,8 @@ defmodule Ecto.Repo.Schema do
     # On insert, we need to nilify non-writable fields in
     # the underlying data so that the returned struct reflects
     # that the write was not actually performed.
-    changeset = update_in(changeset.data, &nilify_unsurfaced_non_writable_data!(&1, drop_fields, schema))
-    changeset = update_in(changeset.changes, &drop_non_writable_changes!(&1, drop_fields, schema, :insert))
+    changeset = nilify_unsurfaced_non_writable_data!(changeset, drop_fields, schema)
+    changeset = drop_non_writable_changes!(changeset, drop_fields, schema, :insert)
 
     wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
       assoc_opts = assoc_opts(assocs, opts)
@@ -526,9 +526,9 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :insert, repo, tuplet)}
   end
 
-  defp nilify_unsurfaced_non_writable_data!(data, non_writable_fields, schema) do
+  defp nilify_unsurfaced_non_writable_data!(changeset, non_writable_fields, schema) do
     updates = Enum.reduce(non_writable_fields, [], fn field, updates ->
-      case data do
+      case changeset.data do
         %{^field => value} when value != nil ->
           handle_writable_violation(field, schema, :insert)
 
@@ -538,7 +538,7 @@ defmodule Ecto.Repo.Schema do
       end
     end)
 
-    struct!(data, updates)
+    %{changeset | data: struct!(changeset.data, updates)}
   end
 
   @doc """
@@ -580,7 +580,7 @@ defmodule Ecto.Repo.Schema do
     # fields into the changeset. All changes must be in the
     # changeset before hand.
     changeset = put_repo_and_action(changeset, :update, repo, tuplet)
-    changeset = update_in(changeset.changes, &drop_non_writable_changes!(&1, drop_fields, schema, :update))
+    changeset = drop_non_writable_changes!(changeset, drop_fields, schema, :update)
 
     if changeset.changes != %{} or force? do
       wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
@@ -644,8 +644,8 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :update, repo, tuplet)}
   end
 
-  defp drop_non_writable_changes!(changes, non_writable_fields, schema, action) do
-    Enum.reduce(non_writable_fields, changes, fn field, changes ->
+  defp drop_non_writable_changes!(changeset, non_writable_fields, schema, action) do
+   changes = Enum.reduce(non_writable_fields, changeset.changes, fn field, changes ->
       case changes do
         %{^field => _change} ->
           handle_writable_violation(field, schema, action)
@@ -655,6 +655,8 @@ defmodule Ecto.Repo.Schema do
           changes
       end
     end)
+
+    %{changeset | changes: changes}
   end
 
   defp handle_writable_violation(field, schema, action) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -626,27 +626,29 @@ defmodule Ecto.Repo.Schema do
   end
 
   defp process_non_writable_fields!(changeset, non_writable_fields, schema, action) do
-    changes =
-      Enum.reduce(non_writable_fields, changeset.changes, fn field, changes ->
+    {changes, data_updates} =
+      Enum.reduce(non_writable_fields, {changeset.changes, []}, fn field, {changes, data_updates} ->
         case changes do
           %{^field => _change} ->
             handle_writable_violation(field, schema, action)
-            Map.delete(changes, field)
+
+            # On insert, we need to nilify non-writable fields in
+            # the underlying data so that the returned struct reflects
+            # that the write was not actually performed.
+            data_updates = case action do
+              :insert -> [{field, nil} | data_updates]
+              _ -> data_updates
+            end
+
+            {Map.delete(changes, field), data_updates}
           %{} ->
-            changes
+            {changes, data_updates}
         end
       end)
 
-    # On insert, if the underlying struct has a value for a non-writable
-    # field, we need to nilify it so that the struct returned from the
-    # insert operation reflects that the write was not actually performed.
-    # Discarding the change above only prevents the actual write from happening.
-    data = case action do
-      :insert ->
-        updates = Enum.map(non_writable_fields, fn field -> {field, nil} end)
-        struct!(changeset.data, updates)
-      _ ->
-        changeset.data
+    data = case data_updates do
+      [] -> changeset.data
+      data_updates -> struct!(changeset.data, data_updates)
     end
 
     %{changeset | data: data, changes: changes}

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -452,8 +452,12 @@ defmodule Ecto.Repo.Schema do
     # On insert, we always merge the whole struct into the
     # changeset as changes, except the primary key if it is nil.
     changeset = put_repo_and_action(changeset, :insert, repo, tuplet)
-    changeset = Relation.surface_changes(changeset, struct, keep_fields ++ drop_fields ++ assocs)
-    changeset = process_non_writable_fields!(changeset, drop_fields, schema, :insert)
+    changeset = Relation.surface_changes(changeset, struct, keep_fields ++ assocs)
+    # On insert, we need to nilify non-writable fields in
+    # the underlying data so that the returned struct reflects
+    # that the write was not actually performed.
+    changeset = update_in(changeset.data, &nilify_unsurfaced_non_writable_data!(&1, drop_fields, schema))
+    changeset = update_in(changeset.changes, &drop_non_writable_changes!(&1, drop_fields, schema, :insert))
 
     wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
       assoc_opts = assoc_opts(assocs, opts)
@@ -522,6 +526,21 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :insert, repo, tuplet)}
   end
 
+  defp nilify_unsurfaced_non_writable_data!(data, non_writable_fields, schema) do
+    updates = Enum.reduce(non_writable_fields, [], fn field, updates ->
+      case data do
+        %{^field => value} when value != nil ->
+          handle_writable_violation(field, schema, :insert)
+
+          [{field, nil} | updates]
+        %{} ->
+          updates
+      end
+    end)
+
+    struct!(data, updates)
+  end
+
   @doc """
   Implementation for `Ecto.Repo.update/2`.
   """
@@ -561,7 +580,7 @@ defmodule Ecto.Repo.Schema do
     # fields into the changeset. All changes must be in the
     # changeset before hand.
     changeset = put_repo_and_action(changeset, :update, repo, tuplet)
-    changeset = process_non_writable_fields!(changeset, drop_fields, schema, :update)
+    changeset = update_in(changeset.changes, &drop_non_writable_changes!(&1, drop_fields, schema, :update))
 
     if changeset.changes != %{} or force? do
       wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
@@ -625,33 +644,17 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :update, repo, tuplet)}
   end
 
-  defp process_non_writable_fields!(changeset, non_writable_fields, schema, action) do
-    {changes, data_updates} =
-      Enum.reduce(non_writable_fields, {changeset.changes, []}, fn field, {changes, data_updates} ->
-        case changes do
-          %{^field => _change} ->
-            handle_writable_violation(field, schema, action)
+  defp drop_non_writable_changes!(changes, non_writable_fields, schema, action) do
+    Enum.reduce(non_writable_fields, changes, fn field, changes ->
+      case changes do
+        %{^field => _change} ->
+          handle_writable_violation(field, schema, action)
 
-            # On insert, we need to nilify non-writable fields in
-            # the underlying data so that the returned struct reflects
-            # that the write was not actually performed.
-            data_updates = case action do
-              :insert -> [{field, nil} | data_updates]
-              _ -> data_updates
-            end
-
-            {Map.delete(changes, field), data_updates}
-          %{} ->
-            {changes, data_updates}
-        end
-      end)
-
-    data = case data_updates do
-      [] -> changeset.data
-      data_updates -> struct!(changeset.data, data_updates)
-    end
-
-    %{changeset | data: data, changes: changes}
+          Map.delete(changes, field)
+        %{} ->
+          changes
+      end
+    end)
   end
 
   defp handle_writable_violation(field, schema, action) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -453,9 +453,6 @@ defmodule Ecto.Repo.Schema do
     # changeset as changes, except the primary key if it is nil.
     changeset = put_repo_and_action(changeset, :insert, repo, tuplet)
     changeset = Relation.surface_changes(changeset, struct, keep_fields ++ assocs)
-    # On insert, we need to nilify non-writable fields in
-    # the underlying data so that the returned struct reflects
-    # that the write was not actually performed.
     changeset = detect_unsurfaced_non_writable_data!(changeset, drop_fields, schema)
     changeset = drop_non_writable_changes!(changeset, drop_fields, schema, :insert)
 

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -526,6 +526,10 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :insert, repo, tuplet)}
   end
 
+  defp nilify_unsurfaced_non_writable_data!(changeset, [], _schema) do
+    changeset
+  end
+
   defp nilify_unsurfaced_non_writable_data!(changeset, non_writable_fields, schema) do
     updates = Enum.reduce(non_writable_fields, [], fn field, updates ->
       case changeset.data do
@@ -642,6 +646,10 @@ defmodule Ecto.Repo.Schema do
 
   defp do_update(repo, _name, %Changeset{valid?: false} = changeset, tuplet) do
     {:error, put_repo_and_action(changeset, :update, repo, tuplet)}
+  end
+
+  defp drop_non_writable_changes!(changeset, [], _schema, _action) do
+    changeset
   end
 
   defp drop_non_writable_changes!(changeset, non_writable_fields, schema, action) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -456,7 +456,7 @@ defmodule Ecto.Repo.Schema do
     # On insert, we need to nilify non-writable fields in
     # the underlying data so that the returned struct reflects
     # that the write was not actually performed.
-    changeset = nilify_unsurfaced_non_writable_data!(changeset, drop_fields, schema)
+    changeset = detect_unsurfaced_non_writable_data!(changeset, drop_fields, schema)
     changeset = drop_non_writable_changes!(changeset, drop_fields, schema, :insert)
 
     wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
@@ -526,23 +526,21 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :insert, repo, tuplet)}
   end
 
-  defp nilify_unsurfaced_non_writable_data!(changeset, [], _schema) do
+  defp detect_unsurfaced_non_writable_data!(changeset, [], _schema) do
     changeset
   end
 
-  defp nilify_unsurfaced_non_writable_data!(changeset, non_writable_fields, schema) do
-    updates = Enum.reduce(non_writable_fields, [], fn field, updates ->
+  defp detect_unsurfaced_non_writable_data!(changeset, non_writable_fields, schema) do
+    Enum.each(non_writable_fields, fn field ->
       case changeset.data do
         %{^field => value} when value != nil ->
           handle_writable_violation(field, schema, :insert)
-
-          [{field, nil} | updates]
         %{} ->
-          updates
+          :ok
       end
     end)
 
-    %{changeset | data: struct!(changeset.data, updates)}
+    changeset
   end
 
   @doc """

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -453,7 +453,7 @@ defmodule Ecto.Repo.Schema do
     # changeset as changes, except the primary key if it is nil.
     changeset = put_repo_and_action(changeset, :insert, repo, tuplet)
     changeset = Relation.surface_changes(changeset, struct, keep_fields ++ drop_fields ++ assocs)
-    changeset = update_in(changeset.changes, &drop_non_writable_changes!(&1, drop_fields, schema, :insert))
+    changeset = process_non_writable_fields!(changeset, drop_fields, schema, :insert)
 
     wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
       assoc_opts = assoc_opts(assocs, opts)
@@ -561,7 +561,7 @@ defmodule Ecto.Repo.Schema do
     # fields into the changeset. All changes must be in the
     # changeset before hand.
     changeset = put_repo_and_action(changeset, :update, repo, tuplet)
-    changeset = update_in(changeset.changes, &drop_non_writable_changes!(&1, drop_fields, schema, :update))
+    changeset = process_non_writable_fields!(changeset, drop_fields, schema, :update)
 
     if changeset.changes != %{} or force? do
       wrap_in_transaction(adapter, adapter_meta, opts, changeset, assocs, embeds, prepare, fn ->
@@ -625,16 +625,31 @@ defmodule Ecto.Repo.Schema do
     {:error, put_repo_and_action(changeset, :update, repo, tuplet)}
   end
 
-  defp drop_non_writable_changes!(changes, non_writable_fields, schema, action) do
-    Enum.reduce(non_writable_fields, changes, fn field, changes ->
-      case changes do
-        %{^field => _change} ->
-          handle_writable_violation(field, schema, action)
-          Map.delete(changes, field)
-        %{} ->
-          changes
-      end
-    end)
+  defp process_non_writable_fields!(changeset, non_writable_fields, schema, action) do
+    changes =
+      Enum.reduce(non_writable_fields, changeset.changes, fn field, changes ->
+        case changes do
+          %{^field => _change} ->
+            handle_writable_violation(field, schema, action)
+            Map.delete(changes, field)
+          %{} ->
+            changes
+        end
+      end)
+
+    # On insert, if the underlying struct has a value for a non-writable
+    # field, we need to nilify it so that the struct returned from the
+    # insert operation reflects that the write was not actually performed.
+    # Discarding the change above only prevents the actual write from happening.
+    data = case action do
+      :insert ->
+        updates = Enum.map(non_writable_fields, fn field -> {field, nil} end)
+        struct!(changeset.data, updates)
+      _ ->
+        changeset.data
+    end
+
+    %{changeset | data: data, changes: changes}
   end
 
   defp handle_writable_violation(field, schema, action) do

--- a/lib/ecto/repo/schema.ex
+++ b/lib/ecto/repo/schema.ex
@@ -630,7 +630,7 @@ defmodule Ecto.Repo.Schema do
       case changes do
         %{^field => _change} ->
           handle_writable_violation(field, schema, action)
-          changes
+          Map.delete(changes, field)
         %{} ->
           changes
       end

--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -706,8 +706,7 @@ defmodule Ecto.Schema do
       attempts to modify a field that should not be modified according to it's `:writable` value.
       Must be one of `:nothing`, `:warn`, or `:raise`. If set to `:nothing`, the modification is
       silently ignored. If set to `:warn`, the modification is ignored and a warning is logged. If set
-      to `:raise`, an exception is raised and the operation is aborted. If `:writable` is set to `:always`,
-      `:on_writable_violation` must be set to `:nothing`. Defaults to `:nothing`.
+      to `:raise`, an exception is raised and the operation is aborted. Defaults to `:nothing`.
 
   """
   defmacro field(name, type \\ :string, opts \\ []) do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2439,6 +2439,20 @@ defmodule Ecto.RepoTest do
              ]
     end
 
+    test "update with on_writable_violation: :nothing/warn does not reflect ignored changes in returned struct" do
+      {:ok, %MySchemaWritable{always: 10, never: nil, insert: nil}} =
+        %MySchemaWritable{id: 1}
+        |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+        |> TestRepo.update()
+
+      capture_log(fn ->
+        {:ok, %MySchemaWritableWarn{always: 10, never: nil, insert: nil}} =
+          %MySchemaWritableWarn{id: 1}
+          |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+          |> TestRepo.update()
+      end)
+    end
+
     test "update with on_writable_violation: :nothing saves changes for writable: :always and ignores changes for writable: :insert/:never" do
       %MySchemaWritable{id: 1}
       |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
@@ -2511,6 +2525,20 @@ defmodule Ecto.RepoTest do
                    fn ->
                      TestRepo.update_all(update_query, [])
                    end
+    end
+
+    test "insert with on_writable_violation: :nothing/warn does not reflect ignored changes in returned struct" do
+      {:ok, %MySchemaWritable{always: 10, never: nil, insert: 12}} =
+        %MySchemaWritable{id: 1}
+        |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+        |> TestRepo.insert()
+
+      capture_log(fn ->
+        {:ok, %MySchemaWritableWarn{always: 10, never: nil, insert: 12}} =
+          %MySchemaWritableWarn{id: 2}
+          |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+          |> TestRepo.insert()
+      end)
     end
 
     test "insert with surfaced changes on_writable_violation: :nothing saves changes for writable: :always/:insert and ignores changes for writable: :never" do

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2516,7 +2516,10 @@ defmodule Ecto.RepoTest do
     end
 
     test "insert with surfaced changes on_writable_violation: :nothing saves changes for writable: :always/:insert and ignores changes for writable: :never" do
-      %{always: 10, never: nil, insert: 12} =
+      # For surfaced changes from the underlying struct, the value in the returned struct is
+      # maintained even though the underlying write was not performed, as opposed to "normal" changes
+      # provided via a changeset.
+      %{always: 10, never: 11, insert: 12} =
         %MySchemaWritable{id: 1, always: 10, never: 11, insert: 12}
         |> Ecto.Changeset.change(%{})
         |> TestRepo.insert!()
@@ -2537,7 +2540,10 @@ defmodule Ecto.RepoTest do
 
     test "insert with surfaced changes and on_writable_violation: :warn saves changes for writable: :always/:insert, ignores changes for writable: :never, and logs a warning" do
       log = capture_log(fn ->
-        %{always: 10, never: nil, insert: 12} =
+        # For surfaced changes from the underlying struct, the value in the returned struct is
+        # maintained even though the underlying write was not performed, as opposed to "normal" changes
+        # provided via a changeset.
+        %{always: 10, never: 11, insert: 12} =
           %MySchemaWritableWarn{id: 1, always: 10, never: 11, insert: 12}
           |> Ecto.Changeset.change(%{})
           |> TestRepo.insert!()

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2475,10 +2475,9 @@ defmodule Ecto.RepoTest do
         |> TestRepo.update!()
       end
 
-      %{always: 12, never: nil, insert: nil} =
-        %MySchemaWritableRaise{id: 3}
-        |> Ecto.Changeset.change(%{always: 12})
-        |> TestRepo.update!()
+      %MySchemaWritableRaise{id: 3}
+      |> Ecto.Changeset.change(%{always: 12})
+      |> TestRepo.update!()
 
       assert_received {:update, %{changes: [always: 12]}}
     end
@@ -2571,10 +2570,10 @@ defmodule Ecto.RepoTest do
         |> TestRepo.insert!()
       end
 
-      %{always: 12, never: nil, insert: 11} =
-        %MySchemaWritableRaise{id: 2, insert: 11, always: 12}
-        |> Ecto.Changeset.change(%{})
-        |> TestRepo.insert!()
+
+      %MySchemaWritableRaise{id: 2, insert: 11, always: 12}
+      |> Ecto.Changeset.change(%{})
+      |> TestRepo.insert!()
 
       assert_received {:insert, %{fields: inserted_fields}}
       assert Enum.sort(inserted_fields) == [always: 12, id: 2, insert: 11]
@@ -2587,10 +2586,9 @@ defmodule Ecto.RepoTest do
         |> TestRepo.insert!()
       end
 
-      %{always: 12, never: nil, insert: 11} =
-        %MySchemaWritableRaise{id: 2}
-        |> Ecto.Changeset.change(%{insert: 11, always: 12})
-        |> TestRepo.insert!()
+      %MySchemaWritableRaise{id: 2}
+      |> Ecto.Changeset.change(%{insert: 11, always: 12})
+      |> TestRepo.insert!()
 
       assert_received {:insert, %{fields: inserted_fields}}
       assert Enum.sort(inserted_fields) == [always: 12, id: 2, insert: 11]

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2439,33 +2439,21 @@ defmodule Ecto.RepoTest do
              ]
     end
 
-    test "update with on_writable_violation: :nothing/warn does not reflect ignored changes in returned struct" do
-      {:ok, %MySchemaWritable{always: 10, never: nil, insert: nil}} =
+    test "update with on_writable_violation: :nothing saves changes for writable: :always and ignores changes for writable: :insert/:never" do
+      %{always: 10, never: nil, insert: nil} =
         %MySchemaWritable{id: 1}
         |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-        |> TestRepo.update()
-
-      capture_log(fn ->
-        {:ok, %MySchemaWritableWarn{always: 10, never: nil, insert: nil}} =
-          %MySchemaWritableWarn{id: 1}
-          |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-          |> TestRepo.update()
-      end)
-    end
-
-    test "update with on_writable_violation: :nothing saves changes for writable: :always and ignores changes for writable: :insert/:never" do
-      %MySchemaWritable{id: 1}
-      |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-      |> TestRepo.update()
+        |> TestRepo.update!()
 
       assert_received {:update, %{changes: [always: 10]}}
     end
 
     test "update with on_writable_violation: :warn saves changes for writable: :always, ignores changes for writable: :insert/:never, and logs a warning" do
       log = capture_log(fn ->
-        %MySchemaWritableWarn{id: 1}
-        |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-        |> TestRepo.update()
+        %{always: 10, never: nil, insert: nil} =
+          %MySchemaWritableWarn{id: 1}
+          |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+          |> TestRepo.update!()
 
         assert_received {:update, %{changes: [always: 10]}}
       end)
@@ -2478,18 +2466,19 @@ defmodule Ecto.RepoTest do
       assert_raise ArgumentError, "attempted to write to non-writable field :never during update", fn ->
         %MySchemaWritableRaise{id: 1}
         |> Ecto.Changeset.change(%{never: 10})
-        |> TestRepo.update()
+        |> TestRepo.update!()
       end
 
       assert_raise ArgumentError, "attempted to write to non-writable field :insert during update", fn ->
         %MySchemaWritableRaise{id: 2}
         |> Ecto.Changeset.change(%{insert: 11})
-        |> TestRepo.update()
+        |> TestRepo.update!()
       end
 
-      %MySchemaWritableRaise{id: 3}
-      |> Ecto.Changeset.change(%{always: 12})
-      |> TestRepo.update()
+      %{always: 12, never: nil, insert: nil} =
+        %MySchemaWritableRaise{id: 3}
+        |> Ecto.Changeset.change(%{always: 12})
+        |> TestRepo.update!()
 
       assert_received {:update, %{changes: [always: 12]}}
     end
@@ -2527,43 +2516,32 @@ defmodule Ecto.RepoTest do
                    end
     end
 
-    test "insert with on_writable_violation: :nothing/warn does not reflect ignored changes in returned struct" do
-      {:ok, %MySchemaWritable{always: 10, never: nil, insert: 12}} =
-        %MySchemaWritable{id: 1}
-        |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-        |> TestRepo.insert()
-
-      capture_log(fn ->
-        {:ok, %MySchemaWritableWarn{always: 10, never: nil, insert: 12}} =
-          %MySchemaWritableWarn{id: 2}
-          |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-          |> TestRepo.insert()
-      end)
-    end
-
     test "insert with surfaced changes on_writable_violation: :nothing saves changes for writable: :always/:insert and ignores changes for writable: :never" do
-      %MySchemaWritable{id: 1, always: 10, never: 11, insert: 12}
-      |> Ecto.Changeset.change(%{})
-      |> TestRepo.insert()
+      %{always: 10, never: nil, insert: 12} =
+        %MySchemaWritable{id: 1, always: 10, never: 11, insert: 12}
+        |> Ecto.Changeset.change(%{})
+        |> TestRepo.insert!()
 
       assert_received {:insert, %{fields: inserted_fields}}
       assert Enum.sort(inserted_fields) == [always: 10, id: 1, insert: 12]
     end
 
     test "insert with on_writable_violation: :nothing saves changes for writable: :always/:insert and ignores changes for writable: :never" do
-      %MySchemaWritable{id: 1}
-      |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-      |> TestRepo.insert()
+      %{always: 10, never: nil, insert: 12} =
+        %MySchemaWritable{id: 1}
+        |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+        |> TestRepo.insert!()
 
       assert_received {:insert, %{fields: inserted_fields}}
       assert Enum.sort(inserted_fields) == [always: 10, id: 1, insert: 12]
     end
 
-    test "insert with with surfaced changes and on_writable_violation: :warn saves changes for writable: :always/:insert, ignores changes for writable: :never, and logs a warning" do
+    test "insert with surfaced changes and on_writable_violation: :warn saves changes for writable: :always/:insert, ignores changes for writable: :never, and logs a warning" do
       log = capture_log(fn ->
-        %MySchemaWritableWarn{id: 1, always: 10, never: 11, insert: 12}
-        |> Ecto.Changeset.change(%{})
-        |> TestRepo.insert()
+        %{always: 10, never: nil, insert: 12} =
+          %MySchemaWritableWarn{id: 1, always: 10, never: 11, insert: 12}
+          |> Ecto.Changeset.change(%{})
+          |> TestRepo.insert!()
 
         assert_received {:insert, %{fields: inserted_fields}}
         assert Enum.sort(inserted_fields) == [always: 10, id: 1, insert: 12]
@@ -2574,9 +2552,10 @@ defmodule Ecto.RepoTest do
 
     test "insert with on_writable_violation: :warn saves changes for writable: :always/:insert, ignores changes for writable: :never, and logs a warning" do
       log = capture_log(fn ->
-        %MySchemaWritableWarn{id: 1}
-        |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
-        |> TestRepo.insert()
+        %{always: 10, never: nil, insert: 12} =
+          %MySchemaWritableWarn{id: 1}
+          |> Ecto.Changeset.change(%{always: 10, never: 11, insert: 12})
+          |> TestRepo.insert!()
 
         assert_received {:insert, %{fields: inserted_fields}}
         assert Enum.sort(inserted_fields) == [always: 10, id: 1, insert: 12]
@@ -2589,12 +2568,13 @@ defmodule Ecto.RepoTest do
       assert_raise ArgumentError, "attempted to write to non-writable field :never during insert", fn ->
         %MySchemaWritableRaise{id: 1, never: 10}
         |> Ecto.Changeset.change(%{})
-        |> TestRepo.insert()
+        |> TestRepo.insert!()
       end
 
-      %MySchemaWritableRaise{id: 2, insert: 11, always: 12}
-      |> Ecto.Changeset.change(%{})
-      |> TestRepo.insert()
+      %{always: 12, never: nil, insert: 11} =
+        %MySchemaWritableRaise{id: 2, insert: 11, always: 12}
+        |> Ecto.Changeset.change(%{})
+        |> TestRepo.insert!()
 
       assert_received {:insert, %{fields: inserted_fields}}
       assert Enum.sort(inserted_fields) == [always: 12, id: 2, insert: 11]
@@ -2604,12 +2584,13 @@ defmodule Ecto.RepoTest do
       assert_raise ArgumentError, "attempted to write to non-writable field :never during insert", fn ->
         %MySchemaWritableRaise{id: 1}
         |> Ecto.Changeset.change(%{never: 10})
-        |> TestRepo.insert()
+        |> TestRepo.insert!()
       end
 
-      %MySchemaWritableRaise{id: 2}
-      |> Ecto.Changeset.change(%{insert: 11, always: 12})
-      |> TestRepo.insert()
+      %{always: 12, never: nil, insert: 11} =
+        %MySchemaWritableRaise{id: 2}
+        |> Ecto.Changeset.change(%{insert: 11, always: 12})
+        |> TestRepo.insert!()
 
       assert_received {:insert, %{fields: inserted_fields}}
       assert Enum.sort(inserted_fields) == [always: 12, id: 2, insert: 11]


### PR DESCRIPTION
Oops @greg-rychlewski, I realized just slightly too late that I accidentally broke #4524 / #4525 in #4734. This PR fixes the regression and adds accompanying unit tests.