### PR TITLE
Fix wrong placeholder numbering when a `from` source is a `{fragment, schema}` tuple

### DIFF
--- a/lib/ecto/query/planner.ex
+++ b/lib/ecto/query/planner.ex
@@ -1522,6 +1522,11 @@ defmodule Ecto.Query.Planner do
     {{:fragment, meta, fragments}, acc}
   end
 
+  defp prewalk_source({{:fragment, meta, fragments}, schema}, kind, query, expr, acc, adapter) do
+    {fragments, acc} = prewalk(fragments, kind, query, expr, acc, adapter)
+    {{{:fragment, meta, fragments}, schema}, acc}
+  end
+
   defp prewalk_source({:values, meta, [types, num_rows]}, _kind, _query, _expr, acc, _adapter) do
     length = num_rows * length(types)
     # Adapters will use the schema types to cast the values

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -988,6 +988,26 @@ defmodule Ecto.Query.PlannerTest do
            ] = cache_key
   end
 
+  test "plan: tuple source with fragment numbers later placeholders after the source" do
+    good_query =
+      from(f in fragment("widgets_since(?)", ^"as_of"),
+        where: f.visits in ^[1, 2],
+        select: f
+      )
+      |> normalize()
+
+    assert Macro.to_string(hd(good_query.wheres).expr) == "&0.visits() in ^(1, 2)"
+
+    bad_query =
+      from(f in {fragment("widgets_since(?)", ^"as_of"), Post},
+        where: f.visits in ^[1, 2],
+        select: f
+      )
+      |> normalize()
+
+    assert Macro.to_string(hd(bad_query.wheres).expr) == "&0.visits() in ^(1, 2)"
+  end
+
   describe "plan: CTEs" do
     test "with uncacheable queries are uncacheable" do
       {_, _, _, cache} =

--- a/test/ecto/query/planner_test.exs
+++ b/test/ecto/query/planner_test.exs
@@ -990,7 +990,7 @@ defmodule Ecto.Query.PlannerTest do
 
   test "plan: tuple source with fragment numbers later placeholders after the source" do
     good_query =
-      from(f in fragment("widgets_since(?)", ^"as_of"),
+      from(f in fragment("some_sql_function(?)", ^"value"),
         where: f.visits in ^[1, 2],
         select: f
       )
@@ -999,7 +999,7 @@ defmodule Ecto.Query.PlannerTest do
     assert Macro.to_string(hd(good_query.wheres).expr) == "&0.visits() in ^(1, 2)"
 
     bad_query =
-      from(f in {fragment("widgets_since(?)", ^"as_of"), Post},
+      from(f in {fragment("some_sql_function(?)", ^"value"), Post},
         where: f.visits in ^[1, 2],
         select: f
       )


### PR DESCRIPTION
Fixes #4740 