### PR TITLE
avoid compile-time dependency on modules named in derive

### DIFF
--- a/lib/ecto/schema.ex
+++ b/lib/ecto/schema.ex
@@ -2390,10 +2390,12 @@ defmodule Ecto.Schema do
     on_writable_violation_default = Module.get_attribute(module, :on_writable_violation, :nothing)
 
     struct_fields = Module.get_attribute(module, :ecto_struct_fields) |> Enum.reverse()
-    derive = Module.get_attribute(module, :derive)
 
-    if redacted_fields != [] and not List.keymember?(derive, Inspect, 0) and
-         derive_inspect?(module) do
+    # Reading @derive makes every module named in its options a compile-time
+    # dependency of the schema. Keep the read last so it is skipped unless a
+    # redacted field actually requires deriving Inspect.
+    if redacted_fields != [] and derive_inspect?(module) and
+         not List.keymember?(Module.get_attribute(module, :derive), Inspect, 0) do
       Module.put_attribute(module, :derive, {Inspect, except: redacted_fields})
     end
 


### PR DESCRIPTION
If the `@derive` attribute is read at compile time, a compile dependency is added to any module that is named in the `@derive` options. This PR changes the order of the `if` conditions, so that `@derive` is only read if the schema has redacted fields. That should avoid unnecessary compile dependencies at least some of the time.

Example:

```elixir
defmodule Repro.Post do
  use Ecto.Schema
  alias Repro.Other

  @derive {Repro.MyProtocol, some_option: {Other, :something}}
  
  schema "posts" do
    field :name, :string
  end
end
```

Before the change:

```
$ mix xref trace lib/post.ex
lib/post.ex:5: alias Repro.Other (runtime)
lib/post.ex:7: require Repro.MyProtocol (export)
lib/post.ex:7: struct Repro.Post (export)
lib/post.ex:7: call Repro.MyProtocol.behaviour_info/1 (runtime)
lib/post.ex:7: call Repro.MyProtocol.Any.__deriving__/3 (compile)
@derive:5: alias Repro.MyProtocol (compile)
@derive:5: alias Repro.Other (compile)
```

After the change:

```
$ mix xref trace lib/post.ex
lib/post.ex:5: alias Repro.Other (runtime)
lib/post.ex:7: require Repro.MyProtocol (export)
lib/post.ex:7: struct Repro.Post (export)
lib/post.ex:7: call Repro.MyProtocol.behaviour_info/1 (runtime)
lib/post.ex:7: call Repro.MyProtocol.Any.__deriving__/3 (compile)
```

This was observed with the `ecto_type` option and the `Flop.Schema` protocol: https://github.com/woylie/flop/issues/583.