### PR TITLE
Allow loader/dumper be passed through Ecto.embedded_load / Ecto.embedded_dump

### DIFF
--- a/lib/ecto.ex
+++ b/lib/ecto.ex
@@ -723,14 +723,14 @@ defmodule Ecto do
   @spec embedded_load(
           module_or_map :: module | map(),
           data :: map(),
-          format :: atom()
+          format :: atom() | (Ecto.Type.t(), term -> {:ok, term} | :error)
         ) :: Ecto.Schema.t() | map()
-  def embedded_load(schema_or_types, data, format) do
-    Ecto.Schema.Loader.unsafe_load(
-      schema_or_types,
-      data,
-      &Ecto.Type.embedded_load(&1, &2, format)
-    )
+  def embedded_load(schema_or_types, data, format) when is_atom(format) do
+    embedded_load(schema_or_types, data, &Ecto.Type.embedded_load(&1, &2, format))
+  end
+
+  def embedded_load(schema_or_types, data, loader) when is_function(loader, 2) do
+    Ecto.Schema.Loader.unsafe_load(schema_or_types, data, loader)
   end
 
   @doc """
@@ -743,12 +743,15 @@ defmodule Ecto do
       %{title: "hello"}
 
   """
-  @spec embedded_dump(Ecto.Schema.t(), format :: atom()) :: map()
-  def embedded_dump(%schema{} = data, format) do
-    Ecto.Schema.Loader.safe_dump(
-      data,
-      schema.__schema__(:dump),
-      &Ecto.Type.embedded_dump(&1, &2, format)
-    )
+  @spec embedded_dump(
+          Ecto.Schema.t(),
+          format :: atom() | (Ecto.Type.t(), term -> {:ok, term} | :error)
+        ) :: map()
+  def embedded_dump(data, format) when is_atom(format) do
+    embedded_dump(data, &Ecto.Type.embedded_dump(&1, &2, format))
+  end
+
+  def embedded_dump(%schema{} = data, dumper) when is_function(dumper, 2) do
+    Ecto.Schema.Loader.safe_dump(data, schema.__schema__(:dump), dumper)
   end
 end

--- a/test/ecto/embedded_test.exs
+++ b/test/ecto/embedded_test.exs
@@ -78,6 +78,13 @@ defmodule Ecto.EmbeddedTest do
     assert %Settings{dark_mode: false, default_post: nil} =
              Ecto.embedded_load(Settings, %{"default_post" => nil}, :json)
 
+    assert %Settings{dark_mode: false, default_post: nil} =
+             Ecto.embedded_load(
+               Settings,
+               %{"default_post" => nil},
+               &Ecto.Type.embedded_load(&1, &2, :json)
+             )
+
     assert_raise ArgumentError,
                  ~s[cannot load `"ABC"` as type Ecto.UUID for field `uuid` in schema Ecto.EmbeddedTest.UUIDSchema],
                  fn ->
@@ -100,6 +107,12 @@ defmodule Ecto.EmbeddedTest do
     assert [author1 | _] = dumped.authors
     assert not Map.has_key?(author1, :__struct__)
     assert not Map.has_key?(author1, :__meta__)
+
+    assert %{uuid: ^uuid} =
+             Ecto.embedded_dump(
+               %UUIDSchema{uuid: uuid},
+               &Ecto.Type.embedded_dump(&1, &2, :json)
+             )
   end
 
   test "embedded schemas are not queryable" do


### PR DESCRIPTION
I'm working on a map based type mirroring `embeds_many` for transforming back and forth between ecto schema struct data and json. `Ecto.ParameterizedType` seems to support that usecase without much issue. `Ecto.embedded_load(OuterSchema, %{…}, :json)` works.

```elixir
embedded_schema do
  field :items, MapOf, of: Item, default: %{}
  field :rooms, MapOf, of: Room, default: %{}
end
```

However the implementation needed to hardcode `:json` as the format for dumping/loading (just showing one side, but it's a mirror issue for both)

```elixir
@impl true
def load(data, loader, %{of: schema}) when is_map(data) do
  loaded =
    Map.new(data, fn {key, value} ->

      # Copy implementation of `Ecto.embedded_load`
      # {key, Ecto.Schema.Loader.unsafe_load(schema, value, loader)}

      # Pull dynamic format from anonymous function 
      # {key, Ecto.embedded_load(schema, value, hd(Function.info(loader).env)}

      # Hardcoded format, instead of having it provided to the callback
      {key, Ecto.embedded_load(schema, value, :json)}
    end)

  {:ok, loaded}
end
```

Both `Ecto.embedded_load/3` as well as the loader passed to `c:load/3` are `&Ecto.Type.embeded_load(&1, &2, format)`, so it's as far as I can see mostly an issue of being able to compose those things, where `Ecto.embedded_load/3` doesn't really expect someone to already have the whole dumper callback at hand. 

https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/type.ex#L431 is where the anonymous function passed to the loader is from.

This PR would be a simple solution here, though not sure if there's sideeffects I'm missing. One benefit to it however is that it's truely scoped to the embedded data usecase and doesn't affect loading from database tables.