### PR TITLE
Fix preloader validation for multiple combinations

### DIFF
--- a/lib/ecto/repo/preloader.ex
+++ b/lib/ecto/repo/preloader.ex
@@ -392,7 +392,7 @@ defmodule Ecto.Repo.Preloader do
     # If we are returning many results, we must sort by the key too
     query =
       case {card, query.combinations} do
-        {:many, [{kind, _} | []]} ->
+        {:many, [{kind, _} | _]} ->
           raise ArgumentError,
                 "`#{kind}` queries must be wrapped inside of a subquery " <>
                   "when preloading a `has_many` or `many_to_many` association. " <>

--- a/test/ecto/repo_test.exs
+++ b/test/ecto/repo_test.exs
@@ -2138,6 +2138,11 @@ defmodule Ecto.RepoTest do
         TestRepo.preload(%MySchema{id: 1}, children: union(query, ^query))
       end
 
+      assert_raise ArgumentError, msg, fn ->
+        combination_query = query |> union(^query) |> union(^query)
+        TestRepo.preload(%MySchema{id: 1}, children: combination_query)
+      end
+
       msg = ~r"`union_all` queries must be wrapped inside of a subquery"
 
       assert_raise ArgumentError, msg, fn ->


### PR DESCRIPTION
The previous code matched on exactly one combination leading to a cryptic DB error or misassociated preloads.
This PR relaxes the pattern so an expected `ArgumentError` can be risen