### PR TITLE
Sort escaped map/struct fields for deterministic compile output

### DIFF
--- a/lib/ecto/query/builder.ex
+++ b/lib/ecto/query/builder.ex
@@ -962,7 +962,7 @@ defmodule Ecto.Query.Builder do
   Escape the select alias map
   """
   @spec escape_select_aliases(map()) :: Macro.t()
-  def escape_select_aliases(%{} = aliases), do: {:%{}, [], Map.to_list(aliases)}
+  def escape_select_aliases(%{} = aliases), do: {:%{}, [], Enum.sort(Map.to_list(aliases))}
 
   @doc """
   Escapes a variable according to the given binds.
@@ -1684,7 +1684,7 @@ defmodule Ecto.Query.Builder do
 
   # Escapes an `Ecto.Query` and associated structs.
   @spec escape_query(Query.t()) :: Macro.t()
-  defp escape_query(%Query{} = query), do: {:%{}, [], Map.to_list(query)}
+  defp escape_query(%Query{} = query), do: {:%{}, [], Enum.sort(Map.to_list(query))}
 
   defp parse_access_get({{:., _, [Access, :get]}, _, [left, right]}, acc) do
     parse_access_get(left, [right | acc])

--- a/lib/ecto/query/builder/select.ex
+++ b/lib/ecto/query/builder/select.ex
@@ -318,7 +318,7 @@ defmodule Ecto.Query.Builder.Select do
     {query, binding} = Builder.escape_binding(query, binding, env)
     {expr, {params, acc}} = escape(expr, binding, env)
     params = Builder.escape_params(params)
-    take = {:%{}, [], Map.to_list(acc.take)}
+    take = {:%{}, [], Enum.sort(Map.to_list(acc.take))}
     aliases = escape_aliases(acc.aliases)
 
     select = quote do: %Ecto.Query.SelectExpr{
@@ -340,7 +340,7 @@ defmodule Ecto.Query.Builder.Select do
     end
   end
 
-  defp escape_aliases(%{} = aliases), do: {:%{}, [], Map.to_list(aliases)}
+  defp escape_aliases(%{} = aliases), do: {:%{}, [], Enum.sort(Map.to_list(aliases))}
   defp escape_aliases(aliases), do: aliases
 
   @doc """

--- a/lib/ecto/query/builder/windows.ex
+++ b/lib/ecto/query/builder/windows.ex
@@ -156,7 +156,7 @@ defmodule Ecto.Query.Builder.Windows do
   end
 
   defp build_runtime_window({name, compile_acc, runtime_acc, params, acc}, _env) do
-    {:{}, [], [name, Enum.reverse(compile_acc), runtime_acc, Enum.reverse(params), {:%{}, [], Map.to_list(acc)}]}
+    {:{}, [], [name, Enum.reverse(compile_acc), runtime_acc, Enum.reverse(params), {:%{}, [], Enum.sort(Map.to_list(acc))}]}
   end
 
   @doc """


### PR DESCRIPTION
Several builder escape functions re-embed a compile-time-computed map/struct as a literal AST via bare `Map.to_list/1`. `Map.to_list/1`'s field order isn't guaranteed stable across separate compiler invocations, so two builds of identical source can produce different compiled bytecode whenever any of these get folded into a literal at compile time.