### PR TITLE
Add @on_writable_violation schema attribute to default :on_writable_violation for all schema fields

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -183,6 +183,10 @@ defmodule Ecto.Schema do
       option for the [`field`](`field/3`) macro. It defaults to `fn x -> x end`,
       where no field transformation is done;
 
+    * `@on_writable_violation` - configures the default value of `:on_writable_violation`
+      for all fields in the schema. The value set here can be changed per field through
+      the `:on_writable_violation` option.
+
   The advantage of configuring the schema via those attributes is
   that they can be set with a macro to configure application wide
   defaults.
@@ -2022,8 +2026,11 @@ defmodule Ecto.Schema do
     virtual? = opts[:virtual] || false
     pk? = opts[:primary_key] || false
     writable = opts[:writable] || :always
-    on_writable_violation = opts[:on_writable_violation] || :nothing
     put_struct_field(mod, name, Keyword.get(opts, :default))
+
+    on_writable_violation = Keyword.get_lazy(opts, :on_writable_violation, fn ->
+      Module.get_attribute(mod, :on_writable_violation, :nothing)
+    end)
 
     redact_field? =
       Keyword.get_lazy(opts, :redact, fn ->

--- a/test/ecto/schema_test.exs
+++ b/test/ecto/schema_test.exs
@@ -516,6 +516,39 @@ defmodule Ecto.SchemaTest do
     assert Ecto.primary_key!(sc) == [student_id: 1, course_ref_id: 2]
   end
 
+  ## Default on_writable_violation
+
+  defmodule SchemaWithOnWritableViolation do
+    use Ecto.Schema
+
+    @on_writable_violation :raise
+    schema "on_writable_violation" do
+      field :a, :string, writable: :insert
+      field :b, :string, writable: :insert
+      field :c, :string, writable: :insert, on_writable_violation: :nothing
+      field :d, :string, writable: :insert, on_writable_violation: :warn
+    end
+  end
+
+  defmodule SchemaWithoutOnWritableViolation do
+    use Ecto.Schema
+
+    schema "on_writable_violation" do
+      field :a, :string, writable: :insert
+      field :b, :string, writable: :insert
+      field :c, :string, writable: :insert, on_writable_violation: :warn
+      field :d, :string, writable: :insert, on_writable_violation: :raise
+    end
+  end
+
+  test "schema with @on_writable_violation defaults :on_writable_violation" do
+    %{a: :raise, b: :raise, c: :nothing, d: :warn} = SchemaWithOnWritableViolation.__schema__(:on_writable_violation)
+  end
+
+  test "schema without @on_writable_violation uses the field-level default (:nothing)" do
+    %{a: :nothing, b: :nothing, c: :warn, d: :raise} = SchemaWithoutOnWritableViolation.__schema__(:on_writable_violation)
+  end
+
   ## Errors
 
   test "field name clash" do


### PR DESCRIPTION
This is a follow up to #4734 which adds a new `@on_writable_violation` schema attribute to allow for opting-in to a default at the schema level to make it easier to configure `:warn` or `:raise` across your codebase.