### PR TITLE
Normalize DateTime casts to UTC

### DIFF
--- a/lib/ecto/type.ex
+++ b/lib/ecto/type.ex
@@ -1069,6 +1069,13 @@ defmodule Ecto.Type do
     end
   end
 
+  defp cast_date(%DateTime{} = datetime) do
+    case cast_utc_datetime(datetime) do
+      {:ok, datetime} -> {:ok, DateTime.to_date(datetime)}
+      :error -> :error
+    end
+  end
+
   defp cast_date(%{"year" => empty, "month" => empty, "day" => empty}) when empty in ["", nil],
     do: {:ok, nil}
 
@@ -1189,6 +1196,13 @@ defmodule Ecto.Type do
     case NaiveDateTime.from_iso8601(binary) do
       {:ok, _} = ok -> ok
       {:error, _} -> :error
+    end
+  end
+
+  defp cast_naive_datetime(%DateTime{} = datetime) do
+    case cast_utc_datetime(datetime) do
+      {:ok, datetime} -> {:ok, DateTime.to_naive(datetime)}
+      :error -> :error
     end
   end
 

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -378,6 +378,20 @@ defmodule Ecto.TypeTest do
   @date ~D[2015-12-31]
   @leap_date ~D[2000-02-29]
   @date_unix_epoch ~D[1970-01-01]
+  @non_utc_datetime %DateTime{
+    calendar: Calendar.ISO,
+    year: 2020,
+    month: 6,
+    day: 1,
+    hour: 0,
+    minute: 30,
+    second: 7,
+    microsecond: {8000, 6},
+    std_offset: 3600,
+    utc_offset: 3600,
+    time_zone: "Europe/Berlin",
+    zone_abbr: "CEST"
+  }
 
   describe "date" do
     test "cast" do
@@ -421,6 +435,9 @@ defmodule Ecto.TypeTest do
 
       assert Ecto.Type.cast(:date, DateTime.from_unix!(10)) ==
                {:ok, @date_unix_epoch}
+
+      assert Ecto.Type.cast(:date, @non_utc_datetime) ==
+               {:ok, ~D[2020-05-31]}
 
       assert Ecto.Type.cast(:date, ~N[1970-01-01 12:23:34]) ==
                {:ok, @date_unix_epoch}
@@ -773,6 +790,9 @@ defmodule Ecto.TypeTest do
       assert Ecto.Type.cast(:naive_datetime, DateTime.from_unix!(10, :second)) ==
                {:ok, ~N[1970-01-01 00:00:10]}
 
+      assert Ecto.Type.cast(:naive_datetime, @non_utc_datetime) ==
+               {:ok, ~N[2020-05-31 22:30:07]}
+
       assert Ecto.Type.cast(:naive_datetime, @time) == :error
       assert Ecto.Type.cast(:naive_datetime, 1) == :error
     end
@@ -915,6 +935,9 @@ defmodule Ecto.TypeTest do
     test "cast from DateTime" do
       assert Ecto.Type.cast(:naive_datetime_usec, DateTime.from_unix!(10, :second)) ==
                {:ok, ~N[1970-01-01 00:00:10.000000]}
+
+      assert Ecto.Type.cast(:naive_datetime_usec, @non_utc_datetime) ==
+               {:ok, ~N[2020-05-31 22:30:07.008000]}
     end
 
     test "cast from Time" do


### PR DESCRIPTION
Tentatie fix for #4774

It is a backward-incompatible change for applications that deliberately pass non-UTC `%DateTime{}` structs to naive datetime or date fields. It should not affect phoenix generated CRUD pages