### PR TITLE
Add UUID v7 helper functions

### DIFF
--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -235,6 +235,9 @@ defmodule Ecto.UUID do
    * `:precision` - The timestamp precision for version 7 UUIDs. Supported
      values are `:millisecond` and `:monotonic`. Defaults to `:millisecond`.
 
+   * `:timestamp` - A specific unix timestamp to generate the UUID with.
+     Only works for `precision: :millisecond`.
+
   > #### Monotonic precision {: .info}
   >
   > When using `:monotonic`, sub-millisecond precision is encoded in the
@@ -293,11 +296,12 @@ defmodule Ecto.UUID do
 
   defp bingenerate_v7(opts) do
     {precision, rest} = Keyword.pop(opts, :precision, :millisecond)
+    {timestamp, rest} = Keyword.pop(rest, :timestamp)
     if rest != [], do: raise(ArgumentError, "unsupported options for v7: #{inspect(rest)}")
 
     case precision do
       :millisecond ->
-        timestamp = System.system_time(:millisecond)
+        timestamp = timestamp || System.system_time(:millisecond)
         <<rand_a::12, _::6, rand_b::62>> = :crypto.strong_rand_bytes(10)
         <<timestamp::48, @version_7::4, rand_a::12, @variant::2, rand_b::62>>
 
@@ -374,4 +378,33 @@ defmodule Ecto.UUID do
   defp e(13), do: ?d
   defp e(14), do: ?e
   defp e(15), do: ?f
+
+  @doc """
+  Returns the timestamp from the UUID. Only works for UUID v7.
+
+  Raises `Ecto.ArgumentError` when a UUID is given that's not v7.
+  """
+  def timestamp(<<milliseconds::48, @version_7::4, _::76>>), do: milliseconds
+
+  def timestamp(<<_::48, version::4, _::76>>),
+    do: raise(ArgumentError, "timestamp only supports v7 UUIDs, got v#{version}")
+
+  def timestamp(<<_::288>> = uuid), do: uuid |> dump!() |> timestamp()
+
+  @doc """
+  Tries to fetch the `DateTime` from the UUID. Only works for UUID v7.
+
+  Raises `Ecto.ArgumentError` when a UUID is given that's not v7.
+  """
+  def datetime(uuid) do
+    uuid
+    |> timestamp()
+    |> DateTime.from_unix!(:millisecond)
+  end
+
+  @doc """
+  Returns the version number for the UUID.
+  """
+  def version(<<_::48, version::4, _::76>>), do: version
+  def version(<<_::288>> = uuid), do: uuid |> dump!() |> version()
 end

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -395,12 +395,16 @@ defmodule Ecto.UUID do
   Raises `ArgumentError` for non-v7 UUIDs.
   """
   @spec to_unix(binary()) :: integer()
-  def to_unix(<<unix::48, @version_7::4, _::76>>), do: unix
+  def to_unix(uuid, precision \\ :second)
 
-  def to_unix(<<_::48, version::4, _::76>>),
+  def to_unix(<<unix::48, @version_7::4, _::76>>, precision),
+    do: System.convert_time_unit(unix, :millisecond, precision)
+
+  def to_unix(<<_::48, version::4, _::76>>, _precision),
     do: raise(ArgumentError, "to_unix doesn't support UUID v#{version}")
 
-  def to_unix(uuid), do: uuid |> dump!() |> to_unix()
+  def to_unix(uuid, precision),
+    do: uuid |> dump!() |> to_unix(precision)
 
   @doc """
   Returns the version number for the UUID.

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -235,9 +235,6 @@ defmodule Ecto.UUID do
    * `:precision` - The timestamp precision for version 7 UUIDs. Supported
      values are `:millisecond` and `:monotonic`. Defaults to `:millisecond`.
 
-   * `:timestamp` - A specific unix timestamp to generate the UUID with.
-     Only works for `precision: :millisecond`.
-
   > #### Monotonic precision {: .info}
   >
   > When using `:monotonic`, sub-millisecond precision is encoded in the
@@ -296,12 +293,11 @@ defmodule Ecto.UUID do
 
   defp bingenerate_v7(opts) do
     {precision, rest} = Keyword.pop(opts, :precision, :millisecond)
-    {timestamp, rest} = Keyword.pop(rest, :timestamp)
     if rest != [], do: raise(ArgumentError, "unsupported options for v7: #{inspect(rest)}")
 
     case precision do
       :millisecond ->
-        timestamp = timestamp || System.system_time(:millisecond)
+        timestamp = System.system_time(:millisecond)
         <<rand_a::12, _::6, rand_b::62>> = :crypto.strong_rand_bytes(10)
         <<timestamp::48, @version_7::4, rand_a::12, @variant::2, rand_b::62>>
 
@@ -380,31 +376,49 @@ defmodule Ecto.UUID do
   defp e(15), do: ?f
 
   @doc """
-  Returns the timestamp from the UUID. Only works for UUID v7.
+  Tries to fetch the `DateTime` from the UUID. Only works for UUID v7, not v4.
 
-  Raises `Ecto.ArgumentError` when a UUID is given that's not v7.
+  ## Examples
+
+      iex> match?({:ok, %DateTime{}}, Ecto.UUID.to_datetime(Ecto.UUID.generate(version: 7)))
+      true
+
+      iex> Ecto.UUID.to_datetime(Ecto.UUID.generate())
+      {:error, {:unsupported_uuid_version, 4}}
+
+      iex> Ecto.UUID.to_datetime("icecream vendor")
+      {:error, :invalid_uuid}
   """
-  def timestamp(<<milliseconds::48, @version_7::4, _::76>>), do: milliseconds
+  @spec to_datetime(binary()) :: {:ok, DateTime.t()} | {:error, atom()}
+  def to_datetime(<<milliseconds::48, @version_7::4, _::76>>),
+    do: DateTime.from_unix(milliseconds, :millisecond)
 
-  def timestamp(<<_::48, version::4, _::76>>),
-    do: raise(ArgumentError, "timestamp only supports v7 UUIDs, got v#{version}")
+  def to_datetime(<<_::48, version::4, _::76>>),
+    do: {:error, {:unsupported_uuid_version, version}}
 
-  def timestamp(<<_::288>> = uuid), do: uuid |> dump!() |> timestamp()
+  def to_datetime(uuid) do
+    case dump(uuid) do
+      {:ok, t} -> to_datetime(t)
+      :error -> {:error, :invalid_uuid}
+    end
+  end
 
   @doc """
-  Tries to fetch the `DateTime` from the UUID. Only works for UUID v7.
-
-  Raises `Ecto.ArgumentError` when a UUID is given that's not v7.
+  Same as `to_datetime/1` but raises if no valid datetime could be extracted.
   """
-  def datetime(uuid) do
-    uuid
-    |> timestamp()
-    |> DateTime.from_unix!(:millisecond)
-  end
+  @spec to_datetime!(binary()) :: DateTime.t()
+  def to_datetime!(<<milliseconds::48, @version_7::4, _::76>>),
+    do: DateTime.from_unix!(milliseconds, :millisecond)
+
+  def to_datetime!(<<_::48, version::4, _::76>>),
+    do: raise(ArgumentError, "to_datetime! does not support UUID v#{version}")
+
+  def to_datetime!(uuid), do: uuid |> dump!() |> to_datetime!()
 
   @doc """
   Returns the version number for the UUID.
   """
+  @spec version(binary()) :: 1..8
   def version(<<_::48, version::4, _::76>>), do: version
   def version(<<_::288>> = uuid), do: uuid |> dump!() |> version()
 end

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -394,7 +394,7 @@ defmodule Ecto.UUID do
 
   Raises `ArgumentError` for non-v7 UUIDs.
   """
-  @spec to_unix(binary()) :: integer()
+  @spec to_unix(binary(), System.time_unit()) :: integer()
   def to_unix(uuid, precision \\ :second)
 
   def to_unix(<<unix::48, @version_7::4, _::76>>, precision),

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -376,44 +376,30 @@ defmodule Ecto.UUID do
   defp e(15), do: ?f
 
   @doc """
-  Tries to fetch the `DateTime` from the UUID. Only works for UUID v7, not v4.
+  Converts the timestamp in the UUID to a datetime. Only works for UUID v7.
 
-  ## Examples
-
-      iex> match?({:ok, %DateTime{}}, Ecto.UUID.to_datetime(Ecto.UUID.generate(version: 7)))
-      true
-
-      iex> Ecto.UUID.to_datetime(Ecto.UUID.generate())
-      {:error, {:unsupported_uuid_version, 4}}
-
-      iex> Ecto.UUID.to_datetime("icecream vendor")
-      {:error, :invalid_uuid}
+  Raises `ArgumentError` for non-v7 UUIDs.
   """
   @spec to_datetime(binary()) :: {:ok, DateTime.t()} | {:error, atom()}
   def to_datetime(<<milliseconds::48, @version_7::4, _::76>>),
-    do: DateTime.from_unix(milliseconds, :millisecond)
-
-  def to_datetime(<<_::48, version::4, _::76>>),
-    do: {:error, {:unsupported_uuid_version, version}}
-
-  def to_datetime(uuid) do
-    case dump(uuid) do
-      {:ok, t} -> to_datetime(t)
-      :error -> {:error, :invalid_uuid}
-    end
-  end
-
-  @doc """
-  Same as `to_datetime/1` but raises if no valid datetime could be extracted.
-  """
-  @spec to_datetime!(binary()) :: DateTime.t()
-  def to_datetime!(<<milliseconds::48, @version_7::4, _::76>>),
     do: DateTime.from_unix!(milliseconds, :millisecond)
 
-  def to_datetime!(<<_::48, version::4, _::76>>),
-    do: raise(ArgumentError, "to_datetime! does not support UUID v#{version}")
+  def to_datetime(<<_::48, version::4, _::76>>),
+    do: raise(ArgumentError, "to_datetime doesn't support UUID v#{version}")
 
-  def to_datetime!(uuid), do: uuid |> dump!() |> to_datetime!()
+  def to_datetime(uuid), do: uuid |> dump!() |> to_datetime()
+
+  @doc """
+  Extracts the unix timestamp from the UUID. Only works for v7 UUIDs.
+
+  Raises `ArgumentError` for non-v7 UUIDs.
+  """
+  def to_unix(<<unix::48, @version_7::4, _::76>>), do: unix
+
+  def to_unix(<<_::48, version::4, _::76>>),
+    do: raise(ArgumentError, "to_unix doesn't support UUID v#{version}")
+
+  def to_unix(uuid), do: uuid |> dump!() |> to_unix()
 
   @doc """
   Returns the version number for the UUID.

--- a/lib/ecto/uuid.ex
+++ b/lib/ecto/uuid.ex
@@ -380,7 +380,7 @@ defmodule Ecto.UUID do
 
   Raises `ArgumentError` for non-v7 UUIDs.
   """
-  @spec to_datetime(binary()) :: {:ok, DateTime.t()} | {:error, atom()}
+  @spec to_datetime(binary()) :: DateTime.t()
   def to_datetime(<<milliseconds::48, @version_7::4, _::76>>),
     do: DateTime.from_unix!(milliseconds, :millisecond)
 
@@ -394,6 +394,7 @@ defmodule Ecto.UUID do
 
   Raises `ArgumentError` for non-v7 UUIDs.
   """
+  @spec to_unix(binary()) :: integer()
   def to_unix(<<unix::48, @version_7::4, _::76>>), do: unix
 
   def to_unix(<<_::48, version::4, _::76>>),

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -135,4 +135,29 @@ defmodule Ecto.UUIDTest do
       Ecto.UUID.generate(version: 7, precision: :monotonic, foo: :bar)
     end
   end
+
+  test "timestamp from uuid v7" do
+    now = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+    unix = DateTime.to_unix(now, :millisecond)
+    uuid = Ecto.UUID.generate(version: 7, timestamp: unix)
+
+    assert Ecto.UUID.timestamp(uuid) == unix
+    assert Ecto.UUID.datetime(uuid) == now
+  end
+
+  test "timestamp with non-v7 uuid raises an ArgumentError" do
+    assert_raise ArgumentError, "timestamp only supports v7 UUIDs, got v4", fn ->
+      Ecto.UUID.generate()
+      |> Ecto.UUID.timestamp()
+    end
+  end
+
+  test "extract version" do
+    assert 4 = Ecto.UUID.version(Ecto.UUID.generate())
+    assert 7 = Ecto.UUID.version(Ecto.UUID.generate(version: 7))
+
+    # It generalizes to other versions
+    assert 1 = Ecto.UUID.version("1df7a830-76ee-11f1-ab07-0242ac120002")
+    assert 8 = Ecto.UUID.version("10b0e08c-acaf-81c1-be47-8e84b7ea32ce")
+  end
 end

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -138,23 +138,31 @@ defmodule Ecto.UUIDTest do
 
   test "to_datetime from uuid v7" do
     {uuid, now} = uuidv7_now()
-    assert {:ok, now} == Ecto.UUID.to_datetime(uuid)
+    assert now == Ecto.UUID.to_datetime(uuid)
 
     uuid = Ecto.UUID.generate(version: 7, precision: :monotonic)
-    assert {:ok, %DateTime{}} = Ecto.UUID.to_datetime(uuid)
+    assert %DateTime{} = Ecto.UUID.to_datetime(uuid)
   end
 
-  test "to_datetime! from uuid v7" do
+  test "to_datetime raises ArgumentError on UUID v4" do
+    assert_raise ArgumentError, "to_datetime doesn't support UUID v4", fn ->
+      Ecto.UUID.to_datetime(Ecto.UUID.generate())
+    end
+  end
+
+  test "to_unix" do
     {uuid, now} = uuidv7_now()
-    assert now == Ecto.UUID.to_datetime!(uuid)
+    assert DateTime.to_unix(now, :millisecond) == Ecto.UUID.to_unix(uuid)
 
-    uuid = Ecto.UUID.generate(version: 7, precision: :monotonic)
-    assert %DateTime{} = Ecto.UUID.to_datetime!(uuid)
+    assert num = Ecto.UUID.to_unix(Ecto.UUID.generate(version: 7))
+    assert {:ok, %DateTime{}} = DateTime.from_unix(num, :millisecond)
+    assert num = Ecto.UUID.to_unix(Ecto.UUID.generate(version: 7, precision: :monotonic))
+    assert {:ok, %DateTime{}} = DateTime.from_unix(num, :millisecond)
   end
 
-  test "to_datetime! raises on uuid v4" do
-    assert_raise ArgumentError, "to_datetime! does not support UUID v4", fn ->
-      Ecto.UUID.to_datetime!(Ecto.UUID.generate())
+  test "to_unix raises ArgumentError on UUID v4" do
+    assert_raise ArgumentError, "to_unix doesn't support UUID v4", fn ->
+      Ecto.UUID.to_unix(Ecto.UUID.generate())
     end
   end
 

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -136,19 +136,25 @@ defmodule Ecto.UUIDTest do
     end
   end
 
-  test "timestamp from uuid v7" do
-    now = DateTime.utc_now() |> DateTime.truncate(:millisecond)
-    unix = DateTime.to_unix(now, :millisecond)
-    uuid = Ecto.UUID.generate(version: 7, timestamp: unix)
+  test "to_datetime from uuid v7" do
+    {uuid, now} = uuidv7_now()
+    assert {:ok, now} == Ecto.UUID.to_datetime(uuid)
 
-    assert Ecto.UUID.timestamp(uuid) == unix
-    assert Ecto.UUID.datetime(uuid) == now
+    uuid = Ecto.UUID.generate(version: 7, precision: :monotonic)
+    assert {:ok, %DateTime{}} = Ecto.UUID.to_datetime(uuid)
   end
 
-  test "timestamp with non-v7 uuid raises an ArgumentError" do
-    assert_raise ArgumentError, "timestamp only supports v7 UUIDs, got v4", fn ->
-      Ecto.UUID.generate()
-      |> Ecto.UUID.timestamp()
+  test "to_datetime! from uuid v7" do
+    {uuid, now} = uuidv7_now()
+    assert now == Ecto.UUID.to_datetime!(uuid)
+
+    uuid = Ecto.UUID.generate(version: 7, precision: :monotonic)
+    assert %DateTime{} = Ecto.UUID.to_datetime!(uuid)
+  end
+
+  test "to_datetime! raises on uuid v4" do
+    assert_raise ArgumentError, "to_datetime! does not support UUID v4", fn ->
+      Ecto.UUID.to_datetime!(Ecto.UUID.generate())
     end
   end
 
@@ -159,5 +165,13 @@ defmodule Ecto.UUIDTest do
     # It generalizes to other versions
     assert 1 = Ecto.UUID.version("1df7a830-76ee-11f1-ab07-0242ac120002")
     assert 8 = Ecto.UUID.version("10b0e08c-acaf-81c1-be47-8e84b7ea32ce")
+  end
+
+  defp uuidv7_now() do
+    now = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+    timestamp = DateTime.to_unix(now, :millisecond)
+    <<rand_a::12, _::6, rand_b::62>> = :crypto.strong_rand_bytes(10)
+    uuid = <<timestamp::48, 7::4, rand_a::12, 2::2, rand_b::62>>
+    {uuid, now}
   end
 end

--- a/test/ecto/uuid_test.exs
+++ b/test/ecto/uuid_test.exs
@@ -152,12 +152,20 @@ defmodule Ecto.UUIDTest do
 
   test "to_unix" do
     {uuid, now} = uuidv7_now()
-    assert DateTime.to_unix(now, :millisecond) == Ecto.UUID.to_unix(uuid)
+    assert DateTime.to_unix(now, :millisecond) == Ecto.UUID.to_unix(uuid, :millisecond)
 
-    assert num = Ecto.UUID.to_unix(Ecto.UUID.generate(version: 7))
+    assert num = Ecto.UUID.to_unix(Ecto.UUID.generate(version: 7), :millisecond)
     assert {:ok, %DateTime{}} = DateTime.from_unix(num, :millisecond)
-    assert num = Ecto.UUID.to_unix(Ecto.UUID.generate(version: 7, precision: :monotonic))
+
+    uuid = Ecto.UUID.generate(version: 7, precision: :monotonic)
+    assert num = Ecto.UUID.to_unix(uuid, :millisecond)
+
     assert {:ok, %DateTime{}} = DateTime.from_unix(num, :millisecond)
+  end
+
+  test "to_unix with precision argument" do
+    {uuid, now} = uuidv7_now()
+    assert DateTime.to_unix(now, :second) == Ecto.UUID.to_unix(uuid, :second)
   end
 
   test "to_unix raises ArgumentError on UUID v4" do


### PR DESCRIPTION
Adds `timestamp/1`, `datetime/1`, and `version/1` helpers for dealing with UUIDs.

My main use case is dealing with importing data with existing timestamps but no
UUIDv7 yet. There's currently no way to control the timestamp that's used for
the manual creation of the UUID.

Some parallels with Postgres:

- `uuid_extract_timestamp` -> `Ecto.UUID.timestamp`
- `uuid_extract_version` -> `Ecto.UUID.version`
